### PR TITLE
CircleCi save workspace once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,7 +632,7 @@ jobs:
           name: 'Check node index to save workspace only once'
           command: |
             if [[ "$CIRCLE_NODE_INDEX" -ne 0 ]]; then
-              echo "Skip store cache on this node";
+              echo "Skip persist workspace on this node";
               circleci step halt;
             fi
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,6 +628,13 @@ jobs:
           skip_tests: false
           additional_options: '-PCircleciParallelBuild -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH'
           save_m2_cache: true
+      - run:
+          name: 'Check node index to save workspace only once'
+          command: |
+            if [[ "$CIRCLE_NODE_INDEX" -ne 0 ]]; then
+              echo "Skip store cache on this node";
+              circleci step halt;
+            fi
       - persist_to_workspace:
           root: *root_path
           paths:


### PR DESCRIPTION
## Context

A tweak to CircleCi config that makes sure workspace is saved only once when running parallel jobs.
Change saves about 1:30 minutes when deploying. Retrieving data from 16 different nodes was time consuming.
Works as expected

## Checklist

- [ X] I have labeled the type of changes involved using the `C-*` labels.
- [ X] I have assessed potential risks and labeled using the `R-*` labels.
- [X ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ X] I have considered security and privacy, and added `I-*` labels as needed
- [ X] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [X ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ X] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing
Ran it already!
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [X ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

