### PR TITLE
DDP-4670 allow empty first/last name for join-mailing-list

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -36,10 +36,12 @@ JoinMailingListPayload:
       description: users first name
       type: string
       example: John
+      minLength: 0
     lastName:
       description: users last name
       type: string
       example: Doe
+      minLength: 0
     emailAddress:
       description: users email address
       type: string

--- a/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
+++ b/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
@@ -1,7 +1,7 @@
 post:
   operationId: joinMailingList
   tags:
-    - Operator & Participant
+    - Studies
   summary: joinMailingList
   description: add a user to a studies email list or to a mailing list for a study that does not exist
   requestBody:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/JoinMailingListPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/JoinMailingListPayload.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.json;
 import java.util.List;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -13,11 +14,11 @@ public class JoinMailingListPayload {
     @SerializedName("studyGuid")
     private String studyGuid;
 
-    @NotEmpty
+    @NotNull
     @SerializedName("firstName")
     private String firstName;
 
-    @NotEmpty
+    @NotNull
     @SerializedName("lastName")
     private String lastName;
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/JoinMailingListRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/JoinMailingListRouteTest.java
@@ -225,14 +225,7 @@ public class JoinMailingListRouteTest extends IntegrationTestSuite.TestCase {
     @Test
     public void testAddMissingFieldsFails() {
         addUserAndAssertStatusCode(new JoinMailingListPayload(null,
-                        "lastName",
-                        "foo@datadonationplatform.org",
-                        studyGuid,
                         null,
-                        null),
-                422);
-        addUserAndAssertStatusCode(new JoinMailingListPayload("first name",
-                        "",
                         "foo@datadonationplatform.org",
                         studyGuid,
                         null,
@@ -245,6 +238,31 @@ public class JoinMailingListRouteTest extends IntegrationTestSuite.TestCase {
                         null,
                         null),
                 422);
+    }
+
+    @Test
+    public void testAddEmptyNamePasses() {
+        addUserAndAssertStatusCode(new JoinMailingListPayload("",
+                        "lastName",
+                        "foo" + System.currentTimeMillis() + "@datadonationplatform.org",
+                        studyGuid,
+                        null,
+                        null),
+                204);
+        addUserAndAssertStatusCode(new JoinMailingListPayload("firstName",
+                        "",
+                        "foo" + System.currentTimeMillis() + "@datadonationplatform.org",
+                        studyGuid,
+                        null,
+                        null),
+                204);
+        addUserAndAssertStatusCode(new JoinMailingListPayload("",
+                        "",
+                        "foo" + System.currentTimeMillis() + "@datadonationplatform.org",
+                        studyGuid,
+                        null,
+                        null),
+                204);
     }
 
     @AfterClass


### PR DESCRIPTION
## Context

Allow first/last name to be empty strings in Join Mailing List API.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

