### PR TITLE
DDP-4221 add age-up policy support

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.java
@@ -1,15 +1,20 @@
 package org.broadinstitute.ddp.db.dao;
 
+import java.util.Map;
 import java.util.Optional;
 
 import org.broadinstitute.ddp.db.DaoException;
+import org.broadinstitute.ddp.model.governance.AgeOfMajorityRule;
 import org.broadinstitute.ddp.model.governance.GovernancePolicy;
 import org.broadinstitute.ddp.model.pex.Expression;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
 
 public interface StudyGovernanceDao extends SqlObject {
@@ -21,8 +26,17 @@ public interface StudyGovernanceDao extends SqlObject {
     StudyGovernanceSql getStudyGovernanceSql();
 
     default GovernancePolicy createPolicy(GovernancePolicy policy) {
+        StudyGovernanceSql studyGovernanceSql = getStudyGovernanceSql();
+
         Expression scguExpr = getJdbiExpression().insertExpression(policy.getShouldCreateGovernedUserExpr().getText());
-        long policyId = getStudyGovernanceSql().insertPolicy(true, policy.getStudyId(), null, scguExpr.getId());
+        long policyId = studyGovernanceSql.insertPolicy(true, policy.getStudyId(), null, scguExpr.getId());
+
+        int order = 1;
+        for (AgeOfMajorityRule rule : policy.getAgeOfMajorityRules()) {
+            studyGovernanceSql.insertAgeOfMajorityRule(policyId, rule.getCondition(), rule.getAge(), rule.getPrepMonths(), order);
+            order += 1;
+        }
+
         return findPolicyById(policyId).orElseThrow(() -> new DaoException("Could not find study governance policy with id " + policyId));
     }
 
@@ -30,17 +44,34 @@ public interface StudyGovernanceDao extends SqlObject {
     @SqlQuery("queryPolicyById")
     @RegisterConstructorMapper(Expression.class)
     @RegisterConstructorMapper(GovernancePolicy.class)
+    @RegisterConstructorMapper(value = AgeOfMajorityRule.class, prefix = "aom")
+    @UseRowReducer(PolicyWithAgeOfMajorityRuleReducer.class)
     Optional<GovernancePolicy> findPolicyById(@Bind("id") long policyId);
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryPolicyByStudyId")
     @RegisterConstructorMapper(Expression.class)
     @RegisterConstructorMapper(GovernancePolicy.class)
+    @RegisterConstructorMapper(value = AgeOfMajorityRule.class, prefix = "aom")
+    @UseRowReducer(PolicyWithAgeOfMajorityRuleReducer.class)
     Optional<GovernancePolicy> findPolicyByStudyId(@Bind("studyId") long studyId);
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryPolicyByStudyGuid")
     @RegisterConstructorMapper(Expression.class)
     @RegisterConstructorMapper(GovernancePolicy.class)
+    @RegisterConstructorMapper(value = AgeOfMajorityRule.class, prefix = "aom")
+    @UseRowReducer(PolicyWithAgeOfMajorityRuleReducer.class)
     Optional<GovernancePolicy> findPolicyByStudyGuid(@Bind("studyGuid") String studyGuid);
+
+    class PolicyWithAgeOfMajorityRuleReducer implements LinkedHashMapRowReducer<Long, GovernancePolicy> {
+        @Override
+        public void accumulate(Map<Long, GovernancePolicy> container, RowView view) {
+            long policyId = view.getColumn("study_governance_policy_id", Long.class);
+            GovernancePolicy policy = container.computeIfAbsent(policyId, id -> view.getRow(GovernancePolicy.class));
+            if (view.getColumn("aom_age_of_majority_rule_id", Long.class) != null) {
+                policy.addAgeOfMajorityRule(view.getRow(AgeOfMajorityRule.class));
+            }
+        }
+    }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceSql.java
@@ -17,4 +17,14 @@ public interface StudyGovernanceSql extends SqlObject {
             @Bind("studyId") Long studyId,
             @Bind("studyGuid") String studyGuid,
             @Bind("shouldCreateGovernedUserExprId") long shouldCreateGovernedUserExprId);
+
+    @GetGeneratedKeys
+    @UseStringTemplateSqlLocator
+    @SqlUpdate("insertAgeOfMajorityRule")
+    long insertAgeOfMajorityRule(
+            @Bind("policyId") long policyId,
+            @Bind("condition") String condition,
+            @Bind("age") int age,
+            @Bind("prepMonths") Integer prepMonths,
+            @Bind("order") int order);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/governance/AgeOfMajorityRule.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/governance/AgeOfMajorityRule.java
@@ -1,0 +1,81 @@
+package org.broadinstitute.ddp.model.governance;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+/**
+ * Represents rule that helps determine if participant has reached the moment of age-of-majority, and for calculating that date.
+ */
+public class AgeOfMajorityRule {
+
+    private long id;
+    private long policyId;
+    private String condition;
+    private int age;
+    private Integer prepMonths;
+    private int order;
+
+    @JdbiConstructor
+    public AgeOfMajorityRule(@ColumnName("age_of_majority_rule_id") long id,
+                             @ColumnName("study_governance_policy_id") long policyId,
+                             @ColumnName("condition_expression") String condition,
+                             @ColumnName("age") int age,
+                             @ColumnName("preparation_months") Integer prepMonths,
+                             @ColumnName("execution_order") int order) {
+        this.id = id;
+        this.policyId = policyId;
+        this.condition = condition;
+        this.age = age;
+        this.prepMonths = prepMonths;
+        this.order = order;
+    }
+
+    public AgeOfMajorityRule(String condition, int age, Integer prepMonths) {
+        this.condition = condition;
+        this.age = age;
+        this.prepMonths = prepMonths;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getPolicyId() {
+        return policyId;
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public Integer getPrepMonths() {
+        return prepMonths;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+
+    public LocalDate getDateOfMajority(LocalDate birthDate) {
+        return birthDate.plusYears(age);
+    }
+
+    public Optional<LocalDate> getMajorityPrepDate(LocalDate birthDate) {
+        return Optional.ofNullable(prepMonths).map(months -> getDateOfMajority(birthDate).minusMonths(months));
+    }
+
+    public boolean hasReachedAgeOfMajority(LocalDate birthDate, LocalDate today) {
+        return getDateOfMajority(birthDate).compareTo(today) <= 0;
+    }
+
+    public Optional<Boolean> hasReachedAgeOfMajorityPrep(LocalDate birthDate, LocalDate today) {
+        return getMajorityPrepDate(birthDate).map(prepDate -> prepDate.compareTo(today) <= 0);
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -276,8 +276,7 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
                                         GovernancePolicy policy, User operatorUser, StudyClientConfiguration clientConfig) {
         boolean shouldCreateGoverned;
         try {
-            String expression = policy.getShouldCreateGovernedUserExpr().getText();
-            shouldCreateGoverned = interpreter.eval(expression, handle, operatorUser.getGuid(), null);
+            shouldCreateGoverned = policy.shouldCreateGovernedUser(handle, interpreter, operatorUser.getGuid());
         } catch (Exception e) {
             String msg = "Error while evaluating study governance policy for study " + policy.getStudyGuid();
             LOG.warn(msg, e);

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -176,4 +176,5 @@
     <include file="db-changes/seed/DDP-4266-invitation-types.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4221-refactor-profile-dob.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/DDP-4221-copy-participant-dob.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-4221-age-up-policy-rules.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-4221-age-up-policy-rules.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-4221-age-up-policy-rules.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20191211-age-of-majority-rule-table">
+        <createTable tableName="age_of_majority_rule">
+            <column name="age_of_majority_rule_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="age_of_majority_rule_pk"/>
+            </column>
+            <column name="study_governance_policy_id" type="bigint">
+                <constraints nullable="false"
+                             references="study_governance_policy(study_governance_policy_id)"
+                             foreignKeyName="age_of_majority_rule_study_governance_policy_fk"
+                             deleteCascade="true"/>
+            </column>
+            <column name="condition_expression" type="varchar(10000)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="age" type="tinyint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="preparation_months" type="smallint">
+                <constraints nullable="true"/>
+            </column>
+            <column name="execution_order" type="int">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.sql.stg
@@ -6,23 +6,33 @@ select policy.study_governance_policy_id,
        study.guid              as study_guid,
        scgu.expression_id   as scgu_expression_id,
        scgu.expression_guid as scgu_expression_guid,
-       scgu.expression_text as scgu_expression_text
+       scgu.expression_text as scgu_expression_text,
+       aom.age_of_majority_rule_id    as aom_age_of_majority_rule_id,
+       aom.study_governance_policy_id as aom_study_governance_policy_id,
+       aom.condition_expression       as aom_condition_expression,
+       aom.age                        as aom_age,
+       aom.preparation_months         as aom_preparation_months,
+       aom.execution_order            as aom_execution_order
   from study_governance_policy as policy
   join umbrella_study as study on study.umbrella_study_id = policy.study_id
   join expression as scgu on scgu.expression_id = policy.should_create_governed_user_expression_id
+  left join age_of_majority_rule as aom on aom.study_governance_policy_id = policy.study_governance_policy_id
 >>
 
 queryPolicyById() ::= <<
 <select_all_policies()>
 where policy.study_governance_policy_id = :id
+order by aom.execution_order asc
 >>
 
 queryPolicyByStudyId() ::= <<
 <select_all_policies()>
 where study.umbrella_study_id = :studyId
+order by aom.execution_order asc
 >>
 
 queryPolicyByStudyGuid() ::= <<
 <select_all_policies()>
 where study.guid = :studyGuid
+order by aom.execution_order asc
 >>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/StudyGovernanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/StudyGovernanceSql.sql.stg
@@ -10,3 +10,8 @@ values (
 <endif>
        :shouldCreateGovernedUserExprId)
 >>
+
+insertAgeOfMajorityRule() ::= <<
+insert into age_of_majority_rule (study_governance_policy_id, condition_expression, age, preparation_months, execution_order)
+values (:policyId, :condition, :age, :prepMonths, :order)
+>>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/governance/AgeOfMajorityRuleTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/governance/AgeOfMajorityRuleTest.java
@@ -1,0 +1,77 @@
+package org.broadinstitute.ddp.model.governance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+
+import org.junit.Test;
+
+public class AgeOfMajorityRuleTest {
+
+    @Test
+    public void testGetDateOfMajority() {
+        var rule = new AgeOfMajorityRule("true", 21, 4);
+        var expected = LocalDate.of(2008, 3, 14);
+        var actual = rule.getDateOfMajority(LocalDate.of(1987, 3, 14));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testGetMajorityPrepDate() {
+        var rule = new AgeOfMajorityRule("true", 19, 4);
+        var expected = LocalDate.of(2005, 11, 14);
+        var actual = rule.getMajorityPrepDate(LocalDate.of(1987, 3, 14));
+        assertTrue(actual.isPresent());
+        assertEquals(expected, actual.get());
+    }
+
+    @Test
+    public void testGetMajorityPrepDate_none() {
+        var rule = new AgeOfMajorityRule("true", 19, null);
+        assertTrue(rule.getMajorityPrepDate(LocalDate.of(1987, 3, 14)).isEmpty());
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajority() {
+        var rule = new AgeOfMajorityRule("true", 18, null);
+        var birthDate = LocalDate.of(1982, 12, 13);
+
+        var today = LocalDate.of(1992, 12, 13);
+        var actual = rule.hasReachedAgeOfMajority(birthDate, today);
+        assertFalse(actual);
+
+        today = LocalDate.of(2000, 12, 13);
+        actual = rule.hasReachedAgeOfMajority(birthDate, today);
+        assertTrue(actual);
+
+        today = LocalDate.of(2020, 12, 13);
+        actual = rule.hasReachedAgeOfMajority(birthDate, today);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajorityPrep() {
+        var rule = new AgeOfMajorityRule("true", 18, 4);
+        var birthDate = LocalDate.of(1982, 12, 13);
+
+        var today = LocalDate.of(1992, 12, 13);
+        var actual = rule.hasReachedAgeOfMajorityPrep(birthDate, today).get();
+        assertFalse(actual);
+
+        today = LocalDate.of(2000, 8, 13);
+        actual = rule.hasReachedAgeOfMajorityPrep(birthDate, today).get();
+        assertTrue(actual);
+
+        today = LocalDate.of(2020, 8, 13);
+        actual = rule.hasReachedAgeOfMajorityPrep(birthDate, today).get();
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajorityPrep_none() {
+        var rule = new AgeOfMajorityRule("true", 19, null);
+        assertTrue(rule.hasReachedAgeOfMajorityPrep(LocalDate.now(), LocalDate.now()).isEmpty());
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/governance/GovernancePolicyTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/governance/GovernancePolicyTest.java
@@ -1,0 +1,114 @@
+package org.broadinstitute.ddp.model.governance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDate;
+
+import org.broadinstitute.ddp.model.pex.Expression;
+import org.broadinstitute.ddp.pex.PexException;
+import org.broadinstitute.ddp.pex.PexInterpreter;
+import org.broadinstitute.ddp.pex.TreeWalkInterpreter;
+import org.jdbi.v3.core.Handle;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+public class GovernancePolicyTest {
+
+    private static final PexInterpreter interpreter = new TreeWalkInterpreter();
+    private static final Handle handle = Mockito.mock(Handle.class);
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testShouldCreateGovernedUser() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        assertTrue(policy.shouldCreateGovernedUser(handle, interpreter, "guid"));
+
+        policy = new GovernancePolicy(1, new Expression("false"));
+        assertFalse(policy.shouldCreateGovernedUser(handle, interpreter, "guid"));
+    }
+
+    @Test
+    public void testShouldCreateGovernedUser_errors() {
+        thrown.expect(PexException.class);
+
+        var policy = new GovernancePolicy(1, new Expression("not supported"));
+        policy.shouldCreateGovernedUser(handle, interpreter, "guid");
+    }
+
+    @Test
+    public void testGetApplicableAgeOfMajorityRule_noRules() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        var actual = policy.getApplicableAgeOfMajorityRule(handle, interpreter, "guid");
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void testGetApplicableAgeOfMajorityRule_noneSuccessful() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        policy.addAgeOfMajorityRule(
+                new AgeOfMajorityRule("false", 21, 4),
+                new AgeOfMajorityRule("false", 18, 6));
+
+        var actual = policy.getApplicableAgeOfMajorityRule(handle, interpreter, "guid");
+        assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    public void testGetApplicableAgeOfMajorityRule_firstSuccessfulRule() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        policy.addAgeOfMajorityRule(
+                new AgeOfMajorityRule("false", 21, 4),
+                new AgeOfMajorityRule("true", 19, 5),
+                new AgeOfMajorityRule("true", 18, 6));
+
+        var actual = policy.getApplicableAgeOfMajorityRule(handle, interpreter, "guid");
+        assertTrue(actual.isPresent());
+        assertEquals(19, actual.get().getAge());
+    }
+
+    @Test
+    public void testGetApplicableAgeOfMajorityRule_errors() {
+        thrown.expect(PexException.class);
+
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        policy.addAgeOfMajorityRule(
+                new AgeOfMajorityRule("false", 21, 4),
+                new AgeOfMajorityRule("not supported", 19, 5),
+                new AgeOfMajorityRule("true", 18, 6));
+
+        policy.getApplicableAgeOfMajorityRule(handle, interpreter, "guid");
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajority() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        policy.addAgeOfMajorityRule(new AgeOfMajorityRule("true", 18, 6));
+        var birthDate = LocalDate.of(1982, 12, 13);
+
+        var today = LocalDate.of(2019, 12, 13);
+        var actual = policy.hasReachedAgeOfMajority(handle, interpreter, "guid", birthDate, today);
+        assertTrue(actual);
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajority_defaultsToFalse() {
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        var actual = policy.hasReachedAgeOfMajority(handle, interpreter, "guid", LocalDate.now(), LocalDate.now());
+        assertFalse(actual);
+    }
+
+    @Test
+    public void testHasReachedAgeOfMajority_errors() {
+        thrown.expect(PexException.class);
+
+        var policy = new GovernancePolicy(1, new Expression("true"));
+        policy.addAgeOfMajorityRule(new AgeOfMajorityRule("not supported", 18, 6));
+        policy.hasReachedAgeOfMajority(handle, interpreter, "guid", LocalDate.now(), LocalDate.now());
+    }
+}

--- a/study-builder/studies/study-schema.conf
+++ b/study-builder/studies/study-schema.conf
@@ -35,7 +35,22 @@
         # PEX expression to specify if a new governed user should be created when the operator registers.
         # When this evaluates to true, a new participant user will be created and data will be associated with this new user.
         # When false, no new user will be created and no change will be made to operator.
-        "shouldCreateGovernedUserExpr": "string"
+        "shouldCreateGovernedUserExpr": "string",
+
+        # Rules for age-up process, used for calculating date-of-majority
+        # and determining if participant has reached moment of age-of-majority or not.
+        # Only the first rule that applies to participant will be used.
+        # Order of the listed rules will be the order they are executed in.
+        "ageOfMajorityRules": [
+            {
+                # PEX expression to determine if this rule applies to participant.
+                "condition": "string",
+                # The age particpant needs to be to be considered age-of-majority.
+                "age": "integer",
+                # Optional, the number of months before participant's date-of-majority when we should start preparation process.
+                "prepMonths": "integer"
+            }
+        ]
     },
 
     "studyDetails": [


### PR DESCRIPTION
Part 3 of [DDP-4221](https://broadinstitute.atlassian.net/browse/DDP-4221).

Last piece for age-up policy. This PR adds "rules" for age-of-majority, ways to calculate date-of-majority, and ways to determine if participant has reached AoM.