### PR TITLE
osteo: allow save for prequal country questions

### DIFF
--- a/study-builder/studies/snippets/picklist-question-country-required-eligible-first.conf
+++ b/study-builder/studies/snippets/picklist-question-country-required-eligible-first.conf
@@ -27,6 +27,7 @@
   "validations": [
     {
       "ruleType": "REQUIRED",
+      "allowSave": true,
       "hintTemplate": {
         "templateType": "TEXT",
         "templateCode": null,

--- a/study-builder/studies/snippets/picklist-question-province-required.conf
+++ b/study-builder/studies/snippets/picklist-question-province-required.conf
@@ -27,6 +27,7 @@
   "validations": [
     {
       "ruleType": "REQUIRED",
+      "allowSave": true,
       "hintTemplate": {
         "templateType": "TEXT",
         "templateCode": null,

--- a/study-builder/studies/snippets/picklist-question-state-required.conf
+++ b/study-builder/studies/snippets/picklist-question-state-required.conf
@@ -27,6 +27,7 @@
   "validations": [
     {
       "ruleType": "REQUIRED",
+      "allowSave": true,
       "hintTemplate": {
         "templateType": "TEXT",
         "templateCode": null,


### PR DESCRIPTION
Setting `allowSave=true` on the country questions for Osteo's prequal so we can clear out those answers for DDP-4278.