### PR TITLE
DDP-4512 . thank-you email fix for MBC about-you survey

### DIFF
--- a/study-builder/studies/mbc/study.conf
+++ b/study-builder/studies/mbc/study.conf
@@ -1273,8 +1273,8 @@
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
-        "activityCode": "ABOUTYOU",
-        "statusType": "COMPLETE"
+        "activityCode": "CONSENT",
+        "statusType": "CREATED"
       },
       "action": {
         "type": "SENDGRID_EMAIL",
@@ -1283,9 +1283,6 @@
         "language": "en",
         "pdfAttachments": []
       },
-      "cancelExpr": """
-        !user.studies["cmi-mbc"].forms["ABOUTYOU"].questions["COUNTRY"].answers.hasAnyOption("US", "CA", "PR", "GU", "VI", "MP", "AS")
-      """,
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-4512

Generate a thank you email once next activity, consent is created rather than about-you complete.
consent is created only when supported country is selected.  

requirement:
thank-you email should be generated when about-you is submitted with supported country.
thank-you email should NOT be generated when about-you is submitted with NOT supported country.
This is same as brain study.