### PR TITLE
DDP-4053 osteo: add announcement msg for former proxies

### DIFF
--- a/study-builder/studies/osteo/snippets/former-proxy-announcement-msg.conf
+++ b/study-builder/studies/osteo/snippets/former-proxy-announcement-msg.conf
@@ -1,0 +1,42 @@
+{
+  "templateType": "HTML",
+  "templateText": """
+    <p class="bold infobox-text_small">$osteo_former_proxy_announcement_intro</p>
+    <p class="infobox-text_small">$osteo_former_proxy_announcement_p1</p>
+    <p class="infobox-text_small">$osteo_former_proxy_announcement_p2</p>
+  """,
+  "variables": [
+    {
+      "name": "osteo_former_proxy_announcement_intro",
+      "translations": [
+        {
+          "language": "en",
+          "text": "A Message from the Osteosarcoma Project"
+        }
+      ]
+    },
+    {
+      "name": "osteo_former_proxy_announcement_p1",
+      "translations": [
+        {
+          "language": "en",
+          "text": """
+            Your child has reached the age of consenting for themselves in order to continue their participation in the Osteosarcoma Project.
+            Because of this, access and control of their information related to this project has shifted to their account."""
+        }
+      ]
+    },
+    {
+      "name": "osteo_former_proxy_announcement_p2",
+      "translations": [
+        {
+          "language": "en",
+          "text": """
+            Thank you for your support of the Osteosarcoma Project, if you have any questions about this change or other topics,
+            email us at <a class="Link" href="mailto:info@osproject.org">info@osproject.org</a>
+            or call <a class="Link" href="tel:651-602-2020">651-602-2020</a>."""
+        }
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -2458,6 +2458,20 @@
       "dispatchToHousekeeping": false,
       "order": 2
     },
+    {
+      "trigger": {
+        "type": "GOVERNED_USER_REGISTERED",
+      },
+      "action": {
+        "type": "ANNOUNCEMENT",
+        "permanent": true,
+        "createForProxies": true,
+        "msgTemplate": { include required("snippets/former-proxy-announcement-msg.conf") }
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
 
     # medical update events for release pdfs
     {


### PR DESCRIPTION
After child participant registers for the study, we create a new announcement message for their proxy. When former proxy logs in, they will see it and it cannot be dismissed.