### PR TITLE
No more liquibase at DDP startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
             develop)
               DEPLOY_ENV=dev
             ;;
-            GAE_Backend_Deployment_Config)
+            gae-start)
               DEPLOY_ENV=dev
             ;;
             test)
@@ -679,15 +679,17 @@ jobs:
       - attach_workspace:
           at: *root_path
       - setup-shared-env
+      # Deploy Housekeeping first so hopefully liquibase migrations
+      # are ran before DDP boots up.
+      - build-jar:
+          pom_file: housekeeping-pom.xml
+      - deploy-jar:
+          jar_base_name: Housekeeping
       - build-jar:
           pom_file: pom.xml
       - deploy-jar:
           jar_base_name: DataDonationPlatform
           deploy_config_file_dir: ../output-config
-      - build-jar:
-          pom_file: housekeeping-pom.xml
-      - deploy-jar:
-          jar_base_name: Housekeeping
       - update-dispatch-rules
 
   deploy-stored-jar-job:
@@ -698,15 +700,17 @@ jobs:
       - checkout:
           path: *repo_path
       - setup-shared-env
+      # Deploy Housekeeping first so hopefully liquibase migrations
+      # are ran before DDP boots up.
+      - retrieve-jar:
+          jar_base_name: Housekeeping
+      - deploy-jar:
+          jar_base_name: Housekeeping
       - retrieve-jar:
           jar_base_name: DataDonationPlatform
       - deploy-jar:
           jar_base_name: DataDonationPlatform
           deploy_config_file_dir: ../output-config
-      - retrieve-jar:
-          jar_base_name: Housekeeping
-      - deploy-jar:
-          jar_base_name: Housekeeping
       - update-dispatch-rules
 
   deploy-docs-job:
@@ -746,7 +750,7 @@ workflows:
             branches:
               only:
                 - develop
-                - GAE_Backend_Deployment_Config
+                - gae-start
                 - &rc /^rc.*/
                 - &hotfix /^hotfix.*/
       - parallel-compile-and-test-job:
@@ -760,7 +764,7 @@ workflows:
               only:
                 - develop
                 - scaling_experiment
-                - GAE_Backend_Deployment_Config
+                - gae-start
           requires:
             - parallel-compile-and-test-job
             - compile-and-run-test-suite-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -435,6 +435,8 @@ commands:
               circleci tests split --split-by=timings --timings-type=classname > $THIS_NODE_TESTS_PATH
 
             echo "Number of test classes circleci wants to execute on this node: $(wc -l < $THIS_NODE_TESTS_PATH)"
+            echo "The included test classes are:"
+            cat $THIS_NODE_TESTS_PATH
 
             IGNORE_CLASS_LIST_PATH="${TEST_DATA_PATH}/surefire_classnames_ignore_list"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,9 +120,6 @@ commands:
             develop)
               DEPLOY_ENV=dev
             ;;
-            gae-start)
-              DEPLOY_ENV=dev
-            ;;
             test)
               DEPLOY_ENV=test
             ;;
@@ -752,7 +749,6 @@ workflows:
             branches:
               only:
                 - develop
-                - gae-start
                 - &rc /^rc.*/
                 - &hotfix /^hotfix.*/
       - parallel-compile-and-test-job:
@@ -766,7 +762,6 @@ workflows:
               only:
                 - develop
                 - scaling_experiment
-                - gae-start
           requires:
             - parallel-compile-and-test-job
             - compile-and-run-test-suite-job

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -10,18 +10,20 @@
 {{with $elasticsearchConf := vault (printf "secret/pepper/%s/%s/elasticsearch" $environment $version)}}
 
 {
-    # If set to true, tests will use MySQL from Docker container and dbUrl and housekeepingDbUrl will be ignored
     {{if eq $gae "true"}}
         "useDisposableTestDbs": false,
         "dbUrl": "jdbc:mysql://localhost:3306/studyservicedb?user=root&password=rootpw&characterEncoding=UTF-8&useLegacyDatetimeCode=false&serverTimezone=UTC&useSSL=false&sessionVariables=innodb_strict_mode=on,tx_isolation='READ-COMMITTED',sql_mode='TRADITIONAL'",
         "housekeepingDbUrl": "jdbc:mysql://localhost:3306/housekeepingdb?user=root&password=rootpw&characterEncoding=UTF-8&useLegacyDatetimeCode=false&serverTimezone=UTC&useSSL=false&sessionVariables=innodb_strict_mode=on,tx_isolation='READ-COMMITTED',sql_mode='TRADITIONAL'",
     {{else}}
+        # If set to true, tests will use MySQL from Docker container and dbUrl and housekeepingDbUrl will be ignored
         "useDisposableTestDbs": true,
     {{end}}
     "maxConnections": 50,
     "defaultTimezone": "{{$testingConf.Data.defaultTimezone}}",
     "port": 5556,
     "doLiquibase": true,
+    # If set to true, will run liquibase migrations in DataDonationPlatform startup.
+    "doLiquibaseInStudyServer": true,
     "threadTimeout": 30000,
     "dsmBaseUrl": "http://localhost:9555",
     "dsmJwtSecret": "Dsm test secret!",

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -152,6 +152,7 @@ import org.broadinstitute.ddp.service.WorkflowService;
 import org.broadinstitute.ddp.transformers.NullableJsonTransformer;
 import org.broadinstitute.ddp.transformers.SimpleJsonTransformer;
 import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
@@ -250,6 +251,11 @@ public class DataDonationPlatform {
                 new TransactionWrapper.DbConfiguration(TransactionWrapper.DB.APIS, maxConnections, dbUrl));
         Config sqlConfig = ConfigFactory.load(ConfigFile.SQL_CONFIG_FILE);
         initSqlCommands(sqlConfig);
+
+        if (cfg.hasPath(ConfigFile.DO_LIQUIBASE_IN_STUDY_SERVER) && cfg.getBoolean(ConfigFile.DO_LIQUIBASE_IN_STUDY_SERVER)) {
+            LOG.info("Running liquibase migrations in StudyServer against database url: {}", dbUrl);
+            LiquibaseUtil.runLiquibase(dbUrl, TransactionWrapper.DB.APIS);
+        }
 
         if (appEnginePort != null) {
             port(Integer.parseInt(appEnginePort));

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -251,13 +251,13 @@ public class DataDonationPlatform {
         Config sqlConfig = ConfigFactory.load(ConfigFile.SQL_CONFIG_FILE);
         initSqlCommands(sqlConfig);
 
-        JettyConfig.setupJetty(preferredSourceIPHeader);
         if (appEnginePort != null) {
             port(Integer.parseInt(appEnginePort));
         } else {
             port(configFilePort);
         }
         threadPool(-1, -1, requestThreadTimeout);
+        JettyConfig.setupJetty(preferredSourceIPHeader);
 
         // The first route mapping call will also initialize the Spark server. Make that first call
         // the GAE lifecycle hooks so we capture the GAE call as soon as possible, and respond

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -198,7 +198,9 @@ public class Housekeeping {
         }
 
         if (doLiquibase) {
-            // we only migrate the housekeeping db when starting
+            LOG.info("Running Pepper liquibase migrations against " + apisDbUrl);
+            LiquibaseUtil.runLiquibase(apisDbUrl, TransactionWrapper.DB.APIS);
+            LOG.info("Running Housekeeping liquibase migrations against " + housekeepingDbUrl);
             LiquibaseUtil.runLiquibase(housekeepingDbUrl, TransactionWrapper.DB.HOUSEKEEPING);
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -15,6 +15,7 @@ public class ConfigFile {
 
     // whether or not to run liquibase at app boot
     public static final String DO_LIQUIBASE = "doLiquibase";
+    public static final String DO_LIQUIBASE_IN_STUDY_SERVER = "doLiquibaseInStudyServer";
 
     // Name of the default timezone to be used by system. Does not change VM time zone!
     public static final String DEFAULT_TIMEZONE = "defaultTimezone";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
@@ -45,6 +45,7 @@ public class LiquibaseUtil implements  AutoCloseable {
     private LiquibaseUtil(String dbUrl)  {
         HikariConfig config = new HikariConfig();
         config.setJdbcUrl(dbUrl);
+        config.setMaximumPoolSize(2);
         dataSource = new HikariDataSource(config);
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -46,7 +46,6 @@ import org.broadinstitute.ddp.security.EncryptionKey;
 import org.broadinstitute.ddp.security.JWTConverterTest;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.JavaProcessSpawner;
-import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
 import org.broadinstitute.ddp.util.MySqlTestContainerUtil;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
@@ -181,7 +180,6 @@ public class IntegrationTestSuite {
 
     public static void startupTestServer() {
         bootAppServer();
-        runServerDatabaseMigrations();
         waitForServer(1000);
     }
 
@@ -347,13 +345,6 @@ public class IntegrationTestSuite {
         } catch (InterruptedException e) {
             LOG.info("Wait interrupted", e);
         }
-    }
-
-    private static void runServerDatabaseMigrations() {
-        Config cfg = RouteTestUtil.getConfig();
-        String apisDbUrl = cfg.getString(TransactionWrapper.DB.APIS.getDbUrlConfigKey());
-        LOG.info("Running Pepper liquibase migrations against " + apisDbUrl);
-        LiquibaseUtil.runLiquibase(apisDbUrl, TransactionWrapper.DB.APIS);
     }
 
     /**

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -165,13 +165,11 @@ public class IntegrationTestSuite {
         LogbackConfigurationPrinter.printLoggingConfiguration();
 
         initializeDatabase();
-
         if (!isTestServerRunning()) {
             startupTestServer();
-            insertTestData();
-        } else {
-            RouteTestUtil.setupDatabasePool();
         }
+        insertTestData();
+
         callCounter += 1;
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -46,6 +46,7 @@ import org.broadinstitute.ddp.security.EncryptionKey;
 import org.broadinstitute.ddp.security.JWTConverterTest;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.JavaProcessSpawner;
+import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
 import org.broadinstitute.ddp.util.MySqlTestContainerUtil;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
@@ -182,6 +183,7 @@ public class IntegrationTestSuite {
 
     public static void startupTestServer() {
         bootAppServer();
+        runServerDatabaseMigrations();
         waitForServer(1000);
     }
 
@@ -347,6 +349,13 @@ public class IntegrationTestSuite {
         } catch (InterruptedException e) {
             LOG.info("Wait interrupted", e);
         }
+    }
+
+    private static void runServerDatabaseMigrations() {
+        Config cfg = RouteTestUtil.getConfig();
+        String apisDbUrl = cfg.getString(TransactionWrapper.DB.APIS.getDbUrlConfigKey());
+        LOG.info("Running Pepper liquibase migrations against " + apisDbUrl);
+        LiquibaseUtil.runLiquibase(apisDbUrl, TransactionWrapper.DB.APIS);
     }
 
     /**


### PR DESCRIPTION
## Context

_Issue 1: 404s_

Somehow GAE is still continuing to pass requests through to the server even thought it hasn't fully booted yet. I suspect that one of the `Spark.*` methods early in the startup process is initializing the Spark HTTP server and it's receiving the `/_ah/start` before our handler is even mounted yet. In this case, it's returning `404` for `/_ah/start` and that is enough for GAE to start passing along requests, which will mostly get `404`s as well since our other route handlers are not mounted yet. My attempt to solve this is to move the early `Spark.*` method calls and group them together so hopefully our GAE handlers get mounted as close to Spark server initialization as possible.

_Edit: On closer inspection, I think `JettyConfig.setupJetty()` has something to do with it. I think the way it played out in the old code is that 1) Jetty server is started, 2) we run liquibase which gives us a good 10-15 second window, 3) GAE `/_ah/start` call comes in within this window, 4) Jetty picks that up and returns `404`, 5) GAE starts unleashing other requests which will all `404` as well. So maybe moving the GAE route handlers closer to the Jetty setup call is the right move..._

_Issue 2: Startup Lag Time_

The last time I measured, I saw the startup time (from moment GAE started instance to getting to `ddp startup complete`) took about 30 seconds. Liquibase migrations seem to take up a large portion of that. To speed this up, I have completely removed the liquibase migration step from DDP. Instead, I move the step over to Housekeeping. I think this makes sense because liquibase migrations need only be ran once, and Housekeeping can accomplish that. Also, GAE starts/stops the DDP instance somewhat frequently, so now we're not paying for the liquibase cost. With this change, startup time gone down to around 15 seconds.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

