### PR TITLE
Ddp 4359 change 409 to 500 if multiple answers detected

### DIFF
--- a/pepper-apis/docs/specification/src/components/responses.yml
+++ b/pepper-apis/docs/specification/src/components/responses.yml
@@ -75,12 +75,6 @@ ActivityAnswersPatchBadPayloadResponse:
     application/json:
       schema:
         $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersPatchBadPayload'
-ActivityAnswersMoreThanOneAnswerResponse:
-  description: multiple answers exist for the question. Something is very wrong
-  content:
-    application/json:
-      schema:
-        $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersInternalServerError'
 ActivityAnswersPatchInvalidResponse:
   description: activity instance is read-only or answer submission failed validation
   content:

--- a/pepper-apis/docs/specification/src/components/responses.yml
+++ b/pepper-apis/docs/specification/src/components/responses.yml
@@ -75,12 +75,12 @@ ActivityAnswersPatchBadPayloadResponse:
     application/json:
       schema:
         $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersPatchBadPayload'
-ActivityAnswersPatchExistsResponse:
-  description: answer already exists for question, `answerGuid` should be specified
+ActivityAnswersMoreThanOneAnswerResponse:
+  description: multiple answers exist for the question. Something is very wrong
   content:
     application/json:
       schema:
-        $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersPatchExists'
+        $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersInternalServerError'
 ActivityAnswersPatchInvalidResponse:
   description: activity instance is read-only or answer submission failed validation
   content:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -856,7 +856,7 @@ Error.ActivityAnswersInternalServerError:
           type: string
           enum:
             # Indicates than the question has multiple answers
-            - UNEXPECTED_NUMBER_OF_ELEMENTS
+            - SERVER_ERROR
 Error.ActivityAnswersPatchInvalid:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Error'

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -847,20 +847,16 @@ Error.ActivityAnswersPatchBadPayload:
             - NO_SUCH_ELEMENT
             - REQUIRED_PARAMETER_MISSING
             - UNEXPECTED_NUMBER_OF_ELEMENTS
-Error.ActivityAnswersPatchExists:
+Error.ActivityAnswersInternalServerError:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Error'
     - type: object
-      required:
-        - stableId
       properties:
         code:
           type: string
           enum:
-            - ANSWER_EXISTS
-        stableId:
-          type: string
-          description: identifier of question with existing answer
+            # Indicates than the question has multiple answers
+            - UNEXPECTED_NUMBER_OF_ELEMENTS
 Error.ActivityAnswersPatchInvalid:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Error'

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
@@ -35,8 +35,8 @@ patch:
     `answerGuid` will be treated as an update and the referenced answer will
     be updated accordingly. If `answerGuid` is missing, the server attempts to
     find and update an existing answer only if the question has a single
-    answer. Otherwise, it responses with `409 Conflict`. The response body
-    will contain more details about what failed.
+    answer. Otherwise, it responses with `500 Internal Server Error`. The
+    response body will contain more details about what failed.
 
     **Answer Validations**
 
@@ -64,8 +64,8 @@ patch:
       description: missing credentials or temporary user is invalid
     404:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchNotFoundResponse'
-    409:
-      $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchExistsResponse'
+    500:
+      $ref: '../pepper.yml#/components/responses/ActivityAnswersMoreThanOneAnswerResponse'
     422:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchInvalidResponse'
     default:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
@@ -65,7 +65,7 @@ patch:
     404:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchNotFoundResponse'
     500:
-      $ref: '../pepper.yml#/components/responses/ActivityAnswersMoreThanOneAnswerResponse'
+      $ref: '../pepper.yml#/components/responses/ErrorResponse'
     422:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchInvalidResponse'
     default:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
@@ -64,8 +64,6 @@ patch:
       description: missing credentials or temporary user is invalid
     404:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchNotFoundResponse'
-    500:
-      $ref: '../pepper.yml#/components/responses/ErrorResponse'
     422:
       $ref: '../pepper.yml#/components/responses/ActivityAnswersPatchInvalidResponse'
     default:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -212,7 +212,8 @@ public class PatchFormAnswersRoute implements Route {
                                     .findAnswerIdsByInstanceGuidAndQuestionId(instanceGuid, questionDto.getId());
                             if (answerIds.size() > 1) {
                                 String errMsg = String.format(
-                                        "A question can have 1 and only 1 answer but found %d answers instead",
+                                        "A question %s is expected to have 1 answer but found %d answers instead",
+                                        questionStableId,
                                         answerIds.size()
                                 );
                                 LOG.error(errMsg);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -212,7 +212,7 @@ public class PatchFormAnswersRoute implements Route {
                                     .findAnswerIdsByInstanceGuidAndQuestionId(instanceGuid, questionDto.getId());
                             if (answerIds.size() > 1) {
                                 String errMsg = String.format(
-                                        "A question %s is expected to have 1 answer but found %d answers instead",
+                                        "Question %s is expected to have 1 answer but found %d answers instead",
                                         questionStableId,
                                         answerIds.size()
                                 );

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -40,7 +40,6 @@ import org.broadinstitute.ddp.db.dto.LanguageDto;
 import org.broadinstitute.ddp.db.dto.NumericQuestionDto;
 import org.broadinstitute.ddp.db.dto.QuestionDto;
 import org.broadinstitute.ddp.exception.DDPException;
-import org.broadinstitute.ddp.exception.MoreThanOneAnswerForQuestionExistsException;
 import org.broadinstitute.ddp.exception.OperationNotAllowedException;
 import org.broadinstitute.ddp.exception.RequiredParameterMissingException;
 import org.broadinstitute.ddp.exception.UnexpectedNumberOfElementsException;
@@ -213,12 +212,11 @@ public class PatchFormAnswersRoute implements Route {
                                     .findAnswerIdsByInstanceGuidAndQuestionId(instanceGuid, questionDto.getId());
                             if (answerIds.size() > 1) {
                                 String errMsg = String.format(
-                                        "A question can have 1 and only 1 answer but found %d answers instead. "
-                                        + "Answer ids: %s",
-                                        answerIds.size(),
-                                        answerIds.toString()
+                                        "A question can have 1 and only 1 answer but found %d answers instead",
+                                        answerIds.size()
                                 );
-                                throw new MoreThanOneAnswerForQuestionExistsException(errMsg);
+                                LOG.error(errMsg);
+                                throw ResponseUtil.haltError(response, 500, new ApiError(ErrorCodes.SERVER_ERROR, errMsg));
                             } else if (answerIds.size() == 1) {
                                 answerId = answerIds.iterator().next();
                             }
@@ -263,9 +261,6 @@ public class PatchFormAnswersRoute implements Route {
             } catch (RequiredParameterMissingException e) {
                 LOG.warn(e.getMessage());
                 throw ResponseUtil.haltError(response, 400, new ApiError(ErrorCodes.REQUIRED_PARAMETER_MISSING, e.getMessage()));
-            } catch (MoreThanOneAnswerForQuestionExistsException e) {
-                LOG.error(e.getMessage());
-                throw ResponseUtil.haltError(response, 500, new ApiError(ErrorCodes.UNEXPECTED_NUMBER_OF_ELEMENTS, e.getMessage()));
             }
 
             res.setBlockVisibilities(formService.getBlockVisibilities(handle, participantGuid, instanceGuid));

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.route;
 
 import static io.restassured.RestAssured.given;
+
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -8,6 +9,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -25,19 +27,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
+
 import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
+
 import liquibase.util.StringUtils;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.util.EntityUtils;
+
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.API;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;
@@ -61,7 +68,6 @@ import org.broadinstitute.ddp.json.AnswerResponse;
 import org.broadinstitute.ddp.json.AnswerSubmission;
 import org.broadinstitute.ddp.json.PatchAnswerPayload;
 import org.broadinstitute.ddp.json.PatchAnswerResponse;
-import org.broadinstitute.ddp.json.errors.AnswerExistsError;
 import org.broadinstitute.ddp.json.errors.AnswerValidationError;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
@@ -105,8 +111,11 @@ import org.broadinstitute.ddp.model.activity.types.TemplateType;
 import org.broadinstitute.ddp.model.activity.types.TextInputType;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.broadinstitute.ddp.util.TestUtil;
+
 import org.eclipse.jetty.http.HttpStatus;
+
 import org.jdbi.v3.core.Handle;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -494,7 +503,7 @@ public class PatchFormAnswersRouteTest extends IntegrationTestSuite.TestCase {
     }
 
     @Test
-    public void testPatch_noGuid_multipleExistingAnswer() throws Exception {
+    public void test_givenQuestionHasMultipleAnswers_whenEndpointIsCalled_thenItReturns500() throws Exception {
         TransactionWrapper.useTxn(handle -> {
             Answer answer = new BoolAnswer(null, boolStableId, null, true);
             createAnswerAndDeferCleanup(handle, answer);
@@ -508,12 +517,12 @@ public class PatchFormAnswersRouteTest extends IntegrationTestSuite.TestCase {
 
         Request request = RouteTestUtil.buildAuthorizedPatchRequest(token, url, gson.toJson(data));
         HttpResponse response = request.execute().returnResponse();
-        assertEquals(409, response.getStatusLine().getStatusCode());
+        assertEquals(500, response.getStatusLine().getStatusCode());
 
         String json = EntityUtils.toString(response.getEntity());
-        AnswerExistsError resp = gson.fromJson(json, AnswerExistsError.class);
-        assertEquals(ErrorCodes.ANSWER_EXISTS, resp.getCode());
-        assertEquals(boolStableId, resp.getStableId());
+        ApiError resp = gson.fromJson(json, ApiError.class);
+        assertEquals(ErrorCodes.UNEXPECTED_NUMBER_OF_ELEMENTS, resp.getCode());
+        assertTrue(Pattern.compile("found 2 answers instead").matcher(resp.getMessage()).find());
     }
 
     private void assert200AndNoAnswersResponse(String uri, String payload) throws Exception {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteTest.java
@@ -521,7 +521,7 @@ public class PatchFormAnswersRouteTest extends IntegrationTestSuite.TestCase {
 
         String json = EntityUtils.toString(response.getEntity());
         ApiError resp = gson.fromJson(json, ApiError.class);
-        assertEquals(ErrorCodes.UNEXPECTED_NUMBER_OF_ELEMENTS, resp.getCode());
+        assertEquals(ErrorCodes.SERVER_ERROR, resp.getCode());
         assertTrue(Pattern.compile("found 2 answers instead").matcher(resp.getMessage()).find());
     }
 


### PR DESCRIPTION
 ## Context and the big picture
We now consider a situation when a question has multiple answers an error and halt with `500` instead.
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [ ] These changes are **HIGH RISK**.
    - [ ] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [ ] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [x] :relaxed: All good, business as usual!
  - [ ] :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [ ] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [x I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [x] I have written automated positive tests
 - [x] I have written automated negative tests
 - [ ] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
