### PR TITLE
Bootstrap testboston study

### DIFF
--- a/study-builder/config/manifest-tenant.rb
+++ b/study-builder/config/manifest-tenant.rb
@@ -1,1 +1,2 @@
 render "cmi-config.json.ctmpl"
+render "testboston-config.json.ctmpl"

--- a/study-builder/config/manifest-testboston.rb
+++ b/study-builder/config/manifest-testboston.rb
@@ -1,0 +1,3 @@
+render "application.conf.ctmpl"
+render "local.conf.ctmpl"
+render "testboston-vars.conf.ctmpl"

--- a/study-builder/config/testboston-config.json.ctmpl
+++ b/study-builder/config/testboston-config.json.ctmpl
@@ -1,0 +1,36 @@
+{{$environment := env "ENVIRONMENT"}}
+{{$version := env "VERSION"}}
+{{with $response := vault (printf "secret/pepper/%s/%s/testboston/conf" $environment $version)}}
+{{with $conf := $response.Data}}
+
+{
+  "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+  "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
+  "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
+  "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
+  {{if eq $environment "dev"}}
+    "LOCALHOST_CALLBACKS": "- http://localhost:4200/login-landing",
+    "LOCALHOST_LOGOUTS": "- http://localhost:4200, http://localhost:4200/session-expired",
+    "LOCALHOST_ORIGINS": "- http://localhost:4200",
+  {{else}}
+    "LOCALHOST_CALLBACKS": "",
+    "LOCALHOST_LOGOUTS": "",
+    "LOCALHOST_ORIGINS": "",
+  {{end}}
+    "BASE_URL": "{{$conf.baseWebUrl}}",
+    "ASSETS_BUCKET_URL": "{{$conf.assetsBucketUrl}}",
+    "LOGIN_DOMAIN": "{{$conf.auth0.loginDomain}}",
+    "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}"
+  },
+  "AUTH0_ALLOW_DELETE": false,
+  "INCLUDED_PROPS": {
+  },
+  "EXCLUDED_PROPS": {
+  },
+  "AUTH0_EXCLUDED_RULES": [],
+  "AUTH0_EXCLUDED_CLIENTS": [],
+  "AUTH0_EXCLUDED_RESOURCE_SERVERS": []
+}
+
+{{end}}
+{{end}}

--- a/study-builder/config/testboston-vars.conf.ctmpl
+++ b/study-builder/config/testboston-vars.conf.ctmpl
@@ -1,0 +1,35 @@
+{{$environment := env "ENVIRONMENT"}}
+{{$version := env "VERSION"}}
+{{$study := env "STUDY_KEY"}}
+{{with $response := vault (printf "secret/pepper/%s/%s/%s/conf" $environment $version $study)}}
+{{with $conf := $response.Data}}
+
+{
+  "auth0": {
+    "appClientId": "{{$conf.auth0.appClientId}}",
+    "appClientSecret": "{{$conf.auth0.appClientSecret}}",
+    "crcClientId": "{{$conf.auth0.crcClientId}}",
+    "crcClientSecret": "{{$conf.auth0.crcClientSecret}}",
+    "domain": "{{$conf.auth0.domain}}",
+    "mgmtClientId": "{{$conf.auth0.mgmtClientId}}",
+    "mgmtClientSecret": "{{$conf.auth0.mgmtClientSecret}}",
+  },
+  "baseWebUrl": "{{$conf.baseWebUrl}}",
+  "passwordRedirectUrl": "{{$conf.passwordRedirectUrl}}",
+  "assetsBucketName": "{{$conf.assetsBucketName}}",
+  "sendgridApiKey": "{{$conf.sendgridApiKey}}",
+  "sendgridFromName": "{{$conf.sendgridFromName}}",
+  "sendgridFromEmail": "{{$conf.sendgridFromEmail}}",
+  "sendgridDefaultSalutation" : "{{$conf.sendgridDefaultSalutation}}",
+
+{{if not $conf.irbPassword}}
+  "irbPassword": null,
+{{else}}
+  "irbPassword": "{{$conf.irbPassword}}",
+{{end}}
+
+  "emails": {{$conf.emails | toJSONPretty}}
+}
+
+{{end}}
+{{end}}

--- a/study-builder/render.sh
+++ b/study-builder/render.sh
@@ -11,6 +11,10 @@ if [[ "$3" == 'tenant' ]]; then
   INPUT_DIR=config OUTPUT_DIR=output-config NO_SYSLOG=true \
     VERSION="$1" ENVIRONMENT="$2" MANIFEST=manifest-tenant.rb \
     ruby ../pepper-apis/configure.rb -y
+elif [[ "$3" == 'testboston' ]]; then
+  INPUT_DIR=config OUTPUT_DIR=output-config NO_SYSLOG=true \
+    VERSION="$1" ENVIRONMENT="$2" STUDY_KEY="$3" MANIFEST=manifest-testboston.rb \
+    ruby ../pepper-apis/configure.rb -y
 else
   INPUT_DIR=config OUTPUT_DIR=output-config NO_SYSLOG=true \
     VERSION="$1" ENVIRONMENT="$2" STUDY_KEY="$3" \

--- a/study-builder/src/main/resources/logback.xml
+++ b/study-builder/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="org.broadinstitute.ddp.logging.NonSecureFilter"/>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %X{LogBreadCrumb} %X{X-Forwarded-For} C:%X{ClientId} S:%X{UserId} [%thread] %-5level %logger{36} %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/study-builder/studies/testboston/assisted_consent.conf
+++ b/study-builder/studies/testboston/assisted_consent.conf
@@ -1,0 +1,56 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.assisted_consent},
+  "versionTag": "v1",
+  "displayOrder": 4,
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
+  "formType": "CONSENT",
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.assisted_consent.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.assisted_consent.title}
+    }
+  ],
+  "readonlyHintTemplate": {
+    "templateType": "HTML",
+    "templateText": "$tb_assisted_consent_readonly_hint",
+    "variables": [
+      {
+        "name": "tb_assisted_consent_readonly_hint",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.assisted_consent.readonly_hint}
+          }
+        ]
+      }
+    ]
+  },
+  "consentedExpr": "true"
+  "elections": [],
+  "sections": [
+    {
+      "nameTemplate": null
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Lorem Ipsum.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+  ]
+}

--- a/study-builder/studies/testboston/consent.conf
+++ b/study-builder/studies/testboston/consent.conf
@@ -1,0 +1,167 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.consent},
+  "versionTag": "v1",
+  "displayOrder": 4,
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
+  "formType": "CONSENT",
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.consent.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.consent.title}
+    }
+  ],
+  "translatedSubtitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.consent.subtitle}
+    }
+  ],
+  "readonlyHintTemplate": {
+    "templateType": "HTML",
+    "templateText": "$tb_consent_readonly_hint",
+    "variables": [
+      {
+        "name": "tb_consent_readonly_hint",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.consent.readonly_hint}
+          }
+        ]
+      }
+    ]
+  },
+  "consentedExpr":
+    "user.studies[\""${id.study}"\"].forms[\""${id.act.consent}"\"].questions[\""${id.q.consent_sign}"\"].answers.hasText()",
+  "elections": [],
+  "sections": [
+    {
+      "nameTemplate": {
+        "templateType": "TEXT",
+        "templateText": "Introduction",
+        "variables": []
+      },
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": {
+            "templateType": "HTML",
+            "templateText": "About this consent form",
+            "variables": []
+          },
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Lorem Ipsum. Please read this.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+    {
+      "nameTemplate": {
+        "templateType": "TEXT",
+        "templateText": "Key Information",
+        "variables": []
+      },
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": {
+            "templateType": "HTML",
+            "templateText": "Key Information",
+            "variables": []
+          },
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Lorem Ipsum. Here is the key.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+    {
+      "nameTemplate": {
+        "templateType": "TEXT",
+        "templateText": "Full Form",
+        "variables": []
+      },
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": {
+            "templateType": "HTML",
+            "templateText": "Consent Form",
+            "variables": []
+          },
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Lorem Ipsum. Here is the form.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+    {
+      "nameTemplate": {
+        "templateType": "TEXT",
+        "templateText": "Signature",
+        "variables": []
+      },
+      "icons": [],
+      "blocks": [
+        {
+          "question": {
+            include required("../snippets/text-question-signature-required.conf"),
+            "stableId": ${id.q.consent_sign},
+            "isRestricted": true,
+            "hideNumber": true,
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": "$signature_prompt"
+              "variables": [
+                {
+                  "name": "signature_prompt",
+                  "translations": [
+                    {
+                      "language": "en",
+                      "text": ${i18n.en.consent.signature_prompt}
+                    }
+                  ]
+                }
+              ]
+            },
+            "placeholderTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$signature_placeholder",
+              "variables": [
+                {
+                  "name": "signature_placeholder",
+                  "translations": [
+                    {
+                      "language": "en",
+                      "text": ${i18n.en.consent.signature_placeholder}
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "blockType": "QUESTION",
+          "shownExpr": null
+        }
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/testboston/covid_survey.conf
+++ b/study-builder/studies/testboston/covid_survey.conf
@@ -1,0 +1,52 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.covid_survey},
+  "versionTag": "v1",
+  "displayOrder": 5,
+  "writeOnce": false,
+  "maxInstancesPerUser": 1,
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.covid_survey.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.covid_survey.title}
+    }
+  ],
+  "sections": [
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "question": {
+            include required( "../snippets/bool-question-yes-no-required.conf"),
+            "stableId": ${id.q.been_tested},
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": "$been_tested_prompt",
+              "variables": [
+                {
+                  "name": "been_tested_prompt",
+                  "translations": [
+                    {
+                      "language": "en",
+                      "text": ${i18n.en.covid_survey.been_tested_prompt}
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "blockType": "QUESTION",
+          "shownExpr": null
+        }
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -1,0 +1,39 @@
+{
+  "prequal": {
+    "name": "Prequalifier Survey",
+    "title": "",
+    "age_check_prompt": "Are you 18 years or older?"
+    "age_check_val_msg": "Lorem Ipsum. We're only able to enroll age 18+ right now! This should be a separate error page.",
+  },
+
+  "prescreen_auth": {
+    "name": "Prescreen Authorization",
+    "title": "Prescreen Authorization",
+  },
+
+  "prescreen_survey": {
+    "name": "Prescreen Survey",
+    "title": "Prescreen Survey",
+  },
+
+  "consent": {
+    "name": "Consent Form",
+    "title": "Consent Form",
+    "subtitle": "Download Form (Read-Only)",
+    "readonly_hint": "Lorem Ipsum. Thank you for signing your consent! To make changes, please contact your CRC.",
+    "signature_prompt": "Signature (Full Name)",
+    "signature_placeholder": "Enter your full name",
+  },
+
+  "assisted_consent": {
+    "name": "Consent Form",
+    "title": "Consent Form",
+    "readonly_hint": "Lorem Ipsum.",
+  },
+
+  "covid_survey": {
+    "name": "Covid Survey",
+    "title": "Covid Survey",
+    "been_tested_prompt": "Have you ever been previously tested or COVID-19?"
+  },
+}

--- a/study-builder/studies/testboston/icons/complete.svg
+++ b/study-builder/studies/testboston/icons/complete.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Complete Icon@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="11/20" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Aged-up-Participant-Dashboard-after-they-have-registered-for-the-study-but-have-not-re-consented." transform="translate(-969.000000, -485.000000)">
+            <g id="Complete-Icon" transform="translate(969.000000, 485.000000)">
+                <rect id="Rectangle-Copy-7" fill="#00D39D" x="0" y="0" width="25" height="25" rx="12.5"></rect>
+                <g id="Fill-1245-Copy" transform="translate(6.000000, 6.000000)" fill="#FFFFFF">
+                    <path d="M11.0537035,0.243045906 C10.9690261,0.158368486 10.831371,0.158368486 10.7466935,0.243045906 L4.05630893,6.93343052 L2.29328164,5.17083747 C2.20860422,5.08572581 2.07094913,5.08572581 1.98627171,5.17083747 L0.0699565757,7.08715261 C-0.0147208437,7.17183002 -0.0147208437,7.30905087 0.0699565757,7.39416253 L3.90258685,11.2267928 C3.94514268,11.2689144 4.00072581,11.2901923 4.05630893,11.2901923 C4.11189206,11.2901923 4.16747519,11.2689144 4.20959677,11.2267928 L12.9700186,2.46637097 C13.0108375,2.42555211 13.0334181,2.37040323 13.0334181,2.31264888 C13.0334181,2.25532878 13.0108375,2.2001799 12.9700186,2.15936104 L11.0537035,0.243045906 Z" id="Fill-1245"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/study-builder/studies/testboston/icons/created.svg
+++ b/study-builder/studies/testboston/icons/created.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>New Icon@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="11/20" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Aged-up-Participant-Dashboard-after-they-have-registered-for-the-study-but-have-not-re-consented." transform="translate(-969.000000, -411.000000)">
+            <g id="New-Icon" transform="translate(969.000000, 411.000000)">
+                <g id="Group-3-Copy" fill="#F57437">
+                    <rect id="Rectangle-Copy-7" x="0" y="0" width="25" height="25" rx="12.5"></rect>
+                </g>
+                <path d="M12,12 L12,5" id="Stroke-4036" stroke="#FFFFFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"></path>
+                <path d="M12.0009843,16 L12.0009843,16 L11.982987,16 C11.4310705,16.0090045 10.991137,16.4652326 11.0001356,17.0175088 C11.0101341,17.5637819 11.4550668,18 11.9999844,18 L12.0179817,18 C12.5688984,17.989995 13.0098317,17.5347674 12.9998333,16.9824912 C12.9908346,16.4362181 12.544902,16 12.0009843,16" id="Fill-4037" stroke="#FFFFFF" stroke-width="2" fill="#FFFFFF"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/study-builder/studies/testboston/icons/in_progress.svg
+++ b/study-builder/studies/testboston/icons/in_progress.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="25px" height="25px" viewBox="0 0 25 25" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>In Progress@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="11/20" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="In-Progress">
+            <g id="Group-5-Copy" fill="#7154FF">
+                <rect id="Rectangle-Copy-7" x="0" y="0" width="25" height="25" rx="12.5"></rect>
+            </g>
+            <path d="M7.55,14.18 C6.68,14.18 6.05,13.49 6.05,12.62 C6.05,11.75 6.68,11.06 7.55,11.06 C8.42,11.06 9.05,11.75 9.05,12.62 C9.05,13.49 8.42,14.18 7.55,14.18 Z M12.5,14.18 C11.63,14.18 11,13.49 11,12.62 C11,11.75 11.63,11.06 12.5,11.06 C13.37,11.06 14,11.75 14,12.62 C14,13.49 13.37,14.18 12.5,14.18 Z M17.45,14.18 C16.58,14.18 15.95,13.49 15.95,12.62 C15.95,11.75 16.58,11.06 17.45,11.06 C18.32,11.06 18.95,11.75 18.95,12.62 C18.95,13.49 18.32,14.18 17.45,14.18 Z" id="…" fill="#FFFFFF" fill-rule="nonzero"></path>
+        </g>
+    </g>
+</svg>

--- a/study-builder/studies/testboston/prequal.conf
+++ b/study-builder/studies/testboston/prequal.conf
@@ -1,0 +1,54 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.prequal},
+  "versionTag": "v1",
+  "displayOrder": 1,
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
+  "excludeFromDisplay": true,
+  "allowUnauthenticated": true,
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prequal.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prequal.title}
+    }
+  ],
+  "sections": [
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "question": {
+            include required( "../snippets/bool-question-yes-no-required.conf"),
+            "stableId": ${id.q.age_check},
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": "$age_check_prompt",
+              "variables": [
+                {
+                  "name": "age_check_prompt",
+                  "translations": [
+                    {
+                      "language": "en",
+                      "text": ${i18n.en.prequal.age_check_prompt}
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "blockType": "QUESTION",
+          "shownExpr": null
+        }
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/testboston/prescreen_auth.conf
+++ b/study-builder/studies/testboston/prescreen_auth.conf
@@ -1,0 +1,38 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.prescreen_auth},
+  "versionTag": "v1",
+  "displayOrder": 2,
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prescreen_auth.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prescreen_auth.title}
+    }
+  ],
+  "sections": [
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Lorem Ipsum. Something about prescreen authorization.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+  ]
+}

--- a/study-builder/studies/testboston/prescreen_survey.conf
+++ b/study-builder/studies/testboston/prescreen_survey.conf
@@ -1,0 +1,53 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.prescreen_survey},
+  "versionTag": "v1",
+  "displayOrder": 3,
+  "writeOnce": false,
+  "maxInstancesPerUser": 1,
+  "translatedNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prescreen_survey.name}
+    }
+  ],
+  "translatedTitles": [
+    {
+      "language": "en",
+      "text": ${i18n.en.prescreen_survey.title}
+    }
+  ],
+  "sections": [
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Section 1. Lorem Ipsum.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    },
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "Section 2. Lorem Ipsum.",
+            "variables": []
+          },
+          "blockType": "CONTENT"
+        }
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/testboston/sendgrid_emails.conf
+++ b/study-builder/studies/testboston/sendgrid_emails.conf
@@ -1,0 +1,5 @@
+{
+  "sendgridEmails": [
+    # TODO: add email configs here
+  ]
+}

--- a/study-builder/studies/testboston/study.conf
+++ b/study-builder/studies/testboston/study.conf
@@ -1,0 +1,241 @@
+{
+  "tenant": {
+    "domain": ${auth0.domain},
+    "mgmtClientId": ${auth0.mgmtClientId},
+    "mgmtSecret": ${auth0.mgmtClientSecret}
+  },
+
+  "umbrella": {
+    "name": "Test Boston",
+    "guid": ${id.study}
+  },
+
+  "study": {
+    "name": "Test Boston",
+    "guid": ${id.study},
+    "studyEmail": ${contact.email},
+    "baseWebUrl": ${baseWebUrl},
+    "irbPassword": ${irbPassword},
+    "plusCodePrecision": null,
+    "shareParticipantLocation": false,
+  },
+
+  # TODO: support adding multiple cliens, e.g. the CRC client
+  "client": {
+    "name": "testboston-app-client",
+    "id": ${auth0.appClientId},
+    "secret": ${auth0.appClientSecret},
+    "passwordRedirectUrl": ${passwordRedirectUrl}
+  },
+
+  "adminUser": {
+    "guid": "TESTBOSTONADMINUSR"
+  },
+
+  # TODO: figure this out
+  "governance": null,
+
+  "studyDetails": [
+    {
+      "language": "en",
+      "name": "Test Boston",
+      "summary": "The Test Boston Study"
+    }
+  ],
+
+  "supportedLanguages": ["en"],
+
+  "sendgrid": {
+    "apiKey": ${sendgridApiKey},
+    "fromName": ${sendgridFromName},
+    "fromEmail": ${sendgridFromEmail},
+    "defaultSalutation": ${sendgridDefaultSalutation}
+  },
+
+  include required("sendgrid_emails.conf"),
+
+  # TODO: figure this out
+  "kits": [],
+
+  "activities": [
+    {
+      "filepath": "prequal.conf",
+      "mappings": [],
+      "validations": [
+        {
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$tb_prequal_age_check",
+            "variables": [
+              {
+                "name": "tb_prequal_age_check",
+                "translations": [
+                  {
+                    "language": "en",
+                    "text": ${i18n.en.prequal.age_check_val_msg}
+                  }
+                ]
+              }
+            ]
+          },
+          "stableIds": [ ${id.q.age_check} ],
+          "precondition":
+            "user.studies[\""${id.study}"\"].forms[\""${id.act.prequal}"\"].questions[\""${id.q.age_check}"\"].isAnswered()",
+          "expression":
+            "user.studies[\""${id.study}"\"].forms[\""${id.act.prequal}"\"].questions[\""${id.q.age_check}"\"].answers.hasFalse()"
+        }
+      ]
+    },
+
+    {
+      "filepath": "prescreen_auth.conf",
+      "mappings": [],
+      "validations": []
+    },
+
+    {
+      "filepath": "prescreen_survey.conf",
+      "mappings": [],
+      "validations": []
+    }
+
+    {
+      "filepath": "consent.conf",
+      "mappings": [],
+      "validations": []
+    },
+
+    {
+      "filepath": "assisted_consent.conf",
+      "mappings": [],
+      "validations": []
+    },
+
+    {
+      "filepath": "covid_survey.conf",
+      "mappings": [],
+      "validations": []
+    },
+
+    # TODO: longitudinal activities
+  ],
+
+  "activityTimestamp": null,
+
+  # TODO: get real icon files
+  "activityStatusIcons": [
+    {
+      "filepath": "icons/created.svg",
+      "statusType": "CREATED"
+    },
+    {
+      "filepath": "icons/in_progress.svg",
+      "statusType": "IN_PROGRESS"
+    },
+    {
+      "filepath": "icons/complete.svg",
+      "statusType": "COMPLETE"
+    }
+  ],
+
+  # TODO: this needs work
+  "pdfs": [],
+
+  "workflowTransitions": [
+    {
+      "from": {
+        "type": "START"
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.prequal},
+          "expression": "true"
+        }
+      ]
+    },
+
+    # invited patient workflow
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": ${id.act.prequal},
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.consent},
+          "expression": "true"
+        },
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY",
+        "activityCode": ${id.act.consent}
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.covid_survey},
+          "expression": "true"
+        },
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY",
+        "activityCode": ${id.act.covid_survey}
+      },
+      "to": [
+        {
+          "type": "DASHBOARD",
+          "expression": "true"
+        }
+      ]
+    },
+
+    # return user workflow
+    {
+      "from": {
+        "type": "RETURN_USER"
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.covid_survey},
+          "expression": "user.studies[\""${id.study}"\"].forms[\""${id.act.covid_survey}"\"].isStatus(\"CREATED\", \"IN_PROGRESS\")"
+        },
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.consent},
+          "expression": "user.studies[\""${id.study}"\"].forms[\""${id.act.consent}"\"].isStatus(\"CREATED\", \"IN_PROGRESS\")"
+        },
+        {
+          "type": "DASHBOARD",
+          "expression": "true"
+        }
+      ]
+    }
+  ],
+
+  # TODO: more to come
+  "events": [
+
+    # enrollment events
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.consent},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+
+  ]
+}

--- a/study-builder/studies/testboston/subs.conf
+++ b/study-builder/studies/testboston/subs.conf
@@ -14,7 +14,7 @@
     }
   },
   "id": {
-    "study": "TESTBOSTON",
+    "study": "testboston",
     "act": {
       "prequal": "PREQUAL",
       "prescreen_auth": "PRESCREEN_AUTH",

--- a/study-builder/studies/testboston/subs.conf
+++ b/study-builder/studies/testboston/subs.conf
@@ -1,0 +1,32 @@
+{
+  "contact": {
+    "email": "testboston@datadonationplatform.org",
+    "phone": "XXX-XXX-XXXX"
+  },
+  "social": {
+    "twitter": "foo",
+    "facebook": "bar",
+    "instagram": "baz"
+  },
+  "i18n": {
+    "en": {
+      include required("i18n/en.conf")
+    }
+  },
+  "id": {
+    "study": "TESTBOSTON",
+    "act": {
+      "prequal": "PREQUAL",
+      "prescreen_auth": "PRESCREEN_AUTH",
+      "prescreen_survey": "PRESCREEN_SURVEY",
+      "consent": "CONSENT",
+      "assisted_consent": "ASSISTED_CONSENT",
+      "covid_survey": "COVID_SURVEY",
+    },
+    "q": {
+      "age_check": "AGE_CHECK",
+      "consent_sign": "CONSENT_SIGNATURE",
+      "been_tested": "BEEN_TESTED",
+    }
+  }
+}

--- a/study-builder/tenants/testboston/emails/change_password.html
+++ b/study-builder/tenants/testboston/emails/change_password.html
@@ -1,0 +1,104 @@
+<html>
+<meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no"/>
+<head>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700" rel="stylesheet">
+  <style type="text/css">
+    .ExternalClass,
+    .ExternalClass div,
+    .ExternalClass font,
+    .ExternalClass p,
+    .ExternalClass span,
+    .ExternalClass td,
+    img {
+      line-height: 100%;
+    }
+
+    #outlook a {
+      padding: 0;
+    }
+
+    .ExternalClass,
+    .ReadMsgBody {
+      width: 100%;
+    }
+
+    a,
+    blockquote,
+    body,
+    li,
+    p,
+    table,
+    td {
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      mso-table-lspace: 0;
+      mso-table-rspace: 0;
+    }
+
+    img {
+      -ms-interpolation-mode: bicubic;
+      border: 0;
+      height: auto;
+      outline: 0;
+      text-decoration: none;
+    }
+
+    table {
+      border-collapse: collapse !important;
+    }
+
+    body {
+      height: 100%!important;
+      margin: 0;
+      padding: 0;
+      font-family: 'Roboto', sans-serif;
+    }
+
+    @font-face {
+      font-family: 'Roboto', sans-serif;
+      src: url(https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700);
+      font-weight: 300;
+      font-style: normal;
+    }
+  </style>
+</head>
+<body>
+
+{% assign from = "Test Boston Study" %}
+{% assign studyGuid = client.client_metadata.study %}
+{% assign iconUrl = "##ASSETS_BUCKET_URL##/logo.png" %}
+{% assign studyLink = "##BASE_URL##" %}
+
+<table style="width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-family: Roboto, sans-serif; border-collapse: collapse !important;"
+       border="0" cellpadding="0" cellspacing="0" width="100%">
+  <tr style="width: 540px;">
+    <td align="left" style="margin: 0; padding: 0; font-family: Roboto, sans-serif; width: 278px; height: 33px">
+      <a href="{{ studyLink }}" target="_blank" style="cursor: pointer; text-decoration: none;">
+        <img src="{{ iconUrl }}" alt="project icon"
+             style="-ms-interpolation-mode: bicubic; border: 0; outline: none; text-decoration: none;" width="185px" height="85px" border="0">
+      </a>
+    </td>
+  </tr>
+
+  <tr style="width: 540px;">
+    <td style="padding: 50px 0 0px 0;">
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">You have submitted a password change request. Please confirm the password change <a href="{{ url | remove_first:'#'}}&study={{ studyGuid }}#">by clicking here</a>.</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">If you did not make this request, please contact us by replying to this email.</p>
+    </td>
+  </tr>
+  <tr style="width: 540px;">
+    <td style="padding: 50px 0 80px 0;">
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">Sincerely,</p>
+      <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 300; font-size: 15px; line-height: 23px;">
+        {{ from }}
+      </p>
+    </td>
+  </tr>
+</table>
+</body>
+
+</html>

--- a/study-builder/tenants/testboston/pages/login.html
+++ b/study-builder/tenants/testboston/pages/login.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>Sign In with Auth0</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+</head>
+  <style>
+    body, html {
+      height: 100%;
+      background-color: #f9f9f9;
+    }
+
+    .login-container {
+      position: relative;
+      height: 100%;
+    }
+
+    .login-box {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      padding: 15px;
+      background-color: #fff;
+      box-shadow: 0px 5px 5px #ccc;
+      border-radius: 5px;
+      border-top: 1px solid #e9e9e9;
+    }
+
+    .login-header {
+      text-align: center;
+    }
+
+    .login-header img {
+      width: 75px;
+    }
+
+    #error-message {
+      display: none;
+    }
+  </style>
+<body>
+      <script src="https://angio.dev.datadonationplatform.org/assets/config/pepperConfig.js"></script>
+  <div class="login-container">
+    <div class="col-xs-12 col-sm-4 col-sm-offset-4 login-box">
+      <div class="login-header">
+        <img src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg"/>
+        <h3>Welcome</h3>
+        <h5>PLEASE LOG IN</h5>
+      </div>
+      <div id="error-message" class="alert alert-danger"></div>
+      <form onsubmit="return false;" method="post">
+        <div class="form-group">
+         <label for="name">Email</label>
+          <input
+            type="email"
+            class="form-control"
+            id="email"
+            placeholder="Enter your email">
+        </div>
+        <div class="form-group">
+          <label for="name">Password</label>
+          <input
+            type="password"
+            class="form-control"
+            id="password"
+            placeholder="Enter your password">
+        </div>
+        <button
+          type="submit"
+          id="btn-login"
+          class="btn btn-primary btn-block">
+            Log In
+        </button>
+        <button
+          type="button"
+          id="btn-signup"
+          class="btn btn-default btn-block">
+            Sign Up
+        </button>
+        <hr>
+        <button
+          type="button"
+          id="btn-google"
+          class="btn btn-default btn-danger btn-block">
+            Log In with Google
+        </button>
+      </form>
+    </div>
+  </div>
+
+  <!--[if IE 8]>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/ie8/0.2.5/ie8.js"></script>
+  <![endif]-->
+
+  <!--[if lte IE 9]>
+  <script src="https://cdn.auth0.com/js/polyfills/1.0/base64.min.js"></script>
+  <script src="https://cdn.auth0.com/js/polyfills/1.0/es5-shim.min.js"></script>
+  <![endif]-->
+
+  <script src="https://cdn.auth0.com/js/auth0/9.13/auth0.min.js"></script>
+  <script src="https://cdn.auth0.com/js/polyfills/1.0/object-assign.min.js"></script>
+  <script>
+    window.addEventListener('load', function() {
+
+      var config = JSON.parse(
+        decodeURIComponent(escape(window.atob('@@config@@')))
+      );
+
+      var params = Object.assign({
+        /* additional configuration needed for use of custom domains
+        overrides: {
+          __tenant: config.auth0Tenant,
+          __token_issuer: 'YOUR_CUSTOM_DOMAIN'
+        }, */
+        domain: config.auth0Domain,
+        clientID: config.clientID,
+        redirectUri: config.callbackURL,
+        responseType: 'code'
+      }, config.internalOptions);
+
+      var webAuth = new auth0.WebAuth(params);
+
+      var databaseConnection = 'Username-Password-Authentication';
+
+      function login(e) {
+        e.preventDefault();
+        var username = document.getElementById('email').value;
+        var password = document.getElementById('password').value;
+        webAuth.login({
+          realm: databaseConnection,
+          username: username,
+          password: password
+        }, function(err) {
+          if (err) displayError(err);
+        });
+      }
+
+      function signup() {
+        var email = document.getElementById('email').value;
+        var password = document.getElementById('password').value;
+
+        webAuth.redirect.signupAndLogin({
+          connection: databaseConnection,
+          email: email,
+          password: password
+        }, function(err) {
+          if (err) displayError(err);
+        });
+      }
+
+      function loginWithGoogle() {
+        webAuth.authorize({
+          connection: 'google-oauth2'
+        }, function(err) {
+          if (err) displayError(err);
+        });
+      }
+
+      function displayError(err) {
+        var errorMessage = document.getElementById('error-message');
+        errorMessage.innerHTML = err.description;
+        errorMessage.style.display = 'block';
+      }
+
+      document.getElementById('btn-login').addEventListener('click', login);
+      document.getElementById('btn-google').addEventListener('click', loginWithGoogle);
+      document.getElementById('btn-signup').addEventListener('click', signup);
+    });
+  </script>
+</body>
+</html>

--- a/study-builder/tenants/testboston/pages/login.html
+++ b/study-builder/tenants/testboston/pages/login.html
@@ -1,174 +1,313 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <title>Sign In with Auth0</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Test Boston</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,300italic,400italic,700,700italic|Source+Serif+Pro:600&display=swap" rel="stylesheet" type="text/css">
 </head>
-  <style>
-    body, html {
-      height: 100%;
-      background-color: #f9f9f9;
-    }
-
-    .login-container {
-      position: relative;
-      height: 100%;
-    }
-
-    .login-box {
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-      padding: 15px;
-      background-color: #fff;
-      box-shadow: 0px 5px 5px #ccc;
-      border-radius: 5px;
-      border-top: 1px solid #e9e9e9;
-    }
-
-    .login-header {
-      text-align: center;
-    }
-
-    .login-header img {
-      width: 75px;
-    }
-
-    #error-message {
-      display: none;
-    }
-  </style>
 <body>
-      <script src="https://angio.dev.datadonationplatform.org/assets/config/pepperConfig.js"></script>
-  <div class="login-container">
-    <div class="col-xs-12 col-sm-4 col-sm-offset-4 login-box">
-      <div class="login-header">
-        <img src="https://cdn.auth0.com/styleguide/1.0.0/img/badge.svg"/>
-        <h3>Welcome</h3>
-        <h5>PLEASE LOG IN</h5>
-      </div>
-      <div id="error-message" class="alert alert-danger"></div>
-      <form onsubmit="return false;" method="post">
-        <div class="form-group">
-         <label for="name">Email</label>
-          <input
-            type="email"
-            class="form-control"
-            id="email"
-            placeholder="Enter your email">
-        </div>
-        <div class="form-group">
-          <label for="name">Password</label>
-          <input
-            type="password"
-            class="form-control"
-            id="password"
-            placeholder="Enter your password">
-        </div>
-        <button
-          type="submit"
-          id="btn-login"
-          class="btn btn-primary btn-block">
-            Log In
-        </button>
-        <button
-          type="button"
-          id="btn-signup"
-          class="btn btn-default btn-block">
-            Sign Up
-        </button>
-        <hr>
-        <button
-          type="button"
-          id="btn-google"
-          class="btn btn-default btn-danger btn-block">
-            Log In with Google
-        </button>
-      </form>
-    </div>
-  </div>
 
-  <!--[if IE 8]>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/ie8/0.2.5/ie8.js"></script>
-  <![endif]-->
+<!--[if IE 8]>
+<script src="//cdnjs.cloudflare.com/ajax/libs/ie8/0.2.5/ie8.js"></script>
+<![endif]-->
 
-  <!--[if lte IE 9]>
-  <script src="https://cdn.auth0.com/js/polyfills/1.0/base64.min.js"></script>
-  <script src="https://cdn.auth0.com/js/polyfills/1.0/es5-shim.min.js"></script>
-  <![endif]-->
+<!--[if lte IE 9]>
+<script src="https://cdn.auth0.com/js/base64.js"></script>
+<script src="https://cdn.auth0.com/js/es5-shim.min.js"></script>
+<![endif]-->
 
-  <script src="https://cdn.auth0.com/js/auth0/9.13/auth0.min.js"></script>
-  <script src="https://cdn.auth0.com/js/polyfills/1.0/object-assign.min.js"></script>
-  <script>
-    window.addEventListener('load', function() {
+<script src="https://cdn.auth0.com/js/lock/11.5.2/lock.min.js"></script>
 
-      var config = JSON.parse(
-        decodeURIComponent(escape(window.atob('@@config@@')))
-      );
+<style type="text/css">
+    body {
+        font-family: 'Roboto', sans-serif;
+    }
 
-      var params = Object.assign({
-        /* additional configuration needed for use of custom domains
+    .auth0-lock.auth0-lock .auth0-lock-overlay {
+        background: radial-gradient(#ffffff, #f3f3f2, #f3f3f2);
+        background-image: radial-gradient(#ffffff, #f3f3f2, #f3f3f2);
+        background-color: #fff;
+    }
+
+    .auth0-lock.auth0-lock.auth0-lock-opened .auth0-lock-widget {
+        box-shadow: 0 0 40px 4px #888888;
+    }
+    .auth0-lock-name {
+        font-size:12pt !important;
+        text-align:left;
+        padding-left:0 !important;
+    }
+
+    .auth0-lock-content {
+        padding-top:10px !important;
+    }
+
+    .auth0-lock-header .auth0-lock-header-bg {
+        background-color:white !important;
+    }
+
+    .auth0-lock.auth0-lock .auth0-lock-form p {
+        text-align:left;
+    }
+
+    a:link {
+        text-decoration: underline !important;
+    }
+</style>
+
+<script>
+    // Decode utf8 characters properly
+    var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));
+    config.extraParams = config.extraParams || {};
+
+    var mode = config.extraParams.mode;
+    var study_guid = config.extraParams.study_guid;
+    var headerLogo = '##BASE_URL##/logo.png';
+    var headerText = "Test Boston";
+    var studyColor = 'rgb(24, 130, 194)';
+    var studyHelpEmail = 'testboston@datadonationplatform.org';
+
+    var title = 'Welcome!';
+    if (mode === 'login') {
+        title = 'Please Sign In';
+    }
+    else if (mode === 'signup') {
+        title = 'Create your account';
+    }
+
+    var loginUrl = config.callbackURL + '/login';
+    var registerUrl = '##ANGIO_BASE_URL##/count-me-in';
+
+    var connection = config.connection;
+    var prompt = !prompt;
+    var languageDictionary;
+    var language;
+    var showPasswordRecentText = false;
+    var doNotShowRegLink = false;
+
+    languageDictionary = { title: title,signupTitle: title};
+
+    languageDictionary.error = languageDictionary.error || {};
+    languageDictionary.error.signUp = languageDictionary.error.signUp || {};
+    languageDictionary.error.signUp.user_exists = 'If you have already registered, sign in here.';
+    languageDictionary.success = {
+        forgotPassword: "If you have previously registered, please check your email to reset your password.",
+    };
+    languageDictionary.lastLoginInstructions = 'Last time you signed in with';
+    var loginHint = config.extraParams.login_hint;
+
+
+    var realOptions = {
+        avatar: null,
+        auth: {
+            redirectUrl: config.callbackURL,
+            responseType: (config.internalOptions || {}).response_type ||
+            config.callbackOnLocationHash ? 'token' : 'code',
+            params: config.internalOptions
+        },
+        assetsUrl:  config.assetsUrl,
+        allowedConnections: connection ? [connection] : null,
+        rememberLastLogin: false,
+        language: language,
+        languageDictionary: languageDictionary,
+        theme: {
+            logo:            headerLogo,
+            primaryColor:    studyColor
+            //primaryColor:    'green'
+        },
+        prefill: loginHint ? { email: loginHint, username: loginHint } : null,
+        closable: false,
+        configurationBaseUrl: config.clientConfigurationBaseUrl,
         overrides: {
-          __tenant: config.auth0Tenant,
-          __token_issuer: 'YOUR_CUSTOM_DOMAIN'
-        }, */
-        domain: config.auth0Domain,
-        clientID: config.clientID,
-        redirectUri: config.callbackURL,
-        responseType: 'code'
-      }, config.internalOptions);
+            __tenant: config.auth0Tenant,
+            __token_issuer: '##LOGIN_DOMAIN##'}
+        // uncomment if you want small buttons for social providers
+        // socialButtonStyle: 'small'
+    };
+    var options = {allowForgotPassword:true};
+    if (mode === 'signup') {
+        options.allowSignUp = true;
+        options.allowLogin = false;
+    }
+    else if (mode === 'login') {
+        options.allowSignUp = false;
+        options.allowLogin = true;
+    }
+    else {
+        options.allowSignUp = true;
+        options.allowLogin = true;
+    }
 
-      var webAuth = new auth0.WebAuth(params);
+    if (config.extraParams.showPasswordReset) {
+        options.allowSignUp = false;
+        options.allowLogin = false;
+    }
 
-      var databaseConnection = 'Username-Password-Authentication';
+    if (config.extraParams.show_password_reset) {
+        options.initialScreen = 'forgotPassword';
+    }
+    if (config.extraParams.user_email) {
+        realOptions.prefill = {email: config.extraParams.user_email, username: config.extraParams.user_email};
+    }
 
-      function login(e) {
-        e.preventDefault();
-        var username = document.getElementById('email').value;
-        var password = document.getElementById('password').value;
-        webAuth.login({
-          realm: databaseConnection,
-          username: username,
-          password: password
-        }, function(err) {
-          if (err) displayError(err);
-        });
-      }
+    if (config.extraParams.password_was_reset) {
+        showPasswordRecentText = true;
+    }
 
-      function signup() {
-        var email = document.getElementById('email').value;
-        var password = document.getElementById('password').value;
+    var lock = new Auth0Lock(config.clientID, config.auth0Domain, realOptions);
 
-        webAuth.redirect.signupAndLogin({
-          connection: databaseConnection,
-          email: email,
-          password: password
-        }, function(err) {
-          if (err) displayError(err);
-        });
-      }
+    function addHelp() {
+        // we use setInterval because auth0's on() methods for display
+        // do not account for all the display modes and they appear to fire
+        // before animations complete, not after
+        setInterval(function() {
+            if (document.getElementsByClassName('auth0-global-message').length > 0) {
+                if (languageDictionary.error.signUp.user_exists.toUpperCase() === document.getElementsByClassName('auth0-global-message')[0].children[0].children[0].innerText.toUpperCase()) {
+                     if (!document.getElementById('ddp-already-registered')) {
+                        var auth0GlobalMessage = document.getElementsByClassName('auth0-global-message')[0].children[0].children[0];
 
-      function loginWithGoogle() {
-        webAuth.authorize({
-          connection: 'google-oauth2'
-        }, function(err) {
-          if (err) displayError(err);
-        });
-      }
+                        console.log('parent: ' + auth0GlobalMessage.parentElement);
+                        auth0GlobalMessage.parentElement.removeChild(auth0GlobalMessage);
 
-      function displayError(err) {
-        var errorMessage = document.getElementById('error-message');
-        errorMessage.innerHTML = err.description;
-        errorMessage.style.display = 'block';
-      }
+                        var alreadyRegistered = document.createElement('a');
+                        alreadyRegistered.setAttribute('href', loginUrl);
+                        alreadyRegistered.setAttribute('style','color:black');
+                        alreadyRegistered.setAttribute('id','ddp-already-registered');
+                        alreadyRegistered.innerText = 'If you have already registered, sign in here.';
+                        document.getElementsByClassName('auth0-global-message')[0].children[0].appendChild(alreadyRegistered);
 
-      document.getElementById('btn-login').addEventListener('click', login);
-      document.getElementById('btn-google').addEventListener('click', loginWithGoogle);
-      document.getElementById('btn-signup').addEventListener('click', signup);
+                    }
+                }
+            }
+
+            if (!document.getElementById('ddp-header')) {
+                // tweak the header
+                var header = document.createElement('div');
+                header.innerHTML = '<div id="ddp-header" style="display:flex;flex-direction:row;justify-content: flex-start;align-items:center;"><img class="auth0-lock-header-logo" src="' + headerLogo + '"><div style="padding-left:8px;">' + headerText + '</div></div></div>';
+                var auth0LockHeader = document.getElementsByClassName('auth0-lock-header-logo')[0];
+
+                if (auth0LockHeader) {
+                    console.log('parent' + auth0LockHeader.parentElement);
+                    auth0LockHeader.parentElement.removeChild(auth0LockHeader);
+                    var headerWelcome = document.getElementsByClassName('auth0-lock-header-welcome')[0];
+                    headerWelcome.insertBefore(header,(headerWelcome.hasChildNodes())
+                        ? headerWelcome.childNodes[0]
+                        : null);
+                    //document.getElementsByClassName('auth0-lock-header-welcome')[0].prepend(header);
+                }
+
+            }
+            if (!document.getElementById('ddp-help')) {
+                var lockForm = document.getElementsByClassName('auth0-lock-form');
+                var showSignUpHelp = document.getElementsByClassName('auth0-lock-last-login-pane').length === 0;
+
+                if (mode === 'login' && !doNotShowRegLink) {
+                    // navigate back to registration
+                    var registerMessageWrapper = document.createElement("p");
+                    registerMessageWrapper.setAttribute('class','auth0-lock-alternative');
+                    registerMessageWrapper.setAttribute('id','ddp-reg');
+                    registerMessageWrapper.setAttribute('style','margin-top:0;font-size: small;text-align: left;');
+
+                    if (showSignUpHelp) {
+                        var registerMessage = document.createElement('p');
+                        registerMessage.setAttribute('style','margin-bottom:0;');
+                        registerMessage.innerHTML =  "If you haven't registered yet, please <a class='auth0-lock-alternative-link' href='" + registerUrl + "'>do so here</a>.";
+                        registerMessageWrapper.appendChild(registerMessage);
+
+                        if (lockForm) {
+                            lockForm[0].appendChild(registerMessageWrapper);
+                        }
+                    }
+                }
+
+                var helpWrapper = document.createElement('div');
+                helpWrapper.setAttribute('id','ddp-help');
+                helpWrapper.setAttribute('style','display:flex;flex-direction:row;align-items:center;margin-top:5px;flex-wrap:none;');
+                var help = '<p style="text-align:left;margin-bottom:0;">For help, please contact ' + studyHelpEmail + '.</p>';
+                helpWrapper.innerHTML = help;
+                if (lockForm) {
+                    lockForm[0].appendChild(helpWrapper);
+                }
+
+                if (mode === 'signup' || options.allowSignUp) {
+                    console.log('appending sign in with existing account');
+                    var loginLink = document.createElement('a');
+                    loginLink.setAttribute('class', 'auth0-lock-alternative-link');
+                    loginLink.setAttribute('href', loginUrl);
+                    loginLink.innerText = 'Sign in with existing account.';
+                    var switchToLogin = document.createElement('p');
+                    switchToLogin.setAttribute('class','auth0-lock-alternative');
+                    switchToLogin.setAttribute('style','text-align:left;margin-top:5px;');
+                    switchToLogin.innerText = 'Already registered? ';
+                    switchToLogin.appendChild(loginLink);
+                    helpWrapper.parentElement.appendChild(switchToLogin);
+                }
+
+                if (showPasswordRecentText) {
+                    if (!document.getElementById('ddp-pwd')) {
+                        var resetPasswordWrapper = document.createElement("p");
+                        resetPasswordWrapper.setAttribute('class','auth0-lock-alternative');
+                        resetPasswordWrapper.setAttribute('id','ddp-pwd');
+                        resetPasswordWrapper.setAttribute('style','margin-top:0px;');
+
+                        var resetPasswordText = document.createElement("div");
+                        resetPasswordText.innerText = "Password reset successfully.  Please sign in with your new password.";
+
+                        resetPasswordWrapper.appendChild(resetPasswordText);
+                        document.getElementsByClassName('auth0-lock-content')[0].prepend(resetPasswordWrapper);
+                    }
+                }
+            }
+        },200);
+    };
+
+    lock.on('show',function() {
+        addHelp();
+
+        if(realOptions.prefill && realOptions.prefill.email){
+            var getInputElement = function(name) {
+                return document.getElementsByName(name)[0];
+            };
+            var setFocus = function(theElement) {
+                theElement.focus();
+                return true;
+            };
+            var getElementWithFocus = function() {
+                return document.querySelector(':focus');
+            };
+            var intervalId = setInterval(function() {
+                var pwdElement = getInputElement('password');
+                var emailElement = getInputElement('email');
+                if(pwdElement && emailElement && emailElement.value.trim()){
+                    setFocus(pwdElement);
+                    var elementWithFocus = getElementWithFocus();
+                    if(elementWithFocus && elementWithFocus.name && pwdElement.name === elementWithFocus.name){
+                        clearInterval(intervalId);
+                    }
+                }
+            }, 200);
+        }
+
     });
-  </script>
+
+    lock.on('forgot_password ready', function() {
+        //doNotShowRegLink = true;
+        //var registerLink = document.getElementById('ddp-reg');
+        //if (registerLink) {
+        //  registerLink.parentNode.removeChild(registerLink);
+        //}
+    });
+
+    //lock.on('signin ready', function() {
+    //doNotShowRegLink = false;
+    //});
+
+    console.log('auth mode: ' + mode);
+    console.log('study_guid: ' + study_guid);
+
+    lock.show(options);
+</script>
 </body>
 </html>

--- a/study-builder/tenants/testboston/pages/password_reset.html
+++ b/study-builder/tenants/testboston/pages/password_reset.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title>Change your password</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+
+    <style type="text/css">
+        body,html{padding:0;margin:0}.table{display:table;position:absolute;height:100%;width:100%;background:linear-gradient(rgba(255,255,255,.3),rgba(255,255,255,0));background-color:#e8ebef}.cell{display:table-cell;vertical-align:middle}.content{padding:25px 0;margin-left:auto;margin-right:auto;width:280px}
+    </style>
+
+
+</head>
+<body>
+<div class="table">
+    <div class="cell">
+        <div class="content">
+            <!-- WIDGET -->
+            <div id="change-password-widget-container"></div>
+            <!-- END WIDGET -->
+        </div>
+    </div>
+</div>
+
+
+
+<script src="https://cdn.auth0.com/js/change-password-1.1.min.js"></script>
+
+<style type="text/css">
+    body {
+        font-family: Roboto;
+    }
+
+    .auth0-lock.auth0-lock .auth0-lock-overlay {
+        background: radial-gradient(#ffffff, #f3f3f2, #f3f3f2);
+        background-image: radial-gradient(#ffffff, #f3f3f2, #f3f3f2);
+        background-color: #fff;
+    }
+
+    .auth0-lock.auth0-lock.auth0-lock-opened .auth0-lock-widget {
+        box-shadow: 0 0 40px 4px #888888;
+    }
+    .auth0-lock-name {
+        font-size:12pt !important;
+        text-align:left;
+        padding-left:0 !important;
+    }
+
+    .auth0-lock-content {
+        padding-top:10px !important;
+    }
+
+    .auth0-lock-header .auth0-lock-header-bg {
+        background-color:white !important;
+    }
+
+    .auth0-lock.auth0-lock .auth0-lock-form p {
+        text-align:left;
+    }
+
+    a:link {
+        text-decoration: underline !important;
+    }
+
+
+</style>
+
+<script>
+    var getQueryParamValue = function(paramName){
+        var tokens = location.search.split(/&|#|\?/);
+        var queryParamPrefix = paramName + '=';
+        for(var i =0; i < tokens.length; i++){
+            if(tokens[i].indexOf(queryParamPrefix) == 0){
+                return tokens[i].substring(queryParamPrefix.length);
+            }
+        }
+        return null;
+    }
+
+    var study_guid = getQueryParamValue('study');
+    var headerImage = '##ASSETS_BUCKET_URL##/logo.png';
+    var studyColor = 'rgb(24, 130, 194)';
+    var headerText = 'Test Boston Study';
+    var headerLogo = '##ASSETS_BUCKET_URL##/logo.png';
+
+    var lock = new Auth0ChangePassword({
+        container:         "change-password-widget-container",     // required
+        email:             "{{email}}",                            // DO NOT CHANGE THIS
+        csrf_token:        '{{csrf_token}}',                       // DO NOT CHANGE THIS
+        ticket:            '{{ticket}}',                           // DO NOT CHANGE THIS
+        password_policy:   '{{password_policy}}',                  // DO NOT CHANGE THIS
+        theme: {
+            icon: headerLogo,
+            primaryColor: studyColor
+        },
+        dict: {
+            title : 'Password Update',
+            forgotPassword: 'If you have previously registered, you will receive an email shortly',
+            passwordPlaceholder: "Type your new password",
+            passwordConfirmationPlaceholder: "Confirm your new password",
+            passwordConfirmationMatchError: "Your entries didn't match. Please re-enter your new password in both fields below.",
+            // passwordStrength: {
+            //   containsAtLeast: "Contain at least %d of the following %d types of characters:",
+            //   identicalChars: "No more than %d identical characters in a row (e.g., \"%s\" not allowed)",
+            //   nonEmpty: "Non-empty password required",
+            //   numbers: "Numbers (i.e. 0-9)",
+            //   lengthAtLeast: "At least %d characters in length",
+            //   lowerCase: "Lower case letters (a-z)",
+            //   shouldContain: "Should contain:",
+            //   specialCharacters: "Special characters (e.g. !@#$%^&*)",
+            //   upperCase: "Upper case letters (A-Z)"
+            // },
+            // successMessage: "Your password has been reset successfully.",
+            // configurationError: "An error ocurred. There appears to be a misconfiguration in the form.",
+            // networkError: "The server cannot be reached, there is a problem with the network.",
+            // timeoutError: "The server cannot be reached, please try again.",
+            // serverError: "There was an error processing the password reset.",
+            headerText: "Please enter a new password for<br />{email}",
+            // title: "Change Password",
+            // weakPasswordError: "Password is too weak."
+            // passwordHistoryError: "Password has previously been used."
+        }
+    });
+
+    function setHeader() {
+        // we use setInterval because auth0's on() methods for display
+        // do not account for all the display modes and they appear to fire
+        // before animations complete, not after
+        setInterval(function() {
+            if (!document.getElementById('ddp-header')) {
+                // tweak the header
+                var header = document.createElement('div');
+                if (header) {
+                    header.innerHTML = '<div id="ddp-header" style="display:flex;flex-direction:row;justify-content: flex-start;align-items:center;"><img class="auth0-lock-header-logo" src="' + headerLogo + '"><div style="padding-left:8px;">' + headerText + '</div></div></div>';
+                    var elementToRemove = document.getElementsByClassName('auth0-lock-header-logo')[0];
+                    elementToRemove.parentNode.removeChild(elementToRemove);
+
+                    var parentElement = document.getElementsByClassName('auth0-lock-header-welcome')[0];
+                    parentElement.insertBefore(header, parentElement.firstChild);
+                }}},200);
+    };
+    setHeader();
+
+</script>
+</body>
+</html>

--- a/study-builder/tenants/testboston/tenant.yaml
+++ b/study-builder/tenants/testboston/tenant.yaml
@@ -37,7 +37,7 @@ clients:
       - '##BASE_URL##'
       ##LOCALHOST_ORIGINS##
     client_metadata:
-      study: TESTBOSTON
+      study: testboston
 
   - name: testboston-crc-client
     app_type: spa
@@ -52,4 +52,4 @@ clients:
       - '##BASE_URL##'
       ##LOCALHOST_ORIGINS##
     client_metadata:
-      study: TESTBOSTON
+      study: testboston

--- a/study-builder/tenants/testboston/tenant.yaml
+++ b/study-builder/tenants/testboston/tenant.yaml
@@ -1,0 +1,55 @@
+rules:
+  - name: Register User in Pepper
+    script: ../register-user-in-pepper.js
+    stage: login_success
+    enabled: true
+    order: 1
+
+pages:
+  - name: login
+    html: ./pages/login.html
+    enabled: true
+  - name: password_reset
+    html: ./pages/password_reset.html
+    enabled: true
+
+emailTemplates:
+  - template: reset_email
+    body: ./emails/change_password.html
+    from: Test Boston Study <testboston@datadonationplatform.org>
+    resultUrl: '##SERVER_BASE_URL##/pepper/v1/post-password-reset?clientId={{ application.clientID }}'
+    subject: Test Boston Study
+    urlLifetimeInSeconds: 432000
+    syntax: liquid
+    enabled: true
+
+clients:
+  - name: testboston-app-client
+    app_type: spa
+    callbacks:
+      - '##BASE_URL##/login-landing'
+      ##LOCALHOST_CALLBACKS##
+    allowed_logout_urls:
+      - '##BASE_URL##'
+      - '##BASE_URL##/session-expired'
+      ##LOCALHOST_LOGOUTS##
+    web_origins:
+      - '##BASE_URL##'
+      ##LOCALHOST_ORIGINS##
+    client_metadata:
+      study: TESTBOSTON
+
+  - name: testboston-crc-client
+    app_type: spa
+    callbacks:
+      - '##BASE_URL##/login-landing'
+      ##LOCALHOST_CALLBACKS##
+    allowed_logout_urls:
+      - '##BASE_URL##'
+      - '##BASE_URL##/session-expired'
+      ##LOCALHOST_LOGOUTS##
+    web_origins:
+      - '##BASE_URL##'
+      ##LOCALHOST_ORIGINS##
+    client_metadata:
+      study: TESTBOSTON


### PR DESCRIPTION
Added a few things to bootstrap the `testboston` study:
* Configuration for Auth0 tenant
* Vault entries and rendering study secrets
* Activity config files with dummy content
* Basic `study.conf` layout

You should be able to run `render.sh` and initialize the study locally.