### PR TITLE
Streamline creation and update of sendgrid emails with study-builder

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
@@ -2,10 +2,13 @@ package org.broadinstitute.ddp.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
 import com.sendgrid.Attachments;
 import com.sendgrid.Mail;
 import com.sendgrid.Method;
@@ -21,14 +24,21 @@ import org.slf4j.LoggerFactory;
  */
 public class SendGridClient {
 
-    // Note: API endpoint paths should not have leading slash.
+    // Note: API endpoint paths should not have leading slash,
+    // and path parameters uses colon syntax like SparkJava.
     public static final String API_MAIL_SEND = "mail/send";
     public static final String API_TEMPLATES = "templates";
+    public static final String API_TEMPLATES_VERSIONS = "templates/:templateId/versions";
+    public static final String PARAM_TEMPLATE_ID = ":templateId";
 
     private static final Logger LOG = LoggerFactory.getLogger(SendGridClient.class);
     private static final Gson gson = new Gson();
     private static final String ATTACHMENT_DISPOSITION = "attachment";
     private static final String ATTACHMENT_PDF_TYPE = "application/pdf";
+    private static final String GEN_LEGACY = "legacy";
+    private static final String GEN_DYNAMIC = "dynamic";
+    private static final String EDITOR_CODE = "code";
+    private static final String EDITOR_DESIGN = "design";
 
     private final SendGrid sendGrid;
 
@@ -46,6 +56,120 @@ public class SendGridClient {
 
     public SendGridClient(SendGrid sendGrid) {
         this.sendGrid = sendGrid;
+    }
+
+    /**
+     * Create a new legacy template. Currently the error response is simply the string representation.
+     *
+     * @param name the name for the template
+     * @return result with created template, or error details
+     */
+    public ApiResult<Template, String> createTemplate(String name) {
+        Map<String, String> payload = new HashMap<>();
+        payload.put("name", name);
+        payload.put("generation", GEN_LEGACY);
+
+        Request request = new Request();
+        request.setMethod(Method.POST);
+        request.setEndpoint(API_TEMPLATES);
+        request.setBody(gson.toJson(payload));
+
+        try {
+            Response response = sendGrid.api(request);
+            int statusCode = response.getStatusCode();
+            if (statusCode == 201) {
+                Template template = gson.fromJson(response.getBody(), Template.class);
+                return ApiResult.ok(statusCode, template);
+            } else {
+                return ApiResult.err(statusCode, response.getBody());
+            }
+        } catch (IOException | JsonSyntaxException e) {
+            return ApiResult.thrown(e);
+        }
+    }
+
+    /**
+     * Create a new version for the given template with the code editor experience. Currently the error response is
+     * simply the string representation.
+     *
+     * @param templateId the template id
+     * @param name       the name for the version
+     * @param subject    the email subject
+     * @param html       the email html content
+     * @param isActive   is version active or not
+     * @return result with created version, or error details
+     */
+    public ApiResult<TemplateVersion, String> createTemplateVersion(
+            String templateId, String name, String subject, String html, boolean isActive) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("name", name);
+        payload.put("subject", subject);
+        payload.put("html_content", html);
+        payload.put("active", isActive ? 1 : 0);
+        payload.put("editor", EDITOR_CODE);
+
+        Request request = new Request();
+        request.setMethod(Method.POST);
+        request.setEndpoint(API_TEMPLATES_VERSIONS.replace(PARAM_TEMPLATE_ID, templateId));
+        request.setBody(gson.toJson(payload));
+
+        try {
+            Response response = sendGrid.api(request);
+            int statusCode = response.getStatusCode();
+            if (statusCode == 201) {
+                TemplateVersion version = gson.fromJson(response.getBody(), TemplateVersion.class);
+                return ApiResult.ok(statusCode, version);
+            } else {
+                return ApiResult.err(statusCode, response.getBody());
+            }
+        } catch (IOException | JsonSyntaxException e) {
+            return ApiResult.thrown(e);
+        }
+    }
+
+    /**
+     * Edit a template version. If arguments are `null`, then they will not be included in the PATCH payload. Currently
+     * the error response is simply the string representation.
+     *
+     * @param templateId the template id
+     * @param versionId  the version id
+     * @param name       the updated version name
+     * @param subject    the updated email subject
+     * @param html       the updated email html content
+     * @return result with updated version, or error details
+     */
+    public ApiResult<TemplateVersion, String> updateTemplateVersion(
+            String templateId, String versionId, String name, String subject, String html) {
+        Map<String, Object> payload = new HashMap<>();
+        if (name != null) {
+            payload.put("name", name);
+        }
+        if (subject != null) {
+            payload.put("subject", subject);
+        }
+        if (html != null) {
+            payload.put("html_content", html);
+        }
+
+        String path = API_TEMPLATES_VERSIONS.replace(PARAM_TEMPLATE_ID, templateId) + "/" + versionId;
+
+        Request request = new Request();
+        request.setMethod(Method.PATCH);
+        request.setEndpoint(path);
+        request.setBody(gson.toJson(payload));
+
+        try {
+            Response response = sendGrid.api(request);
+            int statusCode = response.getStatusCode();
+            if (statusCode == 200) {
+                TemplateVersion version = gson.fromJson(response.getBody(), TemplateVersion.class);
+                return ApiResult.ok(statusCode, version);
+            } else {
+                return ApiResult.err(statusCode, response.getBody());
+            }
+        } catch (IOException | JsonSyntaxException e) {
+            return ApiResult.thrown(e);
+        }
     }
 
     /**
@@ -69,10 +193,10 @@ public class SendGridClient {
 
             Template template = gson.fromJson(response.getBody(), Template.class);
             String versionId = null;
-            if (CollectionUtils.isNotEmpty(template.versions)) {
-                for (var version : template.versions) {
-                    if (version.active == 1) {
-                        versionId = version.id;
+            if (CollectionUtils.isNotEmpty(template.getVersions())) {
+                for (var version : template.getVersions()) {
+                    if (version.isActive()) {
+                        versionId = version.getId();
                         break;
                     }
                 }
@@ -111,28 +235,89 @@ public class SendGridClient {
         }
     }
 
-    // Currently the model classes below are only used for deserialization internally.
-    // If they are more broadly consumed, then they should be refactored.
-
-    static class Template {
-        public String id;
-        public String name;
-        public List<TemplateVersion> versions;
+    public static class Template {
+        private String id;
+        private String name;
+        private String generation;   // either `legacy` or `dynamic`
+        @SerializedName("updated_at")
+        private String updatedAt;
+        private List<TemplateVersion> versions;
 
         public Template(String id, String name, List<TemplateVersion> versions) {
             this.id = id;
             this.name = name;
             this.versions = versions;
         }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getGeneration() {
+            return generation;
+        }
+
+        public String getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public List<TemplateVersion> getVersions() {
+            return versions;
+        }
     }
 
-    static class TemplateVersion {
-        public String id;
-        public int active;  // 0 if inactive, 1 if active. Only one version can be active at a time.
+    public static class TemplateVersion {
+        private String id;
+        @SerializedName("template_id")
+        private String templateId;
+        private String name;
+        private String subject;
+        @SerializedName("html_content")
+        private String htmlContent;
+        @SerializedName("updated_at")
+        private String updatedAt;
+        private String editor;   // either `code` or `design`
+        private int active;      // 0 if inactive, 1 if active. Only one version can be active at a time.
 
         public TemplateVersion(String id, int active) {
             this.id = id;
             this.active = active;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getTemplateId() {
+            return templateId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getSubject() {
+            return subject;
+        }
+
+        public String getHtmlContent() {
+            return htmlContent;
+        }
+
+        public String getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public String getEditor() {
+            return editor;
+        }
+
+        public boolean isActive() {
+            return active == 1;
         }
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
@@ -40,6 +40,15 @@ public class SendGridClient {
     private static final String EDITOR_CODE = "code";
     private static final String EDITOR_DESIGN = "design";
 
+    private static final String KEY_NAME = "name";
+    private static final String KEY_GENERATION = "generation";
+    private static final String KEY_SUBJECT = "subject";
+    private static final String KEY_HTML_CONTENT = "html_content";
+    private static final String KEY_ACTIVE = "active";
+    private static final String KEY_EDITOR = "editor";
+    private static final String KEY_TEMPLATE_ID = "template_id";
+    private static final String KEY_UPDATED_AT = "updated_at";
+
     private final SendGrid sendGrid;
 
     // Convenient helper to create new pdf attachment for a mail.
@@ -66,8 +75,8 @@ public class SendGridClient {
      */
     public ApiResult<Template, String> createTemplate(String name) {
         Map<String, String> payload = new HashMap<>();
-        payload.put("name", name);
-        payload.put("generation", GEN_LEGACY);
+        payload.put(KEY_NAME, name);
+        payload.put(KEY_GENERATION, GEN_LEGACY);
 
         Request request = new Request();
         request.setMethod(Method.POST);
@@ -102,11 +111,11 @@ public class SendGridClient {
     public ApiResult<TemplateVersion, String> createTemplateVersion(
             String templateId, String name, String subject, String html, boolean isActive) {
         Map<String, Object> payload = new HashMap<>();
-        payload.put("name", name);
-        payload.put("subject", subject);
-        payload.put("html_content", html);
-        payload.put("active", isActive ? 1 : 0);
-        payload.put("editor", EDITOR_CODE);
+        payload.put(KEY_NAME, name);
+        payload.put(KEY_SUBJECT, subject);
+        payload.put(KEY_HTML_CONTENT, html);
+        payload.put(KEY_ACTIVE, isActive ? 1 : 0);
+        payload.put(KEY_EDITOR, EDITOR_CODE);
 
         Request request = new Request();
         request.setMethod(Method.POST);
@@ -142,13 +151,13 @@ public class SendGridClient {
             String templateId, String versionId, String name, String subject, String html) {
         Map<String, Object> payload = new HashMap<>();
         if (name != null) {
-            payload.put("name", name);
+            payload.put(KEY_NAME, name);
         }
         if (subject != null) {
-            payload.put("subject", subject);
+            payload.put(KEY_SUBJECT, subject);
         }
         if (html != null) {
-            payload.put("html_content", html);
+            payload.put(KEY_HTML_CONTENT, html);
         }
 
         String path = API_TEMPLATES_VERSIONS.replace(PARAM_TEMPLATE_ID, templateId) + "/" + versionId;
@@ -239,7 +248,7 @@ public class SendGridClient {
         private String id;
         private String name;
         private String generation;   // either `legacy` or `dynamic`
-        @SerializedName("updated_at")
+        @SerializedName(KEY_UPDATED_AT)
         private String updatedAt;
         private List<TemplateVersion> versions;
 
@@ -272,13 +281,13 @@ public class SendGridClient {
 
     public static class TemplateVersion {
         private String id;
-        @SerializedName("template_id")
+        @SerializedName(KEY_TEMPLATE_ID)
         private String templateId;
         private String name;
         private String subject;
-        @SerializedName("html_content")
+        @SerializedName(KEY_HTML_CONTENT)
         private String htmlContent;
-        @SerializedName("updated_at")
+        @SerializedName(KEY_UPDATED_AT)
         private String updatedAt;
         private String editor;   // either `code` or `design`
         private int active;      // 0 if inactive, 1 if active. Only one version can be active at a time.

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
@@ -76,13 +76,13 @@ public class EmailBuilder {
             EmailInfo email = createSendGridEmail(emailCfg);
             if (email != null) {
                 emails.add(email);
-                LOG.info("Created email {} with templateId={} versionId={}", email.key, email.templateId, email.versionId);
+                LOG.info("Created email {} with templateId={} versionId={}",
+                        email.getKey(), email.getTemplateId(), email.getVersionId());
             }
         }
-        if (!emails.isEmpty()) {
-            Map<String, String> mappings = emails.stream().collect(Collectors.toMap(e -> e.key, e -> e.templateId));
-            LOG.info("Created {} email templates:\n{}", emails.size(), prettyGson.toJson(mappings));
-        }
+        Map<String, String> mappings = emails.stream()
+                .collect(Collectors.toMap(EmailInfo::getKey, EmailInfo::getTemplateId));
+        LOG.info("Created {} email templates:\n{}", emails.size(), prettyGson.toJson(mappings));
     }
 
     private EmailInfo createSendGridEmail(Config emailCfg) {
@@ -138,12 +138,11 @@ public class EmailBuilder {
             EmailInfo email = updateSendGridEmail(emailCfg);
             if (email != null) {
                 emails.add(email);
-                LOG.info("Updated email {} with templateId={} versionId={}", email.key, email.templateId, email.versionId);
+                LOG.info("Updated email {} with templateId={} versionId={}",
+                        email.getKey(), email.getTemplateId(), email.getVersionId());
             }
         }
-        if (!emails.isEmpty()) {
-            LOG.info("Updated active versions of {} email templates", emails.size());
-        }
+        LOG.info("Updated active versions of {} email templates", emails.size());
     }
 
     private EmailInfo updateSendGridEmail(Config emailCfg) {
@@ -200,14 +199,26 @@ public class EmailBuilder {
     }
 
     private static class EmailInfo {
-        public String key;
-        public String templateId;
-        public String versionId;
+        private String key;
+        private String templateId;
+        private String versionId;
 
         public EmailInfo(String key, String templateId, String versionId) {
             this.key = key;
             this.templateId = templateId;
             this.versionId = versionId;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getTemplateId() {
+            return templateId;
+        }
+
+        public String getVersionId() {
+            return versionId;
         }
     }
 }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
@@ -1,0 +1,229 @@
+package org.broadinstitute.ddp.studybuilder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.typesafe.config.Config;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.broadinstitute.ddp.client.SendGridClient;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmailBuilder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EmailBuilder.class);
+    private static final int PROGRESS_STEP_COUNT = 5;
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+    private SendGridClient sendGrid;
+    private VelocityEngine velocity;
+
+    public EmailBuilder(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+        this.sendGrid = new SendGridClient(studyCfg.getString("sendgrid.apiKey"));
+        this.velocity = new VelocityEngine();
+        initVelocityEngine();
+    }
+
+    private void initVelocityEngine() {
+        // If templates reference a non-existing variable, then throw exception.
+        velocity.addProperty(RuntimeConstants.RUNTIME_REFERENCES_STRICT, true);
+        velocity.init();
+    }
+
+    public void createAll() {
+        createForConfigs(List.copyOf(studyCfg.getConfigList("sendgridEmails")));
+    }
+
+    public void createForFiles(String[] filepaths) {
+        List<Config> found = studyCfg.getConfigList("sendgridEmails")
+                .stream()
+                .filter(cfg -> {
+                    String path = cfgPath.getParent().resolve(cfg.getString("filepath")).toString();
+                    for (var filepath : filepaths) {
+                        if (path.endsWith(filepath)) {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .collect(Collectors.toList());
+        if (found.size() != filepaths.length) {
+            throw new DDPException("Could not find emails for all specified filepaths");
+        }
+        createForConfigs(found);
+    }
+
+    private void createForConfigs(List<Config> emailCfgs) {
+        List<EmailInfo> emails = new ArrayList<>();
+        for (int i = 0; i < emailCfgs.size(); i++) {
+            Config emailCfg = emailCfgs.get(i);
+            EmailInfo email = createSendGridEmail(emailCfg);
+            if (email != null) {
+                emails.add(email);
+            }
+            if ((i + 1) % PROGRESS_STEP_COUNT == 0) {
+                LOG.info("Processed {}/{} emails", i + 1, emailCfgs.size());
+            }
+        }
+
+        if (!emails.isEmpty()) {
+            String table = emails.stream()
+                    .map(email -> String.format("name=%s templateId=%s versionId=%s",
+                            email.name, email.templateId, email.versionId))
+                    .collect(Collectors.joining("\n"));
+            LOG.info("Created {} email templates:\n{}", emails.size(), table);
+        }
+    }
+
+    private EmailInfo createSendGridEmail(Config emailCfg) {
+        String name = emailCfg.getString("name");
+        String templateId = emailCfg.getString("templateId");
+        if (!templateId.isEmpty()) {
+            LOG.error("Email {} already has template id set to {}, not creating", name, templateId);
+            return null;
+        }
+
+        File file = cfgPath.getParent().resolve(emailCfg.getString("filepath")).toFile();
+        String html = readRawHtmlContent(file);
+        if (emailCfg.getBoolean("render")) {
+            html = renderHtmlContent(file.getName(), html);
+        }
+        String subject = emailCfg.getString("subject");
+
+        var templateResult = sendGrid.createTemplate(name);
+        templateResult.rethrowIfThrown(DDPException::new);
+        if (templateResult.hasError()) {
+            LOG.error("Error while creating email with name {}: {}", name, templateResult.getError());
+            return null;
+        }
+
+        templateId = templateResult.getBody().getId();
+        String versionId = null;
+
+        var versionResult = sendGrid.createTemplateVersion(templateId, name, subject, html, true);
+        versionResult.rethrowIfThrown(DDPException::new);
+        if (versionResult.hasError()) {
+            LOG.error("Error while creating version for email with name {}."
+                            + " You might need to manually create the version and run update-emails to load HTML content: {}",
+                    name, versionResult.getError());
+        } else {
+            versionId = versionResult.getBody().getId();
+        }
+
+        return new EmailInfo(name, templateId, versionId);
+    }
+
+    public void updateAll() {
+        updateForConfigs(List.copyOf(studyCfg.getConfigList("sendgridEmails")));
+    }
+
+    public void updateForTemplates(String[] templateIds) {
+        Set<String> ids = Set.of(templateIds);
+        List<Config> found = studyCfg.getConfigList("sendgridEmails")
+                .stream()
+                .filter(cfg -> ids.contains(cfg.getString("templateId")))
+                .collect(Collectors.toList());
+        if (found.size() != templateIds.length) {
+            throw new DDPException("Could not find emails for all specified template ids");
+        }
+        updateForConfigs(found);
+    }
+
+    private void updateForConfigs(List<Config> emailCfgs) {
+        List<EmailInfo> emails = new ArrayList<>();
+        for (int i = 0; i < emailCfgs.size(); i++) {
+            Config emailCfg = emailCfgs.get(i);
+            EmailInfo email = updateSendGridEmail(emailCfg);
+            if (email != null) {
+                emails.add(email);
+            }
+            if ((i + 1) % PROGRESS_STEP_COUNT == 0) {
+                LOG.info("Processed {}/{} emails", i + 1, emailCfgs.size());
+            }
+        }
+
+        if (!emails.isEmpty()) {
+            String table = emails.stream()
+                    .map(email -> String.format("name=%s templateId=%s versionId=%s",
+                            email.name, email.templateId, email.versionId))
+                    .collect(Collectors.joining("\n"));
+            LOG.info("Updated active versions of {} email templates:\n{}", emails.size(), table);
+        }
+    }
+
+    private EmailInfo updateSendGridEmail(Config emailCfg) {
+        File file = cfgPath.getParent().resolve(emailCfg.getString("filepath")).toFile();
+        String html = readRawHtmlContent(file);
+        if (emailCfg.getBoolean("render")) {
+            html = renderHtmlContent(file.getName(), html);
+        }
+        String subject = emailCfg.getString("subject");
+        String name = emailCfg.getString("name");
+        String templateId = emailCfg.getString("templateId");
+
+        var versionResult = sendGrid.getTemplateActiveVersionId(templateId);
+        versionResult.rethrowIfThrown(DDPException::new);
+        if (versionResult.hasError()) {
+            LOG.error("Could not find active version for email template id {}: {}",
+                    templateId, versionResult.getError());
+            return null;
+        }
+        String versionId = versionResult.getBody();
+
+        // Note: we're not updating version name since we didn't update template name, so we keep them the same.
+        var updateResult = sendGrid.updateTemplateVersion(templateId, versionId, null, subject, html);
+        updateResult.rethrowIfThrown(DDPException::new);
+        if (updateResult.hasError()) {
+            LOG.error("Error while updating active version {} for email template id {}: {}",
+                    versionId, templateId, versionResult.getError());
+            return null;
+        }
+
+        return new EmailInfo(name, templateId, versionId);
+    }
+
+    private String readRawHtmlContent(File file) {
+        if (!file.exists()) {
+            throw new DDPException("File " + file + " does not exist");
+        }
+        try {
+            return Files.readString(file.toPath());
+        } catch (IOException e) {
+            throw new DDPException(e);
+        }
+    }
+
+    private String renderHtmlContent(String name, String rawHtml) {
+        var ctx = new VelocityContext(varsCfg.root().unwrapped());
+        StringWriter writer = new StringWriter();
+        velocity.evaluate(ctx, writer, name, rawHtml);
+        return writer.toString();
+    }
+
+    private static class EmailInfo {
+        public String name;
+        public String templateId;
+        public String versionId;
+
+        public EmailInfo(String name, String templateId, String versionId) {
+            this.name = name;
+            this.templateId = templateId;
+            this.versionId = versionId;
+        }
+    }
+}

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EmailBuilder.java
@@ -6,7 +6,6 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +57,7 @@ public class EmailBuilder {
                 .filter(cfg -> remaining.remove(cfg.getString("key")))
                 .collect(Collectors.toList());
         if (!remaining.isEmpty()) {
-            throw new DDPException("Could not find emails for keys: " + Arrays.toString(remaining.toArray()));
+            throw new DDPException("Could not find emails for keys: " + remaining.toString());
         }
         return found;
     }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -3,7 +3,6 @@ package org.broadinstitute.ddp.studybuilder;
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -272,7 +271,7 @@ public class StudyBuilderCli {
                 log("executing creation of all study sendgrid emails...");
                 emailBuilder.createAll();
             } else {
-                log("executing creation of sendgrid emails with keys: " + Arrays.toString(keys.toArray()));
+                log("executing creation of sendgrid emails with keys: " + keys.toString());
                 emailBuilder.createForEmailKeys(keys);
             }
         } else {
@@ -280,7 +279,7 @@ public class StudyBuilderCli {
                 log("executing update of all study sendgrid emails...");
                 emailBuilder.updateAll();
             } else {
-                log("executing update of sendgrid emails with keys: " + Arrays.toString(keys.toArray()));
+                log("executing update of sendgrid emails with keys: " + keys.toString());
                 emailBuilder.updateForEmailKeys(keys);
             }
         }

--- a/study-builder/studies/osteo/emails/exit_request.html
+++ b/study-builder/studies/osteo/emails/exit_request.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Participant Withdraw Request</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>

--- a/study-builder/studies/osteo/emails/join_mailing_list.html
+++ b/study-builder/studies/osteo/emails/join_mailing_list.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
 
 <head>
-  <title>Thank you for signing up for the Osteosarcoma Project mailing list</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -98,7 +97,7 @@
 
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+    <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
   </tr>
 </table>
 </body>

--- a/study-builder/studies/osteo/emails/parental_about_child_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_about_child_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Follow-up Survey</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -103,7 +102,7 @@
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thanks for joining this movement. The answers that you provide are an invaluable resource for the osteosarcoma research community.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7155ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_blood_received.html
+++ b/study-builder/studies/osteo/emails/parental_blood_received.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you, your child's kit was received</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -90,11 +89,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you again for your participation in the Osteosarcoma Project. We have learned a tremendous amount from the answers that you have provided about your child's experiences with osteosarcoma, and we want you to know that you are critical to the success of each of our studies.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">As we learn more about osteosarcoma, we will keep you updated through emails, our blog, and social media. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">As we learn more about osteosarcoma, we will keep you updated through emails, our blog, and social media. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_blood_sent.html
+++ b/study-builder/studies/osteo/emails/parental_blood_sent.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project Check-In</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -90,11 +89,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">When you receive this kit, please open it up and read the instructions, and reach out to us if you have any questions. Then take this kit with you to your child's next blood draw. There are instructions for the person drawing your child's blood and information on how you can send the sample to us in a pre-stamped package provided as part of the kit.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_blood_sent_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_blood_sent_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project Check-In</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -88,11 +87,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you again for giving us your consent which will allow us to study a sample of your child's blood. We recently mailed you a kit with instructions on how to have a sample of blood drawn, and are now checking in to see if you received it.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have not yet received the kit, or if you have any questions about the process, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have not yet received the kit, or if you have any questions about the process, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_consent_1wk_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_consent_1wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_consent_2wk_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_consent_2wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_consent_3wk_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_consent_3wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_consent_completed.html
+++ b/study-builder/studies/osteo/emails/parental_consent_completed.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for providing your consent</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -101,11 +100,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_release_completed.html
+++ b/study-builder/studies/osteo/emails/parental_release_completed.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -94,11 +93,11 @@
 
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_release_reminder.html
+++ b/study-builder/studies/osteo/emails/parental_release_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please provide additional information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_saliva_received.html
+++ b/study-builder/studies/osteo/emails/parental_saliva_received.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you, your child's saliva kit was received</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -87,11 +86,11 @@
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Dear -ddp.proxy.firstName-,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for sending us a sample of your child's saliva. We're writing to let you know that we have received it.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Our next step will be to send out a request to your child's hospital(s) and clinic(s) to send us a copy of your child's medical records. Once we have received and reviewed your child's records, we may also send a request to your child's hospital(s) for a portion of stored tumor sample so that we can analyze it.</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/parental_welcome.html
+++ b/study-builder/studies/osteo/emails/parental_welcome.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -101,11 +100,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osoproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_child_contact.html
+++ b/study-builder/studies/osteo/emails/reconsent_child_contact.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Request for your child's contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions about this process and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions about this process and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_child_contact_1wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_child_contact_1wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Request for your child's contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_child_contact_2wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_child_contact_2wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Request for your child's contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_child_contact_4wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_child_contact_4wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Request for your child's contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_email_verification.html
+++ b/study-builder/studies/osteo/emails/reconsent_email_verification.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project - Email Verification & Consent</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -101,11 +100,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have any questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have any questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_next_steps.html
+++ b/study-builder/studies/osteo/emails/reconsent_next_steps.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project - Consent for Research</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -105,11 +104,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have any questions about this process or anything else, and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have any questions about this process or anything else, and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_next_steps_1wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_next_steps_1wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Sign the consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -107,11 +106,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_next_steps_2wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_next_steps_2wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Sign the consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -107,11 +106,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_next_steps_4wk_reminder.html
+++ b/study-builder/studies/osteo/emails/reconsent_next_steps_4wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Sign the consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -107,11 +106,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_release_completed.html
+++ b/study-builder/studies/osteo/emails/reconsent_release_completed.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -94,11 +93,11 @@
 
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/reconsent_thank_you.html
+++ b/study-builder/studies/osteo/emails/reconsent_thank_you.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for providing your consent</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. Please contact us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a> if you have any questions or concerns.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. Please contact us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a> if you have any questions or concerns.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_about_you_reminder.html
+++ b/study-builder/studies/osteo/emails/self_about_you_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Follow-up Survey</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -103,7 +102,7 @@
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thanks for joining this movement. The answers that you provide are an invaluable resource for the osteosarcoma research community.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_blood_received.html
+++ b/study-builder/studies/osteo/emails/self_blood_received.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you, your kit was received</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -90,11 +89,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you again for your participation in the Osteosarcoma Project. We have learned a tremendous amount from the answers that you have provided about your experiences with osteosarcoma, and we want you to know that you are critical to the success of each of our studies.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">As we learn more about osteosarcoma, we will keep you updated through emails, our blog, and social media. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">As we learn more about osteosarcoma, we will keep you updated through emails, our blog, and social media. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_blood_sent.html
+++ b/study-builder/studies/osteo/emails/self_blood_sent.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project Check-In</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -90,11 +89,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">When you receive this kit, please open it up and read the instructions, and reach out to us if you have any questions. Then take this kit with you to your next blood draw. There are instructions for the person drawing your blood and information on how you can send the sample to us in a pre-stamped package provided as part of the kit.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_blood_sent_reminder.html
+++ b/study-builder/studies/osteo/emails/self_blood_sent_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Osteosarcoma Project Check-In</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -88,11 +87,11 @@
 
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you again for giving us your consent which will allow us to study a sample of your blood. We recently mailed you a kit with instructions on how to have a sample of blood drawn, and are now checking in to see if you received it.</p>
 
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have not yet received the kit, or if you have any questions about the process, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have not yet received the kit, or if you have any questions about the process, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_consent_1wk_reminder.html
+++ b/study-builder/studies/osteo/emails/self_consent_1wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_consent_2wk_reminder.html
+++ b/study-builder/studies/osteo/emails/self_consent_2wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_consent_3wk_reminder.html
+++ b/study-builder/studies/osteo/emails/self_consent_3wk_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please sign the Osteosarcoma Project Consent form</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_consent_completed.html
+++ b/study-builder/studies/osteo/emails/self_consent_completed.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for providing your consent</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -101,11 +100,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For your convenience, we have attached a copy of your signed consent form. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_release_completed.html
+++ b/study-builder/studies/osteo/emails/self_release_completed.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your contact information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -94,11 +93,11 @@
 
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_release_reminder.html
+++ b/study-builder/studies/osteo/emails/self_release_reminder.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Reminder: Please provide additional information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -99,11 +98,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_saliva_received.html
+++ b/study-builder/studies/osteo/emails/self_saliva_received.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you, your saliva kit was received</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -87,11 +86,11 @@
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Dear -ddp.participant.firstName-,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for sending us a sample of your saliva. We're writing to let you know that we have received it.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Our next step will be to send out a request to your hospital(s) and clinic(s) to send us a copy of your medical records. Once we have received and reviewed your records, we may also send a request to your hospital(s) for a portion of stored tumor sample so that we can analyze it.</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/emails/self_welcome.html
+++ b/study-builder/studies/osteo/emails/self_welcome.html
@@ -2,7 +2,6 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your information</title>
   <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro&display=swap" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +74,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 50px 0 0 0; font-family: 'Source Sans Pro', sans-serif;">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/osteo/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/osteo/project-logo.png"
              alt="Osteosarcoma Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="230px" height="63px" border="0">
       </a>
@@ -101,11 +100,11 @@
   </tr>
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@osoproject.org" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">info@osproject.org</a>
-        or call <a href="tel:651-602-2020" style="color: #7154ff; text-decoration: none; cursor: pointer;">651-602-2020</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Thank you for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:${contact.email}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.email}</a>
+        or call <a href="tel:${contact.phone}" style="color: #7154ff; text-decoration: none; cursor: pointer;">${contact.phone}</a>.</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">Sincerely,</p>
       <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">The Osteosarcoma Project Team</p>
-      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="https://twitter.com/the_osproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="https://www.facebook.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="https://www.instagram.com/osteosarcomaproject/" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
+      <p style="font-family: 'Source Sans Pro', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">For additional updates, follow us on <a href="${social.twitter}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Twitter</a>, <a href="${social.facebook}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Facebook</a> or <a href="${social.instagram}" target="_blank" style="color: #7154ff; text-decoration: none; cursor: pointer;">Instagram</a>.</p>
     </td>
   </tr>
 </table>

--- a/study-builder/studies/osteo/sendgrid_emails.conf
+++ b/study-builder/studies/osteo/sendgrid_emails.conf
@@ -1,0 +1,263 @@
+{
+  "sendgridEmails": [
+    {
+      "templateId": ${emails.exitRequest},
+      "name": "OSTEO_EXIT_REQUEST",
+      "subject": "Participant Withdraw Request",
+      "filepath": "emails/exit_request.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.joinMailingList},
+      "name": "OSTEO_JOIN_MAILING_LIST",
+      "subject": "Thank you for signing up for the Osteosarcoma Project mailing list",
+      "filepath": "emails/join_mailing_list.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.aboutChildReminder},
+      "name": "OSTEO_PARENTAL_ABOUT_CHILD_REMINDER",
+      "subject": "Reminder: Follow-up Survey",
+      "filepath": "emails/parental_about_child_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalBloodReceived},
+      "name": "OSTEO_PARENTAL_BLOOD_RECEIVED",
+      "subject": "Thank you, your child's kit was received",
+      "filepath": "emails/parental_blood_received.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalBloodSent},
+      "name": "OSTEO_PARENTAL_BLOOD_SENT",
+      "subject": "Osteosarcoma Project Check-In",
+      "filepath": "emails/parental_blood_sent.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalBloodSentReminder},
+      "name": "OSTEO_PARENTAL_BLOOD_SENT_REMINDER",
+      "subject": "Osteosarcoma Project Check-In",
+      "filepath": "emails/parental_blood_sent_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalConsent1wkReminder},
+      "name": "OSTEO_PARENTAL_CONSENT_1WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/parental_consent_1wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalConsent2wkReminder},
+      "name": "OSTEO_PARENTAL_CONSENT_2WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/parental_consent_2wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalConsent3wkReminder},
+      "name": "OSTEO_PARENTAL_CONSENT_3WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/parental_consent_3wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalConsentCompleted},
+      "name": "OSTEO_PARENTAL_CONSENT_COMPLETED",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/parental_consent_completed.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalReleaseCompleted},
+      "name": "OSTEO_PARENTAL_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/parental_release_completed.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalReleaseReminder},
+      "name": "OSTEO_PARENTAL_RELEASE_REMINDER",
+      "subject": "Reminder: Please provide additional information",
+      "filepath": "emails/parental_release_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalSalivaReceived},
+      "name": "OSTEO_PARENTAL_SALIVA_RECEIVED",
+      "subject": "Thank you, your child's saliva kit was received",
+      "filepath": "emails/parental_saliva_received.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.parentalWelcome},
+      "name": "OSTEO_PARENTAL_WELCOME",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/parental_welcome.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentChildContact},
+      "name": "OSTEO_RECONSENT_CHILD_CONTACT",
+      "subject": "Request for your child's contact information",
+      "filepath": "emails/reconsent_child_contact.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentChildContact1wkReminder},
+      "name": "OSTEO_RECONSENT_CHILD_CONTACT_1WK_REMINDER",
+      "subject": "Reminder: Request for your child's contact information",
+      "filepath": "emails/reconsent_child_contact_1wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentChildContact2wkReminder},
+      "name": "OSTEO_RECONSENT_CHILD_CONTACT_2WK_REMINDER",
+      "subject": "Reminder: Request for your child's contact information",
+      "filepath": "emails/reconsent_child_contact_2wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentChildContact4wkReminder},
+      "name": "OSTEO_RECONSENT_CHILD_CONTACT_4WK_REMINDER",
+      "subject": "Reminder: Request for your child's contact information",
+      "filepath": "emails/reconsent_child_contact_4wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentEmailVerification},
+      "name": "OSTEO_RECONSENT_EMAIL_VERIFICATION",
+      "subject": "Osteosarcoma Project - Email Verification & Consent",
+      "filepath": "emails/reconsent_email_verification.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentNextSteps},
+      "name": "OSTEO_RECONSENT_NEXT_STEPS",
+      "subject": "Osteosarcoma Project - Consent for Research",
+      "filepath": "emails/reconsent_next_steps.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentNextSteps1wkReminder},
+      "name": "OSTEO_RECONSENT_NEXT_STEPS_1WK_REMINDER",
+      "subject": "Reminder: Sign the consent form",
+      "filepath": "emails/reconsent_next_steps_1wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentNextSteps2wkReminder},
+      "name": "OSTEO_RECONSENT_NEXT_STEPS_2WK_REMINDER",
+      "subject": "Reminder: Sign the consent form",
+      "filepath": "emails/reconsent_next_steps_2wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentNextSteps4wkReminder},
+      "name": "OSTEO_RECONSENT_NEXT_STEPS_4WK_REMINDER",
+      "subject": "Reminder: Sign the consent form",
+      "filepath": "emails/reconsent_next_steps_4wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentReleaseCompleted},
+      "name": "OSTEO_RECONSENT_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/reconsent_release_completed.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.reconsentThankYou},
+      "name": "OSTEO_RECONSENT_THANK_YOU",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/reconsent_thank_you.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.aboutYouReminder},
+      "name": "OSTEO_SELF_ABOUT_YOU_REMINDER",
+      "subject": "Reminder: Follow-up Survey",
+      "filepath": "emails/self_about_you_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfBloodReceived},
+      "name": "OSTEO_SELF_BLOOD_RECEIVED",
+      "subject": "Thank you, your kit was received",
+      "filepath": "emails/self_blood_received.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfBloodSent},
+      "name": "OSTEO_SELF_BLOOD_SENT",
+      "subject": "Osteosarcoma Project Check-In",
+      "filepath": "emails/self_blood_sent.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfBloodSentReminder},
+      "name": "OSTEO_SELF_BLOOD_SENT_REMINDER",
+      "subject": "Osteosarcoma Project Check-In",
+      "filepath": "emails/self_blood_sent_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfConsent1wkReminder},
+      "name": "OSTEO_SELF_CONSENT_1WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/self_consent_1wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfConsent2wkReminder},
+      "name": "OSTEO_SELF_CONSENT_2WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/self_consent_2wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfConsent3wkReminder},
+      "name": "OSTEO_SELF_CONSENT_3WK_REMINDER",
+      "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
+      "filepath": "emails/self_consent_3wk_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfConsentCompleted},
+      "name": "OSTEO_SELF_CONSENT_COMPLETED",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/self_consent_completed.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfReleaseCompleted},
+      "name": "OSTEO_SELF_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/self_release_completed.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfReleaseReminder},
+      "name": "OSTEO_SELF_RELEASE_REMINDER",
+      "subject": "Reminder: Please provide additional information",
+      "filepath": "emails/self_release_reminder.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfSalivaReceived},
+      "name": "OSTEO_SELF_SALIVA_RECEIVED",
+      "subject": "Thank you, your saliva kit was received",
+      "filepath": "emails/self_saliva_received.html",
+      "render": true
+    },
+    {
+      "templateId": ${emails.selfWelcome},
+      "name": "OSTEO_SELF_WELCOME",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/self_welcome.html",
+      "render": true
+    }
+  ]
+}

--- a/study-builder/studies/osteo/sendgrid_emails.conf
+++ b/study-builder/studies/osteo/sendgrid_emails.conf
@@ -1,259 +1,259 @@
 {
   "sendgridEmails": [
     {
-      "templateId": ${emails.exitRequest},
+      "key": "exitRequest",
       "name": "OSTEO_EXIT_REQUEST",
       "subject": "Participant Withdraw Request",
       "filepath": "emails/exit_request.html",
       "render": true
     },
     {
-      "templateId": ${emails.joinMailingList},
+      "key": "joinMailingList",
       "name": "OSTEO_JOIN_MAILING_LIST",
       "subject": "Thank you for signing up for the Osteosarcoma Project mailing list",
       "filepath": "emails/join_mailing_list.html",
       "render": true
     },
     {
-      "templateId": ${emails.aboutChildReminder},
+      "key": "aboutChildReminder",
       "name": "OSTEO_PARENTAL_ABOUT_CHILD_REMINDER",
       "subject": "Reminder: Follow-up Survey",
       "filepath": "emails/parental_about_child_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalBloodReceived},
+      "key": "parentalBloodReceived",
       "name": "OSTEO_PARENTAL_BLOOD_RECEIVED",
       "subject": "Thank you, your child's kit was received",
       "filepath": "emails/parental_blood_received.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalBloodSent},
+      "key": "parentalBloodSent",
       "name": "OSTEO_PARENTAL_BLOOD_SENT",
       "subject": "Osteosarcoma Project Check-In",
       "filepath": "emails/parental_blood_sent.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalBloodSentReminder},
+      "key": "parentalBloodSentReminder",
       "name": "OSTEO_PARENTAL_BLOOD_SENT_REMINDER",
       "subject": "Osteosarcoma Project Check-In",
       "filepath": "emails/parental_blood_sent_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalConsent1wkReminder},
+      "key": "parentalConsent1wkReminder",
       "name": "OSTEO_PARENTAL_CONSENT_1WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/parental_consent_1wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalConsent2wkReminder},
+      "key": "parentalConsent2wkReminder",
       "name": "OSTEO_PARENTAL_CONSENT_2WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/parental_consent_2wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalConsent3wkReminder},
+      "key": "parentalConsent3wkReminder",
       "name": "OSTEO_PARENTAL_CONSENT_3WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/parental_consent_3wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalConsentCompleted},
+      "key": "parentalConsentCompleted",
       "name": "OSTEO_PARENTAL_CONSENT_COMPLETED",
       "subject": "Thank you for providing your consent",
       "filepath": "emails/parental_consent_completed.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalReleaseCompleted},
+      "key": "parentalReleaseCompleted",
       "name": "OSTEO_PARENTAL_RELEASE_COMPLETED",
       "subject": "Thank you for submitting your contact information",
       "filepath": "emails/parental_release_completed.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalReleaseReminder},
+      "key": "parentalReleaseReminder",
       "name": "OSTEO_PARENTAL_RELEASE_REMINDER",
       "subject": "Reminder: Please provide additional information",
       "filepath": "emails/parental_release_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalSalivaReceived},
+      "key": "parentalSalivaReceived",
       "name": "OSTEO_PARENTAL_SALIVA_RECEIVED",
       "subject": "Thank you, your child's saliva kit was received",
       "filepath": "emails/parental_saliva_received.html",
       "render": true
     },
     {
-      "templateId": ${emails.parentalWelcome},
+      "key": "parentalWelcome",
       "name": "OSTEO_PARENTAL_WELCOME",
       "subject": "Thank you for submitting your information",
       "filepath": "emails/parental_welcome.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentChildContact},
+      "key": "reconsentChildContact",
       "name": "OSTEO_RECONSENT_CHILD_CONTACT",
       "subject": "Request for your child's contact information",
       "filepath": "emails/reconsent_child_contact.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentChildContact1wkReminder},
+      "key": "reconsentChildContact1wkReminder",
       "name": "OSTEO_RECONSENT_CHILD_CONTACT_1WK_REMINDER",
       "subject": "Reminder: Request for your child's contact information",
       "filepath": "emails/reconsent_child_contact_1wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentChildContact2wkReminder},
+      "key": "reconsentChildContact2wkReminder",
       "name": "OSTEO_RECONSENT_CHILD_CONTACT_2WK_REMINDER",
       "subject": "Reminder: Request for your child's contact information",
       "filepath": "emails/reconsent_child_contact_2wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentChildContact4wkReminder},
+      "key": "reconsentChildContact4wkReminder",
       "name": "OSTEO_RECONSENT_CHILD_CONTACT_4WK_REMINDER",
       "subject": "Reminder: Request for your child's contact information",
       "filepath": "emails/reconsent_child_contact_4wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentEmailVerification},
+      "key": "reconsentEmailVerification",
       "name": "OSTEO_RECONSENT_EMAIL_VERIFICATION",
       "subject": "Osteosarcoma Project - Email Verification & Consent",
       "filepath": "emails/reconsent_email_verification.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentNextSteps},
+      "key": "reconsentNextSteps",
       "name": "OSTEO_RECONSENT_NEXT_STEPS",
       "subject": "Osteosarcoma Project - Consent for Research",
       "filepath": "emails/reconsent_next_steps.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentNextSteps1wkReminder},
+      "key": "reconsentNextSteps1wkReminder",
       "name": "OSTEO_RECONSENT_NEXT_STEPS_1WK_REMINDER",
       "subject": "Reminder: Sign the consent form",
       "filepath": "emails/reconsent_next_steps_1wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentNextSteps2wkReminder},
+      "key": "reconsentNextSteps2wkReminder",
       "name": "OSTEO_RECONSENT_NEXT_STEPS_2WK_REMINDER",
       "subject": "Reminder: Sign the consent form",
       "filepath": "emails/reconsent_next_steps_2wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentNextSteps4wkReminder},
+      "key": "reconsentNextSteps4wkReminder",
       "name": "OSTEO_RECONSENT_NEXT_STEPS_4WK_REMINDER",
       "subject": "Reminder: Sign the consent form",
       "filepath": "emails/reconsent_next_steps_4wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentReleaseCompleted},
+      "key": "reconsentReleaseCompleted",
       "name": "OSTEO_RECONSENT_RELEASE_COMPLETED",
       "subject": "Thank you for submitting your contact information",
       "filepath": "emails/reconsent_release_completed.html",
       "render": true
     },
     {
-      "templateId": ${emails.reconsentThankYou},
+      "key": "reconsentThankYou",
       "name": "OSTEO_RECONSENT_THANK_YOU",
       "subject": "Thank you for providing your consent",
       "filepath": "emails/reconsent_thank_you.html",
       "render": true
     },
     {
-      "templateId": ${emails.aboutYouReminder},
+      "key": "aboutYouReminder",
       "name": "OSTEO_SELF_ABOUT_YOU_REMINDER",
       "subject": "Reminder: Follow-up Survey",
       "filepath": "emails/self_about_you_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfBloodReceived},
+      "key": "selfBloodReceived",
       "name": "OSTEO_SELF_BLOOD_RECEIVED",
       "subject": "Thank you, your kit was received",
       "filepath": "emails/self_blood_received.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfBloodSent},
+      "key": "selfBloodSent",
       "name": "OSTEO_SELF_BLOOD_SENT",
       "subject": "Osteosarcoma Project Check-In",
       "filepath": "emails/self_blood_sent.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfBloodSentReminder},
+      "key": "selfBloodSentReminder",
       "name": "OSTEO_SELF_BLOOD_SENT_REMINDER",
       "subject": "Osteosarcoma Project Check-In",
       "filepath": "emails/self_blood_sent_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfConsent1wkReminder},
+      "key": "selfConsent1wkReminder",
       "name": "OSTEO_SELF_CONSENT_1WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/self_consent_1wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfConsent2wkReminder},
+      "key": "selfConsent2wkReminder",
       "name": "OSTEO_SELF_CONSENT_2WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/self_consent_2wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfConsent3wkReminder},
+      "key": "selfConsent3wkReminder",
       "name": "OSTEO_SELF_CONSENT_3WK_REMINDER",
       "subject": "Reminder: Please sign the Osteosarcoma Project Consent form",
       "filepath": "emails/self_consent_3wk_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfConsentCompleted},
+      "key": "selfConsentCompleted",
       "name": "OSTEO_SELF_CONSENT_COMPLETED",
       "subject": "Thank you for providing your consent",
       "filepath": "emails/self_consent_completed.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfReleaseCompleted},
+      "key": "selfReleaseCompleted",
       "name": "OSTEO_SELF_RELEASE_COMPLETED",
       "subject": "Thank you for submitting your contact information",
       "filepath": "emails/self_release_completed.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfReleaseReminder},
+      "key": "selfReleaseReminder",
       "name": "OSTEO_SELF_RELEASE_REMINDER",
       "subject": "Reminder: Please provide additional information",
       "filepath": "emails/self_release_reminder.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfSalivaReceived},
+      "key": "selfSalivaReceived",
       "name": "OSTEO_SELF_SALIVA_RECEIVED",
       "subject": "Thank you, your saliva kit was received",
       "filepath": "emails/self_saliva_received.html",
       "render": true
     },
     {
-      "templateId": ${emails.selfWelcome},
+      "key": "selfWelcome",
       "name": "OSTEO_SELF_WELCOME",
       "subject": "Thank you for submitting your information",
       "filepath": "emails/self_welcome.html",

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -108,6 +108,8 @@
     "defaultSalutation": ${sendgridDefaultSalutation}
   },
 
+  include required("sendgrid_emails.conf"),
+
   "kits": [
     {
       "type": "SALIVA",

--- a/study-builder/studies/osteo/subs.conf
+++ b/study-builder/studies/osteo/subs.conf
@@ -1,0 +1,11 @@
+{
+  "contact": {
+    "email": "info@osproject.org",
+    "phone": "651-602-2020"
+  },
+  "social": {
+    "twitter": "https://twitter.com/the_osproject/",
+    "facebook": "https://www.facebook.com/osteosarcomaproject/",
+    "instagram": "https://www.instagram.com/the_osproject/"
+  }
+}

--- a/study-builder/studies/study-example.conf
+++ b/study-builder/studies/study-example.conf
@@ -99,10 +99,10 @@
   # Note that sendgrid credentials should be configured for the study. See `sendgrid.apiKey` above.
   "sendgridEmails": [
     {
-      # Id of the email template in sendgrid.
+      # Identifier for the email template.
       #
-      # Can set as empty string when creating emails, but needs to be set to id for updating.
-      "templateId": "string",
+      # This should be the same key used in `emails` config object in `vars.conf` that maps the key to a template id.
+      "key": "string",
 
       # Name of the template.
       #

--- a/study-builder/studies/study-example.conf
+++ b/study-builder/studies/study-example.conf
@@ -93,6 +93,46 @@
     "defaultSalutation": "string"
   },
 
+  # List of sendgrid email configuration objects.
+  #
+  # These are used when creating legacy email templates in sendgrid, or to lookup emails for updating.
+  # Note that sendgrid credentials should be configured for the study. See `sendgrid.apiKey` above.
+  "sendgridEmails": [
+    {
+      # Id of the email template in sendgrid.
+      #
+      # Can set as empty string when creating emails, but needs to be set to id for updating.
+      "templateId": "string",
+
+      # Name of the template.
+      #
+      # This will be use for BOTH the template name and version name when creating a new template.
+      # Note that the name will not be updated when updating the email.
+      "name": "string",
+
+      # The email subject to use.
+      #
+      # This can be set to sendgrid's default of `<%subject%>`.
+      "subject": "string",
+
+      # Path to the email template HTML file, relative to the top-level study config file.
+      "filepath": "string",
+
+      # Whether to render the HTML file.
+      #
+      # If true, HTML file will be rendered using the Apache Velocity templating engine. Currently,
+      # the entire vars config object is made available for templating. These values can be accessed
+      # in the HTML file using Velocity's syntax, e.g. `$assetsBucketName` or `$auth0.domain`.
+      #
+      # Tip: Velocity's formal reference notation can be used, so that the syntax is much closer to
+      # config file's syntax, e.g. `${assetsBucketName}` or `${auth0.domain}`.
+      #
+      # Caution: if using render, make sure the HTML doesn't have usages of special characters like
+      # `$` and `#` that has special meaning to Velocity.
+      "render": "bool"
+    }
+  ]
+
   # Kit configurations.
   #
   # Kits will be created for participants based on


### PR DESCRIPTION
## Context

Are you sick of manually copy&pasting emails into SendGrid? Are you getting dizzy editing social media links in 30+ email files? Do you get confused where to grab the email subject line from?

No more. Introducing new flags in study-builder: `--create-emails` and `--update-emails`. These flags will read the study's email configuration and manages creating or updating the email templates in SendGrid for you. Need to create/update a single or a few emails only? No problem, the `--email-keys` flag has your back. It takes a comma-separated list of keys (e.g. `exitRequest,joinMailingList`) and will only do emails with those keys. Use the `--help` flag for more info.

What's more, you can also do "templating" with the email HTML files and substitute in values! For example, we can centralize the social media links to one place, and reference them in all the email files using variables like `${social.twitter}`. This is done by leveraging the recently added `--substitutions` feature for centralizing substitution values, and by adding templating via the Apache Velocity library. We already use Velocity for activity content templates, so I'm re-using that library here.

As good as it sounds, it does not solve all the issues. The emails are not created/updated as part of the normal "initialize study" command in study-builder. And it's still a bit of manual work where a developer needs to specifically invoke these new commands.

For new studies, I imagine the way we'll go about emails is:
1. Write up the email HTML files, and adding the email configurations.
2. Run `--create-emails` command to create emails in SendGrid.
3. From the command output, copy the template ids and store them in vault.
4. Now we can use the templates in the regular "initialize study".
5. If needed, we can run `--update-emails` command to update emails in SendGrid.

All-in-all, I think this is a vast improvement on what we currently do. Another big improvement we can do is starting to support "dynamic" email templates, which will seriously cut down the number of email files we have to maintain...

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
    - We should probably run this in production to fix typos in some Osteo emails

