### PR TITLE
Rename vault variable for recatpcha server site key

### DIFF
--- a/study-builder/config/testboston-vars.conf.ctmpl
+++ b/study-builder/config/testboston-vars.conf.ctmpl
@@ -15,7 +15,7 @@
     "mgmtClientSecret": "{{$conf.auth0.mgmtClientSecret}}",
   },
   "baseWebUrl": "{{$conf.baseWebUrl}}",
-  "recaptchaSiteKey": "{{$conf.recaptchaSiteKey}}",
+  "recaptchaSiteKey": "{{$conf.recaptchaSiteServerKey}}",
   "passwordRedirectUrl": "{{$conf.passwordRedirectUrl}}",
   "assetsBucketName": "{{$conf.assetsBucketName}}",
   "sendgridApiKey": "{{$conf.sendgridApiKey}}",


### PR DESCRIPTION
## Context
Renamed recaptcha key value in Vault to make it clearer which one is for the server and which one is for the client.
I have also updated the deployment instructions for 1.9 here:
https://broadinstitute.atlassian.net/wiki/spaces/DDP/pages/1224507524/v1.9

## Checklist

- [ X] I have labeled the type of changes involved using the `C-*` labels.
- [ X] I have assessed potential risks and labeled using the `R-*` labels.
- [X ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ X] I have considered security and privacy, and added `I-*` labels as needed
- [X ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ X] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

N/A

## Testing
N/A
## Release

- [ ] These changes require no special release procedures--just code!
- [X ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

