### PR TITLE
Use fixed clock for testing age-up service

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.service;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
@@ -25,14 +26,16 @@ public class AgeUpService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AgeUpService.class);
 
-    private LocalDate overriddenToday;
+    private final Clock clock;
 
-    LocalDate getToday() {
-        return overriddenToday == null ? Instant.now().atZone(ZoneOffset.UTC).toLocalDate() : overriddenToday;
+    public AgeUpService() {
+        // This is the clock `Instant.now()` uses.
+        this(Clock.systemUTC());
     }
 
-    void setToday(LocalDate overriddenToday) {
-        this.overriddenToday = overriddenToday;
+    // Use this constructor and a fixed clock for testing purposes.
+    AgeUpService(Clock clock) {
+        this.clock = clock;
     }
 
     /**
@@ -80,7 +83,7 @@ public class AgeUpService {
                 continue;
             }
 
-            LocalDate today = getToday();
+            LocalDate today = Instant.now(clock).atZone(ZoneOffset.UTC).toLocalDate();
             boolean agedUp = rule.hasReachedAgeOfMajority(candidate.getBirthDate(), today);
             boolean shouldPrepForAgeUp = rule.hasReachedAgeOfMajorityPrep(candidate.getBirthDate(), today).orElse(false);
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
@@ -3,7 +3,10 @@ package org.broadinstitute.ddp.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -32,12 +35,13 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
 
     private static TestDataSetupUtil.GeneratedTestData testData;
     private static PexInterpreter interpreter = new TreeWalkInterpreter();
-    private static AgeUpService service = new AgeUpService();
+    private static AgeUpService service;
 
     @BeforeClass
     public static void setup() {
         testData = TransactionWrapper.withTxn(TestDataSetupUtil::generateBasicUserTestData);
-        service.setToday(LocalDate.of(2020, 3, 14));
+        Instant fixedDate = LocalDate.of(2020, 3, 14).atStartOfDay(ZoneOffset.UTC).toInstant();
+        service = new AgeUpService(Clock.fixed(fixedDate, ZoneOffset.UTC));
     }
 
     @Test


### PR DESCRIPTION
Updated `AgeUpService` to use a `Clock` for getting current date, so it's easier/safer for testing.