### PR TITLE
study-builder: manage angio/brain/mbc emails

### DIFF
--- a/study-builder/studies/angio/emails/about_you_completed.html
+++ b/study-builder/studies/angio/emails/about_you_completed.html
@@ -1,0 +1,81 @@
+<html>
+<head>
+  <title>Thank you for submitting your information</title>
+</head>
+<body>
+<div>&nbsp;
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span style="font-family: Arial; font-size: 16px; white-space: pre-wrap; background-color: rgb(255, 255, 255);">-ddp.salutation-</span></span></p>
+
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="500" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-4937-b606-c261-3d9ce61e8847"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for joining the Angiosarcoma Project and telling us about your experiences with angiosarcoma. After you filled out your experiences with angiosarcoma, we asked you to fill out our research consent form, where we ask your permission to obtain copies of your medical records, a sample of your saliva, a portion of your stored tumor samples and a sample of your blood (about 1 to 2 teaspoons).</span></span></span></p>
+                  &nbsp;
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-4937-b606-c261-3d9ce61e8847"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Below is a link to your consent form for you to review and sign in order to be enrolled in this study. We&rsquo;re sending this along in case you were not able to complete it when you initially signed up.</span></span></span></p>
+                </td>
+              </tr>
+              <tr style="height:0px">
+                <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                  <div><span style="background-color: rgb(255, 255, 255);">&nbsp;&nbsp;</span><a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: rgb(255, 255, 255); text-decoration: none; background-color: rgb(237, 147, 58); border-width: 15px 25px; border-style: solid; border-color: rgb(237, 147, 58); border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; display: inline-block;" target="_blank">Please Sign Consent Form&nbsp;</a></div>
+
+                  <div>&nbsp;</div>
+
+                  <div>&nbsp;</div>
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-4937-b606-c261-3d9ce61e8847"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Once we receive your consent, we will review all of the information you have shared and may send you instructions on how to provide saliva and/or blood samples (using simple kits we will mail you). We may also request your medical records and tumor tissue to help us work towards new discoveries that could impact the entire angiosarcoma community.</span></span></span></p>
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-a97c3b8c-493a-87bb-04fb-ceab806629ca"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;"><span style="color:#666666;">Thank you for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at </span><a href="mailto:info@ascproject.org" target="_blank"><span style="color:#666666;">info@ascproject.org</span></a><span style="color:#666666;"> or call 857-500-6264.</span></span></span></p>
+                  &nbsp;
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-493a-87bb-04fb-ceab806629ca"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely, </span></span></span></p>
+                  <span style="color:#666666;">&nbsp;</span>
+
+                  <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-493a-87bb-04fb-ceab806629ca"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, PhD </span></span></span></p>
+
+                  <div>&nbsp;</div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:20px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;text-align: center;"><span style="color:#666666;"><span id="docs-internal-guid-a97c3b8c-4939-3b24-ceee-cf39fa1890f5"><span style="font-size: 13.333333333333332px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Broad Institute of MIT and Harvard. 415 Main St, Cambridge, MA 02142, United States</span></span></span></p>
+
+          <div>&nbsp;</div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/blood_received.html
+++ b/study-builder/studies/angio/emails/blood_received.html
@@ -14,7 +14,7 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/blood_sent.html
+++ b/study-builder/studies/angio/emails/blood_sent.html
@@ -14,11 +14,11 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">-ddp.salutation-</p>
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">-ddp.salutation-</span></span></p>
 
           &nbsp;
 

--- a/study-builder/studies/angio/emails/consent_completed.html
+++ b/study-builder/studies/angio/emails/consent_completed.html
@@ -1,0 +1,89 @@
+<html>
+<head>
+  <title>Thank you for providing your consent</title>
+</head>
+<body>
+<div>&nbsp;
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 32px; font-family: Arial; color: rgb(51, 51, 51); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you! You are now enrolled in the Angiosarcoma Project.</span></span></p>
+
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="500" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4942-1e2c-80bd-6eb3116c0b11"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for joining the Angiosarcoma Project and for giving us your consent for research. Your participation isn&#39;t just important to our work &mdash; it drives everything that we do.</span></span></p>
+                </td>
+              </tr>
+              <tr style="height:0px">
+                <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4942-74c3-62f9-5614988b1323"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">We will next mail you a kit with instructions on how to provide us a saliva sample. &nbsp;We may also ask you to have a sample of blood (1 tube or 2 teaspoons) drawn at your physician&rsquo;s office, local clinic, or nearby lab facility &ndash; we will provide detailed instructions on how to do this.</span><span style="font-size: 16px; font-family: Arial; color: rgb(255, 0, 0); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;"> </span><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">We may obtain copies of your medical records and, after reviewing them, may also request a small portion of your stored tumor sample from the hospital where it is kept. Once we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us. At this time, we are only able to collect samples from people living in the USA and Canada. However, we are hoping to include international patients soon. We are asking everyone, regardless of where in the world they live, to join this study so that we can learn from your experiences with this disease.</span></span></p>
+                  &nbsp;
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4942-74c3-62f9-5614988b1323"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">If you have not yet provided your mailing address and contact</span></span></p>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4942-74c3-62f9-5614988b1323"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">information for your physician(s) and hospital(s), you can complete the</span></span></p>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4942-74c3-62f9-5614988b1323"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">process here:</span></span></p>
+
+                  <div>&nbsp;</div>
+
+                  <div>&nbsp; <a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#ED933A;border-top:15px solid #ED933A;border-bottom:15px solid #ED933A;border-left:25px solid #ED933A;border-right:25px solid #ED933A;border-radius:3px;display:inline-block" target="_blank">Contact Info Form</a> &nbsp;</div>
+
+                  <div>&nbsp;</div>
+
+                  <div>&nbsp;</div>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">For your convenience, we have attached a copy of your signed</span></span></p>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">consent form. Please contact us via this email address</span></span></p>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;"><a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a> or at </span></span><span style="color:#696969;"><span style="font-family: Arial; font-size: 16px; white-space: pre-wrap; background-color: rgb(255, 255, 255);">857-500-6264 </span></span><span><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">if you have any questions or</span></span></p>
+
+                  <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">concerns.</span></span></p>
+                  &nbsp;
+
+                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">The information you submitted will be stored in a secure database. If you would like your information deleted from our database at any time, now or in the future, please email us at <a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a>.</span></span>&nbsp;&nbsp;</p>
+                </td>
+              </tr>
+              <tr style="height:0px">
+                <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">&nbsp;</td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:20px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, Ph.D.</span></span></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-b0b2a767-4944-08dc-3416-f2c6ae2ca01a"><span style="font-size: 12px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Broad Institute of MIT and Harvard. 415 Main St, Cambridge, MA 02142, United States</span></span></p>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/consent_reminder_1wk.html
+++ b/study-builder/studies/angio/emails/consent_reminder_1wk.html
@@ -14,7 +14,7 @@
         <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 31px 0px 0px;">
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/consent_reminder_2wk.html
+++ b/study-builder/studies/angio/emails/consent_reminder_2wk.html
@@ -14,7 +14,7 @@
         <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 31px 0px 0px;">
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/consent_reminder_3wk.html
+++ b/study-builder/studies/angio/emails/consent_reminder_3wk.html
@@ -14,7 +14,7 @@
         <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 31px 0px 0px;">
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/dashboard_link.html
+++ b/study-builder/studies/angio/emails/dashboard_link.html
@@ -14,7 +14,9 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/exit_request.html
+++ b/study-builder/studies/angio/emails/exit_request.html
@@ -14,7 +14,7 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/join_mailing_list.html
+++ b/study-builder/studies/angio/emails/join_mailing_list.html
@@ -1,0 +1,47 @@
+<html>
+<head>
+  <title>Thank you for your interest</title>
+</head>
+<body>
+<div>&nbsp;
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for signing up for the Angiosarcoma Project mailing list. By being on this list, you will receive regular updates on our work.</span></span></p>
+        </td>
+      </tr>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:20px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">If you have angiosarcoma and are interested in joining the research movement, please visit </span><a href="-ddp.baseWebUrl-" style="text-decoration:none;"><span style="font-size: 16px; font-family: Arial; color: rgb(126, 87, 194); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; text-decoration: underline; vertical-align: baseline; white-space: pre-wrap;">ASCproject.org</span></a><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;"> and click the &ldquo;COUNT ME IN&rdquo; button in the upper right-hand corner.</span></span></p>
+        </td>
+      </tr>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:20px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-9ab64476-ee9f-98f4-8c02-271dc6b3a927"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, Ph.D.</span></span></p>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/loved_one_completed.html
+++ b/study-builder/studies/angio/emails/loved_one_completed.html
@@ -1,0 +1,127 @@
+<html>
+<head>
+  <title>Welcome to the Angiosarcoma Project</title>
+</head>
+<body>
+<div>
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:15px 15px 15px 15px">
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="513" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 7px;">
+                  <div dir="ltr" style="margin-left:0pt;">
+                    <table style="border:none;border-collapse:collapse">
+                      <colgroup>
+                        <col width="500" />
+                      </colgroup>
+                      <tbody>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 0px;">
+                          <p dir="ltr" style="line-height:1.755;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 32px; font-family: Arial; color: rgb(51, 51, 51); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you!</span></span></p>
+                        </td>
+                      </tr>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for providing information on behalf of your loved one for the Angiosarcoma Project. </span></span></p>
+                        </td>
+                      </tr>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Because this cancer is so rare, we are hoping to learn as much as possible from those living with the disease, as well as from the information that you provided on behalf of your loved one.</span></span></p>
+
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">We greatly appreciate your willingness to share information with us.</span></span></p>
+                        </td>
+                      </tr>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">As the Angiosarcoma Project evolves, we will likely reach out with additional surveys to continue growing the body of knowledge around angiosarcoma with your help. We will keep you updated on the progress of our work. Please check our website frequently for updated information, and email us questions or suggestions at <a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a>.</span></span></p>
+                        </td>
+                      </tr>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for helping us drive this project forward.</span></span></p>
+                        </td>
+                      </tr>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>
+
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, PhD</span></span></p>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  &nbsp;
+
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="606" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:7px 7px 7px 7px">&nbsp;
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="593" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 71px 0px 20px;">&nbsp;
+                  <div dir="ltr" style="margin-left:0pt;">
+                    <table style="border:none;border-collapse:collapse">
+                      <colgroup>
+                        <col width="513" />
+                      </colgroup>
+                      <tbody>
+                      <tr style="height:172px">
+                        <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 7px;">
+                          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;text-align: center;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 12px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Broad Institute of MIT and Harvard. 415 Main St, Cambridge, MA 02142, United States</span></span></p>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/loved_one_welcome.html
+++ b/study-builder/studies/angio/emails/loved_one_welcome.html
@@ -1,0 +1,145 @@
+<html>
+<head>
+  <title>Welcome to the Angiosarcoma Project</title>
+</head>
+<body>
+<div>
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:15px 15px 15px 15px">
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="513" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 7px;">
+                  <div dir="ltr" style="margin-left:0pt;">
+                    <table style="border:none;border-collapse:collapse">
+                      <colgroup>
+                        <col width="500" />
+                      </colgroup>
+                      <tbody>
+                      <tr style="height:0px">
+                        <td style="border: 1px solid rgb(255, 255, 255); vertical-align: top; padding: 20px 0px 0px;">
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-05c2-eaf5-e261673838c6"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for joining the Angiosarcoma Project on behalf of your loved one.</span></span></p>
+
+                          <div dir="ltr" style="margin-left:0pt;">
+                            <table style="border:none;border-collapse:collapse">
+                              <colgroup>
+                                <col width="500" />
+                              </colgroup>
+                              <tbody>
+                              <tr style="height:0px">
+                                <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-05c2-eaf5-e261673838c6"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">If you haven&#39;t yet completed the form that tells us more about your loved one&rsquo;s experience with angiosarcoma, this link will take you to back to the form so you can pick up where you left off:</span></span></p>
+                                </td>
+                              </tr>
+                              </tbody>
+                            </table>
+                          </div>
+
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+                          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span style="background-color: rgb(255, 255, 255);">&nbsp;</span><a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; color: rgb(255, 255, 255); text-decoration: none; background-color: rgb(237, 147, 58); border-width: 15px 25px; border-style: solid; border-color: rgb(237, 147, 58); border-top-left-radius: 3px; border-top-right-radius: 3px; border-bottom-right-radius: 3px; border-bottom-left-radius: 3px; display: inline-block;" target="_blank">Return to Questionnaire</a></p>
+
+                          <div dir="ltr" style="margin-left:0pt;">
+                            <table style="border:none;border-collapse:collapse">
+                              <colgroup>
+                                <col width="500" />
+                              </colgroup>
+                              <tbody>
+                              <tr style="height:0px">
+                                <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span style="color:#696969;"><span id="docs-internal-guid-17113c98-43e4-6063-7538-b24383f01943"><span style="font-size: 16px; font-family: Arial; font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">We will save your answers as you go, and you can always use this link to return to the form until you tell us you&#39;re done and Submit.</span></span></span></p>
+                                  &nbsp;
+
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-6063-7538-b24383f01943"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">All the questions we ask are optional &mdash; but if you have any questions, please reach out to us at <a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a>.</span></span></p>
+                                </td>
+                              </tr>
+                              <tr style="height:0px">
+                                <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-6063-7538-b24383f01943"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thanks for joining this movement &mdash; we look forward to working with you to make discoveries that will help end angiosarcoma.</span></span></p>
+                                </td>
+                              </tr>
+                              <tr style="height:0px">
+                                <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-6063-7538-b24383f01943"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>
+
+                                  <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-17113c98-43e4-6063-7538-b24383f01943"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, PhD</span></span></p>
+                                </td>
+                              </tr>
+                              </tbody>
+                            </table>
+                          </div>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  &nbsp;
+
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="606" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;background-color:#ffffff;padding:7px 7px 7px 7px">&nbsp;
+          <div dir="ltr" style="margin-left:0pt;">
+            <table style="border:none;border-collapse:collapse">
+              <colgroup>
+                <col width="593" />
+              </colgroup>
+              <tbody>
+              <tr style="height:0px">
+                <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 71px 0px 20px;">&nbsp;
+                  <div dir="ltr" style="margin-left:0pt;">
+                    <table style="border:none;border-collapse:collapse">
+                      <colgroup>
+                        <col width="513" />
+                      </colgroup>
+                      <tbody>
+                      <tr style="height:172px">
+                        <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 7px;">
+                          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;text-align: center;"><span id="docs-internal-guid-e3b074e4-ee9d-9bd1-8f58-7f33c493b678"><span style="font-size: 12px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Broad Institute of MIT and Harvard. 415 Main St, Cambridge, MA 02142, United States</span></span></p>
+                        </td>
+                      </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/release_completed.html
+++ b/study-builder/studies/angio/emails/release_completed.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+  <title>Thank you for submitting your contact information</title>
+</head>
+<body>
+<div>&nbsp;
+  <div dir="ltr" style="margin-left:0pt;">
+    <table style="border:none;border-collapse:collapse">
+      <colgroup>
+        <col width="593" />
+      </colgroup>
+      <tbody>
+      <tr style="height:0px">
+        <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
+
+          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt; text-align: center;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 32px; font-family: Arial; color: rgb(51, 51, 51); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you! </span></span></p>
+
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for providing your mailing address and contact information </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">for your physician(s) and hospital(s). As a reminder, we will now mail </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">you a kit with instructions on how to provide us a sample of your </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">saliva. We may also mail you a kit with instructions on how to provide a sample of blood as well.</span></span></p>
+          &nbsp;
+
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">We may contact your physician(s) to obtain copies of your </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">medical records, which we will use to review your medical history. </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">After we have reviewed your medical records, we may contact you to </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">inform you that we are requesting a small portion of your stored tumor </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">sample from the hospital where it is kept. After we have analyzed your </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">samples, we will return any unused tumor samples to the pathology </span></span><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">department that sent them to us.</span></span></p>
+
+          <div>&nbsp;</div>
+
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-d1fe-72db-3d308f46e2e9"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Please contact us via this email address</span></span><span id="docs-internal-guid-8a54774e-235e-1baa-2a47-c3054567d224"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;"> <a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a> or at 857-500-6264 if you have any questions or concerns.</span></span></p>
+          &nbsp;
+
+          <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-235e-1baa-2a47-c3054567d224"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>
+          &nbsp;
+
+          <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-235e-1baa-2a47-c3054567d224"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Corrie Painter, PhD</span></span></p>
+          &nbsp;
+
+          <p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-235e-1baa-2a47-c3054567d224"><span style="font-size: 12px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Broad Institute of MIT and Harvard. 415 Main St, Cambridge, MA 02142, United States</span></span></p>
+
+          <div>&nbsp;</div>
+        </td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/study-builder/studies/angio/emails/release_reminder.html
+++ b/study-builder/studies/angio/emails/release_reminder.html
@@ -14,7 +14,7 @@
         <td style="border: 0px solid rgb(0, 0, 0); vertical-align: top; padding: 31px 0px 0px;">
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/resend_email.html
+++ b/study-builder/studies/angio/emails/resend_email.html
@@ -14,7 +14,7 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/saliva_received.html
+++ b/study-builder/studies/angio/emails/saliva_received.html
@@ -14,7 +14,7 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/emails/user_not_in_study.html
+++ b/study-builder/studies/angio/emails/user_not_in_study.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <title>Angiosarcoma Project Check-In</title>
+  <title>Logging into the Angiosarcoma Project</title>
 </head>
 <body>
 <div>&nbsp;
@@ -18,14 +18,16 @@
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height: 1.875; margin-top: 0pt; margin-bottom: 0pt; text-align: center;"><span id="docs-internal-guid-b0b2a767-2345-156d-7484-1c53cb008e3e"><span style="font-size: 32px; font-family: Arial; color: rgb(51, 51, 51); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you. </span></span></p>
-
           <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you again for giving us your consent for research, which will allow us to study a sample of your blood. We recently mailed you a kit with instructions on how to have a sample of blood drawn, and are now checking in to see if you received it.</span></span></p>
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Dear -ddp.participant.fromEmail-,</span></span></p>
+
           &nbsp;
 
-          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">If you have not yet received the kit, or if you have an questions about the process, please contact us via email at <a href="mailto:info@ascproject.org" target="_blank">info@ascproject.org</a> or at 857-500-6264.</span></span></p>
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Thank you for requesting a link to your questionnaire for the Angiosarcoma Project. We are not able to find this email address in our system. If you believe you have already registered for the Angiosarcoma Project, please contact the study team at info@ascproject.org or call us at 857-500-6264.</span></span></p>
+          &nbsp;
+
+          <p dir="ltr" style="line-height:1.7999999999999998;margin-top:0pt;margin-bottom:0pt;"><span id="docs-internal-guid-8a54774e-4946-8854-740a-0463e30e2b56"><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">If you have not yet joined the Angiosarcoma Project and would like to, please visit -ddp.baseWebUrl-/count-me-in and enter your contact information.</span></span></p>
           &nbsp;
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><span><span style="font-size: 16px; font-family: Arial; color: rgb(102, 102, 102); background-color: rgb(255, 255, 255); font-variant-ligatures: normal; font-variant-position: normal; font-variant-numeric: normal; font-variant-alternates: normal; font-variant-east-asian: normal; vertical-align: baseline; white-space: pre-wrap;">Sincerely,</span></span></p>

--- a/study-builder/studies/angio/emails/welcome.html
+++ b/study-builder/studies/angio/emails/welcome.html
@@ -14,7 +14,7 @@
         <td style="border-left:solid #000000 0px;border-right:solid #000000 0px;border-bottom:solid #000000 0px;border-top:solid #000000 0px;vertical-align:top;padding:31px 0px 0px 0px">
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 
-          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/cmi-study-dev-assets/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
+          <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;"><a href="-ddp.baseWebUrl-"><img height="84" src="https://storage.googleapis.com/${assetsBucketName}/angio/project-logo.png" style="width: 235px; height: 84px;" width="235" /></a></p>
 
           <p dir="ltr" style="line-height:1.875;margin-top:0pt;margin-bottom:0pt;">&nbsp;</p>
 

--- a/study-builder/studies/angio/sendgrid_emails.conf
+++ b/study-builder/studies/angio/sendgrid_emails.conf
@@ -1,0 +1,137 @@
+{
+  "sendgridEmails": [
+    {
+      "key": "bloodNotReceived4Weeks",
+      "name": "ANGIO_BLOOD_SENT_REMINDER",
+      "subject": "Angiosarcoma Project Check-In",
+      "filepath": "emails/blood_sent_reminder.html",
+      "render": true
+    },
+    {
+      "key": "bloodReceived",
+      "name": "ANGIO_BLOOD_RECEIVED",
+      "subject": "Thank you, your blood kit was received",
+      "filepath": "emails/blood_received.html",
+      "render": true
+    },
+    {
+      "key": "bloodSent",
+      "name": "ANGIO_BLOOD_SENT",
+      "subject": "Angiosarcoma Project Notification",
+      "filepath": "emails/blood_sent.html",
+      "render": true
+    },
+    {
+      "key": "consentCreated",
+      "name": "ANGIO_ABOUT_YOU_COMPLETED",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/about_you_completed.html",
+      "render": true
+    },
+    {
+      "key": "consentFirstReminder",
+      "name": "ANGIO_CONSENT_FIRST_REMINDER",
+      "subject": "Next step for the ASCproject: please sign the consent form",
+      "filepath": "emails/consent_reminder_1wk.html",
+      "render": true
+    },
+    {
+      "key": "consentSecondReminder",
+      "name": "ANGIO_CONSENT_SECOND_REMINDER",
+      "subject": "Next step for the ASCproject: please sign the consent form",
+      "filepath": "emails/consent_reminder_2wk.html",
+      "render": true
+    },
+    {
+      "key": "consentThirdReminder",
+      "name": "ANGIO_CONSENT_THIRD_REMINDER",
+      "subject": "Next step for the ASCproject: please sign the consent form",
+      "filepath": "emails/consent_reminder_3wk.html",
+      "render": true
+    },
+    {
+      "key": "dashboardEmail",
+      "name": "ANGIO_DASHBOARD_LINK",
+      "subject": "Thank you for the information you have submitted",
+      "filepath": "emails/dashboard_link.html",
+      "render": true
+    },
+    {
+      "key": "exitRequest",
+      "name": "ANGIO_EXIT_REQUEST",
+      "subject": "Participant Withdraw Request",
+      "filepath": "emails/exit_request.html",
+      "render": true
+    },
+    {
+      "key": "joinMailingList",
+      "name": "ANGIO_JOIN_MAILING_LIST",
+      "subject": "Thank you for your interest",
+      "filepath": "emails/join_mailing_list.html",
+      "render": true
+    },
+    {
+      "key": "lovedOneCompleted",
+      "name": "ANGIO_LOVED_ONE_COMPLETED",
+      "subject": "Welcome to the Angiosarcoma Project",
+      "filepath": "emails/loved_one_completed.html",
+      "render": true
+    },
+    {
+      "key": "lovedOneWelcome",
+      "name": "ANGIO_LOVED_ONE_WELCOME",
+      "subject": "Welcome to the Angiosarcoma Project",
+      "filepath": "emails/loved_one_welcome.html",
+      "render": true
+    },
+    {
+      "key": "participantWelcome",
+      "name": "ANGIO_WELCOME",
+      "subject": "Welcome to the Angiosarcoma Project",
+      "filepath": "emails/welcome.html",
+      "render": true
+    },
+    {
+      "key": "releaseCompleted",
+      "name": "ANGIO_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/release_completed.html",
+      "render": true
+    },
+    {
+      "key": "releaseCreated",
+      "name": "ANGIO_CONSENT_COMPLETED",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/consent_completed.html",
+      "render": true
+    },
+    {
+      "key": "releaseReminder",
+      "name": "ANGIO_RELEASE_REMINDER",
+      "subject": "Next step for the ASCproject: we need some additional information from you",
+      "filepath": "emails/release_reminder.html",
+      "render": true
+    },
+    {
+      "key": "resendEmail",
+      "name": "ANGIO_RESEND_EMAIL",
+      "subject": "Link to Your Current Form",
+      "filepath": "emails/resend_email.html",
+      "render": true
+    },
+    {
+      "key": "salivaReceived",
+      "name": "ANGIO_SALIVA_RECEIVED",
+      "subject": "Thank you, your saliva kit was received",
+      "filepath": "emails/saliva_received.html",
+      "render": true
+    },
+    {
+      "key": "userNotEnrolledInStudy",
+      "name": "ANGIO_USER_NOT_IN_STUDY",
+      "subject": "Logging into the Angiosarcoma Project",
+      "filepath": "emails/user_not_in_study.html",
+      "render": true
+    }
+  ]
+}

--- a/study-builder/studies/angio/study.conf
+++ b/study-builder/studies/angio/study.conf
@@ -38,6 +38,8 @@
         "defaultSalutation": ${sendgridDefaultSalutation}
     },
 
+    include required("sendgrid_emails.conf"),
+
     "kits": [
         {
             "type": "SALIVA",

--- a/study-builder/studies/brain/emails/about_you_completed.html
+++ b/study-builder/studies/brain/emails/about_you_completed.html
@@ -2,7 +2,7 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Welcome to the Brain Cancer Project</title>
+  <title>Thank you for submitting your information</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -83,35 +83,38 @@
   </tr>
 
   <tr style="width: 540px;">
-    <td style="padding: 50px 0 0 0;">
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 26px; line-height: 23px;">Welcome</p>
+    <td style="padding: 50px 0 0px 0;">
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">
+        -ddp.salutation-
+      </p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thank
-        you for joining the Brain Cancer Project.</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">If
-        you haven't yet completed the form that tells us more about your cancer, this link will take you to back to
-        the form so you can pick up where you left off:</p>
+        you for joining the Brain Cancer Project and telling us about your experiences with
+        Brain Cancer. We are now asking if you would be willing to sign our research consent form, where
+        we ask your permission to obtain copies of your medical records, a sample of your saliva, a sample of your
+        blood (about 1 to 2 teaspoons), and a portion of your stored tumor samples.</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Once
+        we receive your consent, we will review all of the information you have shared and may send you instructions
+        on how to provide saliva and/or blood samples (using simple kits we will mail you). We may also request your
+        medical records and tumor tissue to help us work towards new discoveries that could impact the entire
+        Brain Cancer community.</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Here
+        is a link to a consent form for you to review and sign in order to be enrolled in the study:</p>
     </td>
   </tr>
   <tr style="height:0px">
     <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
       <div>&nbsp; <a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#3785BF;border-top:15px solid #3785BF;border-bottom:15px solid #3785BF;border-left:25px solid #3785BF;border-right:25px solid #3785BF;border-radius:3px;display:inline-block"
-                     target="_blank">Return to Questionnaire</a>&nbsp;&nbsp;</div>
+                     target="_blank">Please Sign Consent Form</a>&nbsp;&nbsp;</div>
     </td>
   </tr>
 
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">We
-        will save your answers as you go, and you can always use this link to return to the form until you tell us
-        you're done and Submit.</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">If
-        you're having trouble filling out these forms, you may find it helpful to show them to a family member or
-        physician, either by printing them out or displaying them on a smartphone/tablet. Remember, most questions
-        are optional — but the more you tell us, the more we can learn about the biology of Brain Cancer
-        and how to improve our treatments.</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thanks
-        for joining this movement — we look forward to working with you to make discoveries that will help end
-        Brain Cancer.</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thank
+        you for participating. Any insights that we generate will be a direct result of working with you. If you have
+        questions at any point and would like to talk to a member of our study staff, please reach out to us at <a
+            href="mailto:info@braincancerproject.org" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">info@braincancerproject.org</a>
+        or call 651-229-3480.</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Sincerely,</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">The
         Brain Cancer Project Team</p>

--- a/study-builder/studies/brain/emails/blood_received.html
+++ b/study-builder/studies/brain/emails/blood_received.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -114,7 +114,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/blood_sent.html
+++ b/study-builder/studies/brain/emails/blood_sent.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -111,7 +111,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/blood_sent_reminder.html
+++ b/study-builder/studies/brain/emails/blood_sent_reminder.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -109,7 +109,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/consent_completed.html
+++ b/study-builder/studies/brain/emails/consent_completed.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -137,7 +137,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/consent_reminder_1wk.html
+++ b/study-builder/studies/brain/emails/consent_reminder_1wk.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -121,7 +121,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/consent_reminder_2wk.html
+++ b/study-builder/studies/brain/emails/consent_reminder_2wk.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -121,7 +121,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/consent_reminder_3wk.html
+++ b/study-builder/studies/brain/emails/consent_reminder_3wk.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -121,7 +121,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/exit_request.html
+++ b/study-builder/studies/brain/emails/exit_request.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -103,7 +103,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/join_mailing_list.html
+++ b/study-builder/studies/brain/emails/join_mailing_list.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -104,7 +104,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/not_in_study.html
+++ b/study-builder/studies/brain/emails/not_in_study.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -101,7 +101,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/post_consent.html
+++ b/study-builder/studies/brain/emails/post_consent.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -127,7 +127,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/release_completed.html
+++ b/study-builder/studies/brain/emails/release_completed.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -113,7 +113,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/release_reminder.html
+++ b/study-builder/studies/brain/emails/release_reminder.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -126,7 +126,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/resend_email.html
+++ b/study-builder/studies/brain/emails/resend_email.html
@@ -2,7 +2,7 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Thank you for submitting your information</title>
+  <title>Link to your current form</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -84,37 +84,23 @@
 
   <tr style="width: 540px;">
     <td style="padding: 50px 0 0px 0;">
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">
-        -ddp.salutation-
-      </p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thank
-        you for joining the Brain Cancer Project and telling us about your experiences with
-        Brain Cancer. We are now asking if you would be willing to sign our research consent form, where
-        we ask your permission to obtain copies of your medical records, a sample of your saliva, a sample of your
-        blood (about 1 to 2 teaspoons), and a portion of your stored tumor samples.</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Once
-        we receive your consent, we will review all of the information you have shared and may send you instructions
-        on how to provide saliva and/or blood samples (using simple kits we will mail you). We may also request your
-        medical records and tumor tissue to help us work towards new discoveries that could impact the entire
-        Brain Cancer community.</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Here
-        is a link to a consent form for you to review and sign in order to be enrolled in the study:</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">This
+        link will take you to back to your current form so you can pick up where you left off:</p>
     </td>
   </tr>
   <tr style="height:0px">
     <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
       <div>&nbsp; <a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#3785BF;border-top:15px solid #3785BF;border-bottom:15px solid #3785BF;border-left:25px solid #3785BF;border-right:25px solid #3785BF;border-radius:3px;display:inline-block"
-                     target="_blank">Please Sign Consent Form</a>&nbsp;&nbsp;</div>
+                     target="_blank">Return to Questionnaire</a>&nbsp;&nbsp;</div>
     </td>
   </tr>
 
   <tr style="width: 540px;">
     <td style="padding: 20px 0 80px 0;">
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thank
-        you for participating. Any insights that we generate will be a direct result of working with you. If you have
-        questions at any point and would like to talk to a member of our study staff, please reach out to us at <a
-            href="mailto:info@braincancerproject.org" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">info@braincancerproject.org</a>
-        or call 651-229-3480.</p>
+
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Please
+        contact us via email at <a href="mailto:info@braincancerproject.org" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">info@braincancerproject.org</a>
+        or at 651-229-3480 if you have any questions or concerns.</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Sincerely,</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">The
         Brain Cancer Project Team</p>
@@ -129,7 +115,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/saliva_received.html
+++ b/study-builder/studies/brain/emails/saliva_received.html
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -108,7 +108,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/emails/user_not_in_study.html
+++ b/study-builder/studies/brain/emails/user_not_in_study.html
@@ -2,7 +2,7 @@
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 
 <head>
-  <title>Link to your current form</title>
+  <title>Logging into the Brain Cancer Project</title>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700" rel="stylesheet">
   <style type="text/css">
     .ExternalClass,
@@ -75,7 +75,7 @@
   <tr style="width: 540px;">
     <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
       <a href="-ddp.baseWebUrl-" target="_blank" style="cursor: pointer; text-decoration: none;">
-        <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-logo.png"
+        <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-logo.png"
              alt="Brain Cancer Project logo" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
              width="108px" height="90px" border="0">
       </a>
@@ -83,31 +83,17 @@
   </tr>
 
   <tr style="width: 540px;">
-    <td style="padding: 50px 0 0px 0;">
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">This
-        link will take you to back to your current form so you can pick up where you left off:</p>
-    </td>
-  </tr>
-  <tr style="height:0px">
-    <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
-      <div>&nbsp; <a href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#3785BF;border-top:15px solid #3785BF;border-bottom:15px solid #3785BF;border-left:25px solid #3785BF;border-right:25px solid #3785BF;border-radius:3px;display:inline-block"
-                     target="_blank">Return to Questionnaire</a>&nbsp;&nbsp;</div>
-    </td>
-  </tr>
-
-  <tr style="width: 540px;">
-    <td style="padding: 20px 0 80px 0;">
-
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Please
-        contact us via email at <a href="mailto:info@braincancerproject.org" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">info@braincancerproject.org</a>
-        or at 651-229-3480 if you have any questions or concerns.</p>
+    <td style="padding: 50px 0 80px 0;">
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Dear
+        -ddp.participant.fromEmail-,</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Thank
+        you for requesting a link to your questionnaire for the Brain Cancer Project. We are not able to find this
+        email address in our system. If you believe you have already registered for the Brain Cancer Project, please
+        contact the study team at <a href="mailto:info@braincancerproject.org" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">info@braincancerproject.org</a> or call us at 651-229-3480.</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">If you have not yet joined the Brain Cancer Project and would like to, please visit -ddp.baseWebUrl-/count-me-in and enter your contact information.</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Sincerely,</p>
       <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">The
         Brain Cancer Project Team</p>
-      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">For
-        additional updates, follow us on Twitter <a href="https://twitter.com/BrainCancerProj" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">@BrainCancerProj</a>
-        or like our Facebook page, <a href="https://www.facebook.com/braincancerproject" target="_blank" style="color: #3785BF; text-decoration: none; cursor: pointer;">The
-          Brain Cancer Project</a>.</p>
     </td>
   </tr>
 </table>
@@ -115,7 +101,7 @@
 <table style="width: 540px; height: 10px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;"
        border="0" cellpadding="0" cellspacing="0" width="100%">
   <tr style="width: 540px; height: 10px; padding: 0;">
-    <img src="https://storage.googleapis.com/cmi-study-dev-assets/brain/project-line.png"
+    <img src="https://storage.googleapis.com/${assetsBucketName}/brain/project-line.png"
          alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;"
          width="540px" height="10px" border="0">
   </tr>

--- a/study-builder/studies/brain/sendgrid_emails.conf
+++ b/study-builder/studies/brain/sendgrid_emails.conf
@@ -1,0 +1,116 @@
+{
+  "sendgridEmails": [
+    {
+      "key": "bloodNotReceived4Weeks",
+      "name": "BRAIN_BLOOD_SENT_REMINDER",
+      "subject": "Brain Cancer Project Check-In",
+      "filepath": "emails/blood_sent_reminder.html",
+      "render": true
+    },
+    {
+      "key": "bloodReceived",
+      "name": "BRAIN_BLOOD_RECEIVED",
+      "subject": "Thank you, your blood kit was received",
+      "filepath": "emails/blood_received.html",
+      "render": true
+    },
+    {
+      "key": "bloodSent",
+      "name": "BRAIN_BLOOD_SENT",
+      "subject": "Brain Cancer Project Notification",
+      "filepath": "emails/blood_sent.html",
+      "render": true
+    },
+    {
+      "key": "consentCreated",
+      "name": "BRAIN_ABOUT_YOU_COMPLETED",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/about_you_completed.html",
+      "render": true
+    },
+    {
+      "key": "consentFirstReminder",
+      "name": "BRAIN_CONSENT_REMINDER_1WK",
+      "subject": "Next step for the Brain Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_1wk.html",
+      "render": true
+    },
+    {
+      "key": "consentSecondReminder",
+      "name": "BRAIN_CONSENT_REMINDER_2WK",
+      "subject": "Next step for the Brain Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_2wk.html",
+      "render": true
+    },
+    {
+      "key": "consentThirdReminder",
+      "name": "BRAIN_CONSENT_REMINDER_3WK",
+      "subject": "Next step for the Brain Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_3wk.html",
+      "render": true
+    },
+    {
+      "key": "exitRequest",
+      "name": "BRAIN_EXIT_REQUEST",
+      "subject": "Participant Withdraw Request",
+      "filepath": "emails/exit_request.html",
+      "render": true
+    },
+    {
+      "key": "joinMailingList",
+      "name": "BRAIN_JOIN_MAILING_LIST",
+      "subject": "Thank you for signing up for the Brain Cancer Project mailing list",
+      "filepath": "emails/join_mailing_list.html",
+      "render": true
+    },
+    {
+      "key": "participantWelcome",
+      "name": "BRAIN_WELCOME",
+      "subject": "Welcome to the Brain Cancer Project",
+      "filepath": "emails/welcome.html",
+      "render": true
+    },
+    {
+      "key": "releaseCompleted",
+      "name": "BRAIN_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/release_completed.html",
+      "render": true
+    },
+    {
+      "key": "releaseCreated",
+      "name": "BRAIN_CONSENT_COMPLETED",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/consent_completed.html",
+      "render": true
+    },
+    {
+      "key": "releaseReminder",
+      "name": "BRAIN_RELEASE_REMINDER",
+      "subject": "Next step for the Brain Cancer Project: we need some additional information from you",
+      "filepath": "emails/release_reminder.html",
+      "render": true
+    },
+    {
+      "key": "resendEmail",
+      "name": "BRAIN_RESEND_EMAIL",
+      "subject": "Link to your current form",
+      "filepath": "emails/resend_email.html",
+      "render": true
+    },
+    {
+      "key": "salivaReceived",
+      "name": "BRAIN_SALIVA_RECEIVED",
+      "subject": "Thank you, your saliva kit was received",
+      "filepath": "emails/saliva_received.html",
+      "render": true
+    },
+    {
+      "key": "userNotEnrolledInStudy",
+      "name": "BRAIN_USER_NOT_IN_STUDY",
+      "subject": "Logging into the Brain Cancer Project",
+      "filepath": "emails/user_not_in_study.html",
+      "render": true
+    }
+  ]
+}

--- a/study-builder/studies/brain/study.conf
+++ b/study-builder/studies/brain/study.conf
@@ -38,6 +38,8 @@
         "defaultSalutation": ${sendgridDefaultSalutation}
     },
 
+    include required("sendgrid_emails.conf"),
+
     "kits": [
         {
             "type": "SALIVA",

--- a/study-builder/studies/mbc/emails/about_you_completed.html
+++ b/study-builder/studies/mbc/emails/about_you_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Thank you for submitting your contact information</title>
+    <title>Thank you for submitting your information</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -119,7 +119,7 @@
         <td align="center" bgcolor="#ffffff">
           <!-- HIDDEN PREHEADER TEXT -->
           <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
-            Thank you for providing your mailing address and contact information for your physician(s) and hospital(s).
+            Thank you for joining the Metastatic Breast Cancer Project!
           </div>
           <table border="0" cellpadding="0" cellspacing="0" class="wrapper" width="500">
             <!-- LOGO/PREHEADER TEXT -->
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -152,16 +152,49 @@
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for providing your mailing address and contact information for your physician(s) and hospital(s). As a reminder, we will be mailing you a kit with instructions on how to provide us a sample of your saliva. We may also be contacting you to provide a blood sample (1 to 2 teaspoons).</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
+                      Thank you so much for joining the Metastatic Breast Cancer Project and telling us about your experiences with metastatic breast cancer. We are now asking if you would be willing to sign our research consent form, where we ask your permission to obtain copies of your medical records, a sample of your saliva, a sample of your blood (about 1 to 2 teaspoons), and a portion of your stored tumor samples.
+                    </td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We may also contact your physician(s) to obtain copies of your medical records, which we will use to review your medical history. After we have reviewed your medical records, we may contact you to inform you that we are requesting a small portion of your stored tumor sample from the hospital where it is kept. After we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
+                      Once we receive your consent, we will review all of the information you have shared and may send you instructions on how to provide saliva and/or blood samples (using simple kits we will mail you). We may also request your medical records and tumor tissue to help us work towards new discoveries that could impact the entire metastatic breast cancer community.
+                    </td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
+                      Here is a link to a consent form for you to review and sign in order to be enrolled in the study:
+                    </td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
+                    <td align="center">
+                      <!-- BULLETPROOF BUTTON -->
+                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
+                        <tr>
+                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
+                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
+                              <tr>
+                                <td align="center">
+                                  <p>
+                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Please Sign Consent Form</a>
+                                  </p>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
+                      Thank you again for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or call <a href="tel:617-800-1622">617-800-1622</a>.
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
+                      Sincerely,<br>The MBCproject team
+                    </td>
                   </tr>
                 </table>
               </td>
@@ -197,7 +230,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/blood_received.html
+++ b/study-builder/studies/mbc/emails/blood_received.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -200,7 +200,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/blood_sent.html
+++ b/study-builder/studies/mbc/emails/blood_sent.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -200,7 +200,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/blood_sent_reminder.html
+++ b/study-builder/studies/mbc/emails/blood_sent_reminder.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -197,7 +197,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/bloodconsent_completed.html
+++ b/study-builder/studies/mbc/emails/bloodconsent_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Thank you for providing your consent</title>
+    <title>Thank you for submitting your information</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -150,38 +150,11 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research, which will allow us to study a sample of your blood. We will mail you a kit with instructions on how to have a sample of blood drawn at your physician’s office, local clinic, or nearby lab facility. When you receive this kit, please open it up and read the instructions, and reach out to us if you have any questions. Then take this kit with you to your next blood draw. There are instructions for the person drawing your blood and information on how you can send the sample to us in a pre-stamped package provided as part of the kit.</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research. As a reminder, your participation gives us permission to obtain copies of your medical records, a portion of your tumor tissue, and a saliva sample.</td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We will next mail you a kit with instructions on how to provide us a sample of your saliva. We may obtain copies of your medical records and, after reviewing them, may also request a small portion of your stored tumor sample from the hospital where it is kept. Once we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">If you have not yet provided your mailing address and contact information for your physician(s) and hospital(s), you can complete the process here:</td>
-                  </tr>
-                  <tr>
-                    <td align="center">
-                      <!-- BULLETPROOF BUTTON -->
-                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
-                        <tr>
-                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
-                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
-                              <tr>
-                                <td align="center">
-                                  <p>
-                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Contact Info Form</a>
-                                  </p>
-                                </td>
-                              </tr>
-                            </table>
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed consent form. Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed blood draw consent form. Please contact us via <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
                   </tr>
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
@@ -220,7 +193,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/bloodrelease_completed.html
+++ b/study-builder/studies/mbc/emails/bloodrelease_completed.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -194,7 +194,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/consent_completed.html
+++ b/study-builder/studies/mbc/emails/consent_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Thank you, we received your MBCproject follow-up survey #1</title>
+    <title>Thank you for providing your consent</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -119,7 +119,7 @@
         <td align="center" bgcolor="#ffffff">
           <!-- HIDDEN PREHEADER TEXT -->
           <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
-            Thank you, we received your MBCproject follow-up survey #1
+            Thank you for giving us your consent for research.
           </div>
           <table border="0" cellpadding="0" cellspacing="0" class="wrapper" width="500">
             <!-- LOGO/PREHEADER TEXT -->
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -152,11 +152,37 @@
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for filling out The Metastatic Breast Cancer Project follow-up survey #1. We're writing to let you know that the information that you submitted was received.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research. Your participation isn't just important to our work — it drives everything that we do.
+                    </td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Thank you again for your participation in The Metastatic Breast Cancer Project. We are so grateful for your partnership. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or <a href="tel:617-800-1622">617-800-1622</a>.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We will next mail you a kit with instructions on how to provide us a saliva sample. We may also contact you about providing a blood sample (1 tube or 2 teaspoons), which can be drawn at your physician’s office, local clinic, or nearby lab facility. We will provide detailed instructions on how to do this. We may obtain copies of your medical records and, after reviewing them, may also request a small portion of your stored tumor sample from the hospital where it is kept. Once we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">If you have not yet provided your mailing address and contact information for your physician(s) and hospital(s), you can complete the process here:</td>
+                  </tr>
+                  <tr>
+                    <td align="center">
+                      <!-- BULLETPROOF BUTTON -->
+                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
+                        <tr>
+                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
+                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
+                              <tr>
+                                <td align="center">
+                                  <p>
+                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Contact Info Form</a>
+                                  </p>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed consent form. Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
                   </tr>
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
@@ -195,7 +221,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/consent_reminder_1wk.html
+++ b/study-builder/studies/mbc/emails/consent_reminder_1wk.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -220,7 +220,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/consent_reminder_2wk.html
+++ b/study-builder/studies/mbc/emails/consent_reminder_2wk.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -220,7 +220,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/consent_reminder_3wk.html
+++ b/study-builder/studies/mbc/emails/consent_reminder_3wk.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -220,7 +220,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/exit_request.html
+++ b/study-builder/studies/mbc/emails/exit_request.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -176,7 +176,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/followup_completed.html
+++ b/study-builder/studies/mbc/emails/followup_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Thank you for submitting your information</title>
+    <title>Thank you, we received your MBCproject follow-up survey #1</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -119,7 +119,7 @@
         <td align="center" bgcolor="#ffffff">
           <!-- HIDDEN PREHEADER TEXT -->
           <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
-            Thank you for joining the Metastatic Breast Cancer Project!
+            Thank you, we received your MBCproject follow-up survey #1
           </div>
           <table border="0" cellpadding="0" cellspacing="0" class="wrapper" width="500">
             <!-- LOGO/PREHEADER TEXT -->
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -152,49 +152,14 @@
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Thank you so much for joining the Metastatic Breast Cancer Project and telling us about your experiences with metastatic breast cancer. We are now asking if you would be willing to sign our research consent form, where we ask your permission to obtain copies of your medical records, a sample of your saliva, a sample of your blood (about 1 to 2 teaspoons), and a portion of your stored tumor samples.
-                    </td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for filling out The Metastatic Breast Cancer Project follow-up survey #1. We're writing to let you know that the information that you submitted was received.</td>
                   </tr>
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Once we receive your consent, we will review all of the information you have shared and may send you instructions on how to provide saliva and/or blood samples (using simple kits we will mail you). We may also request your medical records and tumor tissue to help us work towards new discoveries that could impact the entire metastatic breast cancer community.
-                    </td>
+                      Thank you again for your participation in The Metastatic Breast Cancer Project. We are so grateful for your partnership. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or <a href="tel:617-800-1622">617-800-1622</a>.</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Here is a link to a consent form for you to review and sign in order to be enrolled in the study:
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="center">
-                      <!-- BULLETPROOF BUTTON -->
-                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
-                        <tr>
-                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
-                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
-                              <tr>
-                                <td align="center">
-                                  <p>
-                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Please Sign Consent Form</a>
-                                  </p>
-                                </td>
-                              </tr>
-                            </table>
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Thank you again for participating. Any insights that we generate will be a direct result of working with you. If you have questions at any point and would like to talk to a member of our study staff, please reach out to us at <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or call <a href="tel:617-800-1622">617-800-1622</a>.
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">
-                      Sincerely,<br>The MBCproject team
-                    </td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
                   </tr>
                 </table>
               </td>
@@ -230,7 +195,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/followup_created.html
+++ b/study-builder/studies/mbc/emails/followup_created.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -220,7 +220,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/followup_reminder.html
+++ b/study-builder/studies/mbc/emails/followup_reminder.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -217,7 +217,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/join_mailing_list.html
+++ b/study-builder/studies/mbc/emails/join_mailing_list.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -193,7 +193,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/release_completed.html
+++ b/study-builder/studies/mbc/emails/release_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Thank you for providing your consent</title>
+    <title>Thank you for submitting your contact information</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -119,7 +119,7 @@
         <td align="center" bgcolor="#ffffff">
           <!-- HIDDEN PREHEADER TEXT -->
           <div style="display: none; font-size: 1px; color: #fefefe; line-height: 1px; font-family: Helvetica, Arial, sans-serif; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden;">
-            Thank you for giving us your consent for research.
+            Thank you for providing your mailing address and contact information for your physician(s) and hospital(s).
           </div>
           <table border="0" cellpadding="0" cellspacing="0" class="wrapper" width="500">
             <!-- LOGO/PREHEADER TEXT -->
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -152,37 +152,13 @@
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research. Your participation isn't just important to our work — it drives everything that we do.
-                    </td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for providing your mailing address and contact information for your physician(s) and hospital(s). As a reminder, we will be mailing you a kit with instructions on how to provide us a sample of your saliva. We may also be contacting you to provide a blood sample (1 to 2 teaspoons).</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We will next mail you a kit with instructions on how to provide us a saliva sample. We may also contact you about providing a blood sample (1 tube or 2 teaspoons), which can be drawn at your physician’s office, local clinic, or nearby lab facility. We will provide detailed instructions on how to do this. We may obtain copies of your medical records and, after reviewing them, may also request a small portion of your stored tumor sample from the hospital where it is kept. Once we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We may also contact your physician(s) to obtain copies of your medical records, which we will use to review your medical history. After we have reviewed your medical records, we may contact you to inform you that we are requesting a small portion of your stored tumor sample from the hospital where it is kept. After we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">If you have not yet provided your mailing address and contact information for your physician(s) and hospital(s), you can complete the process here:</td>
-                  </tr>
-                  <tr>
-                    <td align="center">
-                      <!-- BULLETPROOF BUTTON -->
-                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
-                        <tr>
-                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
-                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
-                              <tr>
-                                <td align="center">
-                                  <p>
-                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Contact Info Form</a>
-                                  </p>
-                                </td>
-                              </tr>
-                            </table>
-                          </td>
-                        </tr>
-                      </table>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed consent form. Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
                   </tr>
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
@@ -221,7 +197,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/release_reminder.html
+++ b/study-builder/studies/mbc/emails/release_reminder.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -219,7 +219,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/saliva_received.html
+++ b/study-builder/studies/mbc/emails/saliva_received.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -199,7 +199,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/tissueconsent_completed.html
+++ b/study-builder/studies/mbc/emails/tissueconsent_completed.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>subject: Thank you for submitting your information</title>
+    <title>Thank you for providing your consent</title>
     <meta charset="utf-8">
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -150,11 +150,38 @@
                 <table border="0" cellpadding="0" cellspacing="0" width="100%">
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">-ddp.salutation-</td>
-                  <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research, which will allow us to study a sample of your blood. We will mail you a kit with instructions on how to have a sample of blood drawn at your physician’s office, local clinic, or nearby lab facility. When you receive this kit, please open it up and read the instructions, and reach out to us if you have any questions. Then take this kit with you to your next blood draw. There are instructions for the person drawing your blood and information on how you can send the sample to us in a pre-stamped package provided as part of the kit.</td>
                   </tr>
                   <tr>
-                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed blood draw consent form. Please contact us via <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Thank you for giving us your consent for research. As a reminder, your participation gives us permission to obtain copies of your medical records, a portion of your tumor tissue, and a saliva sample.</td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">We will next mail you a kit with instructions on how to provide us a sample of your saliva. We may obtain copies of your medical records and, after reviewing them, may also request a small portion of your stored tumor sample from the hospital where it is kept. Once we have analyzed your samples, we will return any unused tumor samples to the pathology department that sent them to us.</td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">If you have not yet provided your mailing address and contact information for your physician(s) and hospital(s), you can complete the process here:</td>
+                  </tr>
+                  <tr>
+                    <td align="center">
+                      <!-- BULLETPROOF BUTTON -->
+                      <table border="0" cellpadding="0" cellspacing="0" class="mobile-button-container" width="100%">
+                        <tr>
+                          <td align="center" class="padding-copy" style="padding: 25px 0 0 0;">
+                            <table border="0" cellpadding="0" cellspacing="0" class="responsive-table">
+                              <tr>
+                                <td align="center">
+                                  <p>
+                                    <a target="blank" style="font-size: 16px; font-family: Helvetica, Arial, sans-serif; font-weight: normal; color: #ffffff; text-decoration: none; background-color: #2bb673; border-top: 15px solid #2bb673; border-bottom: 15px solid #2bb673; border-left: 25px solid #2bb673; border-right: 25px solid #2bb673; border-radius: 3px; -webkit-border-radius: 3px; -moz-border-radius: 3px; display: inline-block;" href="-ddp.baseWebUrl-/activity-link/-ddp.activityInstanceGuid-">Contact Info Form</a>
+                                  </p>
+                                </td>
+                              </tr>
+                            </table>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">For your convenience, we have attached a copy of your signed consent form. Please contact us via this email address <a href="mailto:info@mbcproject.org">info@mbcproject.org</a> or at <a href="tel:617-800-1622">617-800-1622</a> if you have any questions or concerns.</td>
                   </tr>
                   <tr>
                     <td align="left" class="padding-copy" style="padding: 20px 0 0 0; font-size: 16px; line-height: 25px; font-family: Helvetica, Arial, sans-serif; color: #666666;">Sincerely,<br>The MBCproject team</td>
@@ -193,7 +220,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/emails/welcome.html
+++ b/study-builder/studies/mbc/emails/welcome.html
@@ -129,7 +129,7 @@
                   <tr>
                     <td align="center" bgcolor="#ffffff" width="100">
                       <a target="blank" href="-ddp.baseWebUrl-">
-                        <img src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
+                        <img src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-logo.png" alt="Logo" height="69" width="150" border="0" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;"/></a>
                     </td>
                   </tr>
                 </table>
@@ -223,7 +223,7 @@
     <table align="center" style="text-align: center; width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; margin: 25px auto 25px auto" border="0" cellpadding="0" cellspacing="0" width="100%">
       <tr align="center" style="text-align: center; width: 540px; height: 10px; padding: 0; margin: 25px auto 25px auto;">
         <td align="center" style="padding: 0; text-align: center;">
-          <img align="center" src="https://storage.googleapis.com/cmi-study-dev-assets/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
+          <img align="center" src="https://storage.googleapis.com/${assetsBucketName}/mbc/project-line.png" alt="decoration line" style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="540px" height="10px" border="0">
         </td>
       </tr>
     </table>

--- a/study-builder/studies/mbc/sendgrid_emails.conf
+++ b/study-builder/studies/mbc/sendgrid_emails.conf
@@ -1,0 +1,144 @@
+{
+  "sendgridEmails": [
+    {
+      "key": "aboutyouCompleted",
+      "name": "MBC_ABOUT_YOU_COMPLETE",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/about_you_completed.html",
+      "render": true
+    },
+    {
+      "key": "bloodReceived",
+      "name": "MBC_BLOOD_RECEIVED",
+      "subject": "Thank you, your blood kit was received",
+      "filepath": "emails/blood_received.html",
+      "render": true
+    },
+    {
+      "key": "bloodSent",
+      "name": "MBC_BLOOD_SENT",
+      "subject": "Metastatic Breast Cancer Project Notification",
+      "filepath": "emails/blood_sent.html",
+      "render": true
+    },
+    {
+      "key": "bloodSentReminder",
+      "name": "MBC_BLOOD_SENT_REMINDER",
+      "subject": "Metastatic Breast Cancer Project Check-In",
+      "filepath": "emails/blood_sent_reminder.html",
+      "render": true
+    },
+    {
+      "key": "bloodconsentCompleted",
+      "name": "MBC_BLOODCONSENT_COMPLETE",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/bloodconsent_completed.html",
+      "render": true
+    },
+    {
+      "key": "bloodreleaseCompleted",
+      "name": "MBC_BLOODRELEASE_COMPLETE",
+      "subject": "Thank you for submitting your information",
+      "filepath": "emails/bloodrelease_completed.html",
+      "render": true
+    },
+    {
+      "key": "consentCompleted",
+      "name": "MBC_CONSENT_COMPLETE",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/consent_completed.html",
+      "render": true
+    },
+    {
+      "key": "consentFirstReminder",
+      "name": "MBC_CONSENT_REMINDER_1WK",
+      "subject": "Next step for the Metastatic Breast Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_1wk.html",
+      "render": true
+    },
+    {
+      "key": "consentSecondReminder",
+      "name": "MBC_CONSENT_REMINDER_2WK",
+      "subject": "Next step for the Metastatic Breast Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_2wk.html",
+      "render": true
+    },
+    {
+      "key": "consentThirdReminder",
+      "name": "MBC_CONSENT_REMINDER_3WK",
+      "subject": "Next step for the Metastatic Breast Cancer Project: please sign the consent form",
+      "filepath": "emails/consent_reminder_3wk.html",
+      "render": true
+    },
+    {
+      "key": "exitRequest",
+      "name": "MBC_EXIT_REQUEST",
+      "subject": "Participant Withdraw Request",
+      "filepath": "emails/exit_request.html",
+      "render": true
+    },
+    {
+      "key": "followupCompleted",
+      "name": "MBC_FOLLOWUP_COMPLETED",
+      "subject": "Thank you, we received your MBCproject follow-up survey #1",
+      "filepath": "emails/followup_completed.html",
+      "render": true
+    },
+    {
+      "key": "followupCreated",
+      "name": "MBC_FOLLOWUP_CREATED",
+      "subject": "The Metastatic Breast Cancer Project: Follow-Up Survey #1",
+      "filepath": "emails/followup_created.html",
+      "render": true
+    },
+    {
+      "key": "followupReminder",
+      "name": "MBC_FOLLOWUP_REMINDER",
+      "subject": "The Metastatic Breast Cancer Project Reminder: Follow-Up Survey #1",
+      "filepath": "emails/followup_reminder.html",
+      "render": true
+    },
+    {
+      "key": "joinMailingList",
+      "name": "MBC_JOIN_MAILING_LIST",
+      "subject": "Thank you for signing up for the MBC Project mailing list",
+      "filepath": "emails/join_mailing_list.html",
+      "render": true
+    },
+    {
+      "key": "releaseCompleted",
+      "name": "MBC_RELEASE_COMPLETED",
+      "subject": "Thank you for submitting your contact information",
+      "filepath": "emails/release_completed.html",
+      "render": true
+    },
+    {
+      "key": "releaseReminder",
+      "name": "MBC_RELEASE_REMINDER",
+      "subject": "Next step for the Metastatic Breast Cancer Project: we need some additional information from you",
+      "filepath": "emails/release_reminder.html",
+      "render": true
+    },
+    {
+      "key": "salivaReceived",
+      "name": "MBC_SALIVA_RECEIVED",
+      "subject": "Thank you, your saliva kit was received",
+      "filepath": "emails/saliva_received.html",
+      "render": true
+    },
+    {
+      "key": "tissueconsentCompleted",
+      "name": "MBC_TISSUECONSENT_COMPLETED",
+      "subject": "Thank you for providing your consent",
+      "filepath": "emails/tissueconsent_completed.html",
+      "render": true
+    },
+    {
+      "key": "welcome",
+      "name": "MBC_WELCOME",
+      "subject": "Welcome to the Metastatic Breast Cancer Project",
+      "filepath": "emails/welcome.html",
+      "render": true
+    }
+  ]
+}

--- a/study-builder/studies/mbc/study.conf
+++ b/study-builder/studies/mbc/study.conf
@@ -40,6 +40,8 @@
     "defaultSalutation": ${sendgridDefaultSalutation}
   },
 
+  include required("sendgrid_emails.conf"),
+
   "kits": [
     {
       "type": "SALIVA",


### PR DESCRIPTION
Switched Angio/Brain/MBC studies to use email configurations so we can manage it using study-builder. Most of this is updating the email templates. But most important changes are in the `sendgrid_emails.conf` files.