### PR TITLE
Start HTTP server in Housekeeping to handle GAE

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -47,7 +47,8 @@
     "pdfArchiveBucket": "{{$conf.Data.pdfArchiveBucket}}",
     "pdfArchiveUseFilesystem": false,
     "pubsub": {
-        "housekeepingEventsTopic": "{{$conf.Data.pubsub.housekeepingEventsTopic}}",
+        "enableHousekeepingTasks": {{$conf.Data.pubsub.enableHousekeepingTasks}},
+        "housekeepingTasksTopic": "{{$conf.Data.pubsub.housekeepingTasksTopic}}",
     },
     "studyExportBucket": "{{$conf.Data.studyExportBucket}}",
     "schedules": {

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -80,7 +80,8 @@
     "pdfArchiveBucket": "pepper-pdf-dev",
     "pdfArchiveUseFilesystem": true,
     "pubsub": {
-        "housekeepingEventsTopic": "local-housekeeping-events",
+        "enableHousekeepingTasks": false,
+        "housekeepingTasksTopic": "local-housekeeping-tasks",
     },
     "studyExportBucket": "ddp-dev-study-exports-testing",
     "schedules": {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -95,7 +95,8 @@ public class ConfigFile {
     public static final String BACKEND_AUTH0_TEST_CLIENT_ID2 = "backendTestClientId2";
     public static final String BACKEND_AUTH0_TEST_SECRET2 = "backendTestSecret2";
     public static final String BACKEND_AUTH0_TEST_CLIENT_NAME2 = "backendTestClientName2";
-    public static final String PUBSUB_HKEEP_EVENTS_TOPIC = "pubsub.housekeepingEventsTopic";
+    public static final String PUBSUB_ENABLE_HKEEP_TASKS = "pubsub.enableHousekeepingTasks";
+    public static final String PUBSUB_HKEEP_TASKS_TOPIC = "pubsub.housekeepingTasksTopic";
     public static final String SLACK_HOOK = "slack.hook";
     public static final String SLACK_CHANNEL = "slack.channel";
     public static final String TEST_USER_AUTH0_ID = "testUserAuth0Id";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
@@ -130,7 +130,7 @@ public class PubSubConnectionManager {
             if (e.getStatusCode().getCode() != StatusCode.Code.ALREADY_EXISTS) {
                 throw new RuntimeException(String.format("Error creating subscription %s to topic %s",
                         subscription.getName(),
-                        subscription.getTopic()));
+                        subscription.getTopic()), e);
             } else {
                 LOG.info("Subscription {} for topic {} already exists", subscription.getName(), subscription.getTopic());
             }


### PR DESCRIPTION
I have been monitoring the Housekeeping instance on GAE. I noticed that it keeps getting killed every 10 minutes or so, and gets constantly rebooted. I also observed that it will be killed even if a long-running process is underway, such as a data export.

From our GAE config, Housekeeping is set to manual scaling, so I thought it will be long-running but was surprised by the unstable behavior. Looking more at [GAE docs](https://cloud.google.com/appengine/docs/standard/java11/how-instances-are-managed#startup), it sounds like manually scaled app's lifecycle is a different, and we need to respond to their ping on the `/_ah/start` hook. GAE seems to only tolerate 10 minutes max for the ping, so that probably explains the behavior I had observed.

To migitate, I booted up a Spark server to respond to the HTTP request, then subsequently shutting it down so we don't waste resources.

I have hijacked `dev` GAE and deployed this PR's version of Housekeeping to it. So far it seems to be running and is stable.

As an aside, I also renamed things from `events` -> `tasks` so it's more clear that we're dealing with operational tasks instead of actual user events.