### PR TITLE
Make age-up check process more fault-tolerant

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.InvitationDao;
 import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.db.dao.StudyGovernanceDao;
 import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
@@ -17,6 +19,8 @@ import org.broadinstitute.ddp.model.event.EventSignal;
 import org.broadinstitute.ddp.model.governance.AgeOfMajorityRule;
 import org.broadinstitute.ddp.model.governance.AgeUpCandidate;
 import org.broadinstitute.ddp.model.governance.GovernancePolicy;
+import org.broadinstitute.ddp.model.invitation.InvitationType;
+import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.pex.PexException;
 import org.broadinstitute.ddp.pex.PexInterpreter;
 import org.jdbi.v3.core.Handle;
@@ -26,6 +30,9 @@ import org.slf4j.LoggerFactory;
 public class AgeUpService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AgeUpService.class);
+    private static final String SP_AGEUP = "ageup";
+    private static final String SP_PREP = "prep";
+    private static final String SP_STATUS = "status";
 
     private final Clock clock;
 
@@ -45,10 +52,11 @@ public class AgeUpService {
      * @param handle      the database handle
      * @param interpreter the pex interpreter
      * @param policy      the study age-up policy
-     * @return number of participants who has aged up in this run
+     * @return number of participants who has aged up and completed processing events in this run
      */
     public int runAgeUpCheck(Handle handle, PexInterpreter interpreter, GovernancePolicy policy) {
         StudyGovernanceDao studyGovernanceDao = handle.attach(StudyGovernanceDao.class);
+        InvitationDao invitationDao = handle.attach(InvitationDao.class);
         JdbiUserStudyEnrollment jdbiEnrollment = handle.attach(JdbiUserStudyEnrollment.class);
 
         List<AgeUpCandidate> potentialCandidates = studyGovernanceDao
@@ -59,7 +67,7 @@ public class AgeUpService {
         String studyGuid = policy.getStudyGuid();
         Set<Long> exitedCandidates = new HashSet<>();
         Set<Long> preppedCandidateIds = new HashSet<>();
-        Set<Long> agedUpCandidateIds = new HashSet<>();
+        Set<Long> completedCandidateIds = new HashSet<>();
 
         for (var candidate : potentialCandidates) {
             String userGuid = candidate.getParticipantUserGuid();
@@ -88,39 +96,86 @@ public class AgeUpService {
             boolean agedUp = rule.hasReachedAgeOfMajority(candidate.getBirthDate(), today);
             boolean shouldPrepForAgeUp = rule.hasReachedAgeOfMajorityPrep(candidate.getBirthDate(), today).orElse(false);
 
+            // First, handle updating consent status.
+            if (agedUp && candidate.getStatus() != EnrollmentStatusType.CONSENT_SUSPENDED) {
+                LOG.info("Candidate {} in study {} has reached age-of-majority, suspending consent status", userGuid, studyGuid);
+                try {
+                    TransactionWrapper.useSavepoint(named(SP_STATUS, studyGuid, userGuid), handle, h -> {
+                        jdbiEnrollment.suspendUserStudyConsent(candidate.getParticipantUserId(), policy.getStudyId());
+                    });
+                } catch (Exception e) {
+                    LOG.error("Candidate {} in study {} has reached age-of-majority"
+                            + " but could not suspend consent status, skipping", userGuid, studyGuid, e);
+                    continue;
+                }
+            }
+
+            // Second, see if we need to initiate the age-up process.
+            if (shouldPrepForAgeUp && !candidate.hasInitiatedPrep()) {
+                LOG.info("Candidate {} in study {} has reached preparation for age-of-majority,"
+                        + " processing age-up preparation events", userGuid, studyGuid);
+                try {
+                    TransactionWrapper.useSavepoint(named(SP_PREP, studyGuid, userGuid), handle, h -> {
+                        EventSignal signal = new EventSignal(
+                                candidate.getParticipantUserId(),
+                                candidate.getParticipantUserId(),
+                                candidate.getParticipantUserGuid(),
+                                policy.getStudyId(),
+                                EventTriggerType.REACHED_AOM_PREP);
+                        EventService.getInstance().processAllActionsForEventSignal(handle, signal);
+                    });
+                    preppedCandidateIds.add(candidate.getId());
+                } catch (Exception e) {
+                    LOG.error("Error processing age-up preparation events for candidate {} in study {},"
+                            + " rolling back and skipping", userGuid, studyGuid, e);
+                    continue;
+                }
+            }
+
+            // Lastly, see if we're ready to run the remaining age-up process.
             if (agedUp) {
-                LOG.info("Age-up candidate {} in study {} has reached age-of-majority", userGuid, studyGuid);
-                jdbiEnrollment.suspendUserStudyConsent(candidate.getParticipantUserId(), policy.getStudyId());
-                EventSignal signal = new EventSignal(
-                        candidate.getParticipantUserId(),
-                        candidate.getParticipantUserId(),
-                        candidate.getParticipantUserGuid(),
-                        policy.getStudyId(),
-                        EventTriggerType.REACHED_AOM);
-                EventService.getInstance().processAllActionsForEventSignal(handle, signal);
-                agedUpCandidateIds.add(candidate.getId());
-            } else if (!candidate.hasInitiatedPrep() && shouldPrepForAgeUp) {
-                LOG.info("Age-up candidate {} in study {} has reached preparation for age-of-majority", userGuid, studyGuid);
-                EventSignal signal = new EventSignal(
-                        candidate.getParticipantUserId(),
-                        candidate.getParticipantUserId(),
-                        candidate.getParticipantUserGuid(),
-                        policy.getStudyId(),
-                        EventTriggerType.REACHED_AOM_PREP);
-                EventService.getInstance().processAllActionsForEventSignal(handle, signal);
-                preppedCandidateIds.add(candidate.getId());
+                try {
+                    boolean hasInvitation = invitationDao.findInvitations(policy.getStudyId(), candidate.getParticipantUserId())
+                            .stream()
+                            .filter(invitation -> invitation.getInvitationType() == InvitationType.AGE_UP)
+                            .anyMatch(invitation -> !invitation.isVoid() && !invitation.isAccepted());
+                    if (hasInvitation) {
+                        LOG.info("Candidate {} in study {} has an age-up invitation, processing age-up events", userGuid, studyGuid);
+                        TransactionWrapper.useSavepoint(named(SP_AGEUP, studyGuid, userGuid), handle, h -> {
+                            EventSignal signal = new EventSignal(
+                                    candidate.getParticipantUserId(),
+                                    candidate.getParticipantUserId(),
+                                    candidate.getParticipantUserGuid(),
+                                    policy.getStudyId(),
+                                    EventTriggerType.REACHED_AOM);
+                            EventService.getInstance().processAllActionsForEventSignal(handle, signal);
+                        });
+                        completedCandidateIds.add(candidate.getId());
+                    } else {
+                        LOG.warn("Candidate {} in study {} does not have an age-up invitation,"
+                                + " postponing age-up events", userGuid, studyGuid);
+                    }
+                } catch (Exception e) {
+                    LOG.error("Error processing age-up events for candidate {} in study {},"
+                            + " rolling back and skipping", userGuid, studyGuid, e);
+                }
             }
         }
 
         int numRows = studyGovernanceDao.markAgeUpPrepInitiated(preppedCandidateIds);
         LOG.info("Initiated age-of-majority preparation for {} candidates", numRows);
 
-        numRows = studyGovernanceDao.removeAgeUpCandidates(agedUpCandidateIds);
-        LOG.info("Removed {} already aged up candidates", numRows);
+        numRows = studyGovernanceDao.removeAgeUpCandidates(completedCandidateIds);
+        LOG.info("Removed {} already aged up and completed candidates", numRows);
 
         numRows = studyGovernanceDao.removeAgeUpCandidates(exitedCandidates);
         LOG.info("Removed {} exited age-up candidates", numRows);
 
-        return agedUpCandidateIds.size();
+        return completedCandidateIds.size();
+    }
+
+    // Convenient helper to create a savepoint name that should be unique within the running transaction.
+    private String named(String prefix, String studyGuid, String userGuid) {
+        return String.format("%s_%s_%s", prefix, studyGuid, userGuid);
     }
 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -11,6 +12,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
@@ -18,7 +20,9 @@ import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.EventActionDao;
+import org.broadinstitute.ddp.db.dao.EventDao;
 import org.broadinstitute.ddp.db.dao.EventTriggerDao;
+import org.broadinstitute.ddp.db.dao.InvitationFactory;
 import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
 import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
 import org.broadinstitute.ddp.db.dao.JdbiProfile;
@@ -26,6 +30,8 @@ import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.db.dao.StudyGovernanceDao;
 import org.broadinstitute.ddp.db.dao.UserDao;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.db.dto.QueuedEventDto;
+import org.broadinstitute.ddp.db.dto.SendgridEmailEventActionDto;
 import org.broadinstitute.ddp.db.dto.UserProfileDto;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
@@ -34,6 +40,7 @@ import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
 import org.broadinstitute.ddp.model.governance.AgeOfMajorityRule;
 import org.broadinstitute.ddp.model.governance.AgeUpCandidate;
 import org.broadinstitute.ddp.model.governance.GovernancePolicy;
+import org.broadinstitute.ddp.model.invitation.InvitationType;
 import org.broadinstitute.ddp.model.pex.Expression;
 import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.model.user.User;
@@ -70,6 +77,8 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             User user1 = createAgeUpTestCandidate(handle, EnrollmentStatusType.REGISTERED, null);
             User user2 = createAgeUpTestCandidate(handle, EnrollmentStatusType.REGISTERED, LocalDate.of(2000, 1, 14));
+            handle.attach(InvitationFactory.class)
+                    .createInvitation(InvitationType.AGE_UP, testData.getStudyId(), user2.getId(), "test@datadonationplatform.org");
 
             GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));
             policy.addAgeOfMajorityRule(new AgeOfMajorityRule("true", 20, null));
@@ -124,6 +133,12 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
 
             GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));
             policy.addAgeOfMajorityRule(new AgeOfMajorityRule("true", 20, null));
+            assertEquals("should be skipped since there's no invitation",
+                    0, service.runAgeUpCheck(handle, interpreter, policy));
+
+            // Create invitation so they're ready for age-up
+            handle.attach(InvitationFactory.class)
+                    .createInvitation(InvitationType.AGE_UP, testData.getStudyId(), user1.getId(), "test@datadonationplatform.org");
             assertEquals(1, service.runAgeUpCheck(handle, interpreter, policy));
 
             List<AgeUpCandidate> candidates = handle.attach(StudyGovernanceDao.class)
@@ -169,6 +184,59 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
 
             assertTrue("activity instance should have been made read-only", handle.attach(JdbiActivityInstance.class)
                     .getByActivityInstanceId(instanceDto.getId()).get().isReadonly());
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void testRunAgeUpCheck_errorInOneCandidateDoesNotAffectAnother() {
+        TransactionWrapper.useTxn(handle -> {
+            User user1 = createAgeUpTestCandidate(handle, EnrollmentStatusType.REGISTERED, LocalDate.of(2000, 1, 14));
+            User user2 = createAgeUpTestCandidate(handle, EnrollmentStatusType.REGISTERED, LocalDate.of(2000, 1, 24));
+            handle.attach(InvitationFactory.class)
+                    .createInvitation(InvitationType.AGE_UP, testData.getStudyId(), user1.getId(), "test@datadonationplatform.org");
+
+            // Setup downstream event which will fail for second candidate
+            long triggerId = handle.attach(EventTriggerDao.class)
+                    .insertStaticTrigger(EventTriggerType.REACHED_AOM_PREP);
+            long actionId = handle.attach(EventActionDao.class)
+                    .insertInvitationEmailNotificationAction(new SendgridEmailEventActionDto("template", "en"));
+            handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+                    Instant.now().toEpochMilli(), null, 0, null, null, true, 1);
+
+            GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));
+            policy.addAgeOfMajorityRule(new AgeOfMajorityRule("true", 20, 4));
+            assertEquals("should have only completed 1 candidate",
+                    1, service.runAgeUpCheck(handle, interpreter, policy));
+
+            try {
+                // Wait for events to be ready
+                TimeUnit.SECONDS.sleep(1);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            List<AgeUpCandidate> candidates = handle.attach(StudyGovernanceDao.class)
+                    .findAllAgeUpCandidatesByStudyId(testData.getStudyId())
+                    .collect(Collectors.toList());
+            assertEquals(1, candidates.size());
+            assertEquals(user2.getId(), candidates.get(0).getParticipantUserId());
+
+            Optional<EnrollmentStatusType> status = handle.attach(JdbiUserStudyEnrollment.class)
+                    .getEnrollmentStatusByUserAndStudyIds(user1.getId(), testData.getStudyId());
+            assertEquals("should persist changes for first candidate",
+                    EnrollmentStatusType.CONSENT_SUSPENDED, status.get());
+            List<QueuedEventDto> events = handle.attach(EventDao.class).getQueuedEvents();
+            assertTrue("should have an event for first candidate", events.stream()
+                    .anyMatch(event -> event.getParticipantGuid().equals(user1.getGuid())));
+
+            status = handle.attach(JdbiUserStudyEnrollment.class)
+                    .getEnrollmentStatusByUserAndStudyIds(user2.getId(), testData.getStudyId());
+            assertEquals("should still change status for second candidate",
+                    EnrollmentStatusType.CONSENT_SUSPENDED, status.get());
+            assertFalse("should not have an event for second candidate", events.stream()
+                    .anyMatch(event -> event.getParticipantGuid().equals(user2.getGuid())));
 
             handle.rollback();
         });


### PR DESCRIPTION
 ## Context and the big picture

Updated the age-up job/service so that there's better isolation between studies and participants. Also changed how we run the `REACHED_AOM` events, i.e. we'll only run these events after participant has aged-up AND they have an invitation ready.

Some nice properties after these changes:
* Errors in one study will not affect another study
* Errors for one participant in a study will not affect other participants
* Status will always be changed to `consent_suspended` even if we run into errors processing events
* We'll run the `REACHED_AOM_PREP` events first, so that age-up process can be kicked off
* Since we added restriction of having an invitation, once they do have invitation, we kick off the `REACHED_AOM` events. This means that age-up process will be somewhat automated and continues to work even if parent fills out Child Contact _after_ someone reached their date-of-majority.
* And since we changed `consent_suspended` status _before_ the `REACHED_AOM_PREP` events, it means we marked existing activities read-only before creating the Child Contact activity, so that even in the situation where we found out about age-up before we created this activity, we still get the desired read-only behavior while Child Contact is still editable to continue the process.
 
 ## What type of change is this?
  
  - [x] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [x] These changes are **HIGH RISK**.
    - [x] There is an elevated risk that may impact a large number of features
    - [x] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [ ] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [ ] :relaxed: All good, business as usual!
  - [x] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [x] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [x] I have written automated positive tests
 - [ ] I have written automated negative tests
 - [x] I have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
