### PR TITLE
Ddp 4276 study-builder changes for copy configuration

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -26,7 +26,11 @@ import org.broadinstitute.ddp.model.activity.definition.template.Template;
 import org.broadinstitute.ddp.model.activity.types.EventActionType;
 import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
-import org.broadinstitute.ddp.model.event.CopyAnswerTarget;
+import org.broadinstitute.ddp.model.copy.CopyAnswerLocation;
+import org.broadinstitute.ddp.model.copy.CopyConfiguration;
+import org.broadinstitute.ddp.model.copy.CopyConfigurationPair;
+import org.broadinstitute.ddp.model.copy.CopyLocation;
+import org.broadinstitute.ddp.model.copy.CopyLocationType;
 import org.broadinstitute.ddp.model.pdf.PdfConfigInfo;
 import org.broadinstitute.ddp.model.workflow.ActivityState;
 import org.broadinstitute.ddp.model.workflow.StateType;
@@ -45,8 +49,8 @@ public class EventBuilder {
     private static final String ACTION_SENDGRID_EMAIL = "SENDGRID_EMAIL";
     private static final String ACTION_STUDY_EMAIL = "STUDY_EMAIL";
     private static final String ACTION_INVITATION_EMAIL = "INVITATION_EMAIL";
-    public static final String ACTIVITY_CODE_FIELD = "activityCode";
-    public static final String WORKFLOW_STATE_FIELD = "state";
+    private static final String ACTIVITY_CODE_FIELD = "activityCode";
+    private static final String WORKFLOW_STATE_FIELD = "state";
 
     private Gson gson;
     private GsonPojoValidator validator;
@@ -173,7 +177,11 @@ public class EventBuilder {
         } else if (EventActionType.ACTIVITY_INSTANCE_CREATION.name().equals(type)) {
             String activityCode = actionCfg.getString(ACTIVITY_CODE_FIELD);
             long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
-            return actionDao.insertInstanceCreationAction(activityId);
+            CopyConfiguration config = null;
+            if (actionCfg.hasPath("copyConfigPairs")) {
+                config = buildCopyConfiguration(studyDto.getId(), List.copyOf(actionCfg.getConfigList("copyConfigPairs")));
+            }
+            return actionDao.insertInstanceCreationAction(activityId, config);
         } else if (EventActionType.ANNOUNCEMENT.name().equals(type)) {
             Config msgCfg = actionCfg.getConfig("msgTemplate");
             Template tmpl = gson.fromJson(ConfigUtil.toJson(msgCfg), Template.class);
@@ -191,9 +199,9 @@ public class EventBuilder {
 
             return actionDao.insertAnnouncementAction(tmpl.getTemplateId(), isPermanent, createForProxies);
         } else if (EventActionType.COPY_ANSWER.name().equals(type)) {
-            String copySourceQuestionStableId = actionCfg.getString("copySourceQuestionStableId");
-            CopyAnswerTarget copyTarget = actionCfg.getEnum(CopyAnswerTarget.class, "copyTarget");
-            return actionDao.insertCopyAnswerAction(studyDto.getId(), copySourceQuestionStableId, copyTarget);
+            List<Config> pairs = List.copyOf(actionCfg.getConfigList("copyConfigPairs"));
+            CopyConfiguration config = buildCopyConfiguration(studyDto.getId(), pairs);
+            return actionDao.insertCopyAnswerAction(config);
         } else if (EventActionType.CREATE_INVITATION.name().equals(type)) {
             boolean markExistingAsVoided = actionCfg.getBoolean("markExistingAsVoided");
             String contactEmailQuestionStableId = actionCfg.getString("contactEmailQuestionStableId");
@@ -212,6 +220,25 @@ public class EventBuilder {
             return actionDao.insertMarkActivitiesReadOnlyAction(activityIds);
         } else {
             return actionDao.insertStaticAction(EventActionType.valueOf(type));
+        }
+    }
+
+    private CopyConfiguration buildCopyConfiguration(long studyId, List<Config> pairsCfgList) {
+        List<CopyConfigurationPair> pairs = new ArrayList<>();
+        for (var pairCfg : pairsCfgList) {
+            CopyLocation source = buildCopyLocation(pairCfg.getConfig("source"));
+            CopyLocation target = buildCopyLocation(pairCfg.getConfig("target"));
+            pairs.add(new CopyConfigurationPair(source, target));
+        }
+        return new CopyConfiguration(studyId, pairs);
+    }
+
+    private CopyLocation buildCopyLocation(Config locationCfg) {
+        var type = CopyLocationType.valueOf(locationCfg.getString("type"));
+        if (type == CopyLocationType.ANSWER) {
+            return new CopyAnswerLocation(locationCfg.getString("questionStableId"));
+        } else {
+            return new CopyLocation(type);
         }
     }
 
@@ -252,11 +279,14 @@ public class EventBuilder {
             return String.format("%s/%s", type, pdfName);
         } else if (EventActionType.ACTIVITY_INSTANCE_CREATION.name().equals(type)) {
             String activityCode = actionCfg.getString(ACTIVITY_CODE_FIELD);
-            return String.format("%s/%s", type, activityCode);
+            int numPairs = 0;
+            if (actionCfg.hasPath("copyConfigPairs")) {
+                numPairs = actionCfg.getConfigList("copyConfigPairs").size();
+            }
+            return String.format("%s/%s/%d copy pairs", type, activityCode, numPairs);
         } else if (EventActionType.COPY_ANSWER.name().equals(type)) {
-            String copySourceQuestionStableId = actionCfg.getString("copySourceQuestionStableId");
-            CopyAnswerTarget copyTarget = actionCfg.getEnum(CopyAnswerTarget.class, "copyTarget");
-            return String.format("%s/%s/%s", type, copySourceQuestionStableId, copyTarget);
+            int numPairs = actionCfg.getConfigList("copyConfigPairs").size();
+            return String.format("%s/%d copy pairs", type, numPairs);
         } else if (EventActionType.CREATE_INVITATION.name().equals(type)) {
             boolean markExistingAsVoided = actionCfg.getBoolean("markExistingAsVoided");
             String contactEmailQuestionStableId = actionCfg.getString("contactEmailQuestionStableId");

--- a/study-builder/studies/angio/patches/migrate-to-prequal.conf
+++ b/study-builder/studies/angio/patches/migrate-to-prequal.conf
@@ -78,8 +78,17 @@
             },
             "action": {
                 "type": "COPY_ANSWER",
-                "copySourceQuestionStableId": "PREQUAL_FIRST_NAME",
-                "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
+                "copyConfigPairs": [
+                    {
+                        "source": {
+                            "type": "ANSWER",
+                            "questionStableId": "PREQUAL_FIRST_NAME"
+                        },
+                        "target": {
+                            "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+                        }
+                    }
+                ]
             },
             "preconditionExpr": null,
             "cancelExpr": null,
@@ -96,8 +105,17 @@
             },
             "action": {
                 "type": "COPY_ANSWER",
-                "copySourceQuestionStableId": "PREQUAL_LAST_NAME",
-                "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
+                "copyConfigPairs": [
+                    {
+                        "source": {
+                            "type": "ANSWER",
+                            "questionStableId": "PREQUAL_LAST_NAME"
+                        },
+                        "target": {
+                            "type": "PARTICIPANT_PROFILE_LAST_NAME"
+                        }
+                    }
+                ]
             },
             "preconditionExpr": null,
             "cancelExpr": null,

--- a/study-builder/studies/brain/study.conf
+++ b/study-builder/studies/brain/study.conf
@@ -590,8 +590,17 @@
             },
             "action": {
                 "type": "COPY_ANSWER",
-                "copySourceQuestionStableId": "PREQUAL_FIRST_NAME",
-                "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
+                "copyConfigPairs": [
+                    {
+                        "source": {
+                            "type": "ANSWER",
+                            "questionStableId": "PREQUAL_FIRST_NAME"
+                        },
+                        "target": {
+                            "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+                        }
+                    }
+                ]
             },
             "preconditionExpr": null,
             "cancelExpr": null,
@@ -608,8 +617,17 @@
             },
             "action": {
                 "type": "COPY_ANSWER",
-                "copySourceQuestionStableId": "PREQUAL_LAST_NAME",
-                "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
+                "copyConfigPairs": [
+                    {
+                        "source": {
+                            "type": "ANSWER",
+                            "questionStableId": "PREQUAL_LAST_NAME"
+                        },
+                        "target": {
+                            "type": "PARTICIPANT_PROFILE_LAST_NAME"
+                        }
+                    }
+                ]
             },
             "preconditionExpr": null,
             "cancelExpr": null,

--- a/study-builder/studies/mbc/study.conf
+++ b/study-builder/studies/mbc/study.conf
@@ -1001,22 +1001,26 @@
       },
       "action": {
         "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PREQUAL_FIRST_NAME",
-        "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
-      },
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PREQUAL",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PREQUAL_LAST_NAME",
-        "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
+        "copyConfigPairs": [
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PREQUAL_FIRST_NAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PREQUAL_LAST_NAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_LAST_NAME"
+            }
+          }
+        ]
       },
       "dispatchToHousekeeping": false,
       "order": 1

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -1309,184 +1309,35 @@
       },
       "action": {
         "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_FIRSTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
-      },
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_LASTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PARENTAL_CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PARENTAL_CONSENT_CHILD_FIRSTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PARENTAL_CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PARENTAL_CONSENT_CHILD_LASTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PARENTAL_CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PARENTAL_CONSENT_FIRSTNAME",
-        "copyTarget": "OPERATOR_PROFILE_FIRST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PARENTAL_CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PARENTAL_CONSENT_LASTNAME",
-        "copyTarget": "OPERATOR_PROFILE_LAST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT_ASSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_ASSENT_CHILD_FIRSTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT_ASSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_ASSENT_CHILD_LASTNAME",
-        "copyTarget": "PARTICIPANT_PROFILE_LAST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT_ASSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_ASSENT_FIRSTNAME",
-        "copyTarget": "OPERATOR_PROFILE_FIRST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT_ASSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_ASSENT_LASTNAME",
-        "copyTarget": "OPERATOR_PROFILE_LAST_NAME",
-      },
-      "preconditionExpr": null,
-      "cancelExpr": null,
-      "maxOccurrencesPerUser": null,
-      "delaySeconds": null,
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CONSENT",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_DOB",
-        "copyTarget": "PARTICIPANT_PROFILE_BIRTH_DATE",
+        "copyConfigPairs": [
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_FIRSTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_LASTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_LAST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_DOB"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_BIRTH_DATE"
+            }
+          }
+        ]
       },
       "dispatchToHousekeeping": false,
       "order": 1
@@ -1499,8 +1350,53 @@
       },
       "action": {
         "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "PARENTAL_CONSENT_CHILD_DOB",
-        "copyTarget": "PARTICIPANT_PROFILE_BIRTH_DATE",
+        "copyConfigPairs": [
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PARENTAL_CONSENT_CHILD_FIRSTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PARENTAL_CONSENT_CHILD_LASTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_LAST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PARENTAL_CONSENT_CHILD_DOB"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_BIRTH_DATE"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PARENTAL_CONSENT_FIRSTNAME"
+            },
+            "target": {
+              "type": "OPERATOR_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "PARENTAL_CONSENT_LASTNAME"
+            },
+            "target": {
+              "type": "OPERATOR_PROFILE_LAST_NAME"
+            }
+          }
+        ]
       },
       "dispatchToHousekeeping": false,
       "order": 1
@@ -1513,8 +1409,53 @@
       },
       "action": {
         "type": "COPY_ANSWER",
-        "copySourceQuestionStableId": "CONSENT_ASSENT_CHILD_DOB",
-        "copyTarget": "PARTICIPANT_PROFILE_BIRTH_DATE",
+        "copyConfigPairs": [
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_ASSENT_CHILD_FIRSTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_ASSENT_CHILD_LASTNAME"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_LAST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_ASSENT_CHILD_DOB"
+            },
+            "target": {
+              "type": "PARTICIPANT_PROFILE_BIRTH_DATE"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_ASSENT_FIRSTNAME"
+            },
+            "target": {
+              "type": "OPERATOR_PROFILE_FIRST_NAME"
+            }
+          },
+          {
+            "source": {
+              "type": "ANSWER",
+              "questionStableId": "CONSENT_ASSENT_LASTNAME"
+            },
+            "target": {
+              "type": "OPERATOR_PROFILE_LAST_NAME"
+            }
+          }
+        ]
       },
       "dispatchToHousekeeping": false,
       "order": 1

--- a/study-builder/studies/study-schema.conf
+++ b/study-builder/studies/study-schema.conf
@@ -509,26 +509,6 @@
             "order": "integer"
         },
 
-        # populate profile events
-        {
-            "trigger": {
-                "type": "ACTIVITY_STATUS",
-                "activityCode": "string",
-                "statusType": "CREATED | IN_PROGRESS | COMPLETE"
-            },
-            "action": {
-                "type": "COPY_ANSWER",
-                "copySourceQuestionStableId": "string",
-                "copyTarget": "PARTICIPANT_PROFILE_FIRST_NAME | PARTICIPANT_PROFILE_LAST_NAME",
-            },
-            "preconditionExpr": "null | string",
-            "cancelExpr": "null | string",
-            "maxOccurrencesPerUser": "null | integer",
-            "delaySeconds": "null | integer",
-            "dispatchToHousekeeping": "bool",
-            "order": "integer"
-        },
-
         # dsm notification email events
         {
             "trigger": {
@@ -568,14 +548,44 @@
             "order": "integer"
         },
 
-        # event action to send invitation email, which will provide the invitation guid as substitution
+        # event action to create new activity instance
         {
             "action": {
-                "type": "INVITATION_EMAIL",
-                "emailTemplate": "string",
-                "language": "string",
-                "pdfAttachments": []
+                "type": "ACTIVITY_INSTANCE_CREATION",
+                "activityCode": "string",
+                "copyConfigPairs": [
+                    # List of copy pairings to perform after instance is created.
+                    # Optional, see `COPY_ANSWER` action for full schema.
+                ]
             },
+            "dispatchToHousekeeping": "false",
+            # trigger, precondition, etc ...
+        },
+
+        # event action to copy data
+        {
+            "action": {
+                "type": "COPY_ANSWER",
+                # List of copy configuration source/target pairs, each specifying where to copy data from/to.
+                # Current limitations:
+                # - `source` location is limited to `ANSWER` type.
+                # - If both source/target is `ANSWER` type, then question type must match.
+                # - Copying for top-level composite questions is not supported,
+                #   map the composite child questions as source/target pairs instead.
+                "copyConfigPairs": [
+                    {
+                        "source": {
+                            "type": "ANSWER",
+                            "questionStableId": "string"
+                        },
+                        "target": {
+                            "type": "CopyLocationType",
+                            "questionStableId": "string"    # Optional if `type` is not `ANSWER`
+                        }
+                    }
+                ]
+            },
+            "dispatchToHousekeeping": "false",
             # trigger, precondition, etc ...
         },
 
@@ -586,6 +596,7 @@
                 "markExistingAsVoided": "bool",
                 "contactEmailQuestionStableId": "string"
             },
+            "dispatchToHousekeeping": "false",
             # trigger, precondition, etc ...
         },
 
@@ -595,6 +606,19 @@
                 "type": "HIDE_ACTIVITIES",
                 "activityCodes": [ "strings" ]
             },
+            "dispatchToHousekeeping": "false",
+            # trigger, precondition, etc ...
+        },
+
+        # event action to send invitation email, which will provide the invitation guid as substitution
+        {
+            "action": {
+                "type": "INVITATION_EMAIL",
+                "emailTemplate": "string",
+                "language": "string",
+                "pdfAttachments": []
+            },
+            "dispatchToHousekeeping": "true",
             # trigger, precondition, etc ...
         },
 
@@ -604,6 +628,7 @@
                 "type": "MARK_ACTIVITIES_READ_ONLY",
                 "activityCodes": [ "strings" ]
             },
+            "dispatchToHousekeeping": "false",
             # trigger, precondition, etc ...
         },
     ]


### PR DESCRIPTION
 ## Context and the big picture

This PR covers the study-builder changes. `EventBuilder` now handles the new "copy configuration" design.

Note that we do not need study "patches" or custom-tasks. Existing study configuration data is already handled as part of database migration in #49. But I have updated the various study `conf` files so that we can run them locally without issues. For Angio/Brain, I kept it consistent with what will appear in deployed database, while for MBC/Osteo I tried to condense the copy configurations.
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [ ] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [x] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [x] Requires other features before it's human visible.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [ ] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [ ] I have written automated positive tests
 - [ ] I have written automated negative tests
 - [x] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
