### PR TITLE
testboston covid-survey fix

### DIFF
--- a/study-builder/studies/testboston/snippets/question-race.conf
+++ b/study-builder/studies/testboston/snippets/question-race.conf
@@ -117,21 +117,6 @@
           }
         ]
       }
-      "detailLabelTemplate": {
-        "templateType": "TEXT",
-        "templateText": "$race_other_details",
-        "variables": [
-          {
-            "name": "race_other_details",
-            "translations": [
-              { "language": "en", "text": ${i18n.en.option.other_details} },
-              { "language": "es", "text": ${i18n.es.option.other_details} },
-              { "language": "ht", "text": ${i18n.ht.option.other_details} }
-            ]
-          }
-        ]
-      },
-      "allowDetails": true,
     }
   ]
 }


### PR DESCRIPTION
As per jen;s comment (https://broadinstitute.slack.com/archives/G012Y2S45KN/p1597436950117300?thread_ts=1597413658.082300&cid=G012Y2S45KN ) in slack channel remove "other details" for RACE - "Other" option