### PR TITLE
DDP-4053 spec: permanent announcement messages

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1522,6 +1522,7 @@ AnnouncementModel:
   properties:
     guid:
       type: string
+      format: uuid
       description: an identifier for this message
       example: c8716864-3cd8-4a4b-8736-d2eec9756ad9
     permanent:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1516,8 +1516,17 @@ Validation.IntRange:
 AnnouncementModel:
   type: object
   required:
+    - guid
+    - permanent
     - message
   properties:
+    guid:
+      type: string
+      description: an identifier for this message
+      example: c8716864-3cd8-4a4b-8736-d2eec9756ad9
+    permanent:
+      type: boolean
+      description: if true, then message is permanent and should not be able to be dismissed by user
     message:
       type: string
 Drug:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.announcements.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.announcements.yml
@@ -3,7 +3,7 @@ get:
   tags:
     - Announcements
   summary: retrieve announcement messages
-  description: Returns the announcement message objects. Note that currently, messages are automatically deleted once retrieved.
+  description: Returns the announcement message objects. Note that currently, messages are automatically deleted once retrieved if they are not permanent.
   parameters:
     - in: path
       name: user


### PR DESCRIPTION
DDP-4053 adds feature for "permanent" announcement messages. To help clients identify permanent messages, we're adding a `guid` to message objects returned from the API and a `permanent` flag.

Corresponding API/Angular changes will be made separately. This PR is only the OpenAPI spec changes.