### PR TITLE
docs: add notes to LookupInvitation API

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/admin.studies.invitation-lookup.yml
+++ b/pepper-apis/docs/specification/src/endpoints/admin.studies.invitation-lookup.yml
@@ -58,6 +58,10 @@ post:
                 description: timestamp of when invitation is accepted, in ISO-8601 UTC format
                 type: string
                 nullable: true
+              notes:
+                description: the notes for the invitation
+                type: string
+                nullable: true
               userGuid:
                 description: guid of associated user, if invitation is accepted
                 type: string


### PR DESCRIPTION
The lookup API is already returning the `notes`. I simply forgot to update the docs for it. Here it is.