### PR TITLE
Fix parameter path in docs

### DIFF
--- a/pepper-apis/docs/specification/src/components/parameters.yml
+++ b/pepper-apis/docs/specification/src/components/parameters.yml
@@ -1,8 +1,7 @@
-path:
-  studyGuid:
-    in: path
-    name: study
-    required: true
-    description: the study guid
-    schema:
-      type: string
+studyGuid:
+  in: path
+  name: study
+  required: true
+  description: the study guid
+  schema:
+    type: string

--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
@@ -5,7 +5,7 @@ post:
   summary: InvitationCheckStatus
   description: Check the status of an invitation, whether it exits and is valid or not.
   parameters:
-    - $ref: '../pepper.yml#/components/parameters/path/studyGuid'
+    - $ref: '../pepper.yml#/components/parameters/studyGuid'
   requestBody:
     required: true
     content:

--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-details.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-details.yml
@@ -8,7 +8,7 @@ post:
 
     Note: this API is restricted to study admins.
   parameters:
-    - $ref: '../pepper.yml#/components/parameters/path/studyGuid'
+    - $ref: '../pepper.yml#/components/parameters/studyGuid'
   requestBody:
     required: true
     content:

--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-lookup.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-lookup.yml
@@ -8,7 +8,7 @@ post:
 
     Note: this API is restricted to study admins.
   parameters:
-    - $ref: '../pepper.yml#/components/parameters/path/studyGuid'
+    - $ref: '../pepper.yml#/components/parameters/studyGuid'
   requestBody:
     required: true
     content:

--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-verify.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-verify.yml
@@ -7,7 +7,7 @@ post:
     Marks an invitation as verified, e.g. the user is verifying that they can
     receive communications via the contact email associated with the invitation.
   parameters:
-    - $ref: '../pepper.yml#/components/parameters/path/studyGuid'
+    - $ref: '../pepper.yml#/components/parameters/studyGuid'
   requestBody:
     required: true
     content:


### PR DESCRIPTION
The linter (speccy) doesn't like the hierarchy in `parameters.yml`.