### PR TITLE
Add CI checks for study-builder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,12 +519,13 @@ commands:
           condition: << parameters.restore_m2_cache >>
           steps:
             - restore_cache: *m2_cache_keys
-      - run: |
-          pwd
-          mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
-          cd << parameters.repo_path >>/study-builder
-          ls -l
-          mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+      - run:
+          name: Compiling pepper-apis then study-builder
+          command: |
+            mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            cd << parameters.repo_path >>/study-builder
+            mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 
 jobs:
   compile-and-run-test-suite-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,7 +520,7 @@ commands:
           steps:
             - restore_cache: *m2_cache_keys
       - run:
-          name: Compiling and installing Pepper to m2 repository
+          name: Compiling and installing pepper-apis to m2 repository
           command: mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
       - run: cd << parameters.repo_path >>/study-builder
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,8 +568,10 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-all-jars:
+      - run-maven-with-pepper-options:
+          phase: process-test-classes
           restore_m2_cache: true
+          skip_checkstyle: true
       - render-configs
       - create-test-dbs
       - start-ddp-test-server # starts DDP server. And execute Liquibase DB population
@@ -577,7 +579,6 @@ jobs:
       - run-maven-with-pepper-options:
           phase: test
           skip_tests: false
-          skip_checkstyle: true
           additional_options: '-PCircleciParallelBuild -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH'
           save_m2_cache: true
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,8 +502,8 @@ commands:
           port: 5556
           timeout: 60
 
-  compile-pepper-and-study-builder:
-    description: Compile and run checkstyle on study-builder
+  compile-all-jars:
+    description: Compile and run checkstyle on pepper, housekeeping, and study-builder
     parameters:
       m2_repo:
         type: string
@@ -520,10 +520,11 @@ commands:
           steps:
             - restore_cache: *m2_cache_keys
       - run:
-          name: Compiling pepper-apis then study-builder
+          name: Compiling pepper-apis, housekeeping, and study-builder
           command: |
-            mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            mvn package -f housekeeping-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             cd << parameters.repo_path >>/study-builder
             mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 
@@ -536,7 +537,7 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-pepper-and-study-builder:
+      - compile-all-jars:
           restore_m2_cache: true
       - render-configs
       - create-test-dbs
@@ -560,7 +561,7 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-pepper-and-study-builder:
+      - compile-all-jars:
           restore_m2_cache: true
       - run-maven-with-pepper-options:
           phase: process-test-classes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,7 +502,7 @@ commands:
           port: 5556
           timeout: 60
 
-  compile-study-builder:
+  compile-pepper-and-study-builder:
     description: Compile and run checkstyle on study-builder
     parameters:
       m2_repo:
@@ -536,14 +536,14 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-study-builder:
+      - compile-pepper-and-study-builder:
           restore_m2_cache: true
       - render-configs
       - create-test-dbs
       - run-maven-with-pepper-options:
           phase: test
           skip_tests: false
-          skip_checkstyle: false
+          skip_checkstyle: true
           additional_options: '-Dtest=ServerInSameProcessIntegrationTestSuite'
           restore_m2_cache: true
 
@@ -560,6 +560,8 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
+      - compile-pepper-and-study-builder:
+          restore_m2_cache: true
       - run-maven-with-pepper-options:
           phase: process-test-classes
           restore_m2_cache: true
@@ -571,6 +573,7 @@ jobs:
       - run-maven-with-pepper-options:
           phase: test
           skip_tests: false
+          skip_checkstyle: true
           additional_options: '-PCircleciParallelBuild -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH'
           save_m2_cache: true
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,8 +502,8 @@ commands:
           port: 5556
           timeout: 60
 
-  compile-all-jars:
-    description: Compile and run checkstyle on pepper, housekeeping, and study-builder
+  compile-other-jars:
+    description: Compile and run checkstyle on housekeping and study-builder
     parameters:
       m2_repo:
         type: string
@@ -520,13 +520,13 @@ commands:
           steps:
             - restore_cache: *m2_cache_keys
       - run:
-          name: Compiling pepper-apis, housekeeping, and study-builder
+          name: Compile and run checkstyle on housekeping and study-builder
           command: |
-            mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            # pepper-apis should have already ran
             mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
-            mvn package -f housekeeping-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            mvn test-compile -f housekeeping-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             cd << parameters.repo_path >>/study-builder
-            mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+            mvn test-compile --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 
 jobs:
   compile-and-run-test-suite-job:
@@ -537,16 +537,15 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-all-jars:
-          restore_m2_cache: true
       - render-configs
       - create-test-dbs
       - run-maven-with-pepper-options:
-          phase: test
+          phase: install
           skip_tests: false
-          skip_checkstyle: true
+          skip_checkstyle: false
           additional_options: '-Dtest=ServerInSameProcessIntegrationTestSuite'
           restore_m2_cache: true
+      - compile-other-jars
 
   parallel-compile-and-test-job:
     executor:
@@ -561,12 +560,10 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - compile-all-jars:
-          restore_m2_cache: true
       - run-maven-with-pepper-options:
           phase: process-test-classes
+          skip_checkstyle: false
           restore_m2_cache: true
-          skip_checkstyle: true
       - render-configs
       - create-test-dbs
       - start-ddp-test-server # starts DDP server. And execute Liquibase DB population

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -508,6 +508,9 @@ commands:
       m2_repo:
         type: string
         default: *m2_repo_path
+      repo_path:
+        type: string
+        default: *repo_path
       restore_m2_cache:
         type: boolean
         default: false
@@ -516,9 +519,13 @@ commands:
           condition: << parameters.restore_m2_cache >>
           steps:
             - restore_cache: *m2_cache_keys
-      - run: mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
-      - run: cd ./study-builder
-      - run: mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+      - run:
+          name: Compiling and installing Pepper to m2 repository
+          command: mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+      - run: cd << parameters.repo_path >>/study-builder
+      - run:
+          name: Compiling study-builder
+          command: mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 
 jobs:
   compile-and-run-test-suite-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,32 +2,32 @@ version: 2.1
 
 references:
   tcell_dir: &tcell_dir
-             tcell
+      tcell
   # to install a new version of tcell, do  "tar -cvfz tcell-x.y.z.tar.gz tcell" after expanding tcell's zip
   tcell_gcp_path: &tcell_gcp_path
-                  gs://ddp-tcell/tcell-1.10.0.tar.gz
+      gs://ddp-tcell/tcell-1.10.0.tar.gz
   ci_support_image: &ci_support_image
-                       broadinstitute/study-server-build:2020-04-10G
+      broadinstitute/study-server-build:2020-04-10G
   root_path: &root_path
       /home/circleci
   repo_path: &repo_path
-              /home/circleci/repo
+      /home/circleci/repo
   m2_cache_key: &m2_cache_key
-                  pom.xml2-{{ checksum "pom.xml" }}
+      pom.xml2-{{ checksum "pom.xml" }}-{{ checksum "parent-pom.xml" }}
   m2_cache_restore_key: &m2_cache_keys
     keys:
       - *m2_cache_key
       - pom.xml2-
   m2_repo_path: &m2_repo_path
-             /home/circleci/.m2/repository
+      /home/circleci/.m2/repository
   pepper_apis_path: &pepper_apis_path
-            /home/circleci/repo/pepper-apis
+      /home/circleci/repo/pepper-apis
   circleci_path: &circleci_path
-            /home/circleci/repo/.circleci
+      /home/circleci/repo/.circleci
   builds_bucket: &builds_bucket
-            ddp-build-artifacts
+      ddp-build-artifacts
   jar_build_bucket_dir: &jar_build_bucket_dir
-        /ddp-study-server-pepper-apis
+      /ddp-study-server-pepper-apis
   housekeeping_test_db: &housekeeping_test_db
       housekeepingdb
   studyserver_test_db: &studyserver_test_db
@@ -522,9 +522,16 @@ commands:
       - run:
           name: Compile and run checkstyle on all jars
           command: |
+            # Install pepper-apis to .m2 so we can compile study-builder
             mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
-            mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+
+            # Just need to get parent-pom into .m2 so don't need to run checkstyle.
+            mvn install -f parent-pom.xml --batch-mode -DskipTests -Dcheckstyle.skip -Dmaven.repo.local=<< parameters.m2_repo >>
+
+            # Compile housekeeping
             mvn test-compile -f housekeeping-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+
+            # Compile study-builder
             cd << parameters.repo_path >>/study-builder
             mvn test-compile --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,13 +519,12 @@ commands:
           condition: << parameters.restore_m2_cache >>
           steps:
             - restore_cache: *m2_cache_keys
-      - run:
-          name: Compiling and installing pepper-apis to m2 repository
-          command: mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
-      - run: cd << parameters.repo_path >>/study-builder
-      - run:
-          name: Compiling study-builder
-          command: mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+      - run: |
+          pwd
+          mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+          cd << parameters.repo_path >>/study-builder
+          ls -l
+          mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
 
 jobs:
   compile-and-run-test-suite-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,6 +502,24 @@ commands:
           port: 5556
           timeout: 60
 
+  compile-study-builder:
+    description: Compile and run checkstyle on study-builder
+    parameters:
+      m2_repo:
+        type: string
+        default: *m2_repo_path
+      restore_m2_cache:
+        type: boolean
+        default: false
+    steps:
+      - when:
+          condition: << parameters.restore_m2_cache >>
+          steps:
+            - restore_cache: *m2_cache_keys
+      - run: mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+      - run: cd ./study-builder
+      - run: mvn package --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
+
 jobs:
   compile-and-run-test-suite-job:
     executor:
@@ -511,6 +529,8 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
+      - compile-study-builder:
+          restore_m2_cache: true
       - render-configs
       - create-test-dbs
       - run-maven-with-pepper-options:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,8 +502,8 @@ commands:
           port: 5556
           timeout: 60
 
-  compile-other-jars:
-    description: Compile and run checkstyle on housekeping and study-builder
+  compile-all-jars:
+    description: Compile and run checkstyle on all jars
     parameters:
       m2_repo:
         type: string
@@ -520,9 +520,9 @@ commands:
           steps:
             - restore_cache: *m2_cache_keys
       - run:
-          name: Compile and run checkstyle on housekeping and study-builder
+          name: Compile and run checkstyle on all jars
           command: |
-            # pepper-apis should have already ran
+            mvn install --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             mvn install -f parent-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             mvn test-compile -f housekeeping-pom.xml --batch-mode -DskipTests -Dmaven.repo.local=<< parameters.m2_repo >>
             cd << parameters.repo_path >>/study-builder
@@ -537,15 +537,16 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
+      - compile-all-jars:
+          restore_m2_cache: true
       - render-configs
       - create-test-dbs
       - run-maven-with-pepper-options:
-          phase: install
+          phase: test
           skip_tests: false
-          skip_checkstyle: false
+          skip_checkstyle: true
           additional_options: '-Dtest=ServerInSameProcessIntegrationTestSuite'
-          restore_m2_cache: true
-      - compile-other-jars
+          restore_m2_cache: false
 
   parallel-compile-and-test-job:
     executor:
@@ -560,9 +561,7 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
-      - run-maven-with-pepper-options:
-          phase: process-test-classes
-          skip_checkstyle: false
+      - compile-all-jars:
           restore_m2_cache: true
       - render-configs
       - create-test-dbs

--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -43,12 +43,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>3.4.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
@@ -157,6 +151,11 @@
         </dependency>
 
         <!-- database utilities -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>3.4.2</version>
+        </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
@@ -406,6 +405,12 @@
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>2.3.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.zaxxer</groupId>
+                    <artifactId>HikariCP-java6</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -71,7 +71,7 @@ public class StudyBuilder {
 
     public StudyBuilder doEvents(boolean doEvents) {
         this.doEvents = doEvents;
-        var foo = "very long linelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelineline";
+        foo = "a line";
         return this;
     }
 

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -71,6 +71,7 @@ public class StudyBuilder {
 
     public StudyBuilder doEvents(boolean doEvents) {
         this.doEvents = doEvents;
+        var foo = "very long linelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelinelineline";
         return this;
     }
 

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -71,7 +71,6 @@ public class StudyBuilder {
 
     public StudyBuilder doEvents(boolean doEvents) {
         this.doEvents = doEvents;
-        foo = "a line";
         return this;
     }
 


### PR DESCRIPTION
## Context

We occasionally breaks study-builder because it's not part of pepper-apis in the source directory and we do not have compile/checkstyle checks on it. No more. This PR adds a step in CircleCI to ensure that study-builder compiles and passes checkstyle. Also moved pepper-apis and housekeeping compilation/checkstyle checks earlier in the process.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

