### PR TITLE
DDP-4599 testboston: consent signature section

### DIFF
--- a/study-builder/studies/testboston/consent.conf
+++ b/study-builder/studies/testboston/consent.conf
@@ -7,6 +7,22 @@
   "writeOnce": true,
   "maxInstancesPerUser": 1,
   "formType": "CONSENT",
+  "lastUpdated": "2020-06-01T00:00:00",   // todo: TBD
+  "lastUpdatedTextTemplate": {
+    "templateType": "HTML",
+    "templateText": "$tb_consent_last_updated",
+    "variables": [
+      {
+        "name": "tb_consent_last_updated",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.consent.last_updated}
+          }
+        ]
+      }
+    ]
+  },
   "translatedNames": [
     {
       "language": "en",
@@ -42,9 +58,14 @@
   },
   "consentedExpr": """
     user.studies["testboston"].forms["CONSENT"].questions["SELF_SIGNATURE"].answers.hasText()
-    || user.studies["testboston"].forms["CONSENT"].questions["CLINICIAN_SIGNATURE"].answers.hasText()
+    || user.studies["testboston"].forms["CONSENT"].questions["STAFF_SIGNATURE"].answers.hasText()
   """,
-  "elections": [],
+  "elections": [
+    {
+      "stableId": ${id.election.store_sample},
+      "selectedExpr": """user.studies["testboston"].forms["CONSENT"].questions["STORE_SAMPLE"].answers.hasTrue()"""
+    }
+  ],
   "sections": [
     ${_includes.consent.s1},
     ${_includes.consent.s2},

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -73,7 +73,6 @@
     "s4_staff_auth_title": "Statement of Study Doctor or Person Obtaining Consent",
     "s4_staff_auth_item1": "I have explained the research to the study subject.",
     "s4_staff_auth_item2": "I have answered all questions about this research study to the best of my ability.",
-    "s4_staff_sign_statement": "This verbal consent was obtained by phone."
     "s4_interpreter_header": """
       Consent of Non-English Speaking Subjects Using the "Short Form" in the Subject's Spoken Language""",
     "s4_interpreter_auth_title": "Statement of Hospital Medical Interpreter",
@@ -81,7 +80,6 @@
       As someone who understands both English and the language spoken by the subject, I interpreted,
       in the subject's language, the researcher's presentation of the English consent form.
       The subject was given the opportunity to ask questions.""",
-    "s4_interpreter_sign_statement": "This verbal consent was obtained by phone."
   },
 
   "covid_survey": {
@@ -97,11 +95,13 @@
 
   "who_filling_prompt": "Who is filling out this form?",
   "store_sample_prompt": "Do you agree to let us store and use your samples and health information for other research related to COVID-19?",
-  "self_initial_prompt": "Initial",
+  "initial_prompt": "Initial",
   "self_sig_prompt": "Signature of Subject",
   "self_sig_placeholder": "Type your signature here",
-  "staff_sig_prompt": "Study Doctor or Person Obtaining Consent",
-  "interpreter_sig_prompt": "Hospital Medical Interpreter",
+  "staff_sig_prompt": "Study Doctor or Person Obtaining Consent:",
+  "staff_sig_prompt_phone": "This verbal consent was obtained by phone."
+  "interpreter_sig_prompt": "Hospital Medical Interpreter:",
+  "interpreter_sig_prompt_phone": "This verbal consent was obtained by phone."
 
   "covid_been_tested_prompt": "Have you ever been tested for COVID-19?",
   "covid_test_kind_prompt": "What kind of test(s) did you get? (Check all that apply)",

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -8,7 +8,7 @@
     "name": "Consent Form",
     "title": "Consent Form",
     "subtitle": "Download Form (Read-Only)",
-
+    "last_updated": "TestBoston Version 1.0",
     "readonly_hint": """
       Thank you for signing your consent form. If you would like to make any changes,
       please reach out to the study team.""",
@@ -59,19 +59,29 @@
 
     "s4_name": "Signature",
     "s4_title": "Informed Consent and Authorization",
-    "s4_self_title": "Statement of Person Giving Informed Consent and Authorization",
-    "s4_self_item1": "I have read this consent form.",
-    "s4_self_item2": """
+    "s4_self_auth_title": "Statement of Person Giving Informed Consent and Authorization",
+    "s4_self_auth_item1": "I have read this consent form.",
+    "s4_self_auth_item2": """
       This research study has been explained to me, including risks and possible benefits (if any),
       other possible treatments or procedures, and other important things about the study.""",
-    "s4_self_item3": "I have had the opportunity to ask questions.",
-    "s4_self_item4": "I understand the information given to me.",
-    "s4_self_agree": """
+    "s4_self_auth_item3": "I have had the opportunity to ask questions.",
+    "s4_self_auth_item4": "I understand the information given to me.",
+    "s4_self_sign_title": "Signature of Subject:",
+    "s4_self_sign_statement": """
       I give my consent to take part in this research study and agree to allow my health information
       to be used and shared as described above.""",
-    "s4_staff_title": "Statement of Study Doctor or Person Obtaining Consent",
-    "s4_staff_item1": "I have explained the research to the study subject.",
-    "s4_staff_item2": "I have answered all questions about this research study to the best of my ability.",
+    "s4_staff_auth_title": "Statement of Study Doctor or Person Obtaining Consent",
+    "s4_staff_auth_item1": "I have explained the research to the study subject.",
+    "s4_staff_auth_item2": "I have answered all questions about this research study to the best of my ability.",
+    "s4_staff_sign_statement": "This verbal consent was obtained by phone."
+    "s4_interpreter_header": """
+      Consent of Non-English Speaking Subjects Using the "Short Form" in the Subject's Spoken Language""",
+    "s4_interpreter_auth_title": "Statement of Hospital Medical Interpreter",
+    "s4_interpreter_auth_statement": """
+      As someone who understands both English and the language spoken by the subject, I interpreted,
+      in the subject's language, the researcher's presentation of the English consent form.
+      The subject was given the opportunity to ask questions.""",
+    "s4_interpreter_sign_statement": "This verbal consent was obtained by phone."
   },
 
   "covid_survey": {
@@ -86,9 +96,12 @@
   },
 
   "who_filling_prompt": "Who is filling out this form?",
+  "store_sample_prompt": "Do you agree to let us store and use your samples and health information for other research related to COVID-19?",
+  "self_initial_prompt": "Initial",
   "self_sig_prompt": "Signature of Subject",
   "self_sig_placeholder": "Type your signature here",
   "staff_sig_prompt": "Study Doctor or Person Obtaining Consent",
+  "interpreter_sig_prompt": "Hospital Medical Interpreter",
 
   "covid_been_tested_prompt": "Have you ever been tested for COVID-19?",
   "covid_test_kind_prompt": "What kind of test(s) did you get? (Check all that apply)",
@@ -120,6 +133,8 @@
 
   "hint": {
     "select_option": "Please select an option",
+    "initial_required": "Initial is required",
+    "initial_length": "Initial cannot exceed max length",
     "sig_required": "Signature is required",
     "complete_date": "Please enter full date",
     "month_required": "Please select the month",
@@ -129,7 +144,7 @@
 
   "option": {
     "self": "I am filling it out for myself.",
-    "staff": "I am a study clinician filling it out on behalf of a participant.",
+    "staff": "I am a study doctor enrolling a participant.",
 
     "yes": "Yes",
     "no": "No",

--- a/study-builder/studies/testboston/snippets/consent-section1.conf
+++ b/study-builder/studies/testboston/snippets/consent-section1.conf
@@ -19,7 +19,7 @@
     {
       "titleTemplate": {
         "templateType": "HTML",
-        "templateText": "$tb_consent_s1_title",
+        "templateText": "<h2>$tb_consent_s1_title</h2>",
         "variables": [
           {
             "name": "tb_consent_s1_title",

--- a/study-builder/studies/testboston/snippets/consent-section2.conf
+++ b/study-builder/studies/testboston/snippets/consent-section2.conf
@@ -19,7 +19,7 @@
     {
       "titleTemplate": {
         "templateType": "HTML",
-        "templateText": "$tb_consent_s2_title",
+        "templateText": "<h2>$tb_consent_s2_title</h2>",
         "variables": [
           {
             "name": "tb_consent_s2_title",

--- a/study-builder/studies/testboston/snippets/consent-section3.conf
+++ b/study-builder/studies/testboston/snippets/consent-section3.conf
@@ -19,7 +19,7 @@
     {
       "titleTemplate": {
         "templateType": "HTML",
-        "templateText": "$tb_consent_s3_title",
+        "templateText": "<h2>$tb_consent_s3_title</h2>",
         "variables": [
           {
             "name": "tb_consent_s3_title",

--- a/study-builder/studies/testboston/snippets/consent-section4.conf
+++ b/study-builder/studies/testboston/snippets/consent-section4.conf
@@ -17,76 +17,134 @@
   "icons": [],
   "blocks": [
     {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h2>$tb_consent_s4_title</h2>",
+        "variables": [
+          {
+            "name": "tb_consent_s4_title",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_title}
+              }
+            ]
+          }
+        ]
+      },
+      "blockType": "CONTENT",
+      "shownExpr": null
+    },
+    {
       "question": ${_includes.consent.who_filling},
       "blockType": "QUESTION",
       "shownExpr": null
     },
     {
-      "titleTemplate": null,
+      "question": ${_includes.consent.store_sample},
+      "blockType": "QUESTION",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+    },
+    {
+      "question": ${_includes.consent.self_initial},
+      "blockType": "QUESTION",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+    },
+    {
+      "titleTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h3>$tb_consent_s4_self_auth_title</h3>",
+        "variables": [
+          {
+            "name": "tb_consent_s4_self_auth_title",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_self_auth_title}
+              }
+            ]
+          }
+        ]
+      },
       "bodyTemplate": {
         "templateType": "HTML",
         "templateText": """
-          <p>$tb_consent_s4_self_title</p>
           <ul>
-            <li>$tb_consent_s4_self_item1</li>
-            <li>$tb_consent_s4_self_item2</li>
-            <li>$tb_consent_s4_self_item3</li>
-            <li>$tb_consent_s4_self_item4</li>
+            <li>$tb_consent_s4_self_auth_item1</li>
+            <li>$tb_consent_s4_self_auth_item2</li>
+            <li>$tb_consent_s4_self_auth_item3</li>
+            <li>$tb_consent_s4_self_auth_item4</li>
           </ul>
-          <p>$tb_consent_s4_self_agree</p>
         """,
         "variables": [
           {
-            "name": "tb_consent_s4_self_title",
+            "name": "tb_consent_s4_self_auth_item1",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_title}
+                "text": ${i18n.en.consent.s4_self_auth_item1}
               }
             ]
           },
           {
-            "name": "tb_consent_s4_self_item1",
+            "name": "tb_consent_s4_self_auth_item2",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_item1}
+                "text": ${i18n.en.consent.s4_self_auth_item2}
               }
             ]
           },
           {
-            "name": "tb_consent_s4_self_item2",
+            "name": "tb_consent_s4_self_auth_item3",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_item2}
+                "text": ${i18n.en.consent.s4_self_auth_item3}
               }
             ]
           },
           {
-            "name": "tb_consent_s4_self_item3",
+            "name": "tb_consent_s4_self_auth_item4",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_item3}
+                "text": ${i18n.en.consent.s4_self_auth_item4}
               }
             ]
-          },
+          }
+        ]
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+    },
+    {
+      "titleTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h3>$tb_consent_s4_self_sign_title</h3>",
+        "variables": [
           {
-            "name": "tb_consent_s4_self_item4",
+            "name": "tb_consent_s4_self_sign_title",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_item4}
+                "text": ${i18n.en.consent.s4_self_sign_title}
               }
             ]
-          },
+          }
+        ]
+      },
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": "<p>$tb_consent_s4_self_sign_statement</p>",
+        "variables": [
           {
-            "name": "tb_consent_s4_self_agree",
+            "name": "tb_consent_s4_self_sign_statement",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_self_agree}
+                "text": ${i18n.en.consent.s4_self_sign_statement}
               }
             ]
           }
@@ -100,18 +158,12 @@
       "bodyTemplate": {
         "templateType": "HTML",
         "templateText": """
-          <div>
-            <h3>First Name</h3>
-            <p>$DDP_PARTICIPANT_FIRST_NAME</p>
-          </div>
-          <div>
-            <h3>Last Name</h3>
-            <p>$DDP_PARTICIPANT_LAST_NAME</p>
-          </div>
-          <div>
-            <h3>Date</h3>
-            <p>$DDP_DASHED_DATE</p>
-          </div>
+          <h4>First Name</h4>
+          <p>$DDP_PARTICIPANT_FIRST_NAME</p>
+          <h4>Last Name</h4>
+          <p>$DDP_PARTICIPANT_LAST_NAME</p>
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
         """,
         "variables": []
       },
@@ -124,41 +176,57 @@
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
     },
     {
-      "titleTemplate": null,
+      "titleTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h3>$tb_consent_s4_staff_auth_title</h3>",
+        "variables": [
+          {
+            "name": "tb_consent_s4_staff_auth_title",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_staff_auth_title}
+              }
+            ]
+          }
+        ]
+      },
       "bodyTemplate": {
         "templateType": "HTML",
         "templateText": """
-          <p>$tb_consent_s4_staff_title</p>
           <ul>
-            <li>$tb_consent_s4_staff_item1</li>
-            <li>$tb_consent_s4_staff_item2</li>
+            <li>$tb_consent_s4_staff_auth_item1</li>
+            <li>$tb_consent_s4_staff_auth_item2</li>
           </ul>
+          <p>$tb_consent_s4_staff_sign_statement</p>
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
         """,
         "variables": [
           {
-            "name": "tb_consent_s4_staff_title",
+            "name": "tb_consent_s4_staff_auth_item1",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_staff_title}
+                "text": ${i18n.en.consent.s4_staff_auth_item1}
               }
             ]
           },
           {
-            "name": "tb_consent_s4_staff_item1",
+            "name": "tb_consent_s4_staff_auth_item2",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_staff_item1}
+                "text": ${i18n.en.consent.s4_staff_auth_item2}
               }
             ]
           },
           {
-            "name": "tb_consent_s4_staff_item2",
+            "name": "tb_consent_s4_staff_sign_statement",
             "translations": [
               {
                 "language": "en",
-                "text": ${i18n.en.consent.s4_staff_item2}
+                "text": ${i18n.en.consent.s4_staff_sign_statement}
               }
             ]
           }
@@ -169,6 +237,79 @@
     },
     {
       "question": ${_includes.consent.staff_sig},
+      "blockType": "QUESTION",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
+    },
+    {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h2>$tb_consent_s4_interpreter_header</h2>",
+        "variables": [
+          {
+            "name": "tb_consent_s4_interpreter_header",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_interpreter_header}
+              }
+            ]
+          }
+        ]
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
+    },
+    {
+      "titleTemplate": {
+        "templateType": "HTML",
+        "templateText": "<h3>$tb_consent_s4_interpreter_auth_title</h3>",
+        "variables": [
+          {
+            "name": "tb_consent_s4_interpreter_auth_title",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_interpreter_auth_title}
+              }
+            ]
+          }
+        ]
+      },
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": """
+          <p>$tb_consent_s4_interpreter_auth_statement</p>
+          <p>$tb_consent_s4_interpreter_sign_statement</p>
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
+        """,
+        "variables": [
+          {
+            "name": "tb_consent_s4_interpreter_auth_statement",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_interpreter_auth_statement}
+              }
+            ]
+          },
+          {
+            "name": "tb_consent_s4_interpreter_sign_statement",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.consent.s4_interpreter_sign_statement}
+              }
+            ]
+          }
+        ]
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
+    },
+    {
+      "question": ${_includes.consent.interpreter_sig},
       "blockType": "QUESTION",
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
     }

--- a/study-builder/studies/testboston/snippets/consent-section4.conf
+++ b/study-builder/studies/testboston/snippets/consent-section4.conf
@@ -44,12 +44,12 @@
     {
       "question": ${_includes.consent.store_sample},
       "blockType": "QUESTION",
-      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].isAnswered()"""
     },
     {
-      "question": ${_includes.consent.self_initial},
+      "question": ${_includes.consent.initial},
       "blockType": "QUESTION",
-      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].isAnswered()"""
     },
     {
       "titleTemplate": {
@@ -158,12 +158,16 @@
       "bodyTemplate": {
         "templateType": "HTML",
         "templateText": """
-          <h4>First Name</h4>
-          <p>$DDP_PARTICIPANT_FIRST_NAME</p>
-          <h4>Last Name</h4>
-          <p>$DDP_PARTICIPANT_LAST_NAME</p>
-          <h4>Date</h4>
-          <p>$DDP_DASHED_DATE</p>
+          <div class="subject">
+            <div class="subject__block">
+              <h4>First Name</h4>
+              <p>$DDP_PARTICIPANT_FIRST_NAME</p>
+            </div>
+            <div class="subject__block">
+              <h4>Last Name</h4>
+              <p>$DDP_PARTICIPANT_LAST_NAME</p>
+            </div>
+          </div>
         """,
         "variables": []
       },
@@ -175,6 +179,19 @@
       "blockType": "QUESTION",
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
     },
+    {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": """
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
+        """,
+        "variables": []
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("SELF")"""
+    }
     {
       "titleTemplate": {
         "templateType": "HTML",
@@ -198,9 +215,6 @@
             <li>$tb_consent_s4_staff_auth_item1</li>
             <li>$tb_consent_s4_staff_auth_item2</li>
           </ul>
-          <p>$tb_consent_s4_staff_sign_statement</p>
-          <h4>Date</h4>
-          <p>$DDP_DASHED_DATE</p>
         """,
         "variables": [
           {
@@ -220,15 +234,6 @@
                 "text": ${i18n.en.consent.s4_staff_auth_item2}
               }
             ]
-          },
-          {
-            "name": "tb_consent_s4_staff_sign_statement",
-            "translations": [
-              {
-                "language": "en",
-                "text": ${i18n.en.consent.s4_staff_sign_statement}
-              }
-            ]
           }
         ]
       },
@@ -240,6 +245,19 @@
       "blockType": "QUESTION",
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
     },
+    {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": """
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
+        """,
+        "variables": []
+      },
+      "blockType": "CONTENT",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
+    }
     {
       "titleTemplate": null,
       "bodyTemplate": {
@@ -280,9 +298,6 @@
         "templateType": "HTML",
         "templateText": """
           <p>$tb_consent_s4_interpreter_auth_statement</p>
-          <p>$tb_consent_s4_interpreter_sign_statement</p>
-          <h4>Date</h4>
-          <p>$DDP_DASHED_DATE</p>
         """,
         "variables": [
           {
@@ -291,15 +306,6 @@
               {
                 "language": "en",
                 "text": ${i18n.en.consent.s4_interpreter_auth_statement}
-              }
-            ]
-          },
-          {
-            "name": "tb_consent_s4_interpreter_sign_statement",
-            "translations": [
-              {
-                "language": "en",
-                "text": ${i18n.en.consent.s4_interpreter_sign_statement}
               }
             ]
           }
@@ -311,6 +317,19 @@
     {
       "question": ${_includes.consent.interpreter_sig},
       "blockType": "QUESTION",
+      "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
+    },
+    {
+      "titleTemplate": null,
+      "bodyTemplate": {
+        "templateType": "HTML",
+        "templateText": """
+          <h4>Date</h4>
+          <p>$DDP_DASHED_DATE</p>
+        """,
+        "variables": []
+      },
+      "blockType": "CONTENT",
       "shownExpr": """user.studies["testboston"].forms["CONSENT"].questions["WHO_FILLING"].answers.hasOption("STAFF")"""
     }
   ]

--- a/study-builder/studies/testboston/snippets/question-initial.conf
+++ b/study-builder/studies/testboston/snippets/question-initial.conf
@@ -1,18 +1,18 @@
 {
   include required("../../snippets/text-question.conf"),
-  "stableId": ${id.q.self_initial},
+  "stableId": ${id.q.initial},
   "isRestricted": true,
   "hideNumber": true,
   "promptTemplate": {
     "templateType": "HTML",
-    "templateText": "$self_initial_prompt"
+    "templateText": "$initial_prompt"
     "variables": [
       {
-        "name": "self_initial_prompt",
+        "name": "initial_prompt",
         "translations": [
           {
             "language": "en",
-            "text": ${i18n.en.self_initial_prompt}
+            "text": ${i18n.en.initial_prompt}
           }
         ]
       }
@@ -23,10 +23,10 @@
       "ruleType": "REQUIRED",
       "hintTemplate": {
         "templateType": "TEXT",
-        "templateText": "$self_initial_req_hint",
+        "templateText": "$initial_req_hint",
         "variables": [
           {
-            "name": "self_initial_req_hint",
+            "name": "initial_req_hint",
             "translations": [
               {
                 "language": "en",
@@ -42,10 +42,10 @@
       "maxLength": 10,
       "hintTemplate": {
         "templateType": "TEXT",
-        "templateText": "$self_initial_length_hint",
+        "templateText": "$initial_length_hint",
         "variables": [
           {
-            "name": "self_initial_length_hint",
+            "name": "initial_length_hint",
             "translations": [
               {
                 "language": "en",

--- a/study-builder/studies/testboston/snippets/question-interpreter-signature.conf
+++ b/study-builder/studies/testboston/snippets/question-interpreter-signature.conf
@@ -6,7 +6,7 @@
   "hideNumber": true,
   "promptTemplate": {
     "templateType": "HTML",
-    "templateText": "$interpreter_sig_prompt"
+    "templateText": "<h4>$interpreter_sig_prompt</h4><p>$interpreter_sig_prompt_phone</p>"
     "variables": [
       {
         "name": "interpreter_sig_prompt",
@@ -14,6 +14,15 @@
           {
             "language": "en",
             "text": ${i18n.en.interpreter_sig_prompt}
+          }
+        ]
+      },
+      {
+        "name": "interpreter_sig_prompt_phone",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.interpreter_sig_prompt_phone}
           }
         ]
       }

--- a/study-builder/studies/testboston/snippets/question-interpreter-signature.conf
+++ b/study-builder/studies/testboston/snippets/question-interpreter-signature.conf
@@ -1,0 +1,22 @@
+{
+  include required("../../snippets/text-question.conf"),
+  "stableId": ${id.q.interpreter_sig},
+  "inputType": "SIGNATURE",
+  "isRestricted": true,
+  "hideNumber": true,
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": "$interpreter_sig_prompt"
+    "variables": [
+      {
+        "name": "interpreter_sig_prompt",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.interpreter_sig_prompt}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/study-builder/studies/testboston/snippets/question-self-initial.conf
+++ b/study-builder/studies/testboston/snippets/question-self-initial.conf
@@ -1,0 +1,60 @@
+{
+  include required("../../snippets/text-question.conf"),
+  "stableId": ${id.q.self_initial},
+  "isRestricted": true,
+  "hideNumber": true,
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": "$self_initial_prompt"
+    "variables": [
+      {
+        "name": "self_initial_prompt",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.self_initial_prompt}
+          }
+        ]
+      }
+    ]
+  },
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$self_initial_req_hint",
+        "variables": [
+          {
+            "name": "self_initial_req_hint",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.hint.initial_required}
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "ruleType": "LENGTH",
+      "maxLength": 10,
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$self_initial_length_hint",
+        "variables": [
+          {
+            "name": "self_initial_length_hint",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.hint.initial_length}
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/study-builder/studies/testboston/snippets/question-self-signature.conf
+++ b/study-builder/studies/testboston/snippets/question-self-signature.conf
@@ -1,6 +1,7 @@
 {
-  include required("../../snippets/text-question-signature-required.conf"),
+  include required("../../snippets/text-question.conf"),
   "stableId": ${id.q.self_sig},
+  "inputType": "SIGNATURE",
   "isRestricted": true,
   "hideNumber": true,
   "promptTemplate": {

--- a/study-builder/studies/testboston/snippets/question-staff-signature.conf
+++ b/study-builder/studies/testboston/snippets/question-staff-signature.conf
@@ -1,6 +1,7 @@
 {
-  include required("../../snippets/text-question-signature-required.conf"),
+  include required("../../snippets/text-question.conf"),
   "stableId": ${id.q.staff_sig},
+  "inputType": "SIGNATURE",
   "isRestricted": true,
   "hideNumber": true,
   "promptTemplate": {

--- a/study-builder/studies/testboston/snippets/question-staff-signature.conf
+++ b/study-builder/studies/testboston/snippets/question-staff-signature.conf
@@ -6,7 +6,7 @@
   "hideNumber": true,
   "promptTemplate": {
     "templateType": "HTML",
-    "templateText": "$staff_sig_prompt"
+    "templateText": "<h4>$staff_sig_prompt</h4><p>$staff_sig_prompt_phone</p>"
     "variables": [
       {
         "name": "staff_sig_prompt",
@@ -14,6 +14,15 @@
           {
             "language": "en",
             "text": ${i18n.en.staff_sig_prompt}
+          }
+        ]
+      },
+      {
+        "name": "staff_sig_prompt_phone",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.staff_sig_prompt_phone}
           }
         ]
       }

--- a/study-builder/studies/testboston/snippets/question-store-sample.conf
+++ b/study-builder/studies/testboston/snippets/question-store-sample.conf
@@ -1,0 +1,70 @@
+{
+  include required("../../snippets/bool-question-yes-no.conf"),
+  "stableId": ${id.q.store_sample},
+  "hideNumber": true,
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": "$store_sample_prompt"
+    "variables": [
+      {
+        "name": "store_sample_prompt",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.store_sample_prompt}
+          }
+        ]
+      }
+    ]
+  },
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$store_sample_req_hint",
+        "variables": [
+          {
+            "name": "store_sample_req_hint",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.hint.select_option}
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "trueTemplate": {
+    "templateType": "TEXT",
+    "templateText": "$store_sample_yes",
+    "variables": [
+      {
+        "name": "store_sample_yes",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.option.yes}
+          }
+        ]
+      }
+    ]
+  },
+  "falseTemplate": {
+    "templateType": "TEXT",
+    "templateText": "$store_sample_no",
+    "variables": [
+      {
+        "name": "store_sample_no",
+        "translations": [
+          {
+            "language": "en",
+            "text": ${i18n.en.option.no}
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/study-builder/studies/testboston/subs.conf
+++ b/study-builder/studies/testboston/subs.conf
@@ -21,7 +21,7 @@
     "q": {
       "who_filling": "WHO_FILLING",
       "store_sample": "STORE_SAMPLE",
-      "self_initial": "SELF_INITIAL",
+      "initial": "INITIAL",
       "self_sig": "SELF_SIGNATURE",
       "staff_sig": "STAFF_SIGNATURE",
       "interpreter_sig": "INTERPRETER_SIGNATURE",
@@ -53,7 +53,7 @@
       "s4": { include required("snippets/consent-section4.conf") }
       "who_filling": { include required("snippets/question-who-filling.conf") },
       "store_sample": { include required("snippets/question-store-sample.conf") },
-      "self_initial": { include required("snippets/question-self-initial.conf") },
+      "initial": { include required("snippets/question-initial.conf") },
       "self_sig": { include required("snippets/question-self-signature.conf") },
       "staff_sig": { include required("snippets/question-staff-signature.conf") },
       "interpreter_sig": { include required("snippets/question-interpreter-signature.conf") },

--- a/study-builder/studies/testboston/subs.conf
+++ b/study-builder/studies/testboston/subs.conf
@@ -15,10 +15,16 @@
       "covid_survey": "COVID_SURVEY",
       "address": "ADDRESS",
     },
+    "election": {
+      "store_sample": "STORE_SAMPLE",
+    },
     "q": {
       "who_filling": "WHO_FILLING",
+      "store_sample": "STORE_SAMPLE",
+      "self_initial": "SELF_INITIAL",
       "self_sig": "SELF_SIGNATURE",
       "staff_sig": "STAFF_SIGNATURE",
+      "interpreter_sig": "INTERPRETER_SIGNATURE",
       "covid_been_tested": "COVID_BEEN_TESTED",
       "covid_test_kind": "COVID_TEST_KIND",
       "covid_test_result": "COVID_TEST_RESULT",
@@ -46,8 +52,11 @@
       "s3": { include required("snippets/consent-section3.conf") },
       "s4": { include required("snippets/consent-section4.conf") }
       "who_filling": { include required("snippets/question-who-filling.conf") },
+      "store_sample": { include required("snippets/question-store-sample.conf") },
+      "self_initial": { include required("snippets/question-self-initial.conf") },
       "self_sig": { include required("snippets/question-self-signature.conf") },
       "staff_sig": { include required("snippets/question-staff-signature.conf") },
+      "interpreter_sig": { include required("snippets/question-interpreter-signature.conf") },
     },
     "covid_survey": {
       "covid_been_tested": { include required("snippets/question-covid-been-tested.conf") },


### PR DESCRIPTION
Another iteration on the "signature" section of testboston's Consent. See ticket for details.
https://broadinstitute.atlassian.net/browse/DDP-4599