### PR TITLE
DDP-4908 allow using proxy for sengrid api requests

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -70,6 +70,9 @@
         "apiLimitRate": {{$conf.Data.rateLimit.apiLimitRate}}
     },
     "sendgrid": {
+    {{if $conf.Data.sendgrid.proxy}}
+        "proxy": "{{$conf.Data.sendgrid.proxy}}",
+    {{end}}
         "fromName": "{{$conf.Data.sendgrid.fromName}}",
         "fromEmail": "{{$conf.Data.sendgrid.fromEmail}}"
     },

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -106,6 +106,7 @@
     },
     "housekeepingMaxConnections": 50,
     "sendgrid": {
+        "proxy": null,
         "fromName": "Pepper Local",
         "fromEmail": "noreply@datadonationplatform.org"
     },

--- a/pepper-apis/gae-egress-proxy/Dockerfile
+++ b/pepper-apis/gae-egress-proxy/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
-COPY squid.conf /app/squid.conf
 COPY entrypoint.sh /app/entrypoint.sh
 RUN chmod 755 /app/entrypoint.sh
 

--- a/pepper-apis/gae-egress-proxy/docker-compose.yaml
+++ b/pepper-apis/gae-egress-proxy/docker-compose.yaml
@@ -1,6 +1,7 @@
 squid:
   image: broadinstitute/pepper-squid:latest
   volumes:
+    - /app/squid.conf:/app/squid.conf
     - /var/log/squid:/var/log/squid
   ports:
     - "3128:3128"

--- a/pepper-apis/gae-egress-proxy/pepper-squid.sh
+++ b/pepper-apis/gae-egress-proxy/pepper-squid.sh
@@ -22,7 +22,7 @@ case "$CMD" in
   deploy)
     echo "=> deploying to vm..."
     gcloud --project="$PROJECT_ID" compute scp --zone=us-central1-a \
-      docker-compose.yaml "root@$INSTANCE_NAME:/app"
+      squid.conf docker-compose.yaml "root@$INSTANCE_NAME:/app"
     sudo_run "docker-compose -f /app/docker-compose.yaml -p pepper pull \
       && docker-compose -f /app/docker-compose.yaml -p pepper down \
       && docker-compose -f /app/docker-compose.yaml -p pepper up -d"

--- a/pepper-apis/gae-egress-proxy/squid.conf
+++ b/pepper-apis/gae-egress-proxy/squid.conf
@@ -1,6 +1,8 @@
 # Access control definitions.
+acl dest_ports port 443                     # Regular SSL port
 acl dest_ports port 9243                    # Elasticsearch port
 acl allowed_domains dstdomain .cloud.es.io  # Elasticsearch host
+acl allowed_domains dstdomain api.sendgrid.com  # SendGrid API host
 acl allowed_clients src 69.173.64.0/18      # Broad IP range
 acl allowed_clients src 10.8.0.0/28         # GAE internal IP range
 acl CONNECT method CONNECT                  # Use HTTP tunnel

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -88,6 +88,7 @@ import org.broadinstitute.ddp.service.PdfBucketService;
 import org.broadinstitute.ddp.service.PdfGenerationService;
 import org.broadinstitute.ddp.service.PdfService;
 import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.ddp.util.ConfigUtil;
 import org.broadinstitute.ddp.util.GuidUtils;
 import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
@@ -580,7 +581,7 @@ public class Housekeeping {
         PdfGenerationHandler pdfGenerationHandler = new PdfGenerationHandler(pdfService, pdfBucketService, pdfGenerationService);
         Gson gson = new Gson();
         if (sendGridSupplier == null) {
-            sendGridSupplier = SendGridClient::new;
+            sendGridSupplier = apiKey -> new SendGridClient(apiKey, ConfigUtil.getStrIfPresent(cfg, ConfigFile.Sendgrid.PROXY));
         }
         final SendGridSupplier sendGridProvider = sendGridSupplier;
         try {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -185,5 +185,7 @@ public class ConfigFile {
         public static final String TEMPLATE_VERSION = "version";
         public static final String FROM_NAME = "sendgrid.fromName";
         public static final String FROM_EMAIL = "sendgrid.fromEmail";
+        // The proxy URL to use for all outgoing SendGrid requests.
+        public static final String PROXY = "sendgrid.proxy";
     }
 }


### PR DESCRIPTION
## Context

This PR allows setting up SendGrid API calls to be routed through our proxy, so that we can whitelist that IP in our SendGrid account. In terms of performance, sendgrid API is only used by Housekeeping and the frequency of sending emails is moderate to low, so any user-facing degradation is not expected.

**Deployment**: we'll need to rebuild the `pepper-squid` docker image and push up new configs. Also need to add proxy url to vault. Then whitelist the proxy VM's IP in SendGrid account.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.

## Testing

- [x] Tested the squid config, will test more after we put this on `dev`.

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

