### PR TITLE
Fix one cp statement in CircleCI. Easy review!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ commands:
             # And ignore the Suite itself
             echo 'org.broadinstitute.ddp.route.IntegrationTestSuite'  >> $IGNORE_CLASS_LIST_PATH
 
-            cp $THIS_NODE_TESTS_PATH "${TEST_DATA_PATH}" /this_node_circleci_tests
+            cp $THIS_NODE_TESTS_PATH "${TEST_DATA_PATH}"
 
             # save path for next steps
             echo "export IGNORE_CLASS_LIST_PATH=${IGNORE_CLASS_LIST_PATH}" >> $BASH_ENV


### PR DESCRIPTION
## Context
There was an error in command line that copied tests to be run in specific node to artifacts. Makes no difference in running tests, just in reporting.
One line!
