### PR TITLE
DDP-4263 osteo: reorder U.S. territories to top of country dropdown

### DIFF
--- a/study-builder/studies/osteo/prequal.conf
+++ b/study-builder/studies/osteo/prequal.conf
@@ -224,7 +224,7 @@
         },
         {
           "question": {
-            include required("../snippets/picklist-question-country-required.conf"),
+            include required("../snippets/picklist-question-country-required-eligible-first.conf"),
             "stableId": "SELF_COUNTRY",
             "hideNumber": true,
             "promptTemplate": {
@@ -354,7 +354,7 @@
         },
         {
           "question": {
-            include required("../snippets/picklist-question-country-required.conf"),
+            include required("../snippets/picklist-question-country-required-eligible-first.conf"),
             "stableId": "CHILD_COUNTRY",
             "hideNumber": true,
             "promptTemplate": {

--- a/study-builder/studies/snippets/picklist-question-country-required-eligible-first.conf
+++ b/study-builder/studies/snippets/picklist-question-country-required-eligible-first.conf
@@ -1,0 +1,5567 @@
+{
+  "stableId": "COUNTRY",
+  "questionType": "PICKLIST",
+  "selectMode": "SINGLE",
+  "renderMode": "DROPDOWN",
+  "isRestricted": false,
+  "isDeprecated": false,
+  "hideNumber": false,
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateCode": null,
+    "templateText": "$COUNTRY_prompt",
+    "variables": [
+      {
+        "name": "COUNTRY_prompt",
+        "translations": [
+          {
+            "language": "en",
+            "text": "What country do you live in?"
+          }
+        ]
+      }
+    ]
+  },
+  "additionalInfoHeaderTemplate": null,
+  "additionalInfoFooterTemplate": null,
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_req_hint",
+        "variables": [
+          {
+            "name": "COUNTRY_req_hint",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Country is required"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "picklistLabelTemplate": {
+    "templateType": "TEXT",
+    "templateCode": null,
+    "templateText": "$COUNTRY_picklist_label",
+    "variables": [
+      {
+        "name": "COUNTRY_picklist_label",
+        "translations": [
+          {
+            "language": "en",
+            "text": "Choose country..."
+          }
+        ]
+      }
+    ]
+  },
+  "groups": [],
+  "picklistOptions": [
+    {
+      "stableId": "US",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_us",
+        "variables": [
+          {
+            "name": "COUNTRY_us",
+            "translations": [
+              {
+                "language": "en",
+                "text": "United States"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ca",
+        "variables": [
+          {
+            "name": "COUNTRY_ca",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Canada"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_as",
+        "variables": [
+          {
+            "name": "COUNTRY_as",
+            "translations": [
+              {
+                "language": "en",
+                "text": "American Samoa"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gu",
+        "variables": [
+          {
+            "name": "COUNTRY_gu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guam"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MP",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mp",
+        "variables": [
+          {
+            "name": "COUNTRY_mp",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Northern Mariana Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pr",
+        "variables": [
+          {
+            "name": "COUNTRY_pr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Puerto Rico"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_vi",
+        "variables": [
+          {
+            "name": "COUNTRY_vi",
+            "translations": [
+              {
+                "language": "en",
+                "text": "U.S. Virgin Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_af",
+        "variables": [
+          {
+            "name": "COUNTRY_af",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Afghanistan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_al",
+        "variables": [
+          {
+            "name": "COUNTRY_al",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Albania"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_dz",
+        "variables": [
+          {
+            "name": "COUNTRY_dz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Algeria"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ad",
+        "variables": [
+          {
+            "name": "COUNTRY_ad",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Andorra"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ao",
+        "variables": [
+          {
+            "name": "COUNTRY_ao",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Angola"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ai",
+        "variables": [
+          {
+            "name": "COUNTRY_ai",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Anguilla"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AQ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_aq",
+        "variables": [
+          {
+            "name": "COUNTRY_aq",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Antarctica"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ag",
+        "variables": [
+          {
+            "name": "COUNTRY_ag",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Antigua and Barbuda"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ar",
+        "variables": [
+          {
+            "name": "COUNTRY_ar",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Argentina"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_am",
+        "variables": [
+          {
+            "name": "COUNTRY_am",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Armenia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_aw",
+        "variables": [
+          {
+            "name": "COUNTRY_aw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Aruba"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_au",
+        "variables": [
+          {
+            "name": "COUNTRY_au",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Australia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_at",
+        "variables": [
+          {
+            "name": "COUNTRY_at",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Austria"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_az",
+        "variables": [
+          {
+            "name": "COUNTRY_az",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Azerbaijan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bs",
+        "variables": [
+          {
+            "name": "COUNTRY_bs",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bahamas"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bh",
+        "variables": [
+          {
+            "name": "COUNTRY_bh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bahrain"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bd",
+        "variables": [
+          {
+            "name": "COUNTRY_bd",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bangladesh"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BB",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bb",
+        "variables": [
+          {
+            "name": "COUNTRY_bb",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Barbados"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_by",
+        "variables": [
+          {
+            "name": "COUNTRY_by",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Belarus"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_be",
+        "variables": [
+          {
+            "name": "COUNTRY_be",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Belgium"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bz",
+        "variables": [
+          {
+            "name": "COUNTRY_bz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Belize"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BJ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bj",
+        "variables": [
+          {
+            "name": "COUNTRY_bj",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Benin"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bm",
+        "variables": [
+          {
+            "name": "COUNTRY_bm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bermuda"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bt",
+        "variables": [
+          {
+            "name": "COUNTRY_bt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bhutan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bo",
+        "variables": [
+          {
+            "name": "COUNTRY_bo",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bolivia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BQ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bq",
+        "variables": [
+          {
+            "name": "COUNTRY_bq",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bonaire, Sint Eustatius and Saba"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ba",
+        "variables": [
+          {
+            "name": "COUNTRY_ba",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bosnia and Herzegovina"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bw",
+        "variables": [
+          {
+            "name": "COUNTRY_bw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Botswana"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bv",
+        "variables": [
+          {
+            "name": "COUNTRY_bv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bouvet Island"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_br",
+        "variables": [
+          {
+            "name": "COUNTRY_br",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Brazil"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_io",
+        "variables": [
+          {
+            "name": "COUNTRY_io",
+            "translations": [
+              {
+                "language": "en",
+                "text": "British Indian Ocean Territory"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_vg",
+        "variables": [
+          {
+            "name": "COUNTRY_vg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "British Virgin Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bn",
+        "variables": [
+          {
+            "name": "COUNTRY_bn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Brunei"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bg",
+        "variables": [
+          {
+            "name": "COUNTRY_bg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Bulgaria"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bf",
+        "variables": [
+          {
+            "name": "COUNTRY_bf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Burkina Faso"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bi",
+        "variables": [
+          {
+            "name": "COUNTRY_bi",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Burundi"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kh",
+        "variables": [
+          {
+            "name": "COUNTRY_kh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cambodia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cm",
+        "variables": [
+          {
+            "name": "COUNTRY_cm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cameroon"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cv",
+        "variables": [
+          {
+            "name": "COUNTRY_cv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cape Verde"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ky",
+        "variables": [
+          {
+            "name": "COUNTRY_ky",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cayman Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cf",
+        "variables": [
+          {
+            "name": "COUNTRY_cf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Central African Republic"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_td",
+        "variables": [
+          {
+            "name": "COUNTRY_td",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Chad"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cl",
+        "variables": [
+          {
+            "name": "COUNTRY_cl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Chile"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cn",
+        "variables": [
+          {
+            "name": "COUNTRY_cn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "China"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CX",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cx",
+        "variables": [
+          {
+            "name": "COUNTRY_cx",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Christmas Island"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cc",
+        "variables": [
+          {
+            "name": "COUNTRY_cc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cocos Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_co",
+        "variables": [
+          {
+            "name": "COUNTRY_co",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Colombia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_km",
+        "variables": [
+          {
+            "name": "COUNTRY_km",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Comoros"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cg",
+        "variables": [
+          {
+            "name": "COUNTRY_cg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Congo"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ck",
+        "variables": [
+          {
+            "name": "COUNTRY_ck",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cook Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cr",
+        "variables": [
+          {
+            "name": "COUNTRY_cr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Costa Rica"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_hr",
+        "variables": [
+          {
+            "name": "COUNTRY_hr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Croatia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cu",
+        "variables": [
+          {
+            "name": "COUNTRY_cu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cuba"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cw",
+        "variables": [
+          {
+            "name": "COUNTRY_cw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Curaçao"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cy",
+        "variables": [
+          {
+            "name": "COUNTRY_cy",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Cyprus"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cz",
+        "variables": [
+          {
+            "name": "COUNTRY_cz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Czech Republic"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ci",
+        "variables": [
+          {
+            "name": "COUNTRY_ci",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Côte d'Ivoire"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_dk",
+        "variables": [
+          {
+            "name": "COUNTRY_dk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Denmark"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DJ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_dj",
+        "variables": [
+          {
+            "name": "COUNTRY_dj",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Djibouti"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_dm",
+        "variables": [
+          {
+            "name": "COUNTRY_dm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Dominica"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_do",
+        "variables": [
+          {
+            "name": "COUNTRY_do",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Dominican Republic"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "EC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ec",
+        "variables": [
+          {
+            "name": "COUNTRY_ec",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Ecuador"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "EG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_eg",
+        "variables": [
+          {
+            "name": "COUNTRY_eg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Egypt"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sv",
+        "variables": [
+          {
+            "name": "COUNTRY_sv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "El Salvador"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GQ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gq",
+        "variables": [
+          {
+            "name": "COUNTRY_gq",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Equatorial Guinea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ER",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_er",
+        "variables": [
+          {
+            "name": "COUNTRY_er",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Eritrea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "EE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ee",
+        "variables": [
+          {
+            "name": "COUNTRY_ee",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Estonia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ET",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_et",
+        "variables": [
+          {
+            "name": "COUNTRY_et",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Ethiopia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fk",
+        "variables": [
+          {
+            "name": "COUNTRY_fk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Falkland Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fo",
+        "variables": [
+          {
+            "name": "COUNTRY_fo",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Faroe Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FJ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fj",
+        "variables": [
+          {
+            "name": "COUNTRY_fj",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Fiji"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fi",
+        "variables": [
+          {
+            "name": "COUNTRY_fi",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Finland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fr",
+        "variables": [
+          {
+            "name": "COUNTRY_fr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "France"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gf",
+        "variables": [
+          {
+            "name": "COUNTRY_gf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "French Guiana"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pf",
+        "variables": [
+          {
+            "name": "COUNTRY_pf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "French Polynesia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tf",
+        "variables": [
+          {
+            "name": "COUNTRY_tf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "French Southern Territories"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ga",
+        "variables": [
+          {
+            "name": "COUNTRY_ga",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Gabon"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gm",
+        "variables": [
+          {
+            "name": "COUNTRY_gm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Gambia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ge",
+        "variables": [
+          {
+            "name": "COUNTRY_ge",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Georgia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "DE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_de",
+        "variables": [
+          {
+            "name": "COUNTRY_de",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Germany"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gh",
+        "variables": [
+          {
+            "name": "COUNTRY_gh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Ghana"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gi",
+        "variables": [
+          {
+            "name": "COUNTRY_gi",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Gibraltar"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gr",
+        "variables": [
+          {
+            "name": "COUNTRY_gr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Greece"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gl",
+        "variables": [
+          {
+            "name": "COUNTRY_gl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Greenland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gd",
+        "variables": [
+          {
+            "name": "COUNTRY_gd",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Grenada"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GP",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gp",
+        "variables": [
+          {
+            "name": "COUNTRY_gp",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guadeloupe"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gt",
+        "variables": [
+          {
+            "name": "COUNTRY_gt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guatemala"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gg",
+        "variables": [
+          {
+            "name": "COUNTRY_gg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guernsey"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gn",
+        "variables": [
+          {
+            "name": "COUNTRY_gn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guinea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gw",
+        "variables": [
+          {
+            "name": "COUNTRY_gw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guinea-Bissau"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gy",
+        "variables": [
+          {
+            "name": "COUNTRY_gy",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Guyana"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ht",
+        "variables": [
+          {
+            "name": "COUNTRY_ht",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Haiti"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_hm",
+        "variables": [
+          {
+            "name": "COUNTRY_hm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Heard Island And McDonald Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_hn",
+        "variables": [
+          {
+            "name": "COUNTRY_hn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Honduras"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_hk",
+        "variables": [
+          {
+            "name": "COUNTRY_hk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Hong Kong"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "HU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_hu",
+        "variables": [
+          {
+            "name": "COUNTRY_hu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Hungary"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_is",
+        "variables": [
+          {
+            "name": "COUNTRY_is",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Iceland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_in",
+        "variables": [
+          {
+            "name": "COUNTRY_in",
+            "translations": [
+              {
+                "language": "en",
+                "text": "India"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ID",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_id",
+        "variables": [
+          {
+            "name": "COUNTRY_id",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Indonesia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ir",
+        "variables": [
+          {
+            "name": "COUNTRY_ir",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Iran"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IQ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_iq",
+        "variables": [
+          {
+            "name": "COUNTRY_iq",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Iraq"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ie",
+        "variables": [
+          {
+            "name": "COUNTRY_ie",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Ireland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_im",
+        "variables": [
+          {
+            "name": "COUNTRY_im",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Isle Of Man"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_il",
+        "variables": [
+          {
+            "name": "COUNTRY_il",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Israel"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "IT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_it",
+        "variables": [
+          {
+            "name": "COUNTRY_it",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Italy"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "JM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_jm",
+        "variables": [
+          {
+            "name": "COUNTRY_jm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Jamaica"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "JP",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_jp",
+        "variables": [
+          {
+            "name": "COUNTRY_jp",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Japan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "JE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_je",
+        "variables": [
+          {
+            "name": "COUNTRY_je",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Jersey"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "JO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_jo",
+        "variables": [
+          {
+            "name": "COUNTRY_jo",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Jordan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kz",
+        "variables": [
+          {
+            "name": "COUNTRY_kz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Kazakhstan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ke",
+        "variables": [
+          {
+            "name": "COUNTRY_ke",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Kenya"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ki",
+        "variables": [
+          {
+            "name": "COUNTRY_ki",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Kiribati"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kw",
+        "variables": [
+          {
+            "name": "COUNTRY_kw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Kuwait"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kg",
+        "variables": [
+          {
+            "name": "COUNTRY_kg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Kyrgyzstan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_la",
+        "variables": [
+          {
+            "name": "COUNTRY_la",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Laos"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lv",
+        "variables": [
+          {
+            "name": "COUNTRY_lv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Latvia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LB",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lb",
+        "variables": [
+          {
+            "name": "COUNTRY_lb",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Lebanon"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ls",
+        "variables": [
+          {
+            "name": "COUNTRY_ls",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Lesotho"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lr",
+        "variables": [
+          {
+            "name": "COUNTRY_lr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Liberia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ly",
+        "variables": [
+          {
+            "name": "COUNTRY_ly",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Libya"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_li",
+        "variables": [
+          {
+            "name": "COUNTRY_li",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Liechtenstein"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lt",
+        "variables": [
+          {
+            "name": "COUNTRY_lt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Lithuania"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lu",
+        "variables": [
+          {
+            "name": "COUNTRY_lu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Luxembourg"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mo",
+        "variables": [
+          {
+            "name": "COUNTRY_mo",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Macao"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mk",
+        "variables": [
+          {
+            "name": "COUNTRY_mk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Macedonia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mg",
+        "variables": [
+          {
+            "name": "COUNTRY_mg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Madagascar"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mw",
+        "variables": [
+          {
+            "name": "COUNTRY_mw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Malawi"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_my",
+        "variables": [
+          {
+            "name": "COUNTRY_my",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Malaysia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mv",
+        "variables": [
+          {
+            "name": "COUNTRY_mv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Maldives"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ML",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ml",
+        "variables": [
+          {
+            "name": "COUNTRY_ml",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mali"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mt",
+        "variables": [
+          {
+            "name": "COUNTRY_mt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Malta"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mh",
+        "variables": [
+          {
+            "name": "COUNTRY_mh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Marshall Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MQ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mq",
+        "variables": [
+          {
+            "name": "COUNTRY_mq",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Martinique"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mr",
+        "variables": [
+          {
+            "name": "COUNTRY_mr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mauritania"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mu",
+        "variables": [
+          {
+            "name": "COUNTRY_mu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mauritius"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "YT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_yt",
+        "variables": [
+          {
+            "name": "COUNTRY_yt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mayotte"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MX",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mx",
+        "variables": [
+          {
+            "name": "COUNTRY_mx",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mexico"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "FM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_fm",
+        "variables": [
+          {
+            "name": "COUNTRY_fm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Micronesia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_md",
+        "variables": [
+          {
+            "name": "COUNTRY_md",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Moldova"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mc",
+        "variables": [
+          {
+            "name": "COUNTRY_mc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Monaco"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mn",
+        "variables": [
+          {
+            "name": "COUNTRY_mn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mongolia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ME",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_me",
+        "variables": [
+          {
+            "name": "COUNTRY_me",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Montenegro"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ms",
+        "variables": [
+          {
+            "name": "COUNTRY_ms",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Montserrat"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ma",
+        "variables": [
+          {
+            "name": "COUNTRY_ma",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Morocco"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mz",
+        "variables": [
+          {
+            "name": "COUNTRY_mz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Mozambique"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mm",
+        "variables": [
+          {
+            "name": "COUNTRY_mm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Myanmar"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_na",
+        "variables": [
+          {
+            "name": "COUNTRY_na",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Namibia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nr",
+        "variables": [
+          {
+            "name": "COUNTRY_nr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Nauru"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NP",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_np",
+        "variables": [
+          {
+            "name": "COUNTRY_np",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Nepal"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nl",
+        "variables": [
+          {
+            "name": "COUNTRY_nl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Netherlands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_an",
+        "variables": [
+          {
+            "name": "COUNTRY_an",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Netherlands Antilles"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nc",
+        "variables": [
+          {
+            "name": "COUNTRY_nc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "New Caledonia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nz",
+        "variables": [
+          {
+            "name": "COUNTRY_nz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "New Zealand"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ni",
+        "variables": [
+          {
+            "name": "COUNTRY_ni",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Nicaragua"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ne",
+        "variables": [
+          {
+            "name": "COUNTRY_ne",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Niger"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ng",
+        "variables": [
+          {
+            "name": "COUNTRY_ng",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Nigeria"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nu",
+        "variables": [
+          {
+            "name": "COUNTRY_nu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Niue"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_nf",
+        "variables": [
+          {
+            "name": "COUNTRY_nf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Norfolk Island"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KP",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kp",
+        "variables": [
+          {
+            "name": "COUNTRY_kp",
+            "translations": [
+              {
+                "language": "en",
+                "text": "North Korea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "NO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_no",
+        "variables": [
+          {
+            "name": "COUNTRY_no",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Norway"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "OM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_om",
+        "variables": [
+          {
+            "name": "COUNTRY_om",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Oman"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pk",
+        "variables": [
+          {
+            "name": "COUNTRY_pk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Pakistan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pw",
+        "variables": [
+          {
+            "name": "COUNTRY_pw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Palau"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ps",
+        "variables": [
+          {
+            "name": "COUNTRY_ps",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Palestine"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pa",
+        "variables": [
+          {
+            "name": "COUNTRY_pa",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Panama"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pg",
+        "variables": [
+          {
+            "name": "COUNTRY_pg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Papua New Guinea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_py",
+        "variables": [
+          {
+            "name": "COUNTRY_py",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Paraguay"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pe",
+        "variables": [
+          {
+            "name": "COUNTRY_pe",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Peru"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ph",
+        "variables": [
+          {
+            "name": "COUNTRY_ph",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Philippines"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pn",
+        "variables": [
+          {
+            "name": "COUNTRY_pn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Pitcairn"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pl",
+        "variables": [
+          {
+            "name": "COUNTRY_pl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Poland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pt",
+        "variables": [
+          {
+            "name": "COUNTRY_pt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Portugal"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "QA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_qa",
+        "variables": [
+          {
+            "name": "COUNTRY_qa",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Qatar"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "RE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_re",
+        "variables": [
+          {
+            "name": "COUNTRY_re",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Reunion"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "RO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ro",
+        "variables": [
+          {
+            "name": "COUNTRY_ro",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Romania"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "RU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ru",
+        "variables": [
+          {
+            "name": "COUNTRY_ru",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Russia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "RW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_rw",
+        "variables": [
+          {
+            "name": "COUNTRY_rw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Rwanda"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "BL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_bl",
+        "variables": [
+          {
+            "name": "COUNTRY_bl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Barthélemy"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sh",
+        "variables": [
+          {
+            "name": "COUNTRY_sh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Helena"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kn",
+        "variables": [
+          {
+            "name": "COUNTRY_kn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Kitts And Nevis"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lc",
+        "variables": [
+          {
+            "name": "COUNTRY_lc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Lucia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "MF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_mf",
+        "variables": [
+          {
+            "name": "COUNTRY_mf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Martin"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "PM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_pm",
+        "variables": [
+          {
+            "name": "COUNTRY_pm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Pierre And Miquelon"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_vc",
+        "variables": [
+          {
+            "name": "COUNTRY_vc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saint Vincent And The Grenadines"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "WS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ws",
+        "variables": [
+          {
+            "name": "COUNTRY_ws",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Samoa"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sm",
+        "variables": [
+          {
+            "name": "COUNTRY_sm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "San Marino"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ST",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_st",
+        "variables": [
+          {
+            "name": "COUNTRY_st",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sao Tome And Principe"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sa",
+        "variables": [
+          {
+            "name": "COUNTRY_sa",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Saudi Arabia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sn",
+        "variables": [
+          {
+            "name": "COUNTRY_sn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Senegal"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "RS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_rs",
+        "variables": [
+          {
+            "name": "COUNTRY_rs",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Serbia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sc",
+        "variables": [
+          {
+            "name": "COUNTRY_sc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Seychelles"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sl",
+        "variables": [
+          {
+            "name": "COUNTRY_sl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sierra Leone"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sg",
+        "variables": [
+          {
+            "name": "COUNTRY_sg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Singapore"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SX",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sx",
+        "variables": [
+          {
+            "name": "COUNTRY_sx",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sint Maarten (Dutch part)"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sk",
+        "variables": [
+          {
+            "name": "COUNTRY_sk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Slovakia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SI",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_si",
+        "variables": [
+          {
+            "name": "COUNTRY_si",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Slovenia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SB",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sb",
+        "variables": [
+          {
+            "name": "COUNTRY_sb",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Solomon Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_so",
+        "variables": [
+          {
+            "name": "COUNTRY_so",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Somalia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ZA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_za",
+        "variables": [
+          {
+            "name": "COUNTRY_za",
+            "translations": [
+              {
+                "language": "en",
+                "text": "South Africa"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gs",
+        "variables": [
+          {
+            "name": "COUNTRY_gs",
+            "translations": [
+              {
+                "language": "en",
+                "text": "South Georgia And The South Sandwich Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "KR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_kr",
+        "variables": [
+          {
+            "name": "COUNTRY_kr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "South Korea"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SS",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ss",
+        "variables": [
+          {
+            "name": "COUNTRY_ss",
+            "translations": [
+              {
+                "language": "en",
+                "text": "South Sudan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ES",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_es",
+        "variables": [
+          {
+            "name": "COUNTRY_es",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Spain"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "LK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_lk",
+        "variables": [
+          {
+            "name": "COUNTRY_lk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sri Lanka"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sd",
+        "variables": [
+          {
+            "name": "COUNTRY_sd",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sudan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sr",
+        "variables": [
+          {
+            "name": "COUNTRY_sr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Suriname"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SJ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sj",
+        "variables": [
+          {
+            "name": "COUNTRY_sj",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Svalbard And Jan Mayen"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sz",
+        "variables": [
+          {
+            "name": "COUNTRY_sz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Swaziland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_se",
+        "variables": [
+          {
+            "name": "COUNTRY_se",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Sweden"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ch",
+        "variables": [
+          {
+            "name": "COUNTRY_ch",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Switzerland"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "SY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_sy",
+        "variables": [
+          {
+            "name": "COUNTRY_sy",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Syria"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tw",
+        "variables": [
+          {
+            "name": "COUNTRY_tw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Taiwan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TJ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tj",
+        "variables": [
+          {
+            "name": "COUNTRY_tj",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tajikistan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tz",
+        "variables": [
+          {
+            "name": "COUNTRY_tz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tanzania"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_th",
+        "variables": [
+          {
+            "name": "COUNTRY_th",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Thailand"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "CD",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_cd",
+        "variables": [
+          {
+            "name": "COUNTRY_cd",
+            "translations": [
+              {
+                "language": "en",
+                "text": "The Democratic Republic Of Congo"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tl",
+        "variables": [
+          {
+            "name": "COUNTRY_tl",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Timor-Leste"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tg",
+        "variables": [
+          {
+            "name": "COUNTRY_tg",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Togo"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TK",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tk",
+        "variables": [
+          {
+            "name": "COUNTRY_tk",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tokelau"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TO",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_to",
+        "variables": [
+          {
+            "name": "COUNTRY_to",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tonga"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TT",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tt",
+        "variables": [
+          {
+            "name": "COUNTRY_tt",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Trinidad and Tobago"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tn",
+        "variables": [
+          {
+            "name": "COUNTRY_tn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tunisia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TR",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tr",
+        "variables": [
+          {
+            "name": "COUNTRY_tr",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Turkey"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tm",
+        "variables": [
+          {
+            "name": "COUNTRY_tm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Turkmenistan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tc",
+        "variables": [
+          {
+            "name": "COUNTRY_tc",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Turks And Caicos Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "TV",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_tv",
+        "variables": [
+          {
+            "name": "COUNTRY_tv",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Tuvalu"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "UG",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ug",
+        "variables": [
+          {
+            "name": "COUNTRY_ug",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Uganda"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "UA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ua",
+        "variables": [
+          {
+            "name": "COUNTRY_ua",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Ukraine"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ae",
+        "variables": [
+          {
+            "name": "COUNTRY_ae",
+            "translations": [
+              {
+                "language": "en",
+                "text": "United Arab Emirates"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "GB",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_gb",
+        "variables": [
+          {
+            "name": "COUNTRY_gb",
+            "translations": [
+              {
+                "language": "en",
+                "text": "United Kingdom"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "UM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_um",
+        "variables": [
+          {
+            "name": "COUNTRY_um",
+            "translations": [
+              {
+                "language": "en",
+                "text": "United States Minor Outlying Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "UY",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_uy",
+        "variables": [
+          {
+            "name": "COUNTRY_uy",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Uruguay"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "UZ",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_uz",
+        "variables": [
+          {
+            "name": "COUNTRY_uz",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Uzbekistan"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VU",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_vu",
+        "variables": [
+          {
+            "name": "COUNTRY_vu",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Vanuatu"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_va",
+        "variables": [
+          {
+            "name": "COUNTRY_va",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Vatican"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ve",
+        "variables": [
+          {
+            "name": "COUNTRY_ve",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Venezuela"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "VN",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_vn",
+        "variables": [
+          {
+            "name": "COUNTRY_vn",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Vietnam"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "WF",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_wf",
+        "variables": [
+          {
+            "name": "COUNTRY_wf",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Wallis And Futuna"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "EH",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_eh",
+        "variables": [
+          {
+            "name": "COUNTRY_eh",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Western Sahara"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "YE",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ye",
+        "variables": [
+          {
+            "name": "COUNTRY_ye",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Yemen"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ZM",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_zm",
+        "variables": [
+          {
+            "name": "COUNTRY_zm",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Zambia"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "ZW",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_zw",
+        "variables": [
+          {
+            "name": "COUNTRY_zw",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Zimbabwe"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    },
+    {
+      "stableId": "AX",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateCode": null,
+        "templateText": "$COUNTRY_ax",
+        "variables": [
+          {
+            "name": "COUNTRY_ax",
+            "translations": [
+              {
+                "language": "en",
+                "text": "Åland Islands"
+              }
+            ]
+          }
+        ]
+      },
+      "detailLabelTemplate": null,
+      "allowDetails": false,
+      "exclusive": false
+    }
+  ]
+}


### PR DESCRIPTION
Reordered the country list so we have:
* U.S.
* Canada
* U.S. territories alphabetically
* other countries alphabetically

The snippet `picklist-question-country-required.conf` is shared with other studies, so I created a copy of it and did the reordering there.

- [x] Jen/Erin has saw screenshot of the change