### PR TITLE
DDP-4278 update isAnswered PEX predicate to check answer value

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -161,13 +161,6 @@ public interface AnswerDao extends SqlObject {
         return findAnswerIdByQuestionStableIdAndInstanceId(userId, instanceId, questionStableId).map(this::getAnswerById);
     }
 
-    @UseStringTemplateSqlLocator
-    @SqlQuery("queryAnswerForQuestionAndInstanceId")
-    @UseRowReducer(AnswerWithValueReducer.class)
-    Optional<Answer> findAnswerForQuestionAndInstanceId(
-            @Bind("instanceId") long instanceId,
-            @Bind("questionStableId") String questionStableId);
-
     /**
      * Get answer by id. Automatically looks up type.
      *
@@ -253,6 +246,13 @@ public interface AnswerDao extends SqlObject {
     @SqlQuery("queryAnswerByGuid")
     @UseRowReducer(AnswerWithValueReducer.class)
     Optional<Answer> findAnswerByGuid(@Bind("guid") String answerGuid);
+
+    @UseStringTemplateSqlLocator
+    @SqlQuery("queryAnswerForInstanceIdAndQuestionStableId")
+    @UseRowReducer(AnswerWithValueReducer.class)
+    Optional<Answer> findAnswerForInstanceIdAndQuestionStableId(
+            @Bind("instanceId") long instanceId,
+            @Bind("questionStableId") String questionStableId);
 
     class AnswerWithValueReducer implements LinkedHashMapRowReducer<Long, Answer> {
         private Map<Long, Answer> childAnswers = new HashMap<>();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -248,9 +248,9 @@ public interface AnswerDao extends SqlObject {
     Optional<Answer> findAnswerByGuid(@Bind("guid") String answerGuid);
 
     @UseStringTemplateSqlLocator
-    @SqlQuery("queryAnswerForInstanceIdAndQuestionStableId")
+    @SqlQuery("queryAnswerByInstanceIdAndQuestionStableId")
     @UseRowReducer(AnswerWithValueReducer.class)
-    Optional<Answer> findAnswerForInstanceIdAndQuestionStableId(
+    Optional<Answer> findAnswerByInstanceIdAndQuestionStableId(
             @Bind("instanceId") long instanceId,
             @Bind("questionStableId") String questionStableId);
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -73,22 +73,6 @@ public interface AnswerDao extends SqlObject {
     @CreateSqlObject
     JdbiAnswer getJdbiAnswer();
 
-    /**
-     * Finds the answer id to specified question in the last-created activity instance of the specified activity. Useful in cases where we
-     * just need to know if there is an answer or not instead of needing all the data about the answer itself.
-     *
-     * @param userGuid         the user guid
-     * @param activityId       the activity id
-     * @param questionStableId the question stable id
-     * @return answer id if exists, empty otherwise
-     */
-    @UseStringTemplateSqlLocator
-    @SqlQuery("queryAnswerIdForQuestionInLatestInstance")
-    Optional<Long> findAnswerIdForQuestionInLatestInstance(
-            @Bind("userGuid") String userGuid,
-            @Bind("activityId") long activityId,
-            @Bind("questionStableId") String questionStableId);
-
     @SqlQuery(" select da.year, da.month, da.day "
             + " from activity_instance as ai "
             + " join answer as a on ai.activity_instance_id = a.activity_instance_id "
@@ -176,6 +160,13 @@ public interface AnswerDao extends SqlObject {
     default Optional<Answer> findAnswerForQuestionAndInstance(long userId, long instanceId, String questionStableId) {
         return findAnswerIdByQuestionStableIdAndInstanceId(userId, instanceId, questionStableId).map(this::getAnswerById);
     }
+
+    @UseStringTemplateSqlLocator
+    @SqlQuery("queryAnswerForQuestionAndInstanceId")
+    @UseRowReducer(AnswerWithValueReducer.class)
+    Optional<Answer> findAnswerForQuestionAndInstanceId(
+            @Bind("instanceId") long instanceId,
+            @Bind("questionStableId") String questionStableId);
 
     /**
      * Get answer by id. Automatically looks up type.

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
@@ -201,6 +201,13 @@ public interface JdbiActivityInstance extends SqlObject {
             + " order by ai.created_at desc limit 1")
     Optional<String> findLatestInstanceGuidByUserIdAndActivityId(@Bind("userId") long userId, @Bind("activityId") long activityId);
 
+    @SqlQuery("select ai.activity_instance_id from activity_instance as ai"
+            + "  join user as u on u.user_id = ai.participant_id"
+            + " where ai.study_activity_id = :activityId"
+            + "   and u.guid = :userGuid"
+            + " order by ai.created_at desc limit 1")
+    Optional<Long> findLatestInstanceIdByUserGuidAndActivityId(@Bind("userGuid") String userGuid, @Bind("activityId") long activityId);
+
     @SqlQuery("select ai.activity_instance_guid from activity_instance as ai"
             + "  join user as u on u.user_id = ai.participant_id"
             + " where ai.study_activity_id = :activityId"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
@@ -246,7 +246,7 @@ public class TreeWalkInterpreter implements PexInterpreter {
             }
 
             Answer answer = ictx.getHandle().attach(AnswerDao.class)
-                    .findAnswerForInstanceIdAndQuestionStableId(instanceId, stableId)
+                    .findAnswerByInstanceIdAndQuestionStableId(instanceId, stableId)
                     .orElse(null);
             if (answer == null || answer.getValue() == null) {
                 return false;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
@@ -246,7 +246,7 @@ public class TreeWalkInterpreter implements PexInterpreter {
             }
 
             Answer answer = ictx.getHandle().attach(AnswerDao.class)
-                    .findAnswerForQuestionAndInstanceId(instanceId, stableId)
+                    .findAnswerForInstanceIdAndQuestionStableId(instanceId, stableId)
                     .orElse(null);
             if (answer == null || answer.getValue() == null) {
                 return false;

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -64,6 +64,20 @@ where ans.answer_guid = :guid
 <all_answers_order_by()>
 >>
 
+queryAnswerForQuestionAndInstanceId() ::= <<
+<all_answers_select()>
+where ai.activity_instance_id = :instanceId
+  and (qsc.stable_id = :questionStableId
+      or ans.question_id in (
+         select child_question_id from composite_question__question where parent_question_id in (
+                select question_id from question where question_stable_code_id = (
+                       select question_stable_code_id from question_stable_code where stable_id = :questionStableId
+                )
+         )
+      ))
+<all_answers_order_by()>
+>>
+
 /**
  * Note: we use left-join here since different answer types will join to different answer ids.
  */
@@ -78,23 +92,6 @@ delete aa, ba, da, na, ta, pa, ca
   left join picklist_option__answer as pa on pa.answer_id = a.answer_id
   left join composite_answer_item as ca on ca.parent_answer_id = a.answer_id
  where a.activity_instance_id in (<instanceIds>)
->>
-
-queryAnswerIdForQuestionInLatestInstance() ::= <<
-select a.answer_id
-  from activity_instance as ai
-  join user as u on u.user_id = ai.participant_id
-  left join answer as a on a.activity_instance_id = ai.activity_instance_id
-  left join question as q on q.question_id = a.question_id
-  left join question_stable_code as qsc on qsc.question_stable_code_id = q.question_stable_code_id
- where u.guid = :userGuid
-   and ai.study_activity_id = :activityId
-   and qsc.stable_id = :questionStableId
-   and ai.created_at = (
-       select max(created_at)
-         from activity_instance
-        where participant_id = u.user_id
-          and study_activity_id = ai.study_activity_id)
 >>
 
 queryAnswerIdByQuestionStableIdAndLatestInstance() ::= <<

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -64,15 +64,17 @@ where ans.answer_guid = :guid
 <all_answers_order_by()>
 >>
 
-queryAnswerForQuestionAndInstanceId() ::= <<
+queryAnswerForInstanceIdAndQuestionStableId() ::= <<
 <all_answers_select()>
+ join study_activity as act on act.study_activity_id = ai.study_activity_id
 where ai.activity_instance_id = :instanceId
-  and (qsc.stable_id = :questionStableId
+  and ((qsc.stable_id = :questionStableId and qsc.umbrella_study_id = act.study_id)
       or ans.question_id in (
          select child_question_id from composite_question__question where parent_question_id in (
-                select question_id from question where question_stable_code_id = (
-                       select question_stable_code_id from question_stable_code where stable_id = :questionStableId
-                )
+           select question_id from question where question_stable_code_id = (
+             select question_stable_code_id from question_stable_code
+              where stable_id = :questionStableId and umbrella_study_id = act.study_id
+           )
          )
       ))
 <all_answers_order_by()>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -64,7 +64,7 @@ where ans.answer_guid = :guid
 <all_answers_order_by()>
 >>
 
-queryAnswerForInstanceIdAndQuestionStableId() ::= <<
+queryAnswerByInstanceIdAndQuestionStableId() ::= <<
 <all_answers_select()>
  join study_activity as act on act.study_activity_id = ai.study_activity_id
 where ai.activity_instance_id = :instanceId

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -70,13 +70,12 @@ queryAnswerForInstanceIdAndQuestionStableId() ::= <<
 where ai.activity_instance_id = :instanceId
   and ((qsc.stable_id = :questionStableId and qsc.umbrella_study_id = act.study_id)
       or ans.question_id in (
-         select child_question_id from composite_question__question where parent_question_id in (
-           select question_id from question where question_stable_code_id = (
-             select question_stable_code_id from question_stable_code
-              where stable_id = :questionStableId and umbrella_study_id = act.study_id
-           )
-         )
-      ))
+         select cqq.child_question_id
+           from composite_question__question as cqq
+           join question as pq on pq.question_id = cqq.parent_question_id
+           join question_stable_code as pqsc on pqsc.question_stable_code_id = pq.question_stable_code_id
+          where pqsc.stable_id = :questionStableId
+            and pqsc.umbrella_study_id = act.study_id))
 <all_answers_order_by()>
 >>
 


### PR DESCRIPTION
 ## Context and the big picture

Per discussions for DDP-4278, we want to update the `isAnswered()` PEX predicate to make it not only check if there is an answer or not but also check if the answer is "non-empty". This means picklist answer should have non-empty selection list and text answer should be non-blank.
 
 ## What type of change is this?
  
  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [ ] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [x] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 

  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?

 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [ ] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [x] I have written automated positive tests
 - [x] I have written automated negative tests
 - [ ] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
