### PR TITLE
testboston: make covid survey read-only after 72-hours

### DIFF
--- a/study-builder/studies/testboston/covid-survey.conf
+++ b/study-builder/studies/testboston/covid-survey.conf
@@ -5,6 +5,7 @@
   "versionTag": "v1",
   "displayOrder": 2,
   "writeOnce": false,
+  "editTimeoutSec": 259200,   # 72 hours
   "maxInstancesPerUser": 1,
   "translatedNames": [
     {


### PR DESCRIPTION
Per new requirement from Slack conversations.