### PR TITLE
DDP-4421 disable non-prod metrics

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -57,7 +57,18 @@
         "fromEmail": "{{$conf.Data.sendgrid.fromEmail}}"
     },
     "sendgridToken": "{{$conf.Data.sendgridToken}}",
-    "sendMetrics": true,
+    {{if eq $environment "dev"}}
+            "sendMetrics": false,
+    {{end}}
+    {{if eq $environment "test"}}
+        "sendMetrics": false,
+    {{end}}
+    {{if eq $environment "staging"}}
+        "sendMetrics": false,
+    {{end}}
+    {{if eq $environment "prod"}}
+        "sendMetrics": true,
+    {{end}}
     "googleGeocodingApiKey": "{{$conf.Data.geocodingKey}}",
     "elasticsearch": {
         # Whether to enable data sync to ES

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/monitoring/StackdriverMetricsTracker.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/monitoring/StackdriverMetricsTracker.java
@@ -285,7 +285,9 @@ public class StackdriverMetricsTracker {
      * to epochTimeMillis
      */
     public void addPoint(long value, long epochTimeMillis) {
-        metricSeriesPoints.queuePoint(metricsSeries, value, epochTimeMillis);
+        if (DO_STACKDRIVER) {
+            metricSeriesPoints.queuePoint(metricsSeries, value, epochTimeMillis);
+        }
     }
 
     /**


### PR DESCRIPTION
 ## DDP-4421 Context and the big picture
Stackdriver is expensive.  Let's spend less money by not using it on non-prod.

 ## What type of change is this?
[x] Configuration
  
 ## Risk Assessment
  - [x] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!

 
 ## How to we demo these changes?
Log in to stackdriver once the changes are deployed.  There should be a cliff where custom metric collection halts--the moment of deployment of the backend.
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes

## Release
 - [x] These changes require no special release procedures--just code!

