### PR TITLE
DDP-4633 export invitations and language to elasticsearch

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -45,6 +45,9 @@
                 }
               }
             },
+            "preferredLanguage": {
+              "type": "keyword"
+            },
             "doNotContact": {
               "type": "boolean"
             },
@@ -237,6 +240,47 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "invitations": {
+          "properties": {
+            "type": {
+              "type": "keyword"
+            },
+            "guid": {
+              "type": "keyword"
+            },
+            "createdAt": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+            },
+            "voidedAt": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+            },
+            "verifiedAt": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+            },
+            "acceptedAt": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+            },
+            "contactEmail": {
+              "type": "keyword",
+              "fields": {
+                "text": {
+                  "type": "text"
+                }
+              }
+            },
+            "notes": {
+              "type": "text"
             }
           }
         },

--- a/elasticsearch/templates/users.json
+++ b/elasticsearch/templates/users.json
@@ -37,6 +37,9 @@
                 }
               }
             },
+            "preferredLanguage": {
+              "type": "keyword"
+            },
             "doNotContact": {
               "type": "boolean"
             },

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/InvitationDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/InvitationDao.java
@@ -33,6 +33,12 @@ public interface InvitationDao extends SqlObject {
     @RegisterConstructorMapper(InvitationDto.class)
     Optional<InvitationDto> findByInvitationGuid(@Bind("studyId") long studyId, @Bind("guid") String invitationGuid);
 
+    @SqlQuery("select i.*, it.invitation_type_code from invitation as i"
+            + "  join invitation_type as it on i.invitation_type_id = it.invitation_type_id"
+            + " where i.study_id = :studyId")
+    @RegisterConstructorMapper(InvitationDto.class)
+    List<InvitationDto> findAllInvitations(@Bind("studyId") long studyId);
+
     default void saveNotes(long invitationId, String notes) {
         DBUtils.checkUpdate(1, getHandle().attach(InvitationSql.class)
                 .updateNotes(invitationId, notes));

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -37,6 +37,7 @@ import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.DaoException;
 import org.broadinstitute.ddp.db.dao.FormActivityDao;
+import org.broadinstitute.ddp.db.dao.InvitationDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
 import org.broadinstitute.ddp.db.dao.ParticipantDao;
@@ -48,6 +49,7 @@ import org.broadinstitute.ddp.db.dto.ActivityDto;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceStatusDto;
 import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
 import org.broadinstitute.ddp.db.dto.EnrollmentStatusDto;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.elastic.ElasticSearchIndexType;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -469,9 +471,12 @@ public class DataExporter {
                                         Map<String, Set<String>> proxiesMap,
                                         Map<String, Set<String>> governedUsersMap) {
         UserProfile userProfile = user.getProfile();
+        if (userProfile == null) {
+            userProfile = new UserProfile.Builder(user.getId()).build();
+        }
         ParticipantProfile profile = new ParticipantProfile(userProfile.getFirstName(), userProfile.getLastName(),
                 user.getGuid(), user.getHruid(), user.getLegacyAltPid(), user.getLegacyShortId(), user.getEmail(),
-                userProfile.getDoNotContact(), user.getCreatedAt());
+                userProfile.getPreferredLangCode(), userProfile.getDoNotContact(), user.getCreatedAt());
 
         Set<String> proxies = new HashSet<>();
         Set<String> governedUsers = new HashSet<>();
@@ -562,11 +567,13 @@ public class DataExporter {
 
         enrichWithDSMEventDates(handle, medicalRecordService, governancePolicy, studyDto.getId(), dataset);
 
+        List<InvitationDto> invitations = handle.attach(InvitationDao.class)
+                .findAllInvitations(studyDto.getId());
         StudyExtract studyExtract = new StudyExtract(activities,
                 studyPdfConfigs,
                 configPdfVersions,
-                participantProxyGuids);
-
+                participantProxyGuids,
+                invitations);
 
         Map<String, String> participantRecords = prepareParticipantRecordsForJSONExport(
                 studyExtract, dataset, exportStructuredDocument, handle, medicalRecordService);
@@ -729,6 +736,7 @@ public class DataExporter {
         if (userProfile != null) {
             builder.setFirstName(userProfile.getFirstName());
             builder.setLastName(userProfile.getLastName());
+            builder.setPreferredLanguage(userProfile.getPreferredLangCode());
             builder.setDoNotContact(userProfile.getDoNotContact());
         }
         builder.setGuid(user.getGuid())
@@ -794,6 +802,9 @@ public class DataExporter {
         if (proxies == null) {
             proxies = List.of();
         }
+        List<InvitationDto> invitations = studyExtract.getInvitations().stream()
+                .filter(invite -> invite.getUserId() != null && invite.getUserId().equals(user.getId()))
+                .collect(Collectors.toList());
         ParticipantRecord participantRecord = new ParticipantRecord(
                 statusDto.getEnrollmentStatus(),
                 statusDto.getValidFromMillis(),
@@ -802,7 +813,8 @@ public class DataExporter {
                 participant.getProviders(),
                 user.getAddress(),
                 dsmComputedRecord,
-                proxies
+                proxies,
+                invitations
         );
         return gson.toJson(participantRecord);
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/StudyExtract.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/StudyExtract.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.export;
 import java.util.List;
 import java.util.Map;
 
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.model.pdf.PdfConfigInfo;
 import org.broadinstitute.ddp.model.pdf.PdfVersion;
 
@@ -12,15 +13,18 @@ public class StudyExtract {
     private List<PdfConfigInfo> studyPdfConfigs;
     private Map<Long, List<PdfVersion>> pdfVersions;
     private Map<String, List<String>> participantProxyGuids; //<participantGuid, List<proxyGuid>>
+    private List<InvitationDto> invitations;
 
     public StudyExtract(List<ActivityExtract> activities,
                         List<PdfConfigInfo> studyPdfConfigs,
                         Map<Long, List<PdfVersion>> pdfVersions,
-                        Map<String, List<String>> participantProxyGuids) {
+                        Map<String, List<String>> participantProxyGuids,
+                        List<InvitationDto> invitations) {
         this.activities = activities;
         this.studyPdfConfigs = studyPdfConfigs;
         this.pdfVersions = pdfVersions;
         this.participantProxyGuids = participantProxyGuids;
+        this.invitations = invitations;
     }
 
     public List<PdfConfigInfo> getStudyPdfConfigs() {
@@ -39,4 +43,7 @@ public class StudyExtract {
         return participantProxyGuids;
     }
 
+    public List<InvitationDto> getInvitations() {
+        return invitations;
+    }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/InvitationRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/InvitationRecord.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.ddp.export.json.structured;
+
+import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
+import org.broadinstitute.ddp.model.invitation.InvitationType;
+
+public class InvitationRecord {
+
+    @SerializedName("type")
+    private InvitationType type;
+    @SerializedName("guid")
+    private String invitationGuid;
+    @SerializedName("createdAt")
+    private long createdAt;
+    @SerializedName("voidedAt")
+    private Long voidedAt;
+    @SerializedName("verifiedAt")
+    private Long verifiedAt;
+    @SerializedName("acceptedAt")
+    private Long acceptedAt;
+    @SerializedName("contactEmail")
+    private String contactEmail;
+    @SerializedName("notes")
+    private String notes;
+
+    public InvitationRecord(InvitationDto invite) {
+        this(invite.getInvitationType(),
+                invite.getInvitationGuid(),
+                invite.getCreatedAt().toEpochMilli(),
+                invite.getVoidedAt() != null ? invite.getVoidedAt().toEpochMilli() : null,
+                invite.getVerifiedAt() != null ? invite.getVerifiedAt().toEpochMilli() : null,
+                invite.getAcceptedAt() != null ? invite.getAcceptedAt().toEpochMilli() : null,
+                invite.getContactEmail(),
+                invite.getNotes());
+    }
+
+    public InvitationRecord(InvitationType type, String invitationGuid,
+                            long createdAt, Long voidedAt,
+                            Long verifiedAt, Long acceptedAt,
+                            String contactEmail, String notes) {
+        this.type = type;
+        this.invitationGuid = invitationGuid;
+        this.createdAt = createdAt;
+        this.voidedAt = voidedAt;
+        this.verifiedAt = verifiedAt;
+        this.acceptedAt = acceptedAt;
+        this.contactEmail = contactEmail;
+        this.notes = notes;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ParticipantProfile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ParticipantProfile.java
@@ -18,6 +18,8 @@ public class ParticipantProfile {
     private String lastName;
     @SerializedName("email")
     private String email;
+    @SerializedName("preferredLanguage")
+    private String preferredLanguage;
     @SerializedName("doNotContact")
     private boolean doNotContact;
     @SerializedName("createdAt")
@@ -31,6 +33,7 @@ public class ParticipantProfile {
             String legacyAltPid,
             String legacyShortId,
             String email,
+            String preferredLanguage,
             Boolean doNotContact,
             long createdAt
     ) {
@@ -41,6 +44,7 @@ public class ParticipantProfile {
         this.legacyAltPid = legacyAltPid;
         this.legacyShortId = legacyShortId;
         this.email = email;
+        this.preferredLanguage = preferredLanguage;
         this.doNotContact = (doNotContact == null ? false : doNotContact);
         this.createdAt = createdAt;
     }
@@ -57,6 +61,7 @@ public class ParticipantProfile {
         private String legacyAltPid;
         private String legacyShortId;
         private String email;
+        private String preferredLanguage;
         private Boolean doNotContact;
         private long createdAt;
 
@@ -69,6 +74,7 @@ public class ParticipantProfile {
                     legacyAltPid,
                     legacyShortId,
                     email,
+                    preferredLanguage,
                     doNotContact,
                     createdAt
             );
@@ -106,6 +112,11 @@ public class ParticipantProfile {
 
         public Builder setEmail(String email) {
             this.email = email;
+            return this;
+        }
+
+        public Builder setPreferredLanguage(String preferredLanguage) {
+            this.preferredLanguage = preferredLanguage;
             return this;
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ParticipantRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ParticipantRecord.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.db.dto.MedicalProviderDto;
 import org.broadinstitute.ddp.model.address.MailAddress;
 import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
@@ -24,6 +25,8 @@ public class ParticipantRecord {
     private List<ProviderRecord> medicalProviders;
     @SerializedName("activities")
     private List<ActivityInstanceRecord> activityInstanceRecords;
+    @SerializedName("invitations")
+    private List<InvitationRecord> invitations;
     @SerializedName("dsm")
     private DsmComputedRecord dsmComputedRecord;
     @SerializedName("proxies")
@@ -37,7 +40,8 @@ public class ParticipantRecord {
             List<MedicalProviderDto> medicalProviders,
             MailAddress mailAddress,
             DsmComputedRecord dsmComputedRecord,
-            List<String> proxies
+            List<String> proxies,
+            List<InvitationDto> invitations
     ) {
         this.status = enrollmentStatus;
         this.statusTimestamp = enrollmentStatusTimestamp;
@@ -54,5 +58,9 @@ public class ParticipantRecord {
 
         this.dsmComputedRecord = dsmComputedRecord;
         this.proxies = proxies;
+
+        this.invitations = invitations.stream()
+                .map(InvitationRecord::new)
+                .collect(Collectors.toList());
     }
 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExporterTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExporterTest.java
@@ -40,6 +40,7 @@ import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceStatusDto;
 import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
 import org.broadinstitute.ddp.db.dto.EnrollmentStatusDto;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.db.dto.MedicalProviderDto;
 import org.broadinstitute.ddp.export.collectors.ActivityResponseCollector;
 import org.broadinstitute.ddp.model.activity.definition.ActivityDef;
@@ -78,6 +79,7 @@ import org.broadinstitute.ddp.model.activity.types.TextInputType;
 import org.broadinstitute.ddp.model.address.MailAddress;
 import org.broadinstitute.ddp.model.governance.AgeOfMajorityRule;
 import org.broadinstitute.ddp.model.governance.GovernancePolicy;
+import org.broadinstitute.ddp.model.invitation.InvitationType;
 import org.broadinstitute.ddp.model.study.Participant;
 import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.model.user.User;
@@ -412,7 +414,8 @@ public class DataExporterTest extends TxnAwareBaseTest {
         List<ActivityExtract> activities = dataExporterTestData.getActivities();
         List<Participant> participants = dataExporterTestData.getParticipants();
 
-        StudyExtract studyExtract = new StudyExtract(activities, Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        StudyExtract studyExtract = new StudyExtract(activities, Collections.emptyList(),
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
         // Run the test!
         boolean exportStructuredDocument = false;
         Map<String, String> result = TransactionWrapper.withTxn(handle ->
@@ -499,7 +502,8 @@ public class DataExporterTest extends TxnAwareBaseTest {
         DataExporterTestData dataExporterTestData = new DataExporterTestData(false, false);
         List<ActivityExtract> activities = dataExporterTestData.getActivities();
         List<Participant> participants = dataExporterTestData.getParticipants();
-        StudyExtract studyExtract = new StudyExtract(activities, Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        StudyExtract studyExtract = new StudyExtract(activities, Collections.emptyList(),
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
 
         // Run the test!
         boolean exportStructuredDocument = false;
@@ -518,14 +522,20 @@ public class DataExporterTest extends TxnAwareBaseTest {
         DataExporterTestData dataExporterTestData = new DataExporterTestData(false, false);
         List<ActivityExtract> activities = dataExporterTestData.getActivities();
         List<Participant> participants = dataExporterTestData.getParticipants();
+
         boolean exportStructuredDocument = true;
-        StudyExtract studyExtract = new StudyExtract(activities, Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        InvitationDto invite = new InvitationDto(1L, "invite123", InvitationType.RECRUITMENT,
+                Instant.now(), null, null, null, testData.getStudyId(), 1L, null, "invite notes here");
+        StudyExtract studyExtract = new StudyExtract(activities, Collections.emptyList(),
+                Collections.emptyMap(), Collections.emptyMap(), List.of(invite));
+
         Map<String, String> result = TransactionWrapper.withTxn(handle ->
                 exporter.prepareParticipantRecordsForJSONExport(
                         studyExtract, participants, exportStructuredDocument, handle, mockMedicalRecordService
                 )
         );
         assertEquals(1, result.size());
+        assertTrue(result.get(TEST_USER_GUID).contains("invite123"));
     }
 
     @Test
@@ -534,7 +544,8 @@ public class DataExporterTest extends TxnAwareBaseTest {
         List<ActivityExtract> activities = dataExporterTestData.getActivities();
         List<Participant> participants = dataExporterTestData.getParticipants();
         boolean exportStructuredDocument = true;
-        StudyExtract studyExtract = new StudyExtract(activities, Collections.EMPTY_LIST, Collections.EMPTY_MAP, Collections.EMPTY_MAP);
+        StudyExtract studyExtract = new StudyExtract(activities, Collections.emptyList(),
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyList());
         Map<String, String> result = TransactionWrapper.withTxn(handle ->
                 exporter.prepareParticipantRecordsForJSONExport(
                         studyExtract, participants, exportStructuredDocument, handle, mockMedicalRecordService


### PR DESCRIPTION
## Context

DDP-4633
* We're now exporting invitation data to Elasticsearch in the `participants_structured` index.

DDP-4658
* This ticket asks to compute the language based on what was used for answering questions. However, I think a good first step will be to export user profile's preferred language to Elasticsearch. We now have that in `participants_structured` and `users` indices.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
  * Need to update indices in Elasticsearch

