### PR TITLE
testboston: pdf i18n

### DIFF
--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -220,4 +220,5 @@
     <include file="db-changes/seed/DDP-4792-add-hebrew.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/DDP-4803-hebrew-spanish-chinese.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/spanish-and-creole.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/fix-spanish-activity-instance-status-type.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/fix-spanish-activity-instance-status-type.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/fix-spanish-activity-instance-status-type.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200722-fix-spanish-instance-status-type">
+        <update tableName="i18n_activity_instance_status_type_name_trans">
+            <column name="translation_text" value="Completo"/>
+            <where>
+                activity_instance_status_type_id = (select activity_instance_status_type_id from activity_instance_status_type where activity_instance_status_type_code = 'COMPLETE')
+                and language_code_id = (select language_code_id from language_code where iso_language_code = 'es')
+            </where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>

--- a/study-builder/studies/testboston/i18n/es.conf
+++ b/study-builder/studies/testboston/i18n/es.conf
@@ -28,7 +28,7 @@
     "s2_results_p2": "No recibirá los resultados de la prueba de detección de anticuerpos. Presentaremos un resumen de los resultados (sus resultados combinados con los de otros participantes de la investigación) al Departamento de Salud Pública de Massachusetts y otras partes interesadas clave del sector de salud pública. Nuestro objetivo es determinar qué porcentaje de participantes del estudio tienen un anticuerpo positivo y contar con una noción más clara de la prevalencia, o cantidad de personas contagiadas, de COVID-19.",
     "s2_results_p3": "Si lo desea, podemos incluir su correo electrónico en una lista para recibir un boletín de novedades sobre la investigación que estamos haciendo. En el boletín no se anunciarán sus resultados ni los de nadie, sino que se difundirá información que se está recabando sobre COVID-19. Quizás publiquemos los datos que obtengamos en revistas médicas.",
     "s2_sponsor_title": "Patrocinador de la investigación",
-    "s2_sponsor_p1": "Broad Institute de MIT y Harvard.",
+    "s2_sponsor_p1": "Broad Institute of MIT and Harvard.",
     "s2_why_title": "¿Por qué le pedimos que participe y cuántas personas participarán?",
     "s2_why_p1": "Le pedimos que participe en este estudio de investigación porque es una persona adulta que ha recibido atención médica en Brigham and Women's Hospital en los últimos doce meses. Alrededor de diez mil personas participarán en este estudio de investigación.",
     "s2_risks_title": "¿Cuáles son los riesgos asociados con la participación?",

--- a/study-builder/studies/testboston/i18n/ht.conf
+++ b/study-builder/studies/testboston/i18n/ht.conf
@@ -16,7 +16,7 @@
     "s1_header": "TestBoston: Etid sou tès COVID-19 dirèk-pou-pasyan BWH/Broad",
     "s1_subheader": "Doktè Ann E. Woolley, MD, MPH; Doktè Lisa A. Cosimi, MD",
     "s1_who_title": "Kimoun nou ye?",
-    "s1_who_p1": "Nou se chèchè klinik nan Depatman maladi enfektyez (Infectuous Disease Department) nan Brigham and Women's Hospital.",
+    "s1_who_p1": "Nou se chèchè klinik nan Depatman maladi enfektyez (Infectious Disease Department) nan Brigham and Women's Hospital.",
     "s1_about_title": "Apwopo etid sa a",
     "s1_about_p1": "Nou vle konprann risk ki genyen pou enfeksyon SARS-CoV-2 (viris ki lakòz COVID-19 lan) kay moun diferan ki resevwa sèten swen medikal nan Brigham and Women's Hospital epi k ap viv nan gran rejyon Boston lan. Epitou nou vle konprann kimoun ki enfekte san yo pa vin gen sentòm ak kimoun ki gen plis risk pou yo vin gen maladi pi grav.",
     "s1_about_p2": "Etid sa a pral devlope yon modèl pou mete an plas tès pou COVID-19 lakay pou li kapab itilize pou teste yon gwo kantite moun epi pou diminye nesesite pou moun vini nan klinik, sèvis dijans, oswa lòt sant pou tès. Nou pral etidye fason pou suiv pousantaj enfeksyon yo dekwa pou nou ka reyaji si gen nouvo epidemi COVID-19 nan mwa k ap vini yo.",


### PR DESCRIPTION
Part of changes for https://github.com/broadinstitute/ddp-angular/pull/201.

I was going to add the Spanish and Creole PDFs and make appropriate configuration changes, but Pavel beat me to it, so I'm making a PR into his branch.