### PR TITLE
builder: allow activity validation list to be optional

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/ActivityBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/ActivityBuilder.java
@@ -163,6 +163,9 @@ public class ActivityBuilder {
     }
 
     private void insertActivityValidations(Handle handle, Config activityCfg, ActivityDef def, long activityRevisionId) {
+        if (!activityCfg.hasPath("validations")) {
+            return;
+        }
         JdbiActivity jdbiActivity = handle.attach(JdbiActivity.class);
         for (Config validationCfg : activityCfg.getConfigList("validations")) {
             Template errorMessageTemplate = gson.fromJson(ConfigUtil.toJson(validationCfg.getConfig("messageTemplate")), Template.class);

--- a/study-builder/studies/study-schema.conf
+++ b/study-builder/studies/study-schema.conf
@@ -95,6 +95,17 @@
                     "type": "DATE_OF_DIAGNOSIS",
                     "stableId": "string"
                 }
+            ],
+            # List of complex validations for the activity. Optional.
+            "validations": [
+                {
+                    "messageTemplate": {
+                        # Template object
+                    },
+                    "stableIds": [ "strings" ], # List of question stable ids that this validation depends on.
+                    "precondition": "pex",      # If evaluates to true, this validation will be processed. Otherwise this validation is skipped.
+                    "expression": "pex"         # If evaluates to true, this validation will be displayed as error to user.
+                }
             ]
         },
         {


### PR DESCRIPTION
Make the `validations` key optional so we don't have to backfill it.