### PR TITLE
DDP-4703 allow saving snapshot of activity substitutions

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
@@ -135,6 +135,7 @@ public class SqlConstants {
         public static final String READONLY_HINT_TEMPLATE_ID = "readonly_hint_template_id";
         public static final String LAST_UPDATED_TEXT_TEMPLATE_ID = "last_updated_text_template_id";
         public static final String LAST_UPDATED = "last_updated";
+        public static final String SNAPSHOT_SUBSTITUTIONS_ON_SUBMIT = "snapshot_substitutions_on_submit";
     }
 
     public static final class ListStyleHintTable {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.db.dao;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -15,11 +16,21 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
 
 public interface ActivityInstanceSql extends SqlObject {
+
+    @GetGeneratedKeys
+    @SqlBatch("insert into activity_instance_substitution (activity_instance_id, variable_name, value)"
+            + "values (:instanceId, :var, :value)")
+    long[] bulkInsertSubstitutions(
+            @Bind("instanceId") long instanceId,
+            @Bind("var") List<String> variableNames,
+            @Bind("value") List<String> values);
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryFormResponseWithAnswers")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -139,7 +139,8 @@ public interface FormActivityDao extends SqlObject {
 
         getJdbiFormActivitySetting().insert(
                 activityId, activity.getListStyleHint(), introductionSectionId,
-                closingSectionId, revisionId, readonlyHintTemplateId, activity.getLastUpdated(), lastUpdatedTextTemplateId);
+                closingSectionId, revisionId, readonlyHintTemplateId, activity.getLastUpdated(), lastUpdatedTextTemplateId,
+                activity.shouldSnapshotSubstitutionsOnSubmit());
     }
 
     default FormActivityDef findDefByDtoAndVersion(ActivityDto activityDto, ActivityVersionDto revisionDto) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiFormActivitySetting.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiFormActivitySetting.java
@@ -15,9 +15,11 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface JdbiFormActivitySetting extends SqlObject {
 
     @SqlUpdate("insert into form_activity_setting (form_activity_id, list_style_hint_id, introduction_section_id, closing_section_id,"
-            + " revision_id, readonly_hint_template_id, last_updated, last_updated_text_template_id) values (:activityId,"
+            + " revision_id, readonly_hint_template_id, last_updated, last_updated_text_template_id, snapshot_substitutions_on_submit)"
+            + " values (:activityId,"
             + "(select list_style_hint_id from list_style_hint where list_style_hint_code = :listStyleHint),"
-            + ":introductionSectionId, :closingSectionId, :revisionId, :readonlyHintTemplateId, :lastUpdated, :lastUpdatedTemplateId)")
+            + ":introductionSectionId, :closingSectionId, :revisionId, :readonlyHintTemplateId, :lastUpdated, :lastUpdatedTemplateId,"
+            + ":snapshotSubs)")
     @GetGeneratedKeys()
     long insert(
             @Bind("activityId") long activityId,
@@ -27,7 +29,8 @@ public interface JdbiFormActivitySetting extends SqlObject {
             @Bind("revisionId") long revisionId,
             @Bind("readonlyHintTemplateId") Long readonlyHintTemplateId,
             @Bind("lastUpdated") LocalDateTime lastUpdated,
-            @Bind("lastUpdatedTemplateId") Long lastUpdatedTemplateId
+            @Bind("lastUpdatedTemplateId") Long lastUpdatedTemplateId,
+            @Bind("snapshotSubs") boolean snapshotSubstitutionsOnSubmit
     );
 
     @SqlQuery("select lsh.list_style_hint_code, fas.* from form_activity_setting as fas "

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/FormActivitySettingDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/FormActivitySettingDto.java
@@ -21,11 +21,12 @@ public class FormActivitySettingDto {
     private Long readonlyHintTemplateId;
     private Long lastUpdatedTextTemplateId;
     private LocalDateTime lastUpdated;
+    private boolean snapshotSubstitutionsOnSubmit;
     private long revisionId;
 
     public FormActivitySettingDto(long id, ListStyleHint hint, Long introductionSectionId, Long closingSectionId,
                                   Long readonlyHintTemplateId, Long lastUpdatedTextTemplateId, LocalDateTime lastUpdated,
-                                  long revisionId) {
+                                  boolean snapshotSubstitutionsOnSubmit, long revisionId) {
         this.id = id;
         this.listStyleHint = hint;
         this.introductionSectionId = introductionSectionId;
@@ -34,6 +35,7 @@ public class FormActivitySettingDto {
         this.lastUpdatedTextTemplateId = lastUpdatedTextTemplateId;
         this.lastUpdated = lastUpdated;
         this.revisionId = revisionId;
+        this.snapshotSubstitutionsOnSubmit = snapshotSubstitutionsOnSubmit;
     }
 
     public long getId() {
@@ -64,6 +66,10 @@ public class FormActivitySettingDto {
         return lastUpdated;
     }
 
+    public boolean shouldSnapshotSubstitutionsOnSubmit() {
+        return snapshotSubstitutionsOnSubmit;
+    }
+
     public long getRevisionId() {
         return revisionId;
     }
@@ -85,6 +91,7 @@ public class FormActivitySettingDto {
                     (Long) rs.getObject(FormActivitySettingTable.READONLY_HINT_TEMPLATE_ID),
                     (Long) rs.getObject(FormActivitySettingTable.LAST_UPDATED_TEXT_TEMPLATE_ID),
                     lastUpdated,
+                    rs.getBoolean(FormActivitySettingTable.SNAPSHOT_SUBSTITUTIONS_ON_SUBMIT),
                     rs.getLong(FormActivitySettingTable.REVISION_ID));
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ConsentActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ConsentActivityDef.java
@@ -125,6 +125,7 @@ public final class ConsentActivityDef extends FormActivityDef {
         protected ListStyleHint listStyleHint;
         private Template lastUpdatedTextTemplate;
         private LocalDateTime lastUpdated;
+        private boolean snapshotSubstitutionsOnSubmit;
 
         private Builder() {
             // Use static factories.
@@ -207,6 +208,7 @@ public final class ConsentActivityDef extends FormActivityDef {
             consent.setConsentConditionId(consentConditionId);
             consent.setConsentedExprId(consentedExprId);
             consent.closing = closing;
+            consent.snapshotSubstitutionsOnSubmit = snapshotSubstitutionsOnSubmit;
             return consent;
         }
 
@@ -232,6 +234,11 @@ public final class ConsentActivityDef extends FormActivityDef {
 
         public Builder setLastUpdated(LocalDateTime lastUpdatedDate) {
             this.lastUpdated = lastUpdatedDate;
+            return this;
+        }
+
+        public Builder setSnapshotSubstitutionsOnSubmit(boolean snapshotSubstitutionsOnSubmit) {
+            this.snapshotSubstitutionsOnSubmit = snapshotSubstitutionsOnSubmit;
             return this;
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/FormActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/FormActivityDef.java
@@ -48,6 +48,9 @@ public class FormActivityDef extends ActivityDef {
     @SerializedName("lastUpdated")
     protected LocalDateTime lastUpdated;
 
+    @SerializedName("snapshotSubstitutionsOnSubmit")
+    protected boolean snapshotSubstitutionsOnSubmit;
+
     public static FormBuilder formBuilder() {
         return new FormBuilder();
     }
@@ -141,6 +144,10 @@ public class FormActivityDef extends ActivityDef {
         return lastUpdated;
     }
 
+    public boolean shouldSnapshotSubstitutionsOnSubmit() {
+        return snapshotSubstitutionsOnSubmit;
+    }
+
     public List<FormSectionDef> getAllSections() {
         List<FormSectionDef> allSections = new ArrayList<>();
         if (introduction != null) {
@@ -164,6 +171,7 @@ public class FormActivityDef extends ActivityDef {
         private FormSectionDef closing = null;
         private Template lastUpdatedTextTemplate = null;
         private LocalDateTime lastUpdated = null;
+        private boolean snapshotSubstitutionsOnSubmit = false;
 
         protected FormBuilder() {
             // Use static factories.
@@ -219,6 +227,10 @@ public class FormActivityDef extends ActivityDef {
             return this;
         }
 
+        public FormBuilder setSnapshotSubstitutionsOnSubmit(boolean snapshotSubstitutionsOnSubmit) {
+            this.snapshotSubstitutionsOnSubmit = snapshotSubstitutionsOnSubmit;
+            return this;
+        }
 
         public FormActivityDef build() {
             FormActivityDef form = new FormActivityDef(
@@ -246,6 +258,7 @@ public class FormActivityDef extends ActivityDef {
             form.listStyleHint = listStyleHint;
             form.introduction = introduction;
             form.closing = closing;
+            form.snapshotSubstitutionsOnSubmit = snapshotSubstitutionsOnSubmit;
             return form;
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -14,12 +14,12 @@ import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.content.Renderable;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
@@ -32,7 +32,6 @@ import org.broadinstitute.ddp.pex.PexInterpreter;
 import org.broadinstitute.ddp.transformers.DateTimeFormatUtils;
 import org.broadinstitute.ddp.transformers.LocalDateTimeAdapter;
 import org.broadinstitute.ddp.util.MiscUtil;
-
 import org.jdbi.v3.core.Handle;
 
 public final class FormInstance extends ActivityInstance {
@@ -190,6 +189,8 @@ public final class FormInstance extends ActivityInstance {
         }
 
         Map<String, String> context = buildRenderContext(handle);
+        context.putAll(handle.attach(ActivityInstanceDao.class).findSubstitutions(getInstanceId()));
+
         Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId, context);
         Renderable.Provider<String> provider = rendered::get;
 
@@ -225,7 +226,7 @@ public final class FormInstance extends ActivityInstance {
         }
     }
 
-    private Map<String, String> buildRenderContext(Handle handle) {
+    public Map<String, String> buildRenderContext(Handle handle) {
         var context = new HashMap<String, String>();
         context.put(I18nTemplateConstants.DASHED_DATE,
                 DateTimeFormatUtils.MONTH_FIRST_DASHED_DATE_FORMATTER.format(LocalDate.now()));

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -205,4 +205,5 @@
     <include file="db-changes/schema/add-recaptcha-site-secret.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/DDP-4627-testboston-kit-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/zip-code-messages.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-4703-activity-instance-substitutions.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-4703-activity-instance-substitutions.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-4703-activity-instance-substitutions.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200601-activity-instance-substitution-table">
+        <createTable tableName="activity_instance_substitution">
+            <column name="activity_instance_substitution_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="activity_instance_substitution_pk"/>
+            </column>
+            <column name="activity_instance_id" type="bigint">
+                <constraints nullable="false"
+                             references="activity_instance(activity_instance_id)" foreignKeyName="act_inst_sub_act_inst_fk"
+                             deleteCascade="true"/>
+            </column>
+            <column name="variable_name" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="value" type="varchar(500)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addUniqueConstraint tableName="activity_instance_substitution"
+                             columnNames="activity_instance_id, variable_name"
+                             constraintName="act_inst_sub_activity_variable_uk"/>
+    </changeSet>
+
+    <changeSet author="yufeng" id="20200601-activity-setting-snapshot-substitutions-on-submit">
+        <addColumn tableName="form_activity_setting">
+            <column name="snapshot_substitutions_on_submit" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+
+        <update tableName="form_activity_setting">
+            <column name="snapshot_substitutions_on_submit" valueBoolean="false"/>
+            <where>snapshot_substitutions_on_submit is null</where>
+        </update>
+
+        <addNotNullConstraint tableName="form_activity_setting" columnName="snapshot_substitutions_on_submit" columnDataType="boolean"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -33,7 +34,9 @@ import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
+import org.broadinstitute.ddp.db.dao.UserProfileSql;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.instance.answer.BoolAnswer;
 import org.broadinstitute.ddp.model.activity.instance.question.BoolQuestion;
@@ -75,8 +78,11 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     public void setupMocks() {
         mockHandle = mock(Handle.class);
         var mockProfleDao = mock(UserProfileDao.class);
+        var mockActInstDao = mock(ActivityInstanceDao.class);
         doReturn(mockProfleDao).when(mockHandle).attach(UserProfileDao.class);
+        doReturn(mockActInstDao).when(mockHandle).attach(ActivityInstanceDao.class);
         doReturn(Optional.empty()).when(mockProfleDao).findProfileByUserId(anyLong());
+        doNothing().when(mockActInstDao).saveSubstitutions(anyLong(), any());
     }
 
     @Test
@@ -196,19 +202,21 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     public void testRenderContent_specialVarsContext() {
         TransactionWrapper.useTxn(handle -> {
             var testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            handle.attach(UserProfileSql.class).upsertFirstName(testData.getUserId(), "foo");
+            handle.attach(UserProfileSql.class).upsertLastName(testData.getUserId(), "bar");
 
             I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
             doReturn(Collections.emptyMap()).when(mockRenderer).bulkRender(any(), any(), anyLong(), any());
             doReturn(handle.attach(UserProfileDao.class)).when(mockHandle).attach(UserProfileDao.class);
 
-            FormInstance form = buildEmptyTestInstance();
+            FormInstance form = buildEmptyTestInstance(testData.getUserId());
             form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
 
             verify(mockRenderer, times(1)).bulkRender(any(), anySet(), anyLong(), argThat(context -> {
                 assertFalse(context.isEmpty());
                 assertNotNull(context.get(I18nTemplateConstants.DASHED_DATE));
-                assertEquals(testData.getProfile().getFirstName(), context.get(I18nTemplateConstants.PARTICIPANT_FIRST_NAME));
-                assertEquals(testData.getProfile().getLastName(), context.get(I18nTemplateConstants.PARTICIPANT_LAST_NAME));
+                assertEquals("foo", context.get(I18nTemplateConstants.PARTICIPANT_FIRST_NAME));
+                assertEquals("bar", context.get(I18nTemplateConstants.PARTICIPANT_LAST_NAME));
                 return true;
             }));
 
@@ -456,8 +464,12 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     }
 
     private FormInstance buildEmptyTestInstance() {
+        return buildEmptyTestInstance(1L);
+    }
+
+    private FormInstance buildEmptyTestInstance(long participantUserId) {
         return new FormInstance(
-                1L, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "subtitle", "CREATED", false,
+                participantUserId, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "subtitle", "CREATED", false,
                 ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null, false
         );
     }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
@@ -537,7 +537,7 @@ public class AngioConsentVersion2 implements CustomTask {
         long lastUpdatedTemplateId = templateDao.insertTemplate(lastUpdatedTemplate, versionDto.getRevId());
         long newSettingId = jdbiFormSetting.insert(activityId, settings.getListStyleHint(),
                 settings.getIntroductionSectionId(), settings.getClosingSectionId(), versionDto.getRevId(),
-                settings.getReadonlyHintTemplateId(), lastUpdated, lastUpdatedTemplateId);
+                settings.getReadonlyHintTemplateId(), lastUpdated, lastUpdatedTemplateId, false);
 
         LOG.info("Created new form activity setting with id={}, lastUpdatedTemplateText='{}', lastUpdated={}",
                 newSettingId, lastUpdatedTemplate.getTemplateText(), lastUpdated);

--- a/study-builder/studies/snippets/activity-general-form.conf
+++ b/study-builder/studies/snippets/activity-general-form.conf
@@ -10,6 +10,11 @@
   "allowUnauthenticated": false,
   "listStyleHint": "NONE",
 
+  # Should a snapshot of activity substitution values be saved on the first submit?
+  #
+  # Optional, defaults to false. This is typically used with write-once activities.
+  "snapshotSubstitutionsOnSubmit": false,
+
   # Name of the activity.
   # Shows up in places like the dashboard and DSM listing.
   "translatedNames": [],

--- a/study-builder/studies/testboston/consent.conf
+++ b/study-builder/studies/testboston/consent.conf
@@ -5,6 +5,7 @@
   "versionTag": "v1",
   "displayOrder": 1,
   "writeOnce": true,
+  "snapshotSubstitutionsOnSubmit": true,
   "maxInstancesPerUser": 1,
   "formType": "CONSENT",
   "translatedNames": [


### PR DESCRIPTION
## Context

The special activity variables should be substituted dynamically, but only until activity is submitted. Once it is submitted, the substitutions should be effectively "frozen". This PR allows configuring if we should take a "snapshot" of the substitutions for an activity. The snapshot is only done on the first submit and will be used thereafter.

Existing activities and most surveys will not do snapshots. This is mostly useful for consents or other activities that are "write-once".

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

