### PR TITLE
DDP-4222 handle invitation email events

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/NotificationTemplateVariables.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/NotificationTemplateVariables.java
@@ -73,4 +73,8 @@ public class NotificationTemplateVariables {
      */
     public static final String DDP_STUDY_GUID = "-ddp.study.guid-";
 
+    /**
+     * The invitation guid
+     */
+    public static final String DDP_INVITATION_ID = "-ddp.invitationId-";
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
@@ -71,7 +71,8 @@ public class PubSubMessageBuilder {
         if (pendingEvent.getActionType() == EventActionType.NOTIFICATION) {
             QueuedNotificationDto queuedNotificationDto = (QueuedNotificationDto) pendingEvent;
             if (NotificationType.EMAIL == queuedNotificationDto.getNotificationType()
-                    || NotificationType.STUDY_EMAIL == queuedNotificationDto.getNotificationType()) {
+                    || NotificationType.STUDY_EMAIL == queuedNotificationDto.getNotificationType()
+                    || NotificationType.INVITATION_EMAIL == queuedNotificationDto.getNotificationType()) {
                 Collection<String> sendToList = new HashSet<>();
 
                 // todo techdebt: set email field in QueuedEventDao instead of querying it here. make a list of
@@ -206,7 +207,7 @@ public class PubSubMessageBuilder {
                 messageJson = gson.toJson(notificationMessage);
             } else {
                 throw new MessageBuilderException("Unknown notification type "
-                        + queuedNotificationDto.getNotificationServiceType()
+                        + queuedNotificationDto.getNotificationType()
                         + " for queued event " + pendingEvent.getQueuedEventId());
             }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/CreateInvitationEventAction.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/CreateInvitationEventAction.java
@@ -47,7 +47,7 @@ public class CreateInvitationEventAction extends EventAction {
     InvitationCreatedSignal run(Handle handle, EventSignal signal) {
         String contactEmail = fetchContactEmail(handle, signal);
         if (!MiscUtil.isEmailFormatValid(contactEmail)) {
-            throw new DDPException("Answer contact email is not a valid email");
+            throw new DDPException("Contact email answer '" + contactEmail + "' is not a valid email");
         }
 
         if (markExistingAsVoided) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/NotificationEventAction.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/NotificationEventAction.java
@@ -2,14 +2,19 @@ package org.broadinstitute.ddp.model.event;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.broadinstitute.ddp.constants.NotificationTemplateVariables;
+import org.broadinstitute.ddp.db.dao.InvitationDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
+import org.broadinstitute.ddp.db.dao.JdbiQueuedNotification;
+import org.broadinstitute.ddp.db.dao.JdbiQueuedNotificationTemplateSubstitution;
 import org.broadinstitute.ddp.db.dao.QueuedEventDao;
 import org.broadinstitute.ddp.db.dto.EventConfigurationDto;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
 import org.broadinstitute.ddp.pex.PexInterpreter;
@@ -18,13 +23,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class NotificationEventAction extends EventAction {
+
     private static final Logger LOG = LoggerFactory.getLogger(NotificationEventAction.class);
 
     private NotificationType notificationType;
     private NotificationServiceType notificationServiceType;
     private long notificationTemplateId;
     private Long linkedActivityId; // Allowed to be null
-    private List<PdfAttachment> pdfAttachmentList = new ArrayList<>();
+    private List<PdfAttachment> pdfAttachments = new ArrayList<>();
 
     public NotificationEventAction(EventConfiguration eventConfiguration, EventConfigurationDto dto) {
         super(eventConfiguration, dto);
@@ -34,20 +40,18 @@ public class NotificationEventAction extends EventAction {
         this.linkedActivityId = dto.getLinkedActivityId();
     }
 
-    public void addPdfAttachment(PdfAttachment pdfAttachment) {
-        pdfAttachmentList.add(pdfAttachment);
-    }
-
-    public List<PdfAttachment> getPdfAttachmentList() {
-        return pdfAttachmentList;
-    }
-
     @Override
     public void doAction(PexInterpreter pexInterpreter, Handle handle, EventSignal eventSignal) {
         if (!eventConfiguration.dispatchToHousekeeping()) {
             throw new DDPException("NotificationEventActions are currently only supported as asynchronous events."
                     + "Please set dispatch_to_housekeeping to true");
         }
+        long queuedEventId = run(handle, eventSignal);
+        LOG.info("Inserted queued event {} for configuration {}", queuedEventId,
+                eventConfiguration.getEventConfigurationId());
+    }
+
+    long run(Handle handle, EventSignal signal) {
         QueuedEventDao queuedEventDao = handle.attach(QueuedEventDao.class);
         Integer delayBeforePosting = eventConfiguration.getPostDelaySeconds();
         if (delayBeforePosting == null) {
@@ -57,21 +61,62 @@ public class NotificationEventAction extends EventAction {
 
         // FIXME we really shouldn't need to special case this kind of stuff. Lets circle back
         Map<String, String> templateSubstitutions = new HashMap<>();
-        if (eventSignal.getEventTriggerType() == EventTriggerType.ACTIVITY_STATUS) {
+        if (signal.getEventTriggerType() == EventTriggerType.ACTIVITY_STATUS) {
             JdbiActivityInstance jdbiActivityInstance = handle.attach(JdbiActivityInstance.class);
-            ActivityInstanceStatusChangeSignal activityInstanceStatusChangeSignal = (ActivityInstanceStatusChangeSignal) eventSignal;
+            ActivityInstanceStatusChangeSignal activityInstanceStatusChangeSignal = (ActivityInstanceStatusChangeSignal) signal;
             templateSubstitutions.put(NotificationTemplateVariables.DDP_ACTIVITY_INSTANCE_GUID, jdbiActivityInstance
                     .getActivityInstanceGuid(activityInstanceStatusChangeSignal.getActivityInstanceIdThatChanged()));
         }
 
-        Long queuedEventId = queuedEventDao.insertNotification(eventConfiguration.getEventConfigurationId(),
+        long queuedEventId = queuedEventDao.insertNotification(eventConfiguration.getEventConfigurationId(),
                 postAfter,
-                eventSignal.getParticipantId(),
-                eventSignal.getOperatorId(),
+                signal.getParticipantId(),
+                signal.getOperatorId(),
                 templateSubstitutions);
 
-        LOG.info("Inserted queued event {} for configuration {}", queuedEventId,
-                eventConfiguration.getEventConfigurationId());
+        if (notificationType == NotificationType.INVITATION_EMAIL) {
+            InvitationDto invitationDto;
+            if (signal.getEventTriggerType() == EventTriggerType.INVITATION_CREATED) {
+                invitationDto = ((InvitationCreatedSignal) signal).getInvitationDto();
+                if (invitationDto == null) {
+                    throw new DDPException(String.format(
+                            "%s event signal for participant %s and study %d does not have invitation context",
+                            signal.getEventTriggerType(), signal.getParticipantGuid(), signal.getStudyId()));
+                } else {
+                    LOG.info("Received invitation {} from {} event signal for participant {} and study {}",
+                            invitationDto.getInvitationGuid(), signal.getEventTriggerType(),
+                            signal.getParticipantGuid(), signal.getStudyId());
+                }
+            } else {
+                invitationDto = handle.attach(InvitationDao.class)
+                        .findInvitations(signal.getStudyId(), signal.getParticipantId())
+                        .stream()
+                        .filter(invite -> !invite.isVoid())
+                        .max(Comparator.comparing(InvitationDto::getCreatedAt))
+                        .orElse(null);
+                if (invitationDto == null) {
+                    throw new DDPException(String.format(
+                            "Could not find any non-voided invitations for participant %s and study %d",
+                            signal.getParticipantGuid(), signal.getStudyId()));
+                } else {
+                    LOG.info("Found latest non-voided invitation {} for participant {} and study {}",
+                            invitationDto.getInvitationGuid(), signal.getParticipantGuid(), signal.getStudyId());
+                }
+            }
+
+            int numUpdated = handle.attach(JdbiQueuedNotification.class)
+                    .updateEmailAddress(queuedEventId, invitationDto.getContactEmail());
+            if (numUpdated != 1) {
+                throw new DDPException("Could not override recipient email with invitation contact email");
+            }
+
+            handle.attach(JdbiQueuedNotificationTemplateSubstitution.class)
+                    .insert(queuedEventId, NotificationTemplateVariables.DDP_INVITATION_ID, invitationDto.getInvitationGuid());
+            LOG.info("Added invitation id {} as email template substitution to queued event id {}",
+                    invitationDto.getInvitationGuid(), queuedEventId);
+        }
+
+        return queuedEventId;
     }
 
     public NotificationType getNotificationType() {
@@ -88,5 +133,13 @@ public class NotificationEventAction extends EventAction {
 
     public Long getLinkedActivityId() {
         return linkedActivityId;
+    }
+
+    public List<PdfAttachment> getPdfAttachments() {
+        return pdfAttachments;
+    }
+
+    public void addPdfAttachment(PdfAttachment pdfAttachment) {
+        pdfAttachments.add(pdfAttachment);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/NotificationEventAction.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/NotificationEventAction.java
@@ -93,15 +93,11 @@ public class NotificationEventAction extends EventAction {
                         .stream()
                         .filter(invite -> !invite.isVoid())
                         .max(Comparator.comparing(InvitationDto::getCreatedAt))
-                        .orElse(null);
-                if (invitationDto == null) {
-                    throw new DDPException(String.format(
-                            "Could not find any non-voided invitations for participant %s and study %d",
-                            signal.getParticipantGuid(), signal.getStudyId()));
-                } else {
-                    LOG.info("Found latest non-voided invitation {} for participant {} and study {}",
-                            invitationDto.getInvitationGuid(), signal.getParticipantGuid(), signal.getStudyId());
-                }
+                        .orElseThrow(() -> new DDPException(String.format(
+                                "Could not find any non-voided invitations for participant %s and study %d",
+                                signal.getParticipantGuid(), signal.getStudyId())));
+                LOG.info("Found latest non-voided invitation {} for participant {} and study {}",
+                        invitationDto.getInvitationGuid(), signal.getParticipantGuid(), signal.getStudyId());
             }
 
             int numUpdated = handle.attach(JdbiQueuedNotification.class)

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
@@ -77,7 +77,7 @@ public class CreateInvitationEventActionTest extends TxnAwareBaseTest {
     @Test
     public void test_contactEmailAnswerIsNotValidEmail() {
         thrown.expect(DDPException.class);
-        thrown.expectMessage(containsString("contact email is not a valid email"));
+        thrown.expectMessage(containsString("not a valid email"));
 
         TransactionWrapper.useTxn(handle -> {
             FormActivityDef activity = newContactEmailActivity(handle);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
@@ -1,0 +1,201 @@
+package org.broadinstitute.ddp.model.event;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.time.Instant;
+
+import org.broadinstitute.ddp.TxnAwareBaseTest;
+import org.broadinstitute.ddp.constants.NotificationTemplateVariables;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.EventActionDao;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.EventTriggerDao;
+import org.broadinstitute.ddp.db.dao.InvitationDao;
+import org.broadinstitute.ddp.db.dao.InvitationFactory;
+import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
+import org.broadinstitute.ddp.db.dto.EventConfigurationDto;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
+import org.broadinstitute.ddp.db.dto.NotificationDetailsDto;
+import org.broadinstitute.ddp.db.dto.NotificationTemplateSubstitutionDto;
+import org.broadinstitute.ddp.db.dto.SendgridEmailEventActionDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.invitation.InvitationType;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.broadinstitute.ddp.util.TimestampUtil;
+import org.jdbi.v3.core.Handle;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class NotificationEventActionTest extends TxnAwareBaseTest {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @BeforeClass
+    public static void setup() {
+        testData = TransactionWrapper.withTxn(TestDataSetupUtil::generateBasicUserTestData);
+    }
+
+    @Test
+    public void test_invitationEmail_noInvitations_fails() {
+        thrown.expect(DDPException.class);
+        thrown.expectMessage(containsString("Could not find any non-voided invitations"));
+        TransactionWrapper.useTxn(handle -> {
+            var signal = new EventSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),
+                    testData.getStudyId(), EventTriggerType.REACHED_AOM);
+            var dto = createEventConfigurationDto(handle, EventTriggerType.REACHED_AOM,
+                    NotificationType.INVITATION_EMAIL, NotificationServiceType.SENDGRID, 1L, null);
+            var action = new NotificationEventAction(new EventConfiguration(dto), dto);
+            action.doAction(null, handle, signal);
+            fail("expected exception should have been thrown");
+        });
+    }
+
+    @Test
+    public void test_invitationEmail_overridesRecipientEmail() {
+        TransactionWrapper.useTxn(handle -> {
+            var invitationFactory = handle.attach(InvitationFactory.class);
+            InvitationDto invitationDto = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test@datadonationplatform.org");
+
+            var signal = new EventSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),
+                    testData.getStudyId(), EventTriggerType.REACHED_AOM);
+            var dto = createEventConfigurationDto(handle, EventTriggerType.REACHED_AOM,
+                    NotificationType.INVITATION_EMAIL, NotificationServiceType.SENDGRID, 1L, null);
+            var action = new NotificationEventAction(new EventConfiguration(dto), dto);
+            long queuedEventId = action.run(handle, signal);
+
+            NotificationDetailsDto details = fetchQueuedEventDetails(handle, queuedEventId);
+            assertEquals(NotificationType.INVITATION_EMAIL, details.getNotificationType());
+            assertEquals(invitationDto.getContactEmail(), details.getToEmailAddress());
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void test_invitationEmail_providesInvitationIdSubstitution() {
+        TransactionWrapper.useTxn(handle -> {
+            var invitationFactory = handle.attach(InvitationFactory.class);
+            InvitationDto invitationDto = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test@datadonationplatform.org");
+
+            var signal = new EventSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),
+                    testData.getStudyId(), EventTriggerType.REACHED_AOM);
+            var dto = createEventConfigurationDto(handle, EventTriggerType.REACHED_AOM,
+                    NotificationType.INVITATION_EMAIL, NotificationServiceType.SENDGRID, 1L, null);
+            var action = new NotificationEventAction(new EventConfiguration(dto), dto);
+            long queuedEventId = action.run(handle, signal);
+
+            NotificationDetailsDto details = fetchQueuedEventDetails(handle, queuedEventId);
+            assertEquals(NotificationType.INVITATION_EMAIL, details.getNotificationType());
+
+            NotificationTemplateSubstitutionDto substitutionDto = details.getTemplateSubstitutions()
+                    .stream()
+                    .filter(sub -> sub.getVariableName().equals(NotificationTemplateVariables.DDP_INVITATION_ID))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(substitutionDto);
+            assertEquals(invitationDto.getInvitationGuid(), substitutionDto.getValue());
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void test_invitationEmail_usesLatestNonVoidedInvitation() {
+        TransactionWrapper.useTxn(handle -> {
+            var invitationFactory = handle.attach(InvitationFactory.class);
+            InvitationDto invitation1 = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test111@datadonationplatform.org");
+            InvitationDto invitation2 = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test222@datadonationplatform.org");
+            InvitationDto invitation3 = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test333@datadonationplatform.org");
+
+            var invitationDao = handle.attach(InvitationDao.class);
+            invitationDao.updateVoidedAt(TimestampUtil.now(), invitation1.getInvitationGuid());
+
+            var signal = new EventSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),
+                    testData.getStudyId(), EventTriggerType.REACHED_AOM);
+            var dto = createEventConfigurationDto(handle, EventTriggerType.REACHED_AOM,
+                    NotificationType.INVITATION_EMAIL, NotificationServiceType.SENDGRID, 1L, null);
+            var action = new NotificationEventAction(new EventConfiguration(dto), dto);
+            long queuedEventId = action.run(handle, signal);
+
+            NotificationDetailsDto details = fetchQueuedEventDetails(handle, queuedEventId);
+            assertEquals(NotificationType.INVITATION_EMAIL, details.getNotificationType());
+            assertEquals(invitation3.getContactEmail(), details.getToEmailAddress());
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void test_invitationEmail_usesInvitationProvidedInSignal() {
+        TransactionWrapper.useTxn(handle -> {
+            var invitationFactory = handle.attach(InvitationFactory.class);
+            InvitationDto invitation1 = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test111@datadonationplatform.org");
+            InvitationDto invitation2 = invitationFactory.createInvitation(InvitationType.AGE_UP,
+                    testData.getStudyId(), testData.getUserId(), "test222@datadonationplatform.org");
+
+            var signal = new InvitationCreatedSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),
+                    testData.getStudyId(), invitation1);
+            var dto = createEventConfigurationDto(handle, EventTriggerType.INVITATION_CREATED,
+                    NotificationType.INVITATION_EMAIL, NotificationServiceType.SENDGRID, 1L, null);
+            var action = new NotificationEventAction(new EventConfiguration(dto), dto);
+            long queuedEventId = action.run(handle, signal);
+
+            NotificationDetailsDto details = fetchQueuedEventDetails(handle, queuedEventId);
+            assertEquals(NotificationType.INVITATION_EMAIL, details.getNotificationType());
+            assertEquals(invitation1.getContactEmail(), details.getToEmailAddress());
+
+            NotificationTemplateSubstitutionDto substitutionDto = details.getTemplateSubstitutions()
+                    .stream()
+                    .filter(sub -> sub.getVariableName().equals(NotificationTemplateVariables.DDP_INVITATION_ID))
+                    .findFirst()
+                    .orElse(null);
+            assertNotNull(substitutionDto);
+            assertEquals(invitation1.getInvitationGuid(), substitutionDto.getValue());
+
+            handle.rollback();
+        });
+    }
+
+    private EventConfigurationDto createEventConfigurationDto(Handle handle, EventTriggerType triggerType,
+                                                              NotificationType notificationType, NotificationServiceType serviceType,
+                                                              long templateId, Long linkedActivityId) {
+        long eventConfigurationId = insertInvitationEmailEventConfiguration(handle, triggerType);
+        return new EventConfigurationDto(eventConfigurationId, triggerType, EventActionType.NOTIFICATION, 0, true,
+                null, null, null, MessageDestination.PARTICIPANT_NOTIFICATION.name(),
+                null, null, null, null, null, null, null, null,
+                notificationType, serviceType, templateId, linkedActivityId,
+                null, null, null, null, null, null, null);
+    }
+
+    private long insertInvitationEmailEventConfiguration(Handle handle, EventTriggerType staticTriggerType) {
+        long triggerId = handle.attach(EventTriggerDao.class).insertStaticTrigger(staticTriggerType);
+        long actionId = handle.attach(EventActionDao.class).insertInvitationEmailNotificationAction(
+                new SendgridEmailEventActionDto("dummy-template-key", "en"));
+        return handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+                Instant.now().toEpochMilli(), null, 0, null, null, true, 1);
+    }
+
+    private NotificationDetailsDto fetchQueuedEventDetails(Handle handle, long queuedEventId) {
+        EventDao eventDao = handle.attach(EventDao.class);
+        NotificationDetailsDto dto = eventDao.getNotificationDetailsDtoForQueuedEvent(queuedEventId, testData.getUserGuid());
+        assertNotNull("notification details for queued event with id " + queuedEventId + " should exists", dto);
+        dto.setTemplateSubstitutions(eventDao.getTemplateSubstitutionsForQueuedNotification(queuedEventId));
+        return dto;
+    }
+}


### PR DESCRIPTION
 ## Context and the big picture

A follow-up PR to #28. This PR implements handling of the `INVITATION_EMAIL` notification type. I made some slightly different design decisions here than what's specified in the design doc, which I think makes the feature a bit more nicer. The idea here is that when we need to send out emails dealing with invitations, we use the `INVITATION_EMAIL` notification type. Two scenarios can happen:

1. If it's triggered by `INVITATION_CREATED`, then the email will use the newly created invitation object. We can use this behavior for sending contact email verification.
2. If it's triggered by something else, it instead finds the latest non-voided invitation to use. We can use this behavior for sending invite when child reaches age-of-majority.

The main things this does are:
* Overrides the recipient `to` email with the invitation's contact email, so the email gets send to the contact email.
* Adds the invitation guid as an email template substitution, so we can embedded it in the email URL link.
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [ ] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [x] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 

  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?

 - [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [x] Requires other features before it's human visible. Will need study configuration to drive it.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [x] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [x] I have written automated positive tests
 - [x] I have written automated negative tests
 - [ ] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes

## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
