### PR TITLE
Allow admin to check invite without recaptcha

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
+++ b/pepper-apis/docs/specification/src/endpoints/studies.invitation-check.yml
@@ -3,7 +3,11 @@ post:
   tags:
     - Invitations
   summary: InvitationCheckStatus
-  description: Check the status of an invitation, whether it exits and is valid or not.
+  description: |
+    Check the status of an invitation, whether it exits and is valid or not.
+
+    If request has a study admin auth token, then the reCAPTCHA token is not required.
+    But reCAPTCHA token will still be checked if provided in request.
   parameters:
     - $ref: '../pepper.yml#/components/parameters/studyGuid'
   requestBody:
@@ -25,8 +29,9 @@ post:
               description: the id of the invitation
               type: string
             recaptchaToken:
-              description: the user's reCAPTCHA token
+              description: the user's reCAPTCHA token, nullable if request made by study admin
               type: string
+              nullable: true
             qualificationDetails:
               description: additional user qualifications for checking the invitation
               type: object

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/invitation/InvitationCheckStatusPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/invitation/InvitationCheckStatusPayload.java
@@ -21,7 +21,6 @@ public class InvitationCheckStatusPayload {
     @SerializedName("qualificationDetails")
     private Map<String, Object> qualificationDetails = new HashMap<>();
 
-    @NotEmpty
     @SerializedName("recaptchaToken")
     private String recaptchaToken;
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/security/UserPermissions.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/security/UserPermissions.java
@@ -151,28 +151,20 @@ public class UserPermissions {
     }
 
     /**
-     * Returns whether or not this user has admin access
-     * to a study.
+     * Returns whether or not this user has admin access to a study.
      */
     public boolean hasAdminAccessToStudy(String requestedStudyGuid) {
-        if (!isDisabled() && adminStudiesWithAccess.contains(requestedStudyGuid)) {
-            return true;
-        }
-        return false;
+        return !isDisabled() && adminStudiesWithAccess != null && adminStudiesWithAccess.contains(requestedStudyGuid);
     }
 
     /**
      * Returns if user is an admin of any studies.
      */
     public boolean isAdmin() {
-        if (!isDisabled() && adminStudiesWithAccess != null && !adminStudiesWithAccess.isEmpty()) {
-            return true;
-        }
-        return false;
+        return !isDisabled() && adminStudiesWithAccess != null && !adminStudiesWithAccess.isEmpty();
     }
 
     public boolean canUpdateLoginData(String requestedUserGuid) {
         return operatorGuid.equals(requestedUserGuid);
     }
-
 }


### PR DESCRIPTION
## Context

In the CRC interface, clients will use the Invite Check API to check the zip code. However we don't want study staff to put in recaptcha. Thus, if operator is study admin AND there's no recaptcha token provided, we skip the recaptcha check. If recaptcha is provided either way, we'll still check it.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

