### PR TITLE
testboston: survey read-only

### DIFF
--- a/study-builder/studies/testboston/followup-survey.conf
+++ b/study-builder/studies/testboston/followup-survey.conf
@@ -5,7 +5,7 @@
   "versionTag": "v1",
   "displayOrder": 4,
   "writeOnce": false,
-  "editTimeoutSec": 864000,   # 10 days
+  "editTimeoutSec": 1209600,   # 14 days
   "maxInstancesPerUser": 5,
   "translatedNames": [
     { "language": "en", "text": ${i18n.en.followup.name} },

--- a/study-builder/studies/testboston/study-events.conf
+++ b/study-builder/studies/testboston/study-events.conf
@@ -138,6 +138,18 @@
       "dispatchToHousekeeping": true,
       "order": 1
     },
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "TESTBOSTON_RECEIVED"
+      },
+      "action": {
+        "type": "MARK_ACTIVITIES_READ_ONLY",
+        "activityCodes": [${id.act.covid_survey}, ${id.act.followup}]
+      },
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
 
     # when time for longitudinal kit
     {


### PR DESCRIPTION
When DSM tells Pepper that kit is received back in lab, we mark surveys read-only.