### PR TITLE
Allow configuring read-only when suspending consent

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUserStudyEnrollment.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUserStudyEnrollment.java
@@ -311,13 +311,7 @@ public interface JdbiUserStudyEnrollment extends SqlObject {
     }
 
     default long suspendUserStudyConsent(long userId, long studyId) {
-        //update EnrollmentStatus to EnrollmentStatusType.CONSENT_SUSPENDED
-        //Update All existing activity instances as read-only
-        long id = changeUserStudyEnrollmentStatus(
-                userId, studyId, EnrollmentStatusType.CONSENT_SUSPENDED, null);
-        Set<Long> instanceIds = getActivityInstanceDao().findAllInstanceIdsByUserIdAndStudyId(userId, studyId);
-        getActivityInstanceDao().bulkUpdateReadOnlyByActivityIds(userId, true, instanceIds);
-        return id;
+        return changeUserStudyEnrollmentStatus(userId, studyId, EnrollmentStatusType.CONSENT_SUSPENDED, null);
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
@@ -33,6 +33,9 @@ public class EventConfigurationDto {
     private InstanceStatusType instanceStatusType;
     private Long activityStatusTriggerStudyActivityId;
 
+    /* CONSENT_SUSPENDED */
+    // No sub-table
+
     /* WORKFLOW_STATE */
     private Long workflowStateId;
     private Boolean triggerAutomatically;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/EventTriggerType.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/EventTriggerType.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.model.activity.types;
 
 public enum EventTriggerType {
     ACTIVITY_STATUS(false),
+    CONSENT_SUSPENDED(true),
     DSM_NOTIFICATION(false),
     EXIT_REQUEST(true),
     GOVERNED_USER_REGISTERED(true),

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
@@ -39,6 +39,8 @@ public class EventConfiguration {
             case DSM_NOTIFICATION:
                 eventTrigger = new DsmNotificationTrigger(dto);
                 break;
+            case CONSENT_SUSPENDED:
+                // No sub-tables
             case GOVERNED_USER_REGISTERED:
                 // No sub-tables
             case INVITATION_CREATED:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -102,6 +102,13 @@ public class AgeUpService {
                 try {
                     TransactionWrapper.useSavepoint(named(SP_STATUS, studyGuid, userGuid), handle, h -> {
                         jdbiEnrollment.suspendUserStudyConsent(candidate.getParticipantUserId(), policy.getStudyId());
+                        EventSignal signal = new EventSignal(
+                                candidate.getParticipantUserId(),
+                                candidate.getParticipantUserId(),
+                                candidate.getParticipantUserGuid(),
+                                policy.getStudyId(),
+                                EventTriggerType.CONSENT_SUSPENDED);
+                        EventService.getInstance().processAllActionsForEventSignal(handle, signal);
                     });
                 } catch (Exception e) {
                     LOG.error("Candidate {} in study {} has reached age-of-majority"

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -187,4 +187,5 @@
     <include file="db-changes/seed/DDP-4222-age-up-event-types.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4276-restructure-copy-answer.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/answer-cascade-delete.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/consent-suspended-event-trigger.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/consent-suspended-event-trigger.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/consent-suspended-event-trigger.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200130-add-consent-suspended-event-trigger-type">
+        <insert tableName="event_trigger_type">
+            <column name="event_trigger_type_code" value="CONSENT_SUSPENDED"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -2493,6 +2493,9 @@
         "language": "en",
         "pdfAttachments": []
       },
+      # Invitation is created after participant reached age-of-majority,
+      # so skip verify email since we'll send out the next-steps emails.
+      "cancelExpr": """user.studies["CMI-OSTEO"].hasAgedUp()""",
       "dispatchToHousekeeping": true,
       "order": 1
     },
@@ -2500,11 +2503,11 @@
     ## events at age-up
     {
       "trigger": {
-        "type": "REACHED_AOM"
+        "type": "CONSENT_SUSPENDED"
       },
       "action": {
         "type": "MARK_ACTIVITIES_READ_ONLY",
-        "activityCodes": ["PARENTAL_CONSENT", "CONSENT_ASSENT", "RELEASE_MINOR", "ABOUTCHILD", "CHILD_CONTACT"]
+        "activityCodes": ["PARENTAL_CONSENT", "CONSENT_ASSENT", "RELEASE_MINOR", "ABOUTCHILD"]
       },
       "dispatchToHousekeeping": false,
       "order": 1


### PR DESCRIPTION
 ## Context and the big picture

Updated how consent_suspended works. Instead of blindly setting all activity instances to read-only, we make it more configurable.

The issue with current implementation is that, if proxy has not submitted the Child Contact and then child reaches age-up, we change status to `consent_suspended` and marked the Child Contact read-only so that proxy won't be able to submit without reaching out to study-staff. To take some operational burden off of study-staff, we exclude Child Contact from being read-only (Child Contact is defined to be write-once, so it will be read-only after submission).

Some nice properties of this change:
* Proxy can continue to provide child contact email even after they have aged-up
* Coupled with #72, this helps automate more of the age-up process and lessen operational burden for study-staff
* Studies can use the new `consent_suspended` trigger to potential do other work as well
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [x] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [x] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [ ] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [x] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [ ] I have written automated positive tests
 - [ ] I have written automated negative tests
 - [x] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
