### PR TITLE
Cleanup logging of expired token

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -47,8 +48,6 @@ public class DsmAuthFilter implements Filter {
         if (StringUtils.isNotBlank(authorizationHeaderValue)) {
             if (isAuthorizationHeaderValid(authorizationHeaderValue)) {
                 return;
-            } else {
-                LOG.error("Did not find a valid token in Authorization header: {}", authorizationHeaderValue);
             }
         } else {
             LOG.error("Missing {} header on request with URL: {}", AUTHORIZATION, request.url());
@@ -70,6 +69,9 @@ public class DsmAuthFilter implements Filter {
         DecodedJWT jwt;
         try {
             jwt = JWTConverter.verifyDDPToken(tokenValue, this.jwkProvider);
+        } catch (TokenExpiredException e) {
+            LOG.warn("Found expired token", e);
+            return false;
         } catch (Exception e) {
             LOG.error("Could not decode token", e);
             return false;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
@@ -70,7 +70,7 @@ public class DsmAuthFilter implements Filter {
         try {
             jwt = JWTConverter.verifyDDPToken(tokenValue, this.jwkProvider);
         } catch (TokenExpiredException e) {
-            LOG.warn("Found expired token", e);
+            LOG.error("Found expired token", e);
             return false;
         } catch (Exception e) {
             LOG.error("Could not decode token", e);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/TokenConverterFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/TokenConverterFilter.java
@@ -34,7 +34,7 @@ public class TokenConverterFilter implements Filter {
             DDPAuth ddpAuth = jwtConverter.convertJWTFromHeader(request.headers(AUTHORIZATION));
             request.attribute(DDP_TOKEN, ddpAuth);
         } catch (TokenExpiredException e) {
-            LOG.warn("Found expired token for request", e);
+            LOG.error("Found expired token for request", e);
             halt(401);
         } catch (Exception e) {
             LOG.error("Error while converting token " + DDP_TOKEN + " for request", e);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/TokenConverterFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/TokenConverterFilter.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.filter;
 import static org.broadinstitute.ddp.constants.RouteConstants.AUTHORIZATION;
 import static spark.Spark.halt;
 
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.security.JWTConverter;
 import org.slf4j.Logger;
@@ -32,6 +33,9 @@ public class TokenConverterFilter implements Filter {
         try {
             DDPAuth ddpAuth = jwtConverter.convertJWTFromHeader(request.headers(AUTHORIZATION));
             request.attribute(DDP_TOKEN, ddpAuth);
+        } catch (TokenExpiredException e) {
+            LOG.warn("Found expired token for request", e);
+            halt(401);
         } catch (Exception e) {
             LOG.error("Error while converting token " + DDP_TOKEN + " for request", e);
             halt(401);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
@@ -8,6 +8,7 @@ import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.JwkProviderBuilder;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.auth0.jwt.interfaces.RSAKeyProvider;
 import org.apache.commons.lang3.StringUtils;
@@ -46,7 +47,8 @@ public class JWTConverter {
      * @param jwt         the token to verify
      * @param jwkProvider the provider of jwk data, typically auth0's jwk endpoint
      * @return a verified, decoded JWT
-     * @throws DDPTokenException if issues with jwt or key provider, i.e. token expired, invalid claims, etc.
+     * @throws DDPTokenException if issues with key provider
+     * @throws com.auth0.jwt.exceptions.JWTVerificationException if issues with jwt, e.g. token expired, invalid claims, etc.
      */
     public static DecodedJWT verifyDDPToken(String jwt, JwkProvider jwkProvider) {
         DecodedJWT validToken;
@@ -60,6 +62,10 @@ public class JWTConverter {
 
         try {
             validToken = JWT.require(Algorithm.RSA256(keyProvider)).acceptLeeway(10).build().verify(jwt);
+        } catch (TokenExpiredException e) {
+            // TokenExpired is one of the benign variants of JWTVerificationException that the `verify()` method throws.
+            LOG.warn("Expired token: {}", jwt);
+            throw e;
         } catch (Exception e) {
             LOG.error("Could not verify token {}", jwt, e);
             throw (e);
@@ -130,7 +136,7 @@ public class JWTConverter {
                                 auth0ClientId);
                         String preferredLanguage = getPreferredLanguageCodeForUser(handle, ddpUserGuid);
                         txnDdpAuth = new DDPAuth(auth0ClientId, ddpUserGuid, jwt, userPermissions, preferredLanguage);
-                    } catch (DDPTokenException e) {
+                    } catch (Exception e) {
                         LOG.warn("Could not verify token. User "
                                 + decodedJwt.getClaim(Auth0Constants.DDP_USER_ID_CLAIM).asString()
                                 + " tried to authenticate against client auth0clientId "


### PR DESCRIPTION
 ## Context

Cleanup up where/what we're logging, but kept the `log.error()` at the filters so they will still show up in Slack alerts.
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  - [x] refactor
  
 ## Risk Assessment
  - [x] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [x] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [ ] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [x] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [x] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [ ] I have written automated positive tests
 - [ ] I have written automated negative tests
 - [x] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
