### PR TITLE
housekeeping jvm param updates

### DIFF
--- a/pepper-apis/config/housekeeping-docker-compose.yaml.ctmpl
+++ b/pepper-apis/config/housekeeping-docker-compose.yaml.ctmpl
@@ -17,6 +17,7 @@ housekeeping:
     - {{$dir}}/application.conf:/app/config/application.conf
     - {{$dir}}/housekeeping_startup.sh:/app/housekeeping_startup.sh
     - {{$dir}}/housekeeping-service-account.json:/app/housekeeping-service-account.json
+  restart: always
   environment:
     - GOOGLE_APPLICATION_CREDENTIALS=/app/housekeeping-service-account.json
   links:

--- a/pepper-apis/config/housekeeping_startup.sh.ctmpl
+++ b/pepper-apis/config/housekeeping_startup.sh.ctmpl
@@ -5,7 +5,7 @@ echo 'Starting housekeeping...'
 {{with $version := env "VERSION"}}
 {{with $conf := vault (printf "secret/pepper/%s/%s/conf" $environment $version)}}
 
-CORE_COMMAND="-Dconfig.file=config/application.conf -Xms256m -Xmx512m -jar target/Housekeeping.jar"
+CORE_COMMAND="-Dconfig.file=config/application.conf -Xms256m -Xmx2048m -jar target/Housekeeping.jar"
 DEBUG="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=9876"
 
 # pass in debug flag


### PR DESCRIPTION
PR to update recent jvm param changes made to prod housekeeping vm. 
1. set "restart always"
2. set heap size to 2g (2048m)