### PR TITLE
DDP 4202 post consent flow

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/user/EnrollmentStatusType.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/user/EnrollmentStatusType.java
@@ -11,7 +11,7 @@ public enum EnrollmentStatusType {
     ENROLLED(true, false, false,  true),
     EXITED_BEFORE_ENROLLMENT(false, true, true, false),
     EXITED_AFTER_ENROLLMENT(false, true, true, false),
-    CONSENT_SUSPENDED(true, false, true, true);
+    CONSENT_SUSPENDED(true, false, false, true);
 
     private final boolean shouldReceiveCommunications;
 

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -2400,7 +2400,8 @@
         ! (user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")
-        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE"))
+        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE")
+        && !user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance())
       """,
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2417,7 +2418,8 @@
         ! (user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")
-        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE"))
+        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE")
+        && !user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance())
       """,
       "dispatchToHousekeeping": true,
       "order": 1

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -1700,7 +1700,6 @@
         "activityCode": "ABOUTYOU"
       },
       "maxOccurrencesPerUser": 1,
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()""",
       "dispatchToHousekeeping": false,
       "order": 1
     },
@@ -2648,7 +2647,7 @@
       "order": 1
     },
 
-    ## reconsent release
+    ## aged-up release
     {
     "trigger": {
       "type": "ACTIVITY_STATUS",

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -1700,6 +1700,7 @@
         "activityCode": "ABOUTYOU"
       },
       "maxOccurrencesPerUser": 1,
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()""",
       "dispatchToHousekeeping": false,
       "order": 1
     },
@@ -2644,6 +2645,22 @@
       "dispatchToHousekeeping": true,
       "cancelExpr": """!(user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].hasInstance()
         || user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].hasInstance())""",
+      "order": 1
+    },
+
+    ## reconsent release
+    {
+    "trigger": {
+      "type": "ACTIVITY_STATUS",
+      "activityCode": "CONSENT",
+      "statusType": "COMPLETE"
+    },
+    "action": {
+      "type": "HIDE_ACTIVITIES",
+      "activityCodes": ["RELEASE_MINOR"],
+    },
+      "cancelExpr": """!user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()""",
+      "dispatchToHousekeeping": false,
       "order": 1
     },
 

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -2400,8 +2400,8 @@
         ! (user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")
-        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE")
-        && !user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance())
+        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE"))
+        || user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance()
       """,
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2418,8 +2418,8 @@
         ! (user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")
-        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE")
-        && !user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance())
+        && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE"))
+        || user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance()
       """,
       "dispatchToHousekeeping": true,
       "order": 1


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-4202
Implemented using first Impl sketch (reuse existing  RELEASE_SELF activity)
Once reconsent (CONSENT) is completed RELEASE_SELF is created.
Emails are triggered as per scenario#1 [CONSENT and RELEASE_SELF] event configurations.
