### PR TITLE
Add substitutions flag to study-builder

### DIFF
--- a/study-builder/README.md
+++ b/study-builder/README.md
@@ -44,8 +44,18 @@ properly. Here's a breakdown of the types of configuration types:
   And there may be values that varies depending on the environment (whether
   dev/test/staging/prod). For the builder tool, these values are collectively
   called "variables", or "vars" for short. We can put values in here, and they
-  will be substituted into the study config, as described later. This file can
-  be specified using the `--vars` flag.
+  will be substituted into the study config, as described later. This file is
+  optional (so no need to have one if the study doesn't use secrets) and can be
+  specified using the `--vars` flag.
+
+- **substitutions config** This is the configuration file for study-wide
+  substitution values. Unlike the vars file which is often generated and not
+  checked into source version control, the substitutions file can store
+  non-secret values that can be checked in. This is useful to centralize
+  study-wide values, like a study's email or phone number that's used in
+  various activity definitions, or even used for centralizing
+  internationalization strings. This file is optional and can be specified
+  using the `--substitutions` flag.
 
 - **study config** This is the configuration file for the study. This is what
   the builder looks at to do its work. This is a required argument to the
@@ -68,22 +78,23 @@ script.
 ## Configuration Loading and Resolution
 
 Configurations are loaded at runtime using the `typesafe-config`
-[library][tscfg-lib]. The study config is first loaded from the provided file,
-and then it is "resolved" using the vars config. Resolution will take care of
-value substitutions.
+[library][tscfg-lib]. The vars config and substitutions config will be merged
+into a single config, so try to avoid duplicate keys. If there are duplicates,
+keys in substitutions config will override those in vars config. The study
+config is first loaded from the provided file, and then it is "resolved" using
+this merged config. Resolution will take care of value substitutions.
 
 *Note: A vars config is not required if the study config does not have any
 substitutions that refers to the vars config. In this case, the study config
-will be resolved with an empty config.*
+will be resolved with an empty config. Likewise for substitutions config.*
 
 Due to limitations of the config library, activity definitions for a study are
 loaded from separate files. The file path to the activity definition config
-file is understood to be a resource path and loaded as such. Once loaded, the
+file is understood to be relative to the `study.conf` file. Once loaded, the
 activity definition config will be resolved with the vars config.
 
 *Note: Paths in the study config that references other files, like icons and
-pdfs, are also understood to be resource paths to resources on the Java
-classpath.*
+pdfs, are also understood to be relative to the `study.conf` file.*
 
 [hocon]: https://github.com/lightbend/config/blob/master/HOCON.md
 [go-tmpl]: https://golang.org/pkg/text/template/

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/CustomTask.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/CustomTask.java
@@ -15,7 +15,7 @@ public interface CustomTask {
      *
      * @param cfgPath  the path to study config file
      * @param studyCfg the study configuration
-     * @param varsCfg  the secrets/variables configuration for study
+     * @param varsCfg  the secrets/variables/substitutions configuration for study
      */
     void init(Path cfgPath, Config studyCfg, Config varsCfg);
 


### PR DESCRIPTION
I went with a more general solution here. Instead of a `--translations` flag, I opted for a `--substitutions` flag instead. It allows you to do the same thing that we discussed (see DDP-4367), but also let's you do other substitutions as well. E.g. (very rough pseudocode):
```
# substitutions.conf
{
  "studyEmail": "a@b.com",
  "studyPhone": "123-456-7890",
  "i18n": {
    "en": { include("en.conf") },
    ...
  }
}
```
```
# consent.conf
{
  ...
  "readonlyHint": {
    ... "If you need help, please email us at" ${studyEmail} "or call us at" ${studyPhone}
  }
  "template": {
    "text": "$age_prompt",
    "vars": [
      { "age_prompt", "en", ${i18n.en.age} }
  ...
}
```