### PR TITLE
DDP-4703 support special vars in activity templating

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -254,7 +254,7 @@ public class DataDonationPlatform {
             LiquibaseUtil.runLiquibase(dbUrl, TransactionWrapper.DB.APIS);
         }
 
-        SectionBlockDao sectionBlockDao = new SectionBlockDao(new I18nContentRenderer());
+        SectionBlockDao sectionBlockDao = new SectionBlockDao();
 
         FormInstanceDao formInstanceDao = FormInstanceDao.fromDaoAndConfig(sectionBlockDao, sqlConfig);
         ActivityInstanceDao activityInstanceDao = new ActivityInstanceDao(formInstanceDao);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
@@ -172,10 +172,11 @@ public class I18nContentRenderer {
      * @param handle      the database handle
      * @param templateIds the set of template ids
      * @param langCodeId  the language code id
+     * @param context     the additional context containing variable substitutions to use
      * @return mapping of template id to its rendered template string
      * @throws NoSuchElementException when any one of the templates is not found
      */
-    public Map<Long, String> bulkRender(Handle handle, Set<Long> templateIds, long langCodeId) {
+    public Map<Long, String> bulkRender(Handle handle, Set<Long> templateIds, long langCodeId, Map<String, String> context) {
         if (templateIds == null || templateIds.isEmpty()) {
             return new HashMap<>();
         }
@@ -197,10 +198,18 @@ public class I18nContentRenderer {
                         templateId, vars.size(), data.getVarCount());
             }
 
+            // Var count is the count of explicitly declared variables in template,
+            // which excludes special vars. So we add context here after the count check.
+            vars.putAll(context);
+
             rendered.put(templateId, renderToString(data.getText(), vars));
         }
 
         return rendered;
+    }
+
+    public Map<Long, String> bulkRender(Handle handle, Set<Long> templateIds, long langCodeId) {
+        return bulkRender(handle, templateIds, langCodeId, Collections.emptyMap());
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nTemplateConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nTemplateConstants.java
@@ -2,4 +2,7 @@ package org.broadinstitute.ddp.content;
 
 public class I18nTemplateConstants {
     public static final String LAST_UPDATED_DATE_TEMPLATE_VAR_NAME = "LAST_UPDATED";
+    public static final String PARTICIPANT_FIRST_NAME = "DDP_PARTICIPANT_FIRST_NAME";
+    public static final String PARTICIPANT_LAST_NAME = "DDP_PARTICIPANT_LAST_NAME";
+    public static final String DASHED_DATE = "DDP_DASHED_DATE";
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
@@ -100,6 +100,7 @@ public class FormInstanceDao {
                 Long introductionSectionId = (Long) rs.getObject("introduction_section_id");
                 Long closingSectionId = (Long) rs.getObject("closing_section_id");
 
+                long participantUserId = rs.getLong("participant_user_id");
                 long instanceId = rs.getLong(ActivityInstanceTable.ID);
                 long activityId = rs.getLong(StudyActivityTable.ID);
                 String statusTypeCode = rs.getString(ActivityInstanceStatusTypeTable.ACTIVITY_STATUS_TYPE_CODE);
@@ -115,6 +116,7 @@ public class FormInstanceDao {
                 boolean isFollowup = rs.getBoolean(StudyActivityTable.IS_FOLLOWUP);
 
                 form = new FormInstance(
+                        participantUserId,
                         instanceId,
                         activityId,
                         activityCode,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/SectionBlockDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/SectionBlockDao.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.dao.ComponentDao;
 import org.broadinstitute.ddp.db.dao.JdbiBlockContent;
 import org.broadinstitute.ddp.db.dao.JdbiBlockGroupHeader;
@@ -31,12 +30,6 @@ import org.slf4j.LoggerFactory;
 public class SectionBlockDao {
 
     private static final Logger LOG = LoggerFactory.getLogger(SectionBlockDao.class);
-
-    private final I18nContentRenderer i18nRenderer;
-
-    public SectionBlockDao(I18nContentRenderer i18nRenderer) {
-        this.i18nRenderer = i18nRenderer;
-    }
 
     /**
      * Find and build all blocks for given sections, respecting the display order of blocks within each section.
@@ -97,7 +90,7 @@ public class SectionBlockDao {
                 break;
             case COMPONENT:
                 ComponentDao componentDao = handle.attach(ComponentDao.class);
-                FormComponent formComponent = componentDao.findByBlockId(instanceGuid, dto.getId(), i18nRenderer, langCodeId);
+                FormComponent formComponent = componentDao.findByBlockId(instanceGuid, dto.getId());
                 block = new ComponentBlock(formComponent);
                 break;
             case CONDITIONAL:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.ddp.db.dao;
 
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.db.DaoException;
 import org.broadinstitute.ddp.db.dto.ComponentDto;
@@ -43,7 +42,7 @@ public interface ComponentDao extends SqlObject {
     JdbiInstitutionPhysicianComponent getJdbiInstitutionPhysicianComponent();
 
 
-    default FormComponent findByBlockId(String activityInstanceGuid, long blockId, I18nContentRenderer i18nRenderer, long languageCodeId) {
+    default FormComponent findByBlockId(String activityInstanceGuid, long blockId) {
         // query for component type by block id
         JdbiComponent jdbiComponent = getJdbiComponent();
 
@@ -67,15 +66,10 @@ public interface ComponentDao extends SqlObject {
             MailingAddressComponentDto mailingAddressComponentDto = getJdbiComponent()
                     .findMailingAddressComponentDtoById(componentId)
                     .orElseThrow(() -> new DaoException("Could not find mailing address component with id " + componentId));
-            String titleText = null;
-            if (mailingAddressComponentDto.getTitleTemplateId() != null) {
-                titleText = i18nRenderer.renderContent(getHandle(), mailingAddressComponentDto.getTitleTemplateId(), languageCodeId);
-            }
-            String subtitleText = null;
-            if (mailingAddressComponentDto.getSubtitleTemplateId() != null) {
-                subtitleText = i18nRenderer.renderContent(getHandle(), mailingAddressComponentDto.getSubtitleTemplateId(), languageCodeId);
-            }
-            formComponent = new MailingAddressComponent(titleText, subtitleText, componentDto.shouldHideNumber());
+            formComponent = new MailingAddressComponent(
+                    mailingAddressComponentDto.getTitleTemplateId(),
+                    mailingAddressComponentDto.getSubtitleTemplateId(),
+                    componentDto.shouldHideNumber());
         } else {
             throw new DaoException("Cannot process component type " + componentDto.getComponentType());
         }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
@@ -37,16 +37,19 @@ public class ActivityInstance {
     @SerializedName("isFollowup")
     private boolean isFollowup;
 
+    private transient long participantUserId;
     private transient long instanceId;
     private transient long activityId;
     private transient long createdAtMillis;
     private transient Long firstCompletedAt;
 
     public ActivityInstance(
+            long participantUserId,
             long instanceId, long activityId, ActivityType activityType, String guid, String title, String subtitle,
             String statusTypeCode, Boolean readonly, String activityCode, long createdAtMillis, Long firstCompletedAt,
             boolean isFollowup
     ) {
+        this.participantUserId = participantUserId;
         this.instanceId = instanceId;
         this.activityId = activityId;
         this.activityType = MiscUtil.checkNonNull(activityType, "activityType");
@@ -59,6 +62,10 @@ public class ActivityInstance {
         this.createdAtMillis = createdAtMillis;
         this.firstCompletedAt = firstCompletedAt;
         this.isFollowup = isFollowup;
+    }
+
+    public long getParticipantUserId() {
+        return participantUserId;
     }
 
     public ActivityType getActivityType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -20,13 +20,16 @@ import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.content.Renderable;
+import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.FormType;
 import org.broadinstitute.ddp.model.activity.types.ListStyleHint;
+import org.broadinstitute.ddp.model.user.UserProfile;
 import org.broadinstitute.ddp.pex.PexException;
 import org.broadinstitute.ddp.pex.PexInterpreter;
+import org.broadinstitute.ddp.transformers.DateTimeFormatUtils;
 import org.broadinstitute.ddp.transformers.LocalDateTimeAdapter;
 import org.broadinstitute.ddp.util.MiscUtil;
 
@@ -68,6 +71,7 @@ public final class FormInstance extends ActivityInstance {
     private transient Long lastUpdatedTextTemplateId;
 
     public FormInstance(
+            long participantUserId,
             long instanceId,
             long activityId,
             String activityCode,
@@ -87,7 +91,7 @@ public final class FormInstance extends ActivityInstance {
             LocalDateTime activityDefinitionLastUpdated,
             boolean isFollowup
     ) {
-        super(instanceId, activityId, ActivityType.FORMS, guid, title, subtitle, statusTypeCode, readonly, activityCode,
+        super(participantUserId, instanceId, activityId, ActivityType.FORMS, guid, title, subtitle, statusTypeCode, readonly, activityCode,
                 createdAtMillis, firstCompletedAt, isFollowup);
         this.formType = MiscUtil.checkNonNull(formType, "formType");
         if (listStyleHint != null) {
@@ -185,7 +189,8 @@ public final class FormInstance extends ActivityInstance {
             section.registerTemplateIds(consumer);
         }
 
-        Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId);
+        Map<String, String> context = buildRenderContext(handle);
+        Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId, context);
         Renderable.Provider<String> provider = rendered::get;
 
         for (FormSection section : allSections) {
@@ -218,6 +223,26 @@ public final class FormInstance extends ActivityInstance {
                 activityDefinitionLastUpdatedText = HtmlConverter.getPlainText(activityDefinitionLastUpdatedText);
             }
         }
+    }
+
+    private Map<String, String> buildRenderContext(Handle handle) {
+        var context = new HashMap<String, String>();
+        context.put(I18nTemplateConstants.DASHED_DATE,
+                DateTimeFormatUtils.MONTH_FIRST_DASHED_DATE_FORMATTER.format(LocalDate.now()));
+
+        UserProfile profile = handle.attach(UserProfileDao.class)
+                .findProfileByUserId(getParticipantUserId())
+                .orElse(null);
+        if (profile != null) {
+            if (profile.getFirstName() != null) {
+                context.put(I18nTemplateConstants.PARTICIPANT_FIRST_NAME, profile.getFirstName());
+            }
+            if (profile.getLastName() != null) {
+                context.put(I18nTemplateConstants.PARTICIPANT_LAST_NAME, profile.getLastName());
+            }
+        }
+
+        return context;
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/MailingAddressComponent.java
@@ -1,10 +1,11 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.broadinstitute.ddp.content.ContentStyle;
+import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 
 public class MailingAddressComponent extends FormComponent {
@@ -12,31 +13,65 @@ public class MailingAddressComponent extends FormComponent {
     @SerializedName("parameters")
     private SerializedFields serializedFields;
 
-    public MailingAddressComponent(String titleText, String subtitleText, boolean hideNumber) {
+    private transient Long titleTemplateId;
+    private transient Long subtitleTemplateId;
+
+    public MailingAddressComponent(Long titleTemplateId, Long subtitleTemplateId, boolean hideNumber) {
         super(ComponentType.MAILING_ADDRESS);
         hideDisplayNumber = hideNumber;
-        serializedFields = new SerializedFields(titleText, subtitleText);
-    }
-
-    public static class SerializedFields {
-        @SerializedName("titleText")
-        private static String titleText;
-        @SerializedName("subtitleText")
-        private static String subtitleText;
-
-        public SerializedFields(String titleText, String subtitleText) {
-            this.subtitleText = subtitleText;
-            this.titleText = titleText;
-        }
+        titleTemplateId = titleTemplateId;
+        subtitleTemplateId = subtitleTemplateId;
+        serializedFields = new SerializedFields();
     }
 
     @Override
     public void registerTemplateIds(Consumer<Long> registry) {
-        // Implement this method once we decide to use bulk rendering for this component
+        if (titleTemplateId != null) {
+            registry.accept(titleTemplateId);
+        }
+        if (subtitleTemplateId != null) {
+            registry.accept(subtitleTemplateId);
+        }
     }
 
     @Override
     public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
-        // Implement this method once we decide to use bulk rendering for this component
+        if (titleTemplateId != null) {
+            String text = rendered.get(titleTemplateId);
+            if (text == null) {
+                String msg = "No rendered template found for mailing address component title with id " + titleTemplateId;
+                throw new NoSuchElementException(msg);
+            }
+            if (style == ContentStyle.BASIC) {
+                text = HtmlConverter.getPlainText(text);
+            }
+            serializedFields.setTitleText(text);
+        }
+        if (subtitleTemplateId != null) {
+            String text = rendered.get(subtitleTemplateId);
+            if (text == null) {
+                String msg = "No rendered template found for mailing address component subtitle with id " + subtitleTemplateId;
+                throw new NoSuchElementException(msg);
+            }
+            if (style == ContentStyle.BASIC) {
+                text = HtmlConverter.getPlainText(text);
+            }
+            serializedFields.setSubtitleText(text);
+        }
+    }
+
+    public static class SerializedFields {
+        @SerializedName("titleText")
+        private String titleText;
+        @SerializedName("subtitleText")
+        private String subtitleText;
+
+        public void setTitleText(String titleText) {
+            titleText = titleText;
+        }
+
+        public void setSubtitleText(String subtitleText) {
+            subtitleText = subtitleText;
+        }
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/DateTimeFormatUtils.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/DateTimeFormatUtils.java
@@ -15,10 +15,11 @@ public class DateTimeFormatUtils {
     private static final String YYYY_MM_DASH_SEPARATED_FORMAT = "%04d-%02d";
     private static final String YYYY_MM_DD_DASH_SEPARATED_FORMAT = "%04d-%02d-%02d";
 
-    public static final DateTimeFormatter UTC_ISO8601_DATE_TIME_FOMATTER = DateTimeFormatter.ISO_DATE_TIME;
+    public static final DateTimeFormatter UTC_ISO8601_DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
     public static final DateTimeFormatter DEFAULT_DATE_FORMATTER = DateTimeFormatter.ofPattern(DEFAULT_DATE_PATTERN);
     public static final DateTimeFormatter DEFAULT_MONTH_YEAR_FORMATTER = DateTimeFormatter.ofPattern("MM/yyyy");
     public static final DateTimeFormatter DEFAULT_MONTH_DAY_FORMATTER = DateTimeFormatter.ofPattern("MM/dd");
+    public static final DateTimeFormatter MONTH_FIRST_DASHED_DATE_FORMATTER = DateTimeFormatter.ofPattern("MM-dd-uuuu");
 
     public static ZonedDateTime convertUtcMillisToUtcZonedDateTime(long timeInMillis) {
         return ZonedDateTime.ofInstant(Instant.ofEpochMilli(timeInMillis), ZoneId.of("UTC"));
@@ -29,7 +30,7 @@ public class DateTimeFormatUtils {
     }
 
     public static String convertUtcMillisToUtcIso8601String(long timeInMillis) {
-        return UTC_ISO8601_DATE_TIME_FOMATTER.format(convertUtcMillisToUtcZonedDateTime(timeInMillis));
+        return UTC_ISO8601_DATE_TIME_FORMATTER.format(convertUtcMillisToUtcZonedDateTime(timeInMillis));
     }
 
     // DSM-specific format

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/LocalDateTimeAdapter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/LocalDateTimeAdapter.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.ddp.transformers;
 
-import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FOMATTER;
+import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FORMATTER;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ public class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
         if (dateTime == null) {
             writer.nullValue();
         } else {
-            writer.value(UTC_ISO8601_DATE_TIME_FOMATTER.format(dateTime));
+            writer.value(UTC_ISO8601_DATE_TIME_FORMATTER.format(dateTime));
         }
     }
 
@@ -29,7 +29,7 @@ public class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
             jsonReader.nextNull();
             return null;
         } else {
-            return LocalDateTime.parse(jsonReader.nextString(), UTC_ISO8601_DATE_TIME_FOMATTER);
+            return LocalDateTime.parse(jsonReader.nextString(), UTC_ISO8601_DATE_TIME_FORMATTER);
         }
     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/UtcMillisToIsoDateAdapter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/UtcMillisToIsoDateAdapter.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.ddp.transformers;
 
-import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FOMATTER;
+import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FORMATTER;
 import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.convertUtcMillisToUtcIso8601String;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ public class UtcMillisToIsoDateAdapter extends TypeAdapter<Long> {
             in.nextNull();
             return null;
         }
-        return Instant.from(UTC_ISO8601_DATE_TIME_FOMATTER.parse(in.nextString())).toEpochMilli();
+        return Instant.from(UTC_ISO8601_DATE_TIME_FORMATTER.parse(in.nextString())).toEpochMilli();
     }
 
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/UtcSecondsToIsoDateAdapter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/transformers/UtcSecondsToIsoDateAdapter.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.ddp.transformers;
 
-import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FOMATTER;
+import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.UTC_ISO8601_DATE_TIME_FORMATTER;
 import static org.broadinstitute.ddp.transformers.DateTimeFormatUtils.convertUtcMillisToUtcIso8601String;
 
 import java.io.IOException;
@@ -29,6 +29,6 @@ public class UtcSecondsToIsoDateAdapter extends TypeAdapter<Long> {
             in.nextNull();
             return null;
         }
-        return Instant.from(UTC_ISO8601_DATE_TIME_FOMATTER.parse(in.nextString())).getEpochSecond();
+        return Instant.from(UTC_ISO8601_DATE_TIME_FORMATTER.parse(in.nextString())).getEpochSecond();
     }
 }

--- a/pepper-apis/src/main/resources/sql.conf
+++ b/pepper-apis/src/main/resources/sql.conf
@@ -286,6 +286,7 @@
                    i18n_act.title as activity_title,
                    i18n_act.subtitle as activity_subtitle,
                    aist.activity_instance_status_type_code,
+                   ai.participant_id as participant_user_id,
                    ai.activity_instance_id,
                    sa.study_activity_id,
                    sa.edit_timeout_sec,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/ActivityInstanceDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/ActivityInstanceDaoTest.java
@@ -15,7 +15,6 @@ import java.util.function.BiFunction;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.constants.TestConstants;
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
@@ -40,7 +39,7 @@ public class ActivityInstanceDaoTest extends TxnAwareBaseTest {
 
     @BeforeClass
     public static void setup() {
-        SectionBlockDao sectionBlockDao = new SectionBlockDao(new I18nContentRenderer());
+        SectionBlockDao sectionBlockDao = new SectionBlockDao();
         FormInstanceDao formInstanceDao = FormInstanceDao.fromDaoAndConfig(sectionBlockDao, sqlConfig);
         dao = new ActivityInstanceDao(formInstanceDao);
         TransactionWrapper.useTxn(handle -> {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/FormInstanceDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/FormInstanceDaoTest.java
@@ -12,7 +12,6 @@ import java.util.function.Function;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.content.ContentStyle;
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
@@ -25,7 +24,6 @@ import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
 import org.broadinstitute.ddp.model.activity.types.FormType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
-
 import org.jdbi.v3.core.Handle;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -40,7 +38,7 @@ public class FormInstanceDaoTest extends TxnAwareBaseTest {
 
     @BeforeClass
     public static void setup() {
-        SectionBlockDao sectionBlockDao = new SectionBlockDao(new I18nContentRenderer());
+        SectionBlockDao sectionBlockDao = new SectionBlockDao();
         dao = FormInstanceDao.fromDaoAndConfig(sectionBlockDao, sqlConfig);
         TransactionWrapper.useTxn(handle -> {
             data = TestDataSetupUtil.generateBasicUserTestData(handle);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/SectionBlockDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/SectionBlockDaoTest.java
@@ -13,7 +13,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.JdbiLanguageCode;
@@ -55,7 +54,7 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
 
     @BeforeClass
     public static void setUp() {
-        dao = new SectionBlockDao(new I18nContentRenderer());
+        dao = new SectionBlockDao();
         TransactionWrapper.useTxn(handle -> {
             data = TestDataSetupUtil.generateBasicUserTestData(handle);
             userGuid = data.getTestingUser().getUserGuid();

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/FormActivityDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/FormActivityDaoTest.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.FormInstanceDao;
 import org.broadinstitute.ddp.db.SectionBlockDao;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -106,8 +105,7 @@ public class FormActivityDaoTest extends TxnAwareBaseTest {
     @BeforeClass
     public static void setup() {
         org.broadinstitute.ddp.db.ActivityInstanceDao actInstDao = new org.broadinstitute.ddp.db.ActivityInstanceDao(
-                FormInstanceDao.fromDaoAndConfig(
-                        new SectionBlockDao(new I18nContentRenderer()), sqlConfig));
+                FormInstanceDao.fromDaoAndConfig(new SectionBlockDao(), sqlConfig));
         service = new ActivityInstanceService(actInstDao, new TreeWalkInterpreter());
         TransactionWrapper.useTxn(handle -> testData = TestDataSetupUtil.generateBasicUserTestData(handle));
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -2,14 +2,19 @@ package org.broadinstitute.ddp.model.activity.instance;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
@@ -19,13 +24,16 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.constants.TestConstants;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
+import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.instance.answer.BoolAnswer;
 import org.broadinstitute.ddp.model.activity.instance.question.BoolQuestion;
@@ -38,8 +46,10 @@ import org.broadinstitute.ddp.model.activity.types.TextInputType;
 import org.broadinstitute.ddp.pex.PexException;
 import org.broadinstitute.ddp.pex.PexInterpreter;
 import org.broadinstitute.ddp.pex.TreeWalkInterpreter;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.jdbi.v3.core.Handle;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,10 +64,19 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     public ExpectedException thrown = ExpectedException.none();
     private String controlBlockGuid = "CONTROL";
     private String toggledBlockGuid = "TOGGLED";
+    private Handle mockHandle;
 
     @BeforeClass
     public static void setup() {
         interpreter = new TreeWalkInterpreter();
+    }
+
+    @Before
+    public void setupMocks() {
+        mockHandle = mock(Handle.class);
+        var mockProfleDao = mock(UserProfileDao.class);
+        doReturn(mockProfleDao).when(mockHandle).attach(UserProfileDao.class);
+        doReturn(Optional.empty()).when(mockProfleDao).findProfileByUserId(anyLong());
     }
 
     @Test
@@ -67,14 +86,14 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "<p>this is body</p>");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
         assertEquals(fixture.get(1L), content.getTitle());
         assertEquals(fixture.get(2L), content.getBody());
     }
@@ -86,14 +105,14 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "<p>this is body</p>");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
         FormInstance form = buildEmptyTestInstanceWithHtmlInSubtitle();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
         assertEquals("this is title", content.getTitle());
         assertEquals("subtitle", form.getSubtitle());
         assertEquals(fixture.get(2L), content.getBody());
@@ -106,7 +125,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "this is bold prompt");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -115,7 +134,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
         assertTrue(HtmlConverter.hasSameValue(fixture.get(1L), question.getPrompt()));
         assertEquals(fixture.get(2L), question.getTextPrompt());
     }
@@ -126,7 +145,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <b>bold</b> prompt");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -135,7 +154,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
 
         assertTrue(HtmlConverter.hasSameValue(fixture.get(1L), question.getPrompt()));
         assertEquals("this is bold prompt", question.getTextPrompt());
@@ -147,13 +166,13 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
         assertEquals(fixture.get(1L), s1.getName());
     }
 
@@ -163,14 +182,38 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mock(Handle.class), mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
         assertEquals("this is bold section name", s1.getName());
+    }
+
+    @Test
+    public void testRenderContent_specialVarsContext() {
+        TransactionWrapper.useTxn(handle -> {
+            var testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+
+            I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
+            doReturn(Collections.emptyMap()).when(mockRenderer).bulkRender(any(), any(), anyLong(), any());
+            doReturn(handle.attach(UserProfileDao.class)).when(mockHandle).attach(UserProfileDao.class);
+
+            FormInstance form = buildEmptyTestInstance();
+            form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
+
+            verify(mockRenderer, times(1)).bulkRender(any(), anySet(), anyLong(), argThat(context -> {
+                assertFalse(context.isEmpty());
+                assertNotNull(context.get(I18nTemplateConstants.DASHED_DATE));
+                assertEquals(testData.getProfile().getFirstName(), context.get(I18nTemplateConstants.PARTICIPANT_FIRST_NAME));
+                assertEquals(testData.getProfile().getLastName(), context.get(I18nTemplateConstants.PARTICIPANT_LAST_NAME));
+                return true;
+            }));
+
+            handle.rollback();
+        });
     }
 
     @Test
@@ -414,14 +457,14 @@ public class FormInstanceTest extends TxnAwareBaseTest {
 
     private FormInstance buildEmptyTestInstance() {
         return new FormInstance(
-                1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "subtitle", "CREATED", false,
+                1L, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "subtitle", "CREATED", false,
                 ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null, false
         );
     }
 
     private FormInstance buildEmptyTestInstanceWithHtmlInSubtitle() {
         return new FormInstance(
-                1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "<em>subtitle</em>", "CREATED", false,
+                1L, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "<em>subtitle</em>", "CREATED", false,
                 ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null, false
         );
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
@@ -13,7 +13,6 @@ import java.util.Optional;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.content.ContentStyle;
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.db.FormInstanceDao;
 import org.broadinstitute.ddp.db.SectionBlockDao;
@@ -46,7 +45,7 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
     @BeforeClass
     public static void setup() {
         PexInterpreter interpreter = new TreeWalkInterpreter();
-        SectionBlockDao sectBlockDao = new SectionBlockDao(new I18nContentRenderer());
+        SectionBlockDao sectBlockDao = new SectionBlockDao();
 
         org.broadinstitute.ddp.db.ActivityInstanceDao actInstDao =
                 new org.broadinstitute.ddp.db.ActivityInstanceDao(FormInstanceDao.fromDaoAndConfig(sectBlockDao, sqlConfig));

--- a/study-builder/studies/testboston/snippets/consent-section4.conf
+++ b/study-builder/studies/testboston/snippets/consent-section4.conf
@@ -96,6 +96,29 @@
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
     },
     {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": """
+          <div>
+            <h3>First Name</h3>
+            <p>$DDP_PARTICIPANT_FIRST_NAME</p>
+          </div>
+          <div>
+            <h3>Last Name</h3>
+            <p>$DDP_PARTICIPANT_LAST_NAME</p>
+          </div>
+          <div>
+            <h3>Date</h3>
+            <p>$DDP_DASHED_DATE</p>
+          </div>
+        """,
+        "variables": []
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+    },
+    {
       "question": ${_includes.consent.self_sig},
       "blockType": "QUESTION",
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""


### PR DESCRIPTION
## Context

Add support for substituting "special vars" in templates, so we can pull in participant's name into activity content.

THIS DOES NOT SUPPORT ALL FORMS OF TEMPLATING. Only templates within an activity are supported, and only if they hook into the bulk rendering. This should cover major items like content blocks, question prompts and embedded components.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

