### PR TITLE
Update version in API documentation

### DIFF
--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.0
 servers: []
 info:
-  description: 'Specification for the Pepper API: `v1-Poblano`'
-  version: 1.0.0
+  description: 'Pepper API specification'
+  version: 1.8.0
   title: Pepper
   contact:
     email: info@datadonationplatform.org


### PR DESCRIPTION
 ## Context and the big picture
Until we figure out a means of separately versioning the API, let's keep the API specification version up to date with the release version it's tagged to in Github.
 
 ## What type of change is this?
  
  - [X] Bugfix (non-breaking change which fixes an issue)
  
 ## Risk Assessment  
  - [X] These changes are low risk, do not impact security/privacy, do not impact pepper shared
  components/modules, and have no major upgrades to 3rd party services or libraries
 
 ### FUD Score 
 Overall, how are you feeling about these changes?
  - [X] :relaxed: All good, business as usual!
 
 ## How to we demo these changes?

### macOS
#### Process
```bash
cd pepper-apis/docs/specification
build.sh documentation
open build/pepper.html
```
#### Expected Result
The version of Pepper reported should be `1.8.0`- upon opening `build/pepper.html` in a web browser, you should see a line that reads `Pepper (1.8.0)` near the top of the document.
 
 ## UI/UX
  - [X] There ain't no UI/UX in these changes

## Analytics
 - [X] There are no analytics requirements for these changes

## Testing
 - [X] I have written zero automated tests but have poked around locally to verify proper functionality
 
## Release
 - [X] These changes require no special release procedures--just code!
  
 
