### PR TITLE
DDP-4141 add dob validation for age-up

### DIFF
--- a/study-builder/studies/osteo/patches/dob-validations.conf
+++ b/study-builder/studies/osteo/patches/dob-validations.conf
@@ -6,10 +6,10 @@
         {
           "messageTemplate": {
             "templateType": "HTML",
-            "templateText": "$osteo_consent_dob_validation",
+            "templateText": "$osteo_consent_dob_validation_self",
             "variables": [
               {
-                "name": "osteo_consent_dob_validation",
+                "name": "osteo_consent_dob_validation_self",
                 "translations": [
                   {
                     "language": "en",
@@ -26,7 +26,8 @@
           },
           "stableIds": ["CONSENT_DOB"],
           "precondition": """
-            user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_DOB"].isAnswered()
+            user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["PREQUAL_SELF_DESCRIBE"].answers.hasOption("DIAGNOSED")
+            && user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_DOB"].isAnswered()
           """,
           # If adult participant's age derived from DOB is less than 18/19/21, then error.
           "expression": """
@@ -56,6 +57,37 @@
               user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
               && !user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(18, YEARS)
             )
+          """
+        },
+        {
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$osteo_consent_dob_validation_ageup",
+            "variables": [
+              {
+                "name": "osteo_consent_dob_validation_ageup",
+                "translations": [
+                  {
+                    "language": "en",
+                    "text": """The date of birth you entered is different from what was previously entered by your
+                      parent or guardian. Please check the date you entered and correct any errors. If you think there
+                      is a mistake, please reach out to us at <a href="tel:651-602-2020" class="Link">651-602-2020</a>
+                      or <a href="mailto:info@osproject.org" class="Link">info@osproject.org</a>.
+                    """
+                  }
+                ]
+              }
+            ]
+          },
+          "stableIds": ["CONSENT_DOB"],
+          "precondition": """
+            user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["PREQUAL_SELF_DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED")
+            && user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_DOB"].isAnswered()
+          """,
+          # If aged-up participant's DOB answer does not match what's in their profile, then error.
+          # Their profile should have already been populated with birth date as filled out previously by their parent.
+          "expression": """
+            user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_DOB"].answers.value() != user.profile.birthDate()
           """
         }
       ]


### PR DESCRIPTION
This PR fixes a bug where the DOB validations are not showing up in age-up scenario. The expectation is that in this age-up scenario, we want to check that the DOB entered by user matches what we got previously from their parent, which is stored in their profile.

HOW TO APPLY FIX:
* Since this is only on `dev`, I will manually delete the old validations and rerun the patch on `dev`.