### PR TITLE
docs: add api spec for participant-info endpoint

### DIFF
--- a/pepper-apis/docs/specification/src/components/responses.yml
+++ b/pepper-apis/docs/specification/src/components/responses.yml
@@ -403,6 +403,12 @@ StudyNotFoundErrorResponse:
     application/json:
       schema:
         $ref: '../pepper.yml#/components/schemas/Error.StudyNotFound'
+StudyParticipantsInfoResponse:
+  description: info about participants
+  content:
+    application/json:
+      schema:
+        $ref: '../pepper.yml#/components/schemas/StudyParticipantsInfo'
 StudyPasswordRequirementsResponse:
   description: an object describing constraints on the study password
   content:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1863,6 +1863,24 @@ ParticipantStatusTrackingInfo.Kit:
       type: string
     shipper:
       type: string
+
+StudyParticipantsInfo:
+  type: object
+  required:
+    - participantInfoList
+  properties:
+    participantInfoList:
+      type: array
+      description: list of participant info objects
+      items:
+        type: object
+        required:
+          - location
+        properties:
+          location:
+            type: string
+            description: location of the participant, in the form a plus code and converted to the precision set by the study
+
 ### StudyPasswordRequirements
 StudyPasswordRequirements:
   type: object

--- a/pepper-apis/docs/specification/src/endpoints/studies.participant-info.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.participant-info.yml
@@ -1,0 +1,18 @@
+get:
+  operationId: getStudyParticipantInfo
+  tags:
+    - Studies
+  summary: fetch study participant info
+  description: Returns info for enrolled participants, such as location in the form of plus codes. Results in an error if study is not configured to share data.
+  parameters:
+    - in: path
+      name: study
+      required: true
+      description: the study's guid
+      schema:
+        type: string
+  responses:
+    200:
+      $ref: '../pepper.yml#/components/responses/StudyParticipantsInfoResponse'
+    default:
+      $ref: '../pepper.yml#/components/responses/ErrorResponse'

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 servers: []
 info:
-  description: 'Specification for the Pepper API: `v1-Poblano`'
+  description: Specification for the Pepper API
   version: 1.0.0
   title: Pepper
   contact:
@@ -48,12 +48,14 @@ paths:
     $ref: 'endpoints/private/register.yml'
   /temporary-users:
     $ref: 'endpoints/temporary-users.yml'
-  /studies:
-    $ref: 'endpoints/studies.yml'
   /mailing-list:
     $ref: 'endpoints/join.mailing.list.yml'
+  /studies:
+    $ref: 'endpoints/studies.yml'
   /studies/{study}:
     $ref: 'endpoints/studies.study.yml'
+  /studies/participant-info/{study}:
+    $ref: 'endpoints/studies.participant-info.yml'
   /studies/{study}/password-requirements:
     $ref: 'endpoints/studies.password-requirements.yml'
   /studies/{study}/suggestions/drugs:


### PR DESCRIPTION
Came across an API that was not documented in our OpenAPI docs, so added some notes for it.

Rendered:
![Screen Shot 2020-02-26 at 1 20 39 PM](https://user-images.githubusercontent.com/5713833/75374826-f3feee80-589a-11ea-94ca-270aafb73d72.png)
