### PR TITLE
osteo: show CHILD_CONTACT when logging in

### DIFF
--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -1251,6 +1251,11 @@
       "to": [
         {
           "type": "ACTIVITY",
+          "activityCode": "CHILD_CONTACT",
+          "expression": """user.studies["CMI-OSTEO"].forms["CHILD_CONTACT"].isStatus("CREATED", "IN_PROGRESS")"""
+        },
+        {
+          "type": "ACTIVITY",
           "activityCode": "CONSENT",
           "expression": """user.studies["CMI-OSTEO"].forms["CONSENT"].isStatus("CREATED", "IN_PROGRESS")"""
         },


### PR DESCRIPTION
Fixes DDP-4357.

If user has not completed the `CHILD_CONTACT` activity yet, then workflow should show it when they login. When a user logs back in, frontend client calls Workflow API with `from` state `RETURN_USER`, so we add a transition rule there.