### PR TITLE
pex: add profile birth date query

### DIFF
--- a/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
+++ b/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
@@ -25,6 +25,7 @@ query
   | 'user' '.' study '.' form '.' question '.' questionPredicate                         # QuestionQuery
   | 'user' '.' study '.' form '.' question '.' 'answers' '.' predicate                   # DefaultLatestAnswerQuery
   | 'user' '.' study '.' form '.' instance '.' question '.' 'answers' '.' predicate      # AnswerQuery
+  | 'user' '.' 'profile' '.' profileDataQuery   # ProfileQuery
   ;
 
 study : 'studies' '[' STR ']' ;
@@ -58,6 +59,11 @@ predicate
   | 'hasDate' '(' ')'                       # HasDatePredicate
   | 'ageAtLeast' '(' INT ',' TIMEUNIT ')'   # AgeAtLeastPredicate
   | 'value' '(' ')' # ValueQuery    // Not exactly a predicate but putting this here eases implementation and backwards-compatibility.
+  ;
+
+// Queries to pull out various pieces of profile data
+profileDataQuery
+  : 'birthDate' '(' ')'   # ProfileBirthDateQuery
   ;
 
 


### PR DESCRIPTION
## Context

This PR adds a new query to PEX that allows us to pull out the user's birth date (stored in their profile) as a `date` PEX value.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
