### PR TITLE
poc: audit answers with history tracking

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -48,6 +48,9 @@ public interface AnswerDao extends SqlObject {
     String GUID_COLUMN = "answer_guid";
 
     @CreateSqlObject
+    AnswerHistoryDao getAnswerHistoryDao();
+
+    @CreateSqlObject
     PicklistAnswerDao getPicklistAnswerDao();
 
     @CreateSqlObject
@@ -133,6 +136,9 @@ public interface AnswerDao extends SqlObject {
     //
 
     default Answer updateAnswer(long operatorId, long answerId, Answer newAnswer) {
+        long answerHistId = getAnswerHistoryDao().saveAnswer(answerId);
+        LOG.info("Saved answer with id {} into answer history with history id {}", answerId, answerHistId);
+
         long now = Instant.now().toEpochMilli();
         DBUtils.checkUpdate(1, getAnswerSql().updateAnswerById(answerId, operatorId, now));
         updateAnswerValue(operatorId, answerId, newAnswer);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerHistoryDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerHistoryDao.java
@@ -1,0 +1,207 @@
+package org.broadinstitute.ddp.db.dao;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.broadinstitute.ddp.db.DaoException;
+import org.broadinstitute.ddp.model.activity.instance.answer.AgreementAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
+import org.broadinstitute.ddp.model.activity.instance.answer.AnswerRow;
+import org.broadinstitute.ddp.model.activity.instance.answer.BoolAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.CompositeAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.DateAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.NumericIntegerAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.PicklistAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
+import org.broadinstitute.ddp.model.activity.instance.answer.TextAnswer;
+import org.broadinstitute.ddp.model.activity.types.NumericType;
+import org.broadinstitute.ddp.model.activity.types.QuestionType;
+import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
+import org.jdbi.v3.core.result.RowView;
+import org.jdbi.v3.sqlobject.CreateSqlObject;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.UseRowReducer;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
+
+public interface AnswerHistoryDao extends SqlObject {
+
+    @CreateSqlObject
+    PicklistAnswerDao getPicklistAnswerDao();
+
+    @CreateSqlObject
+    JdbiCompositeAnswer getJdbiCompositeAnswer();
+
+    @CreateSqlObject
+    AnswerSql getAnswerSql();
+
+    @CreateSqlObject
+    AnswerHistorySql getAnswerHistorySql();
+
+    default long saveAnswer(long answerId) {
+        QuestionType type = getAnswerSql().findQuestionTypesByAnswerIds(Set.of(answerId)).get(answerId);
+        if (type == null) {
+            throw new DaoException("Could not find question type for answer with id " + answerId);
+        }
+
+        if (type == QuestionType.COMPOSITE) {
+            return saveAnswerWithCompositeValue(answerId);
+        } else if (type == QuestionType.PICKLIST) {
+            return saveAnswerWithPicklistValue(answerId);
+        } else {
+            return saveAnswerWithSimpleValue(answerId);
+        }
+    }
+
+    private long saveAnswerWithSimpleValue(long answerId) {
+        return getAnswerHistorySql().saveAnswerWithSimpleValue(answerId);
+    }
+
+    private long saveAnswerWithPicklistValue(long answerId) {
+        AnswerHistorySql answerHistorySql = getAnswerHistorySql();
+        long answerHistId = answerHistorySql.saveBaseAnswer(answerId);
+        answerHistorySql.saveAnswerPicklistValue(answerId, answerHistId);
+        return answerHistId;
+    }
+
+    private long saveAnswerWithCompositeValue(long answerId) {
+        // todo
+        // CompositeAnswerSummaryDto parentDto = jdbiCompositeAnswer.findCompositeAnswerSummary(answerId)
+        //         .orElseThrow(() -> new DaoException("Could not find parent composite answer with id " + answerId));
+        // parentDto.getChildAnswers().stream()
+        //         .flatMap(Collection::stream)
+        //         .filter(child -> child != null && child.getId() != null)
+        //         .forEach(child -> childAnswerIds.add(child.getId()));
+        AnswerHistorySql answerHistorySql = getAnswerHistorySql();
+        long answerHistId = answerHistorySql.saveBaseAnswer(answerId);
+        return answerHistId;
+    }
+
+    @UseStringTemplateSqlLocator
+    @SqlQuery("findHistoryByAnswerId")
+    @UseRowReducer(HistoryAnswersWithValueReducer.class)
+    List<Answer> findHistoryByAnswerId(@Bind("answerId") long answerId);
+
+    class HistoryAnswersWithValueReducer implements LinkedHashMapRowReducer<Long, Answer> {
+        private Map<Long, Answer> childAnswers = new HashMap<>();
+
+        @Override
+        public void accumulate(Map<Long, Answer> container, RowView view) {
+            reduce(container, view);
+        }
+
+        @Override
+        public Stream<Answer> stream(Map<Long, Answer> container) {
+            if (!childAnswers.isEmpty()) {
+                // There are child answers that has not been consumed by a parent answer,
+                // very likely we're querying for the child answers themselves so return them.
+                container.putAll(childAnswers);
+            }
+            return container.values().stream();
+        }
+
+        /**
+         * Same as accumulate, but also returns the answer that was reduced from the row.
+         *
+         * @param container mapping of answer id to answer object
+         * @param view      the row view
+         * @return reduced answer, or null if row is for a child answer
+         */
+        public Answer reduce(Map<Long, Answer> container, RowView view) {
+            long histId = view.getColumn("answer_history_id", Long.class);
+            long answerId = view.getColumn("answer_id", Long.class);
+            var answerGuid = view.getColumn("answer_guid", String.class);
+            var questionStableId = view.getColumn("question_stable_id", String.class);
+            var type = QuestionType.valueOf(view.getColumn("question_type", String.class));
+            boolean isChildAnswer = view.getColumn("is_child_answer", Boolean.class);
+            long updatedAt = view.getColumn("updated_at", Long.class);
+
+            Answer answer;
+            switch (type) {
+                case AGREEMENT:
+                    answer = new AgreementAnswer(answerId, questionStableId, answerGuid, view.getColumn("bool_value", Boolean.class));
+                    break;
+                case BOOLEAN:
+                    answer = new BoolAnswer(answerId, questionStableId, answerGuid, view.getColumn("bool_value", Boolean.class));
+                    break;
+                case TEXT:
+                    answer = new TextAnswer(answerId, questionStableId, answerGuid, view.getColumn("text_value", String.class));
+                    break;
+                case DATE:
+                    answer = new DateAnswer(answerId, questionStableId, answerGuid,
+                            view.getColumn("date_year", Integer.class),
+                            view.getColumn("date_month", Integer.class),
+                            view.getColumn("date_day", Integer.class));
+                    break;
+                case NUMERIC:
+                    var numericType = NumericType.valueOf(view.getColumn("na_numeric_type", String.class));
+                    if (numericType == NumericType.INTEGER) {
+                        answer = new NumericIntegerAnswer(answerId, questionStableId, answerGuid,
+                                view.getColumn("na_int_value", Long.class));
+                    } else {
+                        throw new DaoException("Unhandled numeric answer type " + numericType);
+                    }
+                    break;
+                case PICKLIST:
+                    var map = isChildAnswer ? childAnswers : container;
+                    answer = map.computeIfAbsent(histId, id ->
+                            new PicklistAnswer(answerId, questionStableId, answerGuid, new ArrayList<>()));
+                    var optionStableId = view.getColumn("pa_option_stable_id", String.class);
+                    if (optionStableId != null) {
+                        var option = new SelectedPicklistOption(optionStableId, view.getColumn("pa_detail_text", String.class));
+                        ((PicklistAnswer) answer).getValue().add(option);
+                    }
+                    break;
+                case COMPOSITE:
+                    answer = container.computeIfAbsent(histId, id -> {
+                        var ans = new CompositeAnswer(answerId, questionStableId, answerGuid);
+                        ans.setAllowMultiple(view.getColumn("ca_allow_multiple", Boolean.class));
+                        ans.setUnwrapOnExport(view.getColumn("ca_unwrap_on_export", Boolean.class));
+                        return ans;
+                    });
+
+                    // todo
+                    // Long childAnswerId = view.getColumn("ca_child_answer_id", Long.class);
+                    // if (childAnswerId != null) {
+                    //     Answer childAnswer = childAnswers.get(childAnswerId);
+                    //     if (childAnswer == null) {
+                    //         throw new DaoException(String.format(
+                    //                 "Could not find child answer with id=%d for composite answer %d", childAnswerId, answerId));
+                    //     }
+                    //
+                    //     int childRow = view.getColumn("ca_child_row", Integer.class); // zero-indexed row number
+                    //     int childCol = view.getColumn("ca_child_col", Integer.class); // zero-indexed column number
+                    //     List<AnswerRow> rows = ((CompositeAnswer) answer).getValue();
+                    //     while (rows.size() < childRow + 1) {
+                    //         rows.add(new AnswerRow());
+                    //     }
+                    //     List<Answer> row = rows.get(childRow).getValues();
+                    //     while (row.size() < childCol + 1) {
+                    //         row.add(null);
+                    //     }
+                    //     row.set(childCol, childAnswer);
+                    //
+                    //     // Pull child answer out of map, indicating we have consumed it
+                    //     childAnswers.remove(childAnswerId);
+                    // }
+                    break;
+                default:
+                    throw new DaoException("Unhandled answer type " + type);
+            }
+
+            answer.setUpdatedAt(updatedAt);
+            if (isChildAnswer) {
+                childAnswers.put(histId, answer);
+                return null;
+            } else {
+                container.put(histId, answer);
+                return answer;
+            }
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerHistorySql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerHistorySql.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.ddp.db.dao;
+
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
+
+public interface AnswerHistorySql extends SqlObject {
+
+    @GetGeneratedKeys
+    @UseStringTemplateSqlLocator
+    @SqlUpdate("saveBaseAnswer")
+    long saveBaseAnswer(@Bind("answerId") long answerId);
+
+    @GetGeneratedKeys
+    @UseStringTemplateSqlLocator
+    @SqlUpdate("saveAnswerWithSimpleValue")
+    long saveAnswerWithSimpleValue(@Bind("answerId") long answerId);
+
+    @UseStringTemplateSqlLocator
+    @SqlUpdate("saveAnswerPicklistValue")
+    int saveAnswerPicklistValue(@Bind("answerId") long answerId, @Bind("answerHistId") long answerHistId);
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/DateQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/DateQuestionRecord.java
@@ -1,9 +1,16 @@
 package org.broadinstitute.ddp.export.json.structured;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
+import org.broadinstitute.ddp.model.activity.instance.answer.DateAnswer;
 import org.broadinstitute.ddp.model.activity.instance.answer.DateValue;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
@@ -13,8 +20,10 @@ public final class DateQuestionRecord extends QuestionRecord {
     private String date;
     @SerializedName("dateFields")
     private DateValue dateFields;
+    @SerializedName("dateHistory")
+    private List<Map<String, Object>> history;
 
-    public DateQuestionRecord(String stableId, DateValue answer) {
+    public DateQuestionRecord(String stableId, DateValue answer, List<Answer> history) {
         super(QuestionType.DATE, stableId);
         this.dateFields = answer;
         if (answer != null) {
@@ -23,5 +32,13 @@ public final class DateQuestionRecord extends QuestionRecord {
             str = (str != null ? str : answer.getYear() == null ? null : String.format("%04d", answer.getYear()));
             this.date = str;
         }
+        this.history = history.stream()
+                .map(ans -> {
+                    Map<String, Object> hist = new HashMap<>();
+                    hist.put("dateFields", ((DateAnswer) ans).getValue());
+                    hist.put("updatedAt", Instant.ofEpochMilli(ans.getUpdatedAt()).toString());
+                    return hist;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -1,13 +1,18 @@
 package org.broadinstitute.ddp.export.json.structured;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections4.CollectionUtils;
+import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
+import org.broadinstitute.ddp.model.activity.instance.answer.PicklistAnswer;
 import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
@@ -17,8 +22,10 @@ public final class PicklistQuestionRecord extends QuestionRecord {
     private List<String> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
+    @SerializedName("picklistHistory")
+    private List<Map<String, Object>> history;
 
-    public PicklistQuestionRecord(String stableId, List<SelectedPicklistOption> answer) {
+    public PicklistQuestionRecord(String stableId, List<SelectedPicklistOption> answer, List<Answer> history) {
         super(QuestionType.PICKLIST, stableId);
         if (CollectionUtils.isNotEmpty(answer)) {
             List<SelectedPicklistOption> selected = new ArrayList<>(answer);
@@ -33,5 +40,25 @@ public final class PicklistQuestionRecord extends QuestionRecord {
                 }
             }
         }
+        this.history = history.stream()
+                .map(ans -> {
+                    List<SelectedPicklistOption> selected = new ArrayList<>(((PicklistAnswer) ans).getValue());
+                    selected.sort(Comparator.comparing(SelectedPicklistOption::getStableId));
+                    List<Map<String, String>> optionDetails = new ArrayList<>();
+                    for (SelectedPicklistOption option : selected) {
+                        if (option.getDetailText() != null) {
+                            Map<String, String> details = new LinkedHashMap<>();
+                            details.put("option", option.getStableId());
+                            details.put("details", option.getDetailText());
+                            optionDetails.add(details);
+                        }
+                    }
+                    Map<String, Object> hist = new HashMap<>();
+                    hist.put("answer", selected.stream().map(SelectedPicklistOption::getStableId).collect(Collectors.toList()));
+                    hist.put("optionDetails", optionDetails);
+                    hist.put("updatedAt", Instant.ofEpochMilli(ans.getUpdatedAt()).toString());
+                    return hist;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/SimpleQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/SimpleQuestionRecord.java
@@ -1,15 +1,32 @@
 package org.broadinstitute.ddp.export.json.structured;
 
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
 public final class SimpleQuestionRecord extends QuestionRecord {
 
     @SerializedName("answer")
     private Object answer;
+    @SerializedName("history")
+    private List<Map<String, String>> history;
 
-    public SimpleQuestionRecord(QuestionType questionType, String stableId, Object answer) {
+    public SimpleQuestionRecord(QuestionType questionType, String stableId, Object answer, List<Answer> history) {
         super(questionType, stableId);
         this.answer = answer;
+        this.history = history.stream()
+                .map(ans -> {
+                    Map<String, String> hist = new HashMap<>();
+                    hist.put("answer", ans.getValue().toString());
+                    hist.put("updatedAt", Instant.ofEpochMilli(ans.getUpdatedAt()).toString());
+                    return hist;
+                })
+                .collect(Collectors.toList());
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/Answer.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/Answer.java
@@ -13,6 +13,7 @@ public abstract class Answer<T> implements Answerable<T> {
 
     protected transient Long answerId;
     protected transient String questionStableId;
+    protected transient long updatedAt;
 
     Answer(QuestionType type, Long answerId, String questionStableId, String answerGuid) {
         this.type = type;
@@ -44,5 +45,13 @@ public abstract class Answer<T> implements Answerable<T> {
 
     public void setAnswerGuid(String answerGuid) {
         this.answerGuid = answerGuid;
+    }
+
+    public long getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(long updatedAt) {
+        this.updatedAt = updatedAt;
     }
 }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -189,4 +189,5 @@
     <include file="db-changes/schema/answer-cascade-delete.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/consent-suspended-event-trigger.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4363-increase-detail-limit.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/answer-history.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/answer-history.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/answer-history.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200206-add-answer-history-tables">
+        <createTable tableName="answer_history">
+            <column name="answer_history_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="answer_history_pk"/>
+            </column>
+            <column name="answer_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="answer_guid" type="varchar(10)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="question_id" type="bigint">
+                <constraints nullable="false"
+                             references="question(question_id)"
+                             foreignKeyName="answer_history_question_fk"/>
+            </column>
+            <column name="question_type" type="varchar(80)">
+                <constraints nullable="false"
+                             references="question_type(question_type_code)"
+                             foreignKeyName="answer_history_question_type_code_fk"/>
+            </column>
+            <column name="activity_instance_id" type="bigint">
+                <constraints nullable="false"
+                             references="activity_instance(activity_instance_id)"
+                             foreignKeyName="answer_history_activity_instance_fk"/>
+            </column>
+            <column name="operator_user_id" type="bigint">
+                <constraints nullable="false"
+                             references="user(user_id)"
+                             foreignKeyName="answer_history_operator_user_fk"/>
+            </column>
+            <column name="created_at" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="updated_at" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_child_answer" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+            <column name="bool_value" type="boolean"/>
+            <column name="text_value" type="varchar(10000)"/>
+            <column name="numeric_int_value" type="bigint"/>
+            <column name="date_year" type="int"/>
+            <column name="date_month" type="int"/>
+            <column name="date_day" type="int"/>
+        </createTable>
+
+        <createTable tableName="picklist_answer_history">
+            <column name="picklist_answer_history_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="picklist_answer_history_pk"/>
+            </column>
+            <column name="answer_history_id" type="bigint">
+                <constraints nullable="false"
+                             references="answer_history(answer_history_id)"
+                             foreignKeyName="picklist_answer_history_ans_hist_fk"
+                             deleteCascade="true"/>
+            </column>
+            <column name="picklist_option_id" type="bigint">
+                <constraints nullable="false"
+                             references="picklist_option(picklist_option_id)"
+                             foreignKeyName="picklist_answer_history_picklist_option_fk"/>
+            </column>
+            <column name="detail_text" type="varchar(500)"/>
+        </createTable>
+
+        <createTable tableName="composite_answer_history">
+            <column name="composite_answer_history_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="composite_answer_history_pk"/>
+            </column>
+            <column name="parent_answer_history_id" type="bigint">
+                <constraints nullable="false"
+                             references="answer_history(answer_history_id)"
+                             foreignKeyName="composite_answer_history_parent_ans_hist_fk"
+                             deleteCascade="true"/>
+            </column>
+            <column name="child_answer_history_id" type="bigint">
+                <constraints nullable="false"
+                             references="answer_history(answer_history_id)"
+                             foreignKeyName="composite_answer_history_child_ans_hist_fk"/>
+            </column>
+            <column name="row_order" type="int">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerHistoryDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerHistoryDao.sql.stg
@@ -1,0 +1,52 @@
+group AnswerHistoryDao;
+
+all_history_answers_select() ::= <<
+select hist.answer_history_id,
+       hist.answer_id,
+       hist.answer_guid,
+       hist.question_type,
+       qsc.stable_id as question_stable_id,
+       hist.bool_value,
+       hist.text_value,
+       hist.date_year,
+       hist.date_month,
+       hist.date_day,
+       nt.numeric_type_code   as na_numeric_type,
+       hist.numeric_int_value as na_int_value,
+       po.picklist_option_stable_id as pa_option_stable_id,
+       pa.detail_text               as pa_detail_text,
+       cq.allow_multiple           as ca_allow_multiple,
+       cq.unwrap_on_export         as ca_unwrap_on_export,
+       ca.child_answer_history_id  as ca_child_answer_hist_id,
+       ca.row_order                as ca_child_row,
+       (select display_order from composite_question__question
+         where parent_question_id = hist.question_id
+           and child_question_id = (select question_id from answer_history where answer_history_id = ca.child_answer_history_id)
+       ) as ca_child_col,
+       hist.is_child_answer,
+       hist.created_at,
+       hist.updated_at
+  from answer_history as hist
+  join question as q on q.question_id = hist.question_id
+  join question_stable_code as qsc on qsc.question_stable_code_id = q.question_stable_code_id
+  join activity_instance as ai on hist.activity_instance_id = ai.activity_instance_id
+  join user as u on u.user_id = ai.participant_id
+  left join numeric_question as nq on nq.question_id = q.question_id
+  left join numeric_type as nt on nt.numeric_type_id = nq.numeric_type_id
+  left join picklist_answer_history as pa on pa.answer_history_id = hist.answer_history_id
+  left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
+  left join composite_question as cq on cq.question_id = q.question_id
+  left join composite_answer_history as ca on ca.parent_answer_history_id = hist.answer_history_id
+>>
+
+// Important: sort the child answers first so we have them in memory when we get to the composite parent answers.
+// History answers are sorted in descending order so we have most recent to least recent.
+all_history_answers_order_by() ::= <<
+order by hist.is_child_answer desc, hist.updated_at desc, po.display_order asc, ca.row_order asc, ca_child_col asc
+>>
+
+findHistoryByAnswerId() ::= <<
+<all_history_answers_select()>
+where hist.answer_id = :answerId
+<all_history_answers_order_by()>
+>>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerHistorySql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerHistorySql.sql.stg
@@ -1,0 +1,57 @@
+group AnswerHistorySql;
+
+saveBaseAnswer() ::= <<
+insert into answer_history (
+       answer_id, answer_guid, question_id, question_type, activity_instance_id,
+       operator_user_id, created_at, updated_at, is_child_answer)
+select ans.answer_id,
+       ans.answer_guid,
+       q.question_id,
+       (select question_type_code from question_type where question_type_id = q.question_type_id),
+       ans.activity_instance_id,
+       ans.operator_user_id,
+       ans.created_at,
+       ans.last_updated_at,
+       coalesce((select 1 from composite_answer_item where child_answer_id = ans.answer_id), 0)
+  from answer as ans
+  join question as q on q.question_id = ans.question_id
+ where ans.answer_id = :answerId
+>>
+
+saveAnswerWithSimpleValue() ::= <<
+insert into answer_history (
+       answer_id, answer_guid, question_id, question_type, activity_instance_id,
+       operator_user_id, created_at, updated_at, is_child_answer,
+       bool_value, text_value, numeric_int_value,
+       date_year, date_month, date_day)
+select ans.answer_id,
+       ans.answer_guid,
+       q.question_id,
+       (select question_type_code from question_type where question_type_id = q.question_type_id),
+       ans.activity_instance_id,
+       ans.operator_user_id,
+       ans.created_at,
+       ans.last_updated_at,
+       coalesce((select 1 from composite_answer_item where child_answer_id = ans.answer_id), 0),
+       coalesce(aa.answer, ba.answer),
+       ta.answer,
+       na.int_value,
+       da.year,
+       da.month,
+       da.day
+  from answer as ans
+  join question as q on q.question_id = ans.question_id
+  left join agreement_answer as aa on aa.answer_id = ans.answer_id
+  left join boolean_answer   as ba on ba.answer_id = ans.answer_id
+  left join text_answer      as ta on ta.answer_id = ans.answer_id
+  left join numeric_answer   as na on na.answer_id = ans.answer_id
+  left join date_answer      as da on da.answer_id = ans.answer_id
+ where ans.answer_id = :answerId
+>>
+
+saveAnswerPicklistValue() ::= <<
+insert into picklist_answer_history (answer_history_id, picklist_option_id, detail_text)
+select :answerHistId, pa.picklist_option_id, pa.detail_text
+  from picklist_option__answer as pa
+ where pa.answer_id = :answerId
+>>


### PR DESCRIPTION
POC/experiment to track changes to answers. This is a VERY early and rough draft/hack. Proceed with caution.

General idea:
* Store historical answers in a separate "history" table (aka [SCD type 4](https://en.wikipedia.org/wiki/Slowly_changing_dimension))
* Things in `answer` table is considered current/latest answer
* Every time we update an answer (and delete as well?) we first save a copy of the current answer into the history table before changing it
* Export historical answers as a separate item in Elasticsearch but collocated with current answer

Why separate table?
* In most cases, we care about the current/latest answer. If we put it all in one table, it will end up being a giant table that we have to scan through on every query. Having historical answers in a separate table will help performance since in most cases we're just grabbing the current answer. If we need the historical answers (e.g. during export) we can then slog through the history table.
* Also, if we have everything in one table, we'll need to rejigger PK/UK keys in order to introduce a "historical answer id" to track answers across time.
* However, a drawback is that since we have different "versions" of the same answer in the history table, we can no longer enforce certain constrains (e.g. `answer_guid` uniqueness). In a way, we're also losing out on some referential integrity. But I think this is okay since it's just historical data?

Why denormalize the history table?
* Performance. There's gonna be a lot of rows in here (imagine someone keep changing their mind on an answer!) so if we have answer values split out to different tables like what we're doing now, there's a lot of joins to work through.
* Maintenance. I didn't want to create a whole entire set of tables to mirror what we currently have for answers...

How to try this locally?
1. Check-out this branch and setup a study to play with (e.g. Osteo)
2. Run Elasticsearch locally (use homebrew, install the community edition, etc)
3. Create `participants_structured` index for your study
    ```
    $ ./elastic.sh v1 local create-templated-index indices/participants_structured.any.json cmi.cmi-osteo
    ```
4. Set config to point to local ES
    ```
    # your/config/file.conf
    {
      "elasticsearch": {
        "syncEnabled": true    # enable data sync job to see stuff show up in local ES
      }
      "elasticsearchUrl": "http://localhost:9200",  # point to your local ES, no credentials needed
      "elasticsearchPassword": "",
      "elasticsearchUsername": "",
      "runScheduler": true,    # turn on data sync job scheduling
    }
    ```
5. Boot up both the server and Housekeeping
6. Answer some questions in study
7. Query the index in local ES (see examples below)

---

Example histories:
```json
{
  "stableId" : "LOVEDONE_FUTURE_CONTACT",
  "answer" : false,
  "history" : [
    {
      "answer" : "true",
      "updatedAt" : "2020-02-06T20:11:44.610Z"
    }
  ],
  "questionType" : "BOOLEAN"
}
```
```json
{
  "stableId" : "LOVEDONE_FIRST_NAME",
  "answer" : "loved one first 3",
  "history" : [
    {
      "answer" : "loved one first 2",
      "updatedAt" : "2020-02-06T20:07:26.925Z"
    },
    {
      "answer" : "loved one first",
      "updatedAt" : "2020-02-06T20:07:20.985Z"
    }
  ],
  "questionType" : "TEXT"
}
```
```json
{
  "date" : "2010-06",
  "dateFields" : {
    "month" : 6,
    "year" : 2010,
    "day" : null
  },
  "stableId" : "LOVEDONE_DIAGNOSIS_DATE",
  "dateHistory" : [
    {
      "dateFields" : {
        "month" : 6,
        "year" : null,
        "day" : null
      },
      "updatedAt" : "2020-02-06T20:07:52.915Z"
    }
  ],
  "questionType" : "DATE"
}
```
```json
{
  "stableId" : "LOVEDONE_RELATION_TO",
  "answer" : [
    "OTHER"
  ],
  "optionDetails" : [
    {
      "details" : "my relation",
      "option" : "OTHER"
    }
  ],
  "questionType" : "PICKLIST",
  "picklistHistory" : [
    {
      "answer" : [
        "OTHER"
      ],
      "optionDetails" : [ ],
      "updatedAt" : "2020-02-06T21:25:37.158Z"
    },
    {
      "answer" : [
        "SPOUSE"
      ],
      "optionDetails" : [ ],
      "updatedAt" : "2020-02-06T20:07:13.269Z"
    },
    {
      "answer" : [ ],
      "optionDetails" : [ ],
      "updatedAt" : "2020-02-06T20:07:08.569Z"
    },
    {
      "answer" : [
        "SPOUSE"
      ],
      "optionDetails" : [ ],
      "updatedAt" : "2020-02-06T20:07:06.467Z"
    }
  ]
}
```