### PR TITLE
MBC user enrollment fix

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
@@ -700,6 +700,12 @@ public class StudyDataLoader {
             return;
         }
 
+        String status = getStringValueFromElement(surveyData, "survey_status");
+        if (status.equalsIgnoreCase("CREATED")) {
+            LOG.warn("Created followup survey instance but no data ");
+            return;
+        }
+
         processSurveyData(handle, "followupsurvey", surveyData, mappingData,
                 studyDto, userDto, instanceDto, answerDao);
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
@@ -570,6 +570,8 @@ public class StudyDataLoader {
         //MBC might have dup physicians because physician list comes in both release and bdrelease surveys
         processPhysicianList(handle, surveyData, userDto, studyDto,
                 "physician_list", InstitutionType.PHYSICIAN, "bdreleasesurvey", instanceDto);
+
+        updateUserStudyEnrollment(handle, surveyData, userDto.getUserGuid(), studyDto.getGuid());
     }
 
 

--- a/study-builder/studies/mbc/study.conf
+++ b/study-builder/studies/mbc/study.conf
@@ -1636,6 +1636,19 @@
       "dispatchToHousekeeping": false,
       "order": 1
     },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "BLOODRELEASE",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
 
     # announcement event
     {


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-4523
Migrated user should be updated as "enrolled" if blood consent and blood survey is completed.
Handle followup instance only creation