### PR TITLE
StudyDataLoader fixt to be compatible with other gen2 studies

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.TreeMap;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Blob;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
@@ -485,7 +485,7 @@ public class StudyDataLoaderMain {
         } else {
             LOG.info("NO existing emails found.");
         }
-        LOG.info("Apltpid Map size: {} first: {} ", altpidBucketDataMap.size(), altpidBucketDataMap.keySet().iterator().next());
+        LOG.info("Apltpid Map size: {} ", altpidBucketDataMap.size());
 
         return new PreProcessedData(userEmailMap, userAddressMap, existingAuth0Emails, altpidBucketDataMap);
     }
@@ -534,15 +534,8 @@ public class StudyDataLoaderMain {
                 cfg.getString(ConfigFile.GEOCODING_API_KEY));
 
         Map<String, Map> altpidBucketDataMap = preProcessedData.getAltpidBucketDataMap();
-        TreeMap<Long, Map> sortedMap = new TreeMap<>();
-        for (String key : altpidBucketDataMap.keySet()) {
-            //WATCHOUT: Any non-numeric altpids will fail
-            sortedMap.put(Long.valueOf(key), altpidBucketDataMap.get(key));
-        }
-        altpidBucketDataMap.clear();
-        for (Long key : sortedMap.keySet()) {
-            String altpid = String.valueOf(key);
-            Map<String, JsonElement> surveyDataMap = sortedMap.get(key);
+        for (String altpid : altpidBucketDataMap.keySet()) {
+            Map<String, JsonElement> surveyDataMap = altpidBucketDataMap.get(altpid);
 
             JsonElement datstatData = surveyDataMap.get("datstatparticipantdata");
             String email = datstatData.getAsJsonObject().get("datstat_email").getAsString();


### PR DESCRIPTION
Minor clean up (actually revert) of sorting loaded gen2 data altpids as numeric to be compatible with other gen2 study migrations like prion. 
MBC is fine but prion have alpha-numerics as altpids.