### PR TITLE
Switching to basic scaling on GAE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -753,6 +753,7 @@ workflows:
             branches:
               only:
                 - develop
+                - scaling_experiment
           requires:
             - parallel-compile-and-test-job
             - compile-and-run-test-suite-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,9 @@ commands:
             develop)
               DEPLOY_ENV=dev
             ;;
+            scaling_experiment)
+              DEPLOY_ENV=dev
+            ;;
             test)
               DEPLOY_ENV=test
             ;;
@@ -737,6 +740,7 @@ workflows:
             branches:
               only:
                 - develop
+                - scaling_experiment
                 - &rc /^rc.*/
                 - &hotfix /^hotfix.*/
       - parallel-compile-and-test-job:

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -10,9 +10,9 @@ automatic_scaling:
   min_idle_instances: 0 #also needs additional setup
   target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
   target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
-  max_concurrent_requests: 10 #default is 10 . Max is 80. GCP recommends 10 max value.
-  max_pending_latency: 60ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 60ms #Default is 30ms. Threshold used to scale down
+  max_concurrent_requests: 30 #default is 10 . Max is 80. GCP recommends 10 max value.
+  max_pending_latency: 2000ms #Default is 30ms. Max time a request is allowed to wait in queue.
+  min_pending_latency: 1500ms #Default is 30ms. Threshold used to scale down
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -1,17 +1,11 @@
 service: pepper-backend
 runtime: java11
-instance_class: F4
+instance_class: B4
 
-automatic_scaling:
-  max_instances: 4 #up to 2147483647
-  min_instances: 0 #0 means first one starts only on first request. Needs additional setup to use
-  max_idle_instances: 1 #default is automatic
-  min_idle_instances: 0 #also needs additional setup
-  target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
-  target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
-  max_concurrent_requests: 30 #default is 10 . Max is 80
-  max_pending_latency: 15000ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 12000ms #Default is 30ms. Threshold used to scale down
+basic_scaling:
+  max_instances: 4
+  idle_timeout: 10m
+
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -2,7 +2,6 @@ service: pepper-backend
 runtime: java11
 instance_class: F4
 
-# @todo back to 2 when dev completed
 automatic_scaling:
   max_instances: 4 #up to 2147483647
   min_instances: 0 #0 means first one starts only on first request. Needs additional setup to use
@@ -10,9 +9,9 @@ automatic_scaling:
   min_idle_instances: 0 #also needs additional setup
   target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
   target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
-  max_concurrent_requests: 30 #default is 10 . Max is 80. GCP recommends 10 max value.
-  max_pending_latency: 15000ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 12000ms #Default is 30ms. Threshold used to scale down
+  max_concurrent_requests: 30 #default is 10 . Max is 80
+  max_pending_latency: 10000ms #Default is 30ms. Max time a request is allowed to wait in queue.
+  min_pending_latency: 8000ms #Default is 30ms. Threshold used to scale down
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -11,8 +11,8 @@ automatic_scaling:
   target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
   target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
   max_concurrent_requests: 30 #default is 10 . Max is 80. GCP recommends 10 max value.
-  max_pending_latency: 12000ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 15000ms #Default is 30ms. Threshold used to scale down
+  max_pending_latency: 15000ms #Default is 30ms. Max time a request is allowed to wait in queue.
+  min_pending_latency: 12000ms #Default is 30ms. Threshold used to scale down
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -10,8 +10,8 @@ automatic_scaling:
   target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
   target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
   max_concurrent_requests: 30 #default is 10 . Max is 80
-  max_pending_latency: 10000ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 8000ms #Default is 30ms. Threshold used to scale down
+  max_pending_latency: 15000ms #Default is 30ms. Max time a request is allowed to wait in queue.
+  min_pending_latency: 12000ms #Default is 30ms. Threshold used to scale down
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 

--- a/pepper-apis/src/appengine/DataDonationPlatform.yaml
+++ b/pepper-apis/src/appengine/DataDonationPlatform.yaml
@@ -11,8 +11,8 @@ automatic_scaling:
   target_cpu_utilization: 0.8 #0.6 is the default. Higher might trigger new instances created
   target_throughput_utilization: 0.8 #default is 0.6 . Also metric to launch more instances
   max_concurrent_requests: 30 #default is 10 . Max is 80. GCP recommends 10 max value.
-  max_pending_latency: 2000ms #Default is 30ms. Max time a request is allowed to wait in queue.
-  min_pending_latency: 1500ms #Default is 30ms. Threshold used to scale down
+  max_pending_latency: 12000ms #Default is 30ms. Max time a request is allowed to wait in queue.
+  min_pending_latency: 15000ms #Default is 30ms. Threshold used to scale down
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 


### PR DESCRIPTION
## Context

Per discussion with @zyme we are switching to use basic scaling for pepper-backend. It is unclear to me when GAE will decide to scale up or whether it ever scales down to 0 instances which would be nice for non-prod environments. Perhaps we can try to get automatic working again after we past testboston?

## Checklist

- [X ] I have labeled the type of changes involved using the `C-*` labels.
- [X ] I have assessed potential risks and labeled using the `R-*` labels.
- [ X] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ X] I have considered security and privacy, and added `I-*` labels as needed
- [ X] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ X] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [X ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

## FUD Score

_Overall, how are you feeling about these changes?_

- [X ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?
N/A
- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing
N/A
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

