### PR TITLE
DDP-2314-update-rendering-for-component-blocks: passing params bundle…

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
@@ -56,40 +56,10 @@ public interface ComponentDao extends SqlObject {
         boolean isPhysician = componentDto.getComponentType() == ComponentType.PHYSICIAN;
         if (isInstitution || isPhysician) {
             InstitutionPhysicianComponentDto institutionDto = getJdbiInstitutionPhysicianComponent().findById(componentId);
-
-            String buttonText = null;
-            if (institutionDto.getButtonTemplateId() != null) {
-                buttonText = i18nRenderer.renderContent(getHandle(), institutionDto.getButtonTemplateId(), languageCodeId);
-            }
-            String titleText = null;
-            if (institutionDto.getTitleTemplateId() != null) {
-                titleText = i18nRenderer.renderContent(getHandle(), institutionDto.getTitleTemplateId(),
-                        languageCodeId);
-            }
-            String subtitleText = null;
-            if (institutionDto.getSubtitleTemplateId() != null) {
-                subtitleText = i18nRenderer.renderContent(getHandle(), institutionDto.getSubtitleTemplateId(),
-                        languageCodeId);
-            }
-
             if (isInstitution) {
-                formComponent = new InstitutionComponent(institutionDto.getAllowMultiple(),
-                        buttonText,
-                        titleText,
-                        subtitleText,
-                        institutionDto.getInstitutionType(),
-                        institutionDto.showFields(),
-                        institutionDto.isRequired(),
-                        componentDto.shouldHideNumber());
+                formComponent = new InstitutionComponent(institutionDto, componentDto.shouldHideNumber());
             } else if (isPhysician) {
-                formComponent = new PhysicianComponent(institutionDto.getAllowMultiple(),
-                        buttonText,
-                        titleText,
-                        subtitleText,
-                        institutionDto.getInstitutionType(),
-                        institutionDto.showFields(),
-                        institutionDto.isRequired(),
-                        componentDto.shouldHideNumber());
+                formComponent = new PhysicianComponent(institutionDto, componentDto.shouldHideNumber());
             } else {
                 throw new DaoException("Unknown component type " + componentDto.getComponentType());
             }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ComponentBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ComponentBlock.java
@@ -37,12 +37,12 @@ public class ComponentBlock extends FormBlock implements Numberable  {
 
     @Override
     public void registerTemplateIds(Consumer<Long> registry) {
-        // todo: plug into template rendering
+        formComponent.registerTemplateIds(registry);
     }
 
     @Override
     public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
-        // todo: plug into template rendering
+        formComponent.applyRenderedTemplates(rendered, style);
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.function.Consumer;
 
 import javax.validation.constraints.NotNull;
@@ -22,12 +20,6 @@ public abstract class FormComponent implements Numberable, Renderable {
     private Integer displayNumber;
 
     protected transient boolean hideDisplayNumber;
-
-    @NotNull
-    @SerializedName("parameters")
-    // derived classes should fill this map explicitly.  this is where the client
-    // gets the list of parameters
-    protected Map<String, Object> parameters = new LinkedHashMap<>();
 
     public FormComponent(ComponentType componentType) {
         this.componentType = componentType;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
@@ -41,12 +41,10 @@ public abstract class FormComponent implements Numberable, Renderable {
     }
 
     @Override
-    public void registerTemplateIds(Consumer<Long> registry) {
-    }
+    public abstract void registerTemplateIds(Consumer<Long> registry);
 
     @Override
-    public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
-    }
+    public abstract void applyRenderedTemplates(Provider<String> rendered, ContentStyle style);
 
     public ComponentType getComponentType() {
         return componentType;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormComponent.java
@@ -2,13 +2,17 @@ package org.broadinstitute.ddp.model.activity.instance;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
+
+import org.broadinstitute.ddp.content.ContentStyle;
+import org.broadinstitute.ddp.content.Renderable;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 
-public abstract class FormComponent implements Numberable {
+public abstract class FormComponent implements Numberable, Renderable {
 
     @NotNull
     @SerializedName("componentType")
@@ -42,6 +46,14 @@ public abstract class FormComponent implements Numberable {
     @Override
     public boolean shouldHideNumber() {
         return hideDisplayNumber;
+    }
+
+    @Override
+    public void registerTemplateIds(Consumer<Long> registry) {
+    }
+
+    @Override
+    public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
     }
 
     public ComponentType getComponentType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/InstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/InstitutionComponent.java
@@ -1,27 +1,14 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import org.broadinstitute.ddp.db.dto.InstitutionPhysicianComponentDto;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
-import org.broadinstitute.ddp.model.activity.types.InstitutionType;
-
 
 public final class InstitutionComponent extends PhysicianInstitutionComponent {
 
-    public InstitutionComponent(boolean allowMultiple,
-                                String addButtonText,
-                                String titleText,
-                                String subtitleText,
-                                InstitutionType institutionType,
-                                boolean showFields,
-                                boolean hideNumber,
-                                boolean required) {
-        super(ComponentType.INSTITUTION,
-                allowMultiple,
-                addButtonText,
-                titleText,
-                subtitleText,
-                institutionType,
-                showFields,
-                hideNumber,
-                required);
+    public InstitutionComponent(
+            InstitutionPhysicianComponentDto instDto,
+            boolean shouldHideNumber
+    ) {
+        super(ComponentType.INSTITUTION, instDto, shouldHideNumber);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
@@ -1,16 +1,29 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import com.google.gson.annotations.SerializedName;
+
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 
 public class MailingAddressComponent extends FormComponent {
 
-    public static final String TITLE_TEXT = "titleText";
-    public static final String SUBTITLE_TEXT = "subtitleText";
+    @SerializedName("parameters")
+    private SerializedFields serializedFields;
 
     public MailingAddressComponent(String titleText, String subtitleText, boolean hideNumber) {
         super(ComponentType.MAILING_ADDRESS);
         hideDisplayNumber = hideNumber;
-        parameters.put(TITLE_TEXT, titleText);
-        parameters.put(SUBTITLE_TEXT, subtitleText);
+        serializedFields = new SerializedFields(titleText, subtitleText);
+    }
+
+    public static class SerializedFields {
+        @SerializedName("titleText")
+        private static String titleText;
+        @SerializedName("subtitleText")
+        private static String subtitleText;
+
+        public SerializedFields(String titleText, String subtitleText) {
+            this.subtitleText = subtitleText;
+            this.titleText = titleText;
+        }
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import java.util.function.Consumer;
+
 import com.google.gson.annotations.SerializedName;
 
+import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 
 public class MailingAddressComponent extends FormComponent {
@@ -25,5 +28,15 @@ public class MailingAddressComponent extends FormComponent {
             this.subtitleText = subtitleText;
             this.titleText = titleText;
         }
+    }
+
+    @Override
+    public void registerTemplateIds(Consumer<Long> registry) {
+        // Implement this method once we decide to use bulk rendering for this component
+    }
+
+    @Override
+    public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
+        // Implement this method once we decide to use bulk rendering for this component
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianComponent.java
@@ -1,27 +1,14 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import org.broadinstitute.ddp.db.dto.InstitutionPhysicianComponentDto;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
-import org.broadinstitute.ddp.model.activity.types.InstitutionType;
-
 
 public final class PhysicianComponent extends PhysicianInstitutionComponent {
 
-    public PhysicianComponent(boolean allowMultiple,
-                              String addButtonText,
-                              String titleText,
-                              String subtitleText,
-                              InstitutionType institutionType,
-                              boolean showFields,
-                              boolean required,
-                              boolean hideNumber) {
-        super(ComponentType.PHYSICIAN,
-                allowMultiple,
-                addButtonText,
-                titleText,
-                subtitleText,
-                institutionType,
-                showFields,
-                required,
-                hideNumber);
+    public PhysicianComponent(
+            InstitutionPhysicianComponentDto instDto,
+            boolean shouldHideNumber
+    ) {
+        super(ComponentType.PHYSICIAN, instDto, shouldHideNumber);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -2,6 +2,9 @@ package org.broadinstitute.ddp.model.activity.instance;
 
 import java.util.Optional;
 import java.util.function.Consumer;
+import javax.validation.constraints.NotNull;
+
+import com.google.gson.annotations.SerializedName;
 
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.db.dto.InstitutionPhysicianComponentDto;
@@ -15,21 +18,17 @@ import org.broadinstitute.ddp.model.activity.types.InstitutionType;
  */
 public abstract class PhysicianInstitutionComponent extends FormComponent {
 
-    public static final String ALLOW_MULTIPLE = "allowMultiple";
-    public static final String ADD_BUTTON_TEXT = "addButtonText";
-    public static final String TITLE_TEXT = "titleText";
-    public static final String SUBTITLE_TEXT = "subtitleText";
-    public static final String INSTITUTION_TYPE = "institutionType";
-    public static final String SHOW_FIELDS = "showFieldsInitially";
-    public static final String REQUIRED = "required";
-
     // fields are marked transient so that gson does not deserialize them.  instead,
     // they are added to the parameters list, which is serialized.
     private transient InstitutionPhysicianComponentDto instDto;
-
     private transient String buttonText;
     private transient String titleText;
     private transient String subtitleText;
+
+    @NotNull
+    @SerializedName("parameters")
+    // That's what is actually serialized
+    private SerializedFields serializedFields = new SerializedFields();
 
     protected PhysicianInstitutionComponent(
             ComponentType physicianOrInstitution,
@@ -45,14 +44,14 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
         this.hideDisplayNumber = shouldHideNumber;
     }
 
-    private final void initParametersMap() {
-        parameters.put(ALLOW_MULTIPLE, instDto.getAllowMultiple());
-        parameters.put(ADD_BUTTON_TEXT, buttonText);
-        parameters.put(TITLE_TEXT, titleText);
-        parameters.put(SUBTITLE_TEXT, subtitleText);
-        parameters.put(INSTITUTION_TYPE, instDto.getInstitutionType().name());
-        parameters.put(SHOW_FIELDS, instDto.showFields());
-        parameters.put(REQUIRED, instDto.isRequired());
+    private final void setSerializedFields() {
+        serializedFields.setAllowMultiple(instDto.getAllowMultiple());
+        serializedFields.setButtonText(buttonText);
+        serializedFields.setTitleText(titleText);
+        serializedFields.setSubtitleText(subtitleText);
+        serializedFields.setInstitutionType(instDto.getInstitutionType().name());
+        serializedFields.setShowFields(instDto.showFields());
+        serializedFields.setIsRequired(instDto.isRequired());
     }
 
     @Override
@@ -70,10 +69,55 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
         titleText = rendered.get(instDto.getTitleTemplateId());
         subtitleText = rendered.get(instDto.getSubtitleTemplateId());
 
-        initParametersMap();
+        setSerializedFields();
     }
 
     public InstitutionType getInstitutionType() {
         return instDto.getInstitutionType();
+    }
+
+    public static class SerializedFields {
+        @SerializedName("allowMultiple")
+        private boolean allowMultiple;
+        @SerializedName("addButtonText")
+        private String buttonText;
+        @SerializedName("titleText")
+        private String titleText;
+        @SerializedName("subtitleText")
+        private String subtitleText;
+        @SerializedName("institutionType")
+        private String institutionType;
+        @SerializedName("showFieldsInitially")
+        private boolean showFields;
+        @SerializedName("required")
+        private boolean isRequired;
+
+        public void setAllowMultiple(boolean allowMultiple) {
+            this.allowMultiple = allowMultiple;
+        }
+
+        public void setButtonText(String buttonText) {
+            this.buttonText = buttonText;
+        }
+
+        public void setTitleText(String titleText) {
+            this.titleText = titleText;
+        }
+
+        public void setSubtitleText(String subtitleText) {
+            this.subtitleText = subtitleText = subtitleText;
+        }
+
+        public void setInstitutionType(String institutionType) {
+            this.institutionType = institutionType;
+        }
+
+        public void setShowFields(boolean showFields) {
+            this.showFields = showFields;
+        }
+
+        public void setIsRequired(boolean isRequired) {
+            this.isRequired = isRequired;
+        }
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -26,7 +26,6 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
     // fields are marked transient so that gson does not deserialize them.  instead,
     // they are added to the parameters list, which is serialized.
     private transient InstitutionPhysicianComponentDto instDto;
-    private transient boolean shouldHideNumber;
 
     private transient String buttonText;
     private transient String titleText;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -1,5 +1,9 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.db.dto.InstitutionPhysicianComponentDto;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 import org.broadinstitute.ddp.model.activity.types.InstitutionType;
@@ -40,11 +44,9 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
         }
         this.instDto = instDto;
         this.hideDisplayNumber = shouldHideNumber;
-        initParametersMap();
     }
 
     private final void initParametersMap() {
-        renderLabels();
         parameters.put(ALLOW_MULTIPLE, instDto.getAllowMultiple());
         parameters.put(ADD_BUTTON_TEXT, buttonText);
         parameters.put(TITLE_TEXT, titleText);
@@ -54,8 +56,22 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
         parameters.put(REQUIRED, instDto.isRequired());
     }
 
-    private final void renderLabels() {
-        //
+    @Override
+    public void registerTemplateIds(Consumer<Long> registry) {
+        super.registerTemplateIds(registry);
+        Optional.ofNullable(instDto.getButtonTemplateId()).ifPresentOrElse(registry::accept, () -> { });
+        Optional.ofNullable(instDto.getTitleTemplateId()).ifPresentOrElse(registry::accept, () -> { });
+        Optional.ofNullable(instDto.getSubtitleTemplateId()).ifPresentOrElse(registry::accept, () -> { });
+    }
+
+    @Override
+    public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
+        super.applyRenderedTemplates(rendered, style);
+        buttonText = rendered.get(instDto.getButtonTemplateId());
+        titleText = rendered.get(instDto.getTitleTemplateId());
+        subtitleText = rendered.get(instDto.getSubtitleTemplateId());
+
+        initParametersMap();
     }
 
     public InstitutionType getInstitutionType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import org.broadinstitute.ddp.db.dto.InstitutionPhysicianComponentDto;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 import org.broadinstitute.ddp.model.activity.types.InstitutionType;
 
@@ -20,56 +21,44 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
 
     // fields are marked transient so that gson does not deserialize them.  instead,
     // they are added to the parameters list, which is serialized.
-    private transient boolean allowMultiple;
+    private transient InstitutionPhysicianComponentDto instDto;
+    private transient boolean shouldHideNumber;
 
-    private transient String addButtonText;
-
+    private transient String buttonText;
     private transient String titleText;
-
     private transient String subtitleText;
 
-    private transient InstitutionType institutionType;
-
-    private transient boolean showFields;
-
-    private transient boolean required;
-
-    protected PhysicianInstitutionComponent(ComponentType physicianOrInstitution,
-                                            boolean allowMultiple,
-                                            String addButtonText,
-                                            String titleText,
-                                            String subtitleText,
-                                            InstitutionType institutionType,
-                                            boolean showFields,
-                                            boolean required,
-                                            boolean hideNumber) {
+    protected PhysicianInstitutionComponent(
+            ComponentType physicianOrInstitution,
+            InstitutionPhysicianComponentDto instDto,
+            boolean shouldHideNumber
+    ) {
         super(physicianOrInstitution);
         if (physicianOrInstitution != ComponentType.PHYSICIAN && physicianOrInstitution != ComponentType.INSTITUTION) {
             throw new IllegalArgumentException("Physician/Institution component must be either " + ComponentType
                     .PHYSICIAN + " or " + ComponentType.INSTITUTION);
         }
-        this.allowMultiple = allowMultiple;
-        this.addButtonText = addButtonText;
-        this.titleText = titleText;
-        this.subtitleText = subtitleText;
-        this.institutionType = institutionType;
-        this.showFields = showFields;
-        this.hideDisplayNumber = hideNumber;
-        this.required = required;
+        this.instDto = instDto;
+        this.hideDisplayNumber = shouldHideNumber;
         initParametersMap();
     }
 
     private final void initParametersMap() {
-        parameters.put(ALLOW_MULTIPLE, allowMultiple);
-        parameters.put(ADD_BUTTON_TEXT, addButtonText);
+        renderLabels();
+        parameters.put(ALLOW_MULTIPLE, instDto.getAllowMultiple());
+        parameters.put(ADD_BUTTON_TEXT, buttonText);
         parameters.put(TITLE_TEXT, titleText);
         parameters.put(SUBTITLE_TEXT, subtitleText);
-        parameters.put(INSTITUTION_TYPE, institutionType.name());
-        parameters.put(SHOW_FIELDS, showFields);
-        parameters.put(REQUIRED, required);
+        parameters.put(INSTITUTION_TYPE, instDto.getInstitutionType().name());
+        parameters.put(SHOW_FIELDS, instDto.showFields());
+        parameters.put(REQUIRED, instDto.isRequired());
+    }
+
+    private final void renderLabels() {
+        //
     }
 
     public InstitutionType getInstitutionType() {
-        return institutionType;
+        return instDto.getInstitutionType();
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -63,9 +63,9 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
 
     @Override
     public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
-        buttonText = rendered.get(instDto.getButtonTemplateId());
-        titleText = rendered.get(instDto.getTitleTemplateId());
-        subtitleText = rendered.get(instDto.getSubtitleTemplateId());
+        buttonText = Optional.ofNullable(instDto.getButtonTemplateId()).map(id -> rendered.get(id)).orElse(null);
+        titleText = Optional.ofNullable(instDto.getTitleTemplateId()).map(id -> rendered.get(id)).orElse(null);
+        subtitleText = Optional.ofNullable(instDto.getSubtitleTemplateId()).map(id -> rendered.get(id)).orElse(null);
 
         setSerializedFields();
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/PhysicianInstitutionComponent.java
@@ -56,7 +56,6 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
 
     @Override
     public void registerTemplateIds(Consumer<Long> registry) {
-        super.registerTemplateIds(registry);
         Optional.ofNullable(instDto.getButtonTemplateId()).ifPresentOrElse(registry::accept, () -> { });
         Optional.ofNullable(instDto.getTitleTemplateId()).ifPresentOrElse(registry::accept, () -> { });
         Optional.ofNullable(instDto.getSubtitleTemplateId()).ifPresentOrElse(registry::accept, () -> { });
@@ -64,7 +63,6 @@ public abstract class PhysicianInstitutionComponent extends FormComponent {
 
     @Override
     public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
-        super.applyRenderedTemplates(rendered, style);
         buttonText = rendered.get(instDto.getButtonTemplateId());
         titleText = rendered.get(instDto.getTitleTemplateId());
         subtitleText = rendered.get(instDto.getSubtitleTemplateId());


### PR DESCRIPTION
## Context and the big picture
Instead of performing ad-hoc rendering of Institution/Physician components, makes them implement `Renderable` and hence the ability to render its constituent parts externally, as a part of the bulk render. This should be faster because each individual call to renderContent() incurs a db trip.
 
 ## What type of change is this?
  
  - [ ] Bugfix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Experimental proof-of-concept
  - [ ] Infosec/Compliance remediation
  
 ## Risk Assessment
  - [x] These changes are **HIGH RISK**.
    - [x] There is an elevated risk that may impact a large number of features
    - [ ] There is an elevated risk to security and privacy
    - [ ] These changes introduce new 3rd party dependencies, alter the network perimeter, or contain
    major upgrades to persistent storage or SaaS dependencies such as auth0, sendgrid, or easypost    
  - [ ] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [ ] :relaxed: All good, business as usual!
  - [x :sweat_smile: There might be some issues here
  - [ ] :scream:I'm sweaty and nervous
 
 ## How to we demo these changes?
 How does one observe these changes in a deployed system?  Note that _user visible_ encompasses
 many personas--not just patients and study staff, but ops your fellow devs, compliance, etc.
 
 - [x] They are user-visible in dev as a regular user journey and require no additional instructions.
 - [ ] Getting dev into a state where this is user-visible requires some tech fiddling.  I have
 documented these steps in the related ticket.
 - [ ] Requires other features before it's human visible.  I have documented the blocking issues
 in jira.
 - [ ] I have no idea how to demo this.  Please help me!
 
 ## UI/UX
  - [x] There ain't no UI/UX in these changes
  - [ ] My changes have passed muster with Erin and Jen via an over-the-shoulder review, screenshots, etc.
  - [ ] Erin and Jen have not had an opportunity to provide feedback yet
 
## Logging
  ###  Backend
   - [ ] I have considered error handling and notification to slack alert rooms via `LOG.error()`.
     #### Route Changes
     - [ ] My changes involve a new route changes to an existing route, so the who/what/when are logged using the usual logback mechanism
at the _start_ of the route, prior to any validation, as well as at the end of the route when work completes.
     ### Housekeeping Changes
     - [ ] My changes involve updates to housekeeping, and I am logging the who/what/when via logback.
  ### Client-side
   - [ ] My changes do not involve backend route change, but I have useful logging statements nonetheless.

## Analytics
 - [ ] I have discussed the analytics needs at both a platform and study level with Jen and instrumented code
 accordingly.
 - [x] There are no analytics requirements for these changes

## Security and Privacy
Ensuring proper security and privacy for our users is essential.

  ###  Backend
   - [ ] These changes alter fundamental auth filter logic
   - [ ] These changes introduce a new backend API route that is behind an auth filter
   - [ ] These changes introduce a new backend API that _does not require auth_
   - [ ] These changes alter auth0 internals (rules, hosted login, configuration, etc.)
   - [ ] These changes expose new information to elastic and I have verified that PHI is not being exposed to the public
    
  ### Browser
  - [ ] These changes alter what we store in browser storage
  
  ### Mobile
  - [ ] TBD 
 
 ## Performance and Stability
  - [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, and performance bottlenecks and written a brief summary in this PR
  - [ ] I'm unsure about stability, performance, fault tolerance, and graceful degradation.  Please help!
  
## Testing
 - [ ] I have written automated positive tests
 - [ ] I have written automated negative tests
 - [ ] I have written zero automated tests but have poked around locally to verify proper functionality
 - [ ] The jira ticket has acceptance criteria and Kiara has in the information she needs to test my changes
 
## Release
 - [x] These changes require no special release procedures--just code!
 - [ ] Releasing these changes requires special handling
   - [ ] I have documented the special procedures in the release plan document
   - [ ] The special procedures require minimal downtime
   - [ ] The special procedures require unavoidable, extended downtime for:
     - [ ] Participant UX
     - [ ] Study staff
  
 
