### PR TITLE
data exporter cli: add flag to do all elastic indices

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -334,7 +334,7 @@ public class DataExporter {
         }
     }
 
-    public void exportActivityDefinitionsToElasticsearch(
+    public List<ActivityExtract> exportActivityDefinitionsToElasticsearch(
             Handle handle, StudyDto studyDto, Config cfg) {
 
         //get study activities
@@ -371,6 +371,8 @@ public class DataExporter {
         } catch (IOException e) {
             LOG.error("[activitydefinition export] failed during export ", e);
         }
+
+        return activityExtracts;
     }
 
     private void exportDataToElasticSearch(String index, Map<String, Object> data, Config cfg) throws IOException {


### PR DESCRIPTION
Instead of running 4 different commands separately, we should just run a single command. Also, running separate commands is not optimal since each command will have to warm up cache and query data separately.