### PR TITLE
Ddp 4366 switch routes to using lang from attr store

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -278,6 +278,8 @@ public class DataDonationPlatform {
         // - StudyLanguageContentLanguageSettingFilter sets the "Content-Language" header later on
         before(API.BASE + "/user/*/studies/*", new StudyLanguageResolutionFilter());
         after(API.BASE + "/user/*/studies/*", new StudyLanguageContentLanguageSettingFilter());
+        before(API.BASE + "/studies/*", new StudyLanguageResolutionFilter());
+        after(API.BASE + "/studies/*", new StudyLanguageContentLanguageSettingFilter());
 
         enableCORS("*", String.join(",", CORS_HTTP_METHODS), String.join(",", CORS_HTTP_HEADERS));
         setupCatchAllErrorHandling();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyI18n.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyI18n.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.db.dao;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 
 import org.broadinstitute.ddp.constants.SqlConstants;
 import org.broadinstitute.ddp.db.dto.StudyI18nDto;
@@ -22,6 +23,17 @@ public interface JdbiUmbrellaStudyI18n extends SqlObject {
                 + "AND i18n.language_code_id = lang.language_code_id")
     @RegisterRowMapper(UmbrellaStudyI18nDtoMapper.class)
     List<StudyI18nDto> findTranslationsByStudyId(@Bind("id") long id);
+
+    @SqlQuery("SELECT lc.iso_language_code, i18n.name, i18n.summary "
+            + "FROM i18n_umbrella_study AS i18n JOIN language_code AS lc "
+            + " ON i18n.language_code_id = lc.language_code_id"
+            + " WHERE i18n.umbrella_study_id = :id AND lc.language_code_id = :langCodeId"
+    )
+    @RegisterRowMapper(UmbrellaStudyI18nDtoMapper.class)
+    Optional<StudyI18nDto> findTranslationByStudyIdAndLanguageCodeId(
+            @Bind("id") long id,
+            @Bind("langCodeId") long languageCodeId
+    );
 
     @SqlUpdate("insert into i18n_umbrella_study "
             + "(umbrella_study_id,language_code_id,name,summary) values "

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyI18n.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyI18n.java
@@ -44,6 +44,9 @@ public interface JdbiUmbrellaStudyI18n extends SqlObject {
                 @Bind("name") String name,
                 @Bind("summary") String summary);
 
+    @SqlUpdate("DELETE FROM i18n_umbrella_study WHERE id = :id")
+    int deleteById(@Bind("id") long id);
+
     class UmbrellaStudyI18nDtoMapper implements RowMapper<StudyI18nDto> {
         @Override
         public StudyI18nDto map(ResultSet rs, StatementContext ctx) throws SQLException {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
@@ -59,7 +59,7 @@ public class StudyLanguageResolutionFilter implements Filter {
                 LOG.warn(
                         "Supported languages can't be detected because the filter is invoked"
                         + " before the route that is outside of the study context. Please"
-                        + " remount the filter under '/user/*/studies/*' instead. Current path = {}",
+                        + " remount the filter under '*/studies/*' instead. Current path = {}",
                         request.url()
                 );
                 return;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetStudyDetailRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetStudyDetailRoute.java
@@ -1,14 +1,11 @@
 package org.broadinstitute.ddp.route;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
-import java.util.Locale.LanguageRange;
-import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
+
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -16,6 +13,7 @@ import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
 import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudyI18n;
 import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.db.dto.EnrollmentStatusDto;
+import org.broadinstitute.ddp.db.dto.LanguageDto;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.db.dto.StudyI18nDto;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -23,11 +21,12 @@ import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.model.study.EnrollmentStatusCount;
 import org.broadinstitute.ddp.model.study.StudyDetail;
 import org.broadinstitute.ddp.security.DDPAuth;
-import org.broadinstitute.ddp.util.I18nUtil;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -36,7 +35,7 @@ public class GetStudyDetailRoute implements Route {
     private static final Logger LOG = LoggerFactory.getLogger(GetStudyDetailRoute.class);
 
     @Override
-    public Object handle(Request request, Response response) throws Exception {
+    public StudyDetail handle(Request request, Response response) throws Exception {
         final String studyIdentifier = request.params(RouteConstants.PathParam.STUDY_GUID);
 
         if (StringUtils.isBlank(studyIdentifier)) {
@@ -45,14 +44,6 @@ public class GetStudyDetailRoute implements Route {
         }
 
         LOG.debug("Received request for details of study {}", studyIdentifier);
-
-        List<LanguageRange> acceptLanguages;
-        String acceptLanguageHeader = request.headers(RouteConstants.ACCEPT_LANGUAGE);
-        if (StringUtils.isNotEmpty(acceptLanguageHeader)) {
-            acceptLanguages = LanguageRange.parse(acceptLanguageHeader);
-        } else {
-            acceptLanguages = new ArrayList<LanguageRange>();
-        }
 
         DDPAuth authInfo = RouteUtil.getDDPAuth(request);
 
@@ -68,19 +59,11 @@ public class GetStudyDetailRoute implements Route {
                 ResponseUtil.haltError(response, HttpStatus.SC_NOT_FOUND, error);
             }
 
-            // Fetch a list of all the available translations for this particular study,
-            //  convert them into a set of Locale objects, and stash them away in a map
-            //  for easy access later.
-            List<StudyI18nDto> translations = translationDao.findTranslationsByStudyId(study.getId());
-            Map<Locale, StudyI18nDto> availableTranslations = new HashMap<Locale, StudyI18nDto>();
-            translations.forEach((translation) -> {
-                Locale locale = Locale.forLanguageTag(translation.getLanguageCode());
-                availableTranslations.put(locale, translation);
-            });
-
-            Locale userLocale = I18nUtil.resolvePreferredLanguage(authInfo.getPreferredLocale(), acceptLanguages,
-                    availableTranslations.keySet());
-            StudyI18nDto preferredTranslation = availableTranslations.get(userLocale);
+            LanguageDto preferredLanguage = RouteUtil.getUserLanguage(request);
+            Optional<StudyI18nDto> preferredTranslation = translationDao.findTranslationByStudyIdAndLanguageCodeId(
+                    study.getId(),
+                    preferredLanguage.getId()
+            );
 
             List<EnrollmentStatusDto> enrollments = enrollmentDao.findByStudyGuid(studyIdentifier);
             if (null == enrollments) {
@@ -92,15 +75,8 @@ public class GetStudyDetailRoute implements Route {
 
             EnrollmentStatusCount enrollmentStatusCount = EnrollmentStatusCount.getEnrollmentStatusCountByEnrollments(enrollments);
 
-            String name;
-            String summary;
-            if (null != preferredTranslation) {
-                name = preferredTranslation.getName();
-                summary = preferredTranslation.getSummary();
-            } else {
-                name = study.getName();
-                summary = null;
-            }
+            String name = preferredTranslation.map(trans -> trans.getName()).orElse(study.getName());
+            String summary = preferredTranslation.map(trans -> trans.getSummary()).orElse(null);
 
             boolean restricted = study.getIrbPassword() != null;
             return new StudyDetail(

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyDetailRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyDetailRouteTest.java
@@ -1,0 +1,34 @@
+package org.broadinstitute.ddp.route;
+
+import io.restassured.RestAssured;
+
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GetStudyDetailRouteTest extends IntegrationTestSuite.TestCase {
+    private static TestDataSetupUtil.GeneratedTestData testData;
+    private static String token;
+    private static String url;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        TransactionWrapper.useTxn(handle -> {
+            testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            token = testData.getTestingUser().getToken();
+        });
+        String endpoint = RouteConstants.API.STUDY_DETAIL
+                .replace(RouteConstants.PathParam.STUDY_GUID, testData.getStudyGuid());
+        url = RouteTestUtil.getTestingBaseUrl() + endpoint;
+    }
+
+    @Test
+    public void test_givenValidStudyId_whenRouteIsCalled_thenItReturns200() {
+        RestAssured.given().auth().oauth2(token)
+                .when().get(url)
+                .then().assertThat().statusCode(200);
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -118,7 +118,8 @@ import org.slf4j.LoggerFactory;
         UpdateUserEmailRouteTest.class,
         GetStudiesRouteTest.class,
         VerifyInvitationRouteTest.class,
-        StudyLanguageContentLanguageSettingFilterTest.class
+        StudyLanguageContentLanguageSettingFilterTest.class,
+        GetStudyDetailRouteTest.class
 })
 public class IntegrationTestSuite {
 


### PR DESCRIPTION
 ## Context and the big picture
Switches one more route to the new scheme of things described in https://broadinstitute.atlassian.net/browse/DDP-4366. `GetStudyDetailRoute` is in the study context but its path doesn't match `*/user/*studies/*` and it was not switched over because of that.

The route was not originally covered by tests so those were added along the way to make sure the change doesn't break anything.
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [ ] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [x] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [ ] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [ ] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [x] I have written automated positive tests
 - [] I have written automated negative tests
 - [ ] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
