### PR TITLE
Updates mailing address creation and update API docs

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1784,15 +1784,6 @@ MailingAddress:
     - $ref: '../pepper.yml#/components/schemas/BaseMailAddress'
     - type: object
       description: a participant's mailing address, to be used for delivery.
-      required:
-        - description
-        - name
-        - street1
-        - city
-        - state
-        - country
-        - zip
-        - phone
       properties:
         guid:
           type: string

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
@@ -28,6 +28,20 @@ put:
   description: updates the specified saved address
   tags:
     - Mailing Address
+  parameters:
+        - in: query
+          name: strict
+          description: |
+            if true, the request will fail if the following fields are `null` or empty.
+              * `name`
+              * `street1`
+              * `city`
+              * `state`
+              * `country`
+              * `zip`
+          schema:
+            type: boolean
+            default: false
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/MailingAddress'
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
@@ -29,19 +29,19 @@ put:
   tags:
     - Mailing Address
   parameters:
-        - in: query
-          name: strict
-          description: |
-            if true, the request will fail if the following fields are `null` or empty.
-              * `name`
-              * `street1`
-              * `city`
-              * `state`
-              * `country`
-              * `zip`
-          schema:
-            type: boolean
-            default: false
+    - in: query
+      name: strict
+      description: |
+        if true, the request will fail if the following fields are `null` or empty.
+          * `name`
+          * `street1`
+          * `city`
+          * `state`
+          * `country`
+          * `zip`
+      schema:
+        type: boolean
+        default: false
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/MailingAddress'
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
@@ -22,6 +22,20 @@ post:
   description: save a new address for a participant
   tags:
     - Mailing Address
+  parameters:
+        - in: query
+          name: strict
+          description: |
+            if true, the request will fail if the following fields are `null` or empty.
+              * `name`
+              * `street1`
+              * `city`
+              * `state`
+              * `country`
+              * `zip`
+          schema:
+            type: boolean
+            default: false
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/MailingAddress'
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
@@ -23,19 +23,19 @@ post:
   tags:
     - Mailing Address
   parameters:
-        - in: query
-          name: strict
-          description: |
-            if true, the request will fail if the following fields are `null` or empty.
-              * `name`
-              * `street1`
-              * `city`
-              * `state`
-              * `country`
-              * `zip`
-          schema:
-            type: boolean
-            default: false
+    - in: query
+      name: strict
+      description: |
+        if true, the request will fail if the following fields are `null` or empty.
+          * `name`
+          * `street1`
+          * `city`
+          * `state`
+          * `country`
+          * `zip`
+      schema:
+        type: boolean
+        default: false
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/MailingAddress'
   responses:


### PR DESCRIPTION
## Context
Updates the mailing address creation and update documentation to include the `strict` parameter, and details the change in behavior when strict mode is enabled.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed

## FUD Score
- [x] :relaxed: All good, business as usual!

## How do we demo these changes?
- [x] They are visible in dev as a regular user journey and require no additional instructions.

## Testing
- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release
- [x] These changes require no special release procedures

