### PR TITLE
osteo: cleanup emails

### DIFF
--- a/study-builder/studies/osteo/emails/reconsent_release_completed.html
+++ b/study-builder/studies/osteo/emails/reconsent_release_completed.html
@@ -1,0 +1,107 @@
+<html>
+<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
+
+<head>
+  <title>Thank you for submitting your contact information</title>
+  <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
+  <style type="text/css">
+    .ExternalClass,
+    .ExternalClass div,
+    .ExternalClass font,
+    .ExternalClass p,
+    .ExternalClass span,
+    .ExternalClass td,
+    img {
+      line-height: 100%;
+    }
+
+    #outlook a {
+      padding: 0;
+    }
+
+    .ExternalClass,
+    .ReadMsgBody {
+      width: 100%;
+    }
+
+    a,
+    blockquote,
+    body,
+    li,
+    p,
+    table,
+    td {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      mso-table-lspace: 0;
+      mso-table-rspace: 0;
+    }
+
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      outline: 0;
+      text-decoration: none;
+    }
+
+    table {
+      border-collapse: collapse !important;
+    }
+
+    body {
+      height: 100% !important;
+      margin: 0;
+      padding: 0;
+      font-family: 'Source Sans Pro', sans-serif;
+    }
+
+    @font-face {
+      font-family: 'Source Sans Pro', sans-serif;
+      src: url(https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap);
+      font-weight: 400;
+      font-style: normal;
+    }
+  </style>
+</head>
+
+<body style="background: #ffffff; width: 100%; height: 100%; padding-top: 60px; padding-left: 60px;">
+<table style="width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-family: 'Source Sans Pro', sans-serif; border-collapse: collapse !important;"
+       border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr style="width: 540px;">
+    <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
+      <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
+        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+             alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
+             width="230px" height="63px" border="0">
+      </a>
+    </td>
+  </tr>
+
+  <tr style="width: 540px;">
+    <td style="padding: 50px 0 0 0;">
+      <p style="font-family: 'Source Sans Pro', serif; text-align: left; font-weight: 600; font-size: 20px; line-height: 26px;">Thank You</p>
+
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for providing your mailing address and contact information for your physician(s) and hospital(s).</p>
+
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">We may contact your physician(s) to obtain copies of your medical records, which we will use to review your medical history. After we have reviewed your medical records, we may contact you to inform you that we are requesting a small portion of your stored tumor sample from the hospital where it is kept. After we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</p>
+    </td>
+  </tr>
+
+  <tr style="width: 540px;">
+    <td style="padding: 20px 0 80px 0;">
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
+        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/osteoproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+    </td>
+  </tr>
+</table>
+</body>
+
+</html>

--- a/study-builder/studies/osteo/emails/reconsent_release_completed.html
+++ b/study-builder/studies/osteo/emails/reconsent_release_completed.html
@@ -98,7 +98,7 @@
         or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/osteoproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -1742,6 +1742,7 @@
           { "pdfName": "osproject-consent", "generateIfMissing": true }
         ]
       },
+      "cancelExpr": """user.studies["CMI-OSTEO"].hasAgedUp()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1
@@ -1798,6 +1799,7 @@
         "language": "en",
         "pdfAttachments": []
       },
+      "cancelExpr": """user.studies["CMI-OSTEO"].hasAgedUp()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1
@@ -1833,7 +1835,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 604800, # one week in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -1887,7 +1890,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 1209600, # two weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -1941,7 +1945,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 1814400, # three weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -1997,7 +2002,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 604800, # one week in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2033,7 +2039,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 1209600, # two weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2069,7 +2076,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")""",
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE")
+        || user.studies["CMI-OSTEO"].hasAgedUp()""",
       "delaySeconds": 1814400, # three weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2394,7 +2402,6 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CHILD_CONTACT"].isStatus("COMPLETE")""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2491,25 +2498,12 @@
         "type": "REACHED_AOM"
       },
       "action": {
-        "type": "ACTIVITY_INSTANCE_CREATION",
-        "activityCode": "CONSENT"
-      },
-      "dispatchToHousekeeping": false,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "REACHED_AOM"
-      },
-      "action": {
         "type": "MARK_ACTIVITIES_READ_ONLY",
         "activityCodes": ["PARENTAL_CONSENT", "CONSENT_ASSENT", "RELEASE_MINOR", "ABOUTCHILD", "CHILD_CONTACT"]
       },
       "dispatchToHousekeeping": false,
       "order": 1
     },
-
-    ## reconsent next steps email
     {
       "trigger": {
         "type": "REACHED_AOM"
@@ -2535,7 +2529,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """(user.studies["CMI-OSTEO"].forms["CONSENT"].hasInstance()
+        && user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE"))""",
       "delaySeconds": 604800, # one week in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2550,7 +2545,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """(user.studies["CMI-OSTEO"].forms["CONSENT"].hasInstance()
+        && user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE"))""",
       "delaySeconds": 1209600, # two weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2565,7 +2561,8 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "cancelExpr": """(user.studies["CMI-OSTEO"].forms["CONSENT"].hasInstance()
+        && user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("COMPLETE"))""",
       "delaySeconds": 2419200, # four weeks in seconds
       "dispatchToHousekeeping": true,
       "order": 1
@@ -2577,11 +2574,22 @@
         "type": "GOVERNED_USER_REGISTERED"
       },
       "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "CONSENT"
+      },
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "GOVERNED_USER_REGISTERED"
+      },
+      "action": {
         "type": "HIDE_ACTIVITIES",
         "activityCodes": ["CHILD_CONTACT"]
       },
       "dispatchToHousekeeping": false,
-      "order": 1
+      "order": 2
     },
     {
       "trigger": {
@@ -2595,7 +2603,7 @@
       },
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 2
+      "order": 3
     },
     {
       "trigger": {
@@ -2607,10 +2615,10 @@
       "dispatchToHousekeeping": false,
       # Order here is important. Since announcement `createForProxies` only create for active proxies,
       # we should queue up announcement before inactivating proxy.
-      "order": 3
+      "order": 4
     },
 
-    ## reconsent complete thank-you
+    ## after submitting new consent
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -2625,29 +2633,56 @@
           { "pdfName": "osproject-consent", "generateIfMissing": true }
         ]
       },
-      "cancelExpr": """!(user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].hasInstance()
-        || user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].hasInstance())""",
+      "cancelExpr": """!user.studies["CMI-OSTEO"].hasAgedUp()""",
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ## aged-up release
     {
-    "trigger": {
-      "type": "ACTIVITY_STATUS",
-      "activityCode": "CONSENT",
-      "statusType": "COMPLETE"
-    },
-    "action": {
-      "type": "HIDE_ACTIVITIES",
-      "activityCodes": ["RELEASE_MINOR"],
-    },
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "HIDE_ACTIVITIES",
+        "activityCodes": ["RELEASE_MINOR"],
+      },
       "cancelExpr": """!user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance()""",
       "dispatchToHousekeeping": false,
       "order": 1
     },
 
-    ## about-you answer copying
+    ## after submitting new release
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "RELEASE_SELF",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "emailTemplate": ${emails.reconsentReleaseCompleted},
+        "language": "en",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["CMI-OSTEO"].hasAgedUp()""",
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "RELEASE_SELF",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "HIDE_ACTIVITIES",
+        "activityCodes": ["ABOUTCHILD"],
+      },
+      "cancelExpr": """!user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance()""",
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",


### PR DESCRIPTION
* Updated implementation of `hasAgedUp()` PEX so that it defaults to `false` when user does not have birthdate yet.
* Delayed creating new consent for aged-up child until after child registers.
* Added hiding of `about_child` activity after new release is submitted.
* Suppress the "regular consent complete" email that typical adult participants get after submitting regular self consent
* Suppress the regular reminder emails we have in place for the self consent
* Suppress the regular release thank you email (which mentions saliva & blood kits)
* Suppress the regular reminder emails for the regular release
* Add a new email for "age-up release thank you", which is sent after child submits new release
