### PR TITLE
testboston: add workflow rule to start invited patient on consent

### DIFF
--- a/study-builder/studies/testboston/study-workflows.conf
+++ b/study-builder/studies/testboston/study-workflows.conf
@@ -83,6 +83,14 @@
           """
         },
         {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.consent},
+          "expression": """
+            !user.studies["testboston"].forms["CONSENT"].hasInstance()
+            && user.studies["testboston"].hasInvitation("RECRUITMENT")
+          """
+        },
+        {
           "type": "DASHBOARD",
           "expression": "true"
         }


### PR DESCRIPTION
In `testboston`'s auth flow, user will get bounced back to the app and then existing code will call `GET /workflow?from=RETURN_USER`. We want to start the workflow when app calls Workflow API, so adding new workflow rule for that.