### PR TITLE
DDP-4792: Fixed issue where new Hebrew language code wasn't recognized.

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
@@ -26,6 +26,12 @@ import spark.Response;
 public class StudyLanguageResolutionFilter implements Filter {
 
     public static final String USER_LANGUAGE = "USER_LANGUAGE";
+    private static final String HEBREW_OLD = "iw";
+    private static final String HEBREW_NEW = "he";
+    private static final String YIDDISH_OLD = "ji";
+    private static final String YIDDISH_NEW = "yi";
+    private static final String INDONESIAN_OLD = "in";
+    private static final String INDONESIAN_NEW = "id";
 
     private static final Logger LOG = LoggerFactory.getLogger(StudyLanguageResolutionFilter.class);
     private static final String STUDY_GUID_REGEX = "/studies/(\\w+)";
@@ -92,12 +98,12 @@ public class StudyLanguageResolutionFilter implements Filter {
     private static String getNewerLanguageCode(String oldCode) {
         // Java converts some language codes to older versions.  If the language is one of these older codes, try
         // converting it to the newer version
-        if ("iw".equals(oldCode)) {
-            return "he";
-        } else if ("ji".equals(oldCode)) {
-            return "yi";
-        } else if ("in".equals(oldCode)) {
-            return "id";
+        if (HEBREW_OLD.equals(oldCode)) {
+            return HEBREW_NEW;
+        } else if (YIDDISH_OLD.equals(oldCode)) {
+            return YIDDISH_NEW;
+        } else if (INDONESIAN_OLD.equals(oldCode)) {
+            return INDONESIAN_NEW;
         }
         return oldCode;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
@@ -80,18 +80,25 @@ public class StudyLanguageResolutionFilter implements Filter {
     }
 
     private static LanguageDto convertLocaleToLanguageDto(Handle handle, Locale preferredLocale) {
-        String preferredLocaleLanguage = preferredLocale.getLanguage();
+        String lang = preferredLocale.getLanguage();
+        LanguageDto languageDto = LanguageStore.getOrCompute(handle, lang);
 
-        // Java converts some language codes to older versions.  If the language is one of these older codes, convert
-        // it back first
-        if ("iw".equals(preferredLocaleLanguage)) {
-            preferredLocaleLanguage = "he";
-        } else if ("ji".equals(preferredLocaleLanguage)) {
-            preferredLocaleLanguage = "yi";
-        } else if ("in".equals(preferredLocaleLanguage)) {
-            preferredLocaleLanguage = "id";
+        if (languageDto == null) {
+            languageDto = LanguageStore.getOrCompute(handle, getNewerLanguageCode(lang));
         }
+        return languageDto;
+    }
 
-        return LanguageStore.getOrCompute(handle, preferredLocaleLanguage);
+    private static String getNewerLanguageCode(String oldCode) {
+        // Java converts some language codes to older versions.  If the language is one of these older codes, try
+        // converting it to the newer version
+        if ("iw".equals(oldCode)) {
+            return "he";
+        } else if ("ji".equals(oldCode)) {
+            return "yi";
+        } else if ("in".equals(oldCode)) {
+            return "id";
+        }
+        return oldCode;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilter.java
@@ -80,6 +80,18 @@ public class StudyLanguageResolutionFilter implements Filter {
     }
 
     private static LanguageDto convertLocaleToLanguageDto(Handle handle, Locale preferredLocale) {
-        return LanguageStore.getOrCompute(handle, preferredLocale.getLanguage());
+        String preferredLocaleLanguage = preferredLocale.getLanguage();
+
+        // Java converts some language codes to older versions.  If the language is one of these older codes, convert
+        // it back first
+        if ("iw".equals(preferredLocaleLanguage)) {
+            preferredLocaleLanguage = "he";
+        } else if ("ji".equals(preferredLocaleLanguage)) {
+            preferredLocaleLanguage = "yi";
+        } else if ("in".equals(preferredLocaleLanguage)) {
+            preferredLocaleLanguage = "id";
+        }
+
+        return LanguageStore.getOrCompute(handle, preferredLocaleLanguage);
     }
 }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -217,4 +217,5 @@
     <include file="db-changes/schema/DDP-2565-study-settings-analytics.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/should-delete-unsendable-emails.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/add-section-index-column-to-activity-instance.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/DDP-4792-add-hebrew.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/DDP-4792-add-hebrew.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/DDP-4792-add-hebrew.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="charlotte" id="20200709-cd-add-hebrew">
+        <insert tableName="language_code">
+            <column name="iso_language_code" value="he"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilterTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/filter/StudyLanguageResolutionFilterTest.java
@@ -18,8 +18,10 @@ public class StudyLanguageResolutionFilterTest extends TxnAwareBaseTest {
     private static final String LANG_EN = "en";
     private static final String LANG_RU = "ru";
     private static final String LANG_FR = "fr";
+    private static final String LANG_HE = "he";
     private static final String LANG_HEADER_RU = "Accept-Language: ru-RU, ru";
     private static final String LANG_HEADER_FR = "Accept-Language: fr-FR, fr";
+    private static final String LANG_HEADER_HE = "Accept-Language: he-HE, he";
 
     @BeforeClass
     public static void setupClass() {
@@ -96,6 +98,20 @@ public class StudyLanguageResolutionFilterTest extends TxnAwareBaseTest {
                     );
                     Assert.assertEquals(LANG_FR, languageDto.getIsoCode());
                     handle.rollback();
+                }
+        );
+    }
+
+    @Test
+    public void test_whenStudyUsesNewerLanguageCodeThanJavaLocale_thenTryNewerLanguageCode() {
+        TransactionWrapper.useTxn(
+                handle -> {
+                    enableLanguageSupportForStudy(handle, testData.getStudyGuid(), LANG_HE);
+                    String acceptLanguageHeader = LANG_HEADER_HE;
+                    LanguageDto languageDto = StudyLanguageResolutionFilter.getPreferredLanguage(
+                            handle, acceptLanguageHeader, Locale.forLanguageTag(LANG_HE), testData.getStudyGuid()
+                    );
+                    Assert.assertEquals(LANG_HE, languageDto.getIsoCode());
                 }
         );
     }


### PR DESCRIPTION
## Context

This ticket covers DDP-4792.  The StudyLanguageResolutionFilter uses Java's locale class to get a language from the locale.  Java's Locale class has some behavior where it converts a few newer language codes ("he", "yi", and "id") to older versions ("iw", "ji", and "in") to maintain compatibility with older things, despite the fact that the "newer" language codes aren't particularly new anymore.  This means that if a study is configured using the correct language code for one of these three languages, even though the new language code is provided, Java will instead substitute the older language code and when users try to see their surveys, an error will happen and prevent them from doing so.  This fixes the problem by converting the old language codes back to the newer language codes, which means it will no longer block DDP-4436.

The performance impact should be minimal.  If the initial language code works, we don't do anything different.  If it doesn't work, we try again with the newer language code, but we only do that once.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] n/a If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] n/a If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing
- [x] I have written an automated test but am not sure if it is a positive or negative test
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

