### PR TITLE
DDP-4433 init profile

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/UserRegistrationPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/UserRegistrationPayload.java
@@ -41,38 +41,43 @@ public class UserRegistrationPayload {
     @SerializedName("tempUserGuid")
     private String tempUserGuid;
 
-    @SerializedName("auth0ClientCountryCode")
-    private String auth0ClientCountryCode;
-
     @SerializedName("mode")
     private String mode;
 
     @SerializedName("invitationId")
     private String invitationGuid;
 
-    public UserRegistrationPayload(String auth0UserId, String auth0ClientId, String auth0ClientCountryCode,
+    @SerializedName("languageCode")
+    private String languageCode;
+
+    @SerializedName("firstName")
+    private String firstName;
+
+    @SerializedName("lastName")
+    private String lastName;
+
+    public UserRegistrationPayload(String auth0UserId, String auth0ClientId,
                                    String studyGuid, String auth0Domain, String tempUserGuid, String mode) {
-        this(auth0UserId, auth0ClientId, auth0ClientCountryCode, studyGuid, auth0Domain, tempUserGuid, mode, null);
+        this(auth0UserId, auth0ClientId, studyGuid, auth0Domain, tempUserGuid, mode, null);
     }
 
-    public UserRegistrationPayload(String auth0UserId, String auth0ClientId, String auth0ClientCountryCode,
+    public UserRegistrationPayload(String auth0UserId, String auth0ClientId,
                                    String studyGuid, String auth0Domain, String tempUserGuid, String mode,
                                    String invitationGuid) {
-        this(auth0UserId, auth0ClientId, auth0ClientCountryCode, studyGuid, auth0Domain, invitationGuid);
+        this(auth0UserId, auth0ClientId, studyGuid, auth0Domain, invitationGuid);
         this.tempUserGuid = tempUserGuid;
         this.mode = mode;
     }
 
-    public UserRegistrationPayload(String auth0UserId, String auth0ClientId, String auth0ClientCountryCode,
+    public UserRegistrationPayload(String auth0UserId, String auth0ClientId,
                                    String studyGuid, String auth0Domain) {
-        this(auth0UserId, auth0ClientId, auth0ClientCountryCode, studyGuid, auth0Domain, null);
+        this(auth0UserId, auth0ClientId, studyGuid, auth0Domain, null);
     }
 
-    public UserRegistrationPayload(String auth0UserId, String auth0ClientId, String auth0ClientCountryCode,
+    public UserRegistrationPayload(String auth0UserId, String auth0ClientId,
                                    String studyGuid, String auth0Domain, String invitationGuid) {
         this.auth0UserId = auth0UserId;
         this.auth0ClientId = auth0ClientId;
-        this.auth0ClientCountryCode = auth0ClientCountryCode;
         this.studyGuid = studyGuid;
         this.auth0Domain = auth0Domain;
         this.invitationGuid = invitationGuid;
@@ -98,10 +103,6 @@ public class UserRegistrationPayload {
         return auth0ClientId;
     }
 
-    public String getAuth0ClientCountryCode() {
-        return auth0ClientCountryCode;
-    }
-
     public String getStudyGuid() {
         return studyGuid;
     }
@@ -120,5 +121,32 @@ public class UserRegistrationPayload {
 
     public String getInvitationGuid() {
         return invitationGuid;
+    }
+
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    public UserRegistrationPayload setLanguageCode(String languageCode) {
+        this.languageCode = languageCode;
+        return this;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public UserRegistrationPayload setFirstName(String firstName) {
+        this.firstName = firstName;
+        return this;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public UserRegistrationPayload setLastName(String lastName) {
+        this.lastName = lastName;
+        return this;
     }
 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserRegistrationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserRegistrationRouteTest.java
@@ -345,7 +345,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
     @Test
     public void testRegister_missingDomain() {
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), null);
+                study1.getGuid(), null);
         makeRequestWith(payload).then().assertThat()
                 .statusCode(400)
                 .contentType(ContentType.JSON)
@@ -356,7 +356,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
     @Test
     public void testRegister_missingUserId() {
         UserRegistrationPayload payload = new UserRegistrationPayload(null, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                study1.getGuid(), auth0Domain);
         makeRequestWith(payload).then().assertThat()
                 .statusCode(400)
                 .contentType(ContentType.JSON)
@@ -369,7 +369,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         RouteTestUtil.revokeTestClient();
         try {
             UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                    EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                    study1.getGuid(), auth0Domain);
             makeRequestWith(payload).then().assertThat().statusCode(401);
         } finally {
             RouteTestUtil.enableTestClient();
@@ -387,7 +387,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         });
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, study.getGuid(), auth0Domain);
+                study.getGuid(), auth0Domain);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(404)
@@ -406,8 +406,11 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         });
         auth0UserIdsToDelete.add(testAuth0UserId);
 
-        UserRegistrationPayload payload = new UserRegistrationPayload(testAuth0UserId, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), auth0Domain);
+        UserRegistrationPayload payload = new UserRegistrationPayload(
+                testAuth0UserId, auth0ClientId, study1.getGuid(), auth0Domain)
+                .setLanguageCode(EN_LANG_CODE)
+                .setFirstName("foo")
+                .setLastName("bar");
 
         Instant start = Instant.now();
         String newUserGuid = makeRequestWith(payload).then().assertThat()
@@ -426,7 +429,9 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
             UserProfile profile = handle.attach(UserProfileDao.class).findProfileByUserId(userDto.getUserId()).get();
 
             Long enLanguageCodeId = handle.attach(JdbiLanguageCode.class).getLanguageCodeId(EN_LANG_CODE);
-            assertEquals(profile.getPreferredLangId(), enLanguageCodeId);
+            assertEquals(enLanguageCodeId, profile.getPreferredLangId());
+            assertEquals("foo", profile.getFirstName());
+            assertEquals("bar", profile.getLastName());
 
             JdbiUserStudyEnrollment jdbiEnrollment = handle.attach(JdbiUserStudyEnrollment.class);
             Optional<EnrollmentStatusType> enrollment = jdbiEnrollment
@@ -455,7 +460,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         String fakeAuth0Id = "fake|" + Instant.now().toEpochMilli();
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
+                testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
 
         String operatorUserGuid = makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -510,7 +515,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         String fakeAuth0Id = "fake|" + Instant.now().toEpochMilli();
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
+                testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
 
         String operatorUserGuid = makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -568,7 +573,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         String expectedUserGuid = RouteTestUtil.getUnverifiedUserGuidFromToken(token);
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                study1.getGuid(), auth0Domain);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -585,7 +590,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
                 .isPresent()));
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, null, "login");
+                tempStudy.getGuid(), auth0Domain, null, "login");
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(HttpStatus.SC_UNPROCESSABLE_ENTITY)
@@ -611,7 +616,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         });
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, null, "login");
+                tempStudy.getGuid(), auth0Domain, null, "login");
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -624,7 +629,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         String fakeAuth0Id = "this-has-no-email" + Instant.now().toEpochMilli();
 
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                study1.getGuid(), auth0Domain);
 
         String newUserGuid = makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -655,7 +660,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         try {
             UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                    EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                    study1.getGuid(), auth0Domain);
             makeRequestWith(payload).then().assertThat().statusCode(200);
 
             TransactionWrapper.useTxn(handle -> {
@@ -678,7 +683,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
                 handle.attach(JdbiUser.class).findByUserId(user1Id).getAuth0UserId());
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserIdForUser1, auth0ClientId,
-                EN_LANG_CODE, study1.getGuid(), auth0Domain);
+                study1.getGuid(), auth0Domain);
 
         makeRequestWith(payload).then().assertThat().statusCode(200);
     }
@@ -703,7 +708,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         String fakeAuth0Id = "fake|" + Instant.now().toEpochMilli();
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
+                testStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
 
         String actualUserGuid = makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -740,7 +745,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         String fakeAuth0Id = "fake|" + Instant.now().toEpochMilli();
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
+                tempStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
 
         String actualUserGuid = makeRequestWith(payload).then().assertThat()
                 .statusCode(200)
@@ -780,7 +785,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         userGuidsToDelete.add(tempUser.getGuid());
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
+                tempStudy.getGuid(), auth0Domain, tempUser.getGuid(), null);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(422)
@@ -801,7 +806,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
 
         String fakeAuth0Id = "fake|" + Instant.now().toEpochMilli();
         UserRegistrationPayload payload = new UserRegistrationPayload(fakeAuth0Id, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, tempUser.getUserGuid(), null);
+                tempStudy.getGuid(), auth0Domain, tempUser.getUserGuid(), null);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(422)
@@ -815,7 +820,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
         String existingUserGuid = RouteTestUtil.getUnverifiedUserGuidFromToken(token);
 
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, existingUserGuid, null);
+                tempStudy.getGuid(), auth0Domain, existingUserGuid, null);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(422)
@@ -827,7 +832,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
     @Test
     public void testUpgradeTempUser_whenGivenNonExistingTempUser_returnsError() {
         UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                EN_LANG_CODE, tempStudy.getGuid(), auth0Domain, "non-existing-temp-guid", null);
+                tempStudy.getGuid(), auth0Domain, "non-existing-temp-guid", null);
 
         makeRequestWith(payload).then().assertThat()
                 .statusCode(422)
@@ -897,7 +902,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
             String invitationGuid = invitation.get().getInvitationGuid();
 
             UserRegistrationPayload payload = new UserRegistrationPayload(auth0UserId, auth0ClientId,
-                    EN_LANG_CODE, testStudy.get().getGuid(), auth0Domain, null, null, invitationGuid);
+                    testStudy.get().getGuid(), auth0Domain, null, null, invitationGuid);
 
             makeRequestWith(payload).then().assertThat()
                     .statusCode(200)
@@ -965,7 +970,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
             String invitationGuid = invitation.get().getInvitationGuid();
             String fakeAuth0UserId = "fake_auth0_id" + System.currentTimeMillis();
             var payload = new UserRegistrationPayload(fakeAuth0UserId, auth0ClientId,
-                    EN_LANG_CODE, testStudy.get().getGuid(), auth0Domain, null, null, invitationGuid);
+                    testStudy.get().getGuid(), auth0Domain, null, null, invitationGuid);
 
             String createdUserGuid = makeRequestWith(payload)
                     .then().assertThat()

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -97,8 +97,18 @@ function (user, context, callback) {
 
         if (context.request.query.invitation_id) {
             pepper_params.invitationId = context.request.query.invitation_id;
+            console.log('Invitation id passed in (via query) = ' + pepper_params.invitationId);
         } else if (context.request.body.invitation_id) {
             pepper_params.invitationId = context.request.body.invitation_id;
+            console.log('Invitation id passed in (via body) = ' + pepper_params.invitationId);
+        }
+
+        if (context.request.query.language) {
+            pepper_params.language = context.request.query.language;
+            console.log('User language passed in (via query) = ' + pepper_params.language);
+        } else if (context.request.body.language) {
+            pepper_params.language = context.request.body.language;
+            console.log('User language passed in (via body) = ' + pepper_params.language);
         }
 
         console.log(context);
@@ -126,6 +136,16 @@ function (user, context, callback) {
             context.idToken[pepperUserGuidClaim] = user.app_metadata.user_guid;
             return callback(null, user, context);
         } else {
+            user.user_metadata = user.user_metadata || {};
+            if (user.user_metadata.first_name) {
+                pepper_params.firstName = user.user_metadata.first_name;
+                console.log('User metadata has first name = ' + pepper_params.firstName);
+            }
+            if (user.user_metadata.last_name) {
+                pepper_params.lastName = user.user_metadata.last_name;
+                console.log('User metadata has last name = ' + pepper_params.lastName);
+            }
+
             request.post({
                 url: configuration.pepperBaseUrl + '/pepper/v1/register',
                 json: pepper_params,

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -56,14 +56,8 @@ function (user, context, callback) {
         var pepper_params = {
             auth0UserId: user.user_id,
             auth0ClientId: context.clientID,
-            auth0Domain: tenantDomain,
-            auth0ClientCountryCode: 'us'
+            auth0Domain: tenantDomain
         };
-
-        if (context.request.geoip.country_code) {
-            pepper_params.auth0ClientCountryCode = context.request.geoip.country_code;
-            console.log('Using country code (via auth0) = ' + pepper_params.auth0ClientCountryCode);
-        }
 
         if (context.request.query.study_guid) {
             pepper_params.studyGuid = context.request.query.study_guid;
@@ -104,11 +98,11 @@ function (user, context, callback) {
         }
 
         if (context.request.query.language) {
-            pepper_params.language = context.request.query.language;
-            console.log('User language passed in (via query) = ' + pepper_params.language);
+            pepper_params.languageCode = context.request.query.language;
+            console.log('User language passed in (via query) = ' + pepper_params.languageCode);
         } else if (context.request.body.language) {
-            pepper_params.language = context.request.body.language;
-            console.log('User language passed in (via body) = ' + pepper_params.language);
+            pepper_params.languageCode = context.request.body.language;
+            console.log('User language passed in (via body) = ' + pepper_params.languageCode);
         }
 
         console.log(context);

--- a/study-builder/tenants/testboston/pages/login.html
+++ b/study-builder/tenants/testboston/pages/login.html
@@ -163,7 +163,7 @@
                 placeholder: "Your first name",
                 validator: function(input) {
                   return {
-                     valid: input != null && input.length > 0,
+                     valid: input != null && input.trim().length > 0,
                      hint: "Can't be blank"
                   };
                 }
@@ -173,7 +173,7 @@
                 placeholder: "Your last name",
                 validator: function(input) {
                     return {
-                        valid: input != null && input.length > 0,
+                        valid: input != null && input.trim().length > 0,
                         hint: "Can't be blank"
                     }
                 }

--- a/study-builder/tenants/testboston/pages/login.html
+++ b/study-builder/tenants/testboston/pages/login.html
@@ -64,7 +64,7 @@
 
     var mode = config.extraParams.mode;
     var study_guid = config.extraParams.study_guid;
-    var headerLogo = '##BASE_URL##/logo.png';
+    var headerLogo = '##ASSETS_BUCKET_URL##/logo.png';
     var headerText = "Test Boston";
     var studyColor = 'rgb(24, 130, 194)';
     var studyHelpEmail = 'testboston@datadonationplatform.org';
@@ -78,7 +78,7 @@
     }
 
     var loginUrl = config.callbackURL + '/login';
-    var registerUrl = '##ANGIO_BASE_URL##/count-me-in';
+    var registerUrl = '##BASE_URL##';
 
     var connection = config.connection;
     var prompt = !prompt;
@@ -154,6 +154,31 @@
 
     if (config.extraParams.password_was_reset) {
         showPasswordRecentText = true;
+    }
+
+    if (mode === 'signup') {
+        realOptions.additionalSignUpFields = [
+            {
+                name: "first_name",
+                placeholder: "Your first name",
+                validator: function(input) {
+                  return {
+                     valid: input != null && input.length > 0,
+                     hint: "Can't be blank"
+                  };
+                }
+            },
+            {
+                name: "last_name",
+                placeholder: "Your last name",
+                validator: function(input) {
+                    return {
+                        valid: input != null && input.length > 0,
+                        hint: "Can't be blank"
+                    }
+                }
+            }
+        ];
     }
 
     var lock = new Auth0Lock(config.clientID, config.auth0Domain, realOptions);


### PR DESCRIPTION
## Context

We can now initialize user profile during registration with data passed in from Auth0. This includes user's selected language and first/last name. These can be passed to Auth0 by the client, and then passed on to backend from there.

Also made some changes to `testboston`'s universal login to show custom fields and how we handle that via `user_metadata`.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

