### PR TITLE
Remove need for auth0 domain in Invitation Check API

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
@@ -14,15 +14,11 @@ post:
           type: object
           required:
             - auth0ClientId
-            - auth0Domain
             - invitationId
             - recaptchaToken
           properties:
             auth0ClientId:
               description: the id of the client
-              type: string
-            auth0Domain:
-              description: the domain of the client
               type: string
             invitationId:
               description: the id of the invitation

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/invitation/InvitationCheckStatusPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/invitation/InvitationCheckStatusPayload.java
@@ -7,10 +7,6 @@ import com.google.gson.annotations.SerializedName;
 public class InvitationCheckStatusPayload {
 
     @NotEmpty
-    @SerializedName("auth0Domain")
-    private String auth0Domain;
-
-    @NotEmpty
     @SerializedName("auth0ClientId")
     private String auth0ClientId;
 
@@ -22,14 +18,9 @@ public class InvitationCheckStatusPayload {
     // @SerializedName("recaptchaToken")
     // private String recaptchaToken;
 
-    public InvitationCheckStatusPayload(String auth0Domain, String auth0ClientId, String invitationGuid) {
-        this.auth0Domain = auth0Domain;
+    public InvitationCheckStatusPayload(String auth0ClientId, String invitationGuid) {
         this.auth0ClientId = auth0ClientId;
         this.invitationGuid = invitationGuid;
-    }
-
-    public String getAuth0Domain() {
-        return auth0Domain;
     }
 
     public String getAuth0ClientId() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
@@ -54,13 +54,13 @@ public class InvitationCheckStatusRoute extends ValidatedJsonInputRoute<Invitati
         }
 
         List<String> permittedStudies = handle.attach(JdbiClientUmbrellaStudy.class)
-                .findPermittedStudyGuidsByAuth0ClientIdAndAuth0Domain(payload.getAuth0ClientId(), payload.getAuth0Domain());
+                .findPermittedStudyGuidsByAuth0ClientIdAndAuth0TenantId(payload.getAuth0ClientId(), studyDto.getAuth0TenantId());
         if (permittedStudies.contains(studyGuid)) {
-            LOG.info("Invitation check by client clientId={}, tenant={}",
-                    payload.getAuth0ClientId(), payload.getAuth0Domain());
+            LOG.info("Invitation check by client clientId={}, study={}",
+                    payload.getAuth0ClientId(), studyGuid);
         } else {
-            LOG.error("Invitation check by client which does not have access to study: clientId={}, tenant={}",
-                    payload.getAuth0ClientId(), payload.getAuth0Domain());
+            LOG.error("Invitation check by client which does not have access to study: clientId={}, study={}",
+                    payload.getAuth0ClientId(), studyGuid);
             return HttpStatus.SC_BAD_REQUEST;
         }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/InvitationCheckStatusRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/InvitationCheckStatusRouteTest.java
@@ -62,7 +62,7 @@ public class InvitationCheckStatusRouteTest extends IntegrationTestSuite.TestCas
     @Test
     public void testCheckStatus_studyNotFound() {
         doReturn(null).when(mockJdbiStudy).findByStudyGuid(any());
-        var payload = new InvitationCheckStatusPayload("foo", "bar", "invite");
+        var payload = new InvitationCheckStatusPayload("foo", "invite");
         int actual = route.checkStatus(mockHandle, "study", payload);
         assertEquals(HttpStatus.SC_BAD_REQUEST, actual);
     }
@@ -73,7 +73,7 @@ public class InvitationCheckStatusRouteTest extends IntegrationTestSuite.TestCas
         doReturn(Collections.emptyList()).when(mockClientStudy)
                 .findPermittedStudyGuidsByAuth0ClientIdAndAuth0Domain(any(), any());
 
-        var payload = new InvitationCheckStatusPayload("foo", "bar", "invite");
+        var payload = new InvitationCheckStatusPayload("foo", "invite");
         int actual = route.checkStatus(mockHandle, "study", payload);
         assertEquals(HttpStatus.SC_BAD_REQUEST, actual);
     }
@@ -84,7 +84,7 @@ public class InvitationCheckStatusRouteTest extends IntegrationTestSuite.TestCas
         doReturn(List.of("study1", "study2")).when(mockClientStudy)
                 .findPermittedStudyGuidsByAuth0ClientIdAndAuth0Domain(any(), any());
 
-        var payload = new InvitationCheckStatusPayload("foo", "bar", "invite");
+        var payload = new InvitationCheckStatusPayload("foo", "invite");
         int actual = route.checkStatus(mockHandle, "study", payload);
         assertEquals(HttpStatus.SC_BAD_REQUEST, actual);
     }
@@ -94,7 +94,7 @@ public class InvitationCheckStatusRouteTest extends IntegrationTestSuite.TestCas
         doReturn(testData.getTestingStudy()).when(mockJdbiStudy).findByStudyGuid(any());
         doReturn(List.of(testData.getStudyGuid())).when(mockClientStudy)
                 .findPermittedStudyGuidsByAuth0ClientIdAndAuth0Domain(any(), any());
-        var payload = new InvitationCheckStatusPayload("foo", "bar", "invite");
+        var payload = new InvitationCheckStatusPayload("foo", "invite");
 
         doReturn(Optional.empty()).when(mockInviteDao).findByInvitationGuid(anyLong(), any());
         int actual = route.checkStatus(mockHandle, "study", payload);
@@ -118,7 +118,6 @@ public class InvitationCheckStatusRouteTest extends IntegrationTestSuite.TestCas
                 .createRecruitmentInvitation(testData.getStudyId(), "invite" + System.currentTimeMillis()));
         try {
             var payload = new InvitationCheckStatusPayload(
-                    testData.getTestingClient().getAuth0Domain(),
                     testData.getAuth0ClientId(),
                     invitation.getInvitationGuid());
             String url = RouteTestUtil.getTestingBaseUrl() + RouteConstants.API.INVITATION_CHECK;


### PR DESCRIPTION
Instead of taking `auth0Domain` in request, we'll use same domain as the study.