### PR TITLE
DDP-4910 remove email from post-password-reset

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -987,6 +987,15 @@ Error.NotFound:
           type: string
           enum:
             - NOT_FOUND
+Error.OperationNotAllowed:
+  allOf:
+    - $ref: '../pepper.yml#/components/schemas/Error'
+    - type: object
+      properties:
+        code:
+          type: string
+          enum:
+            - OPERATION_NOT_ALLOWED
 Error.RegisterNotFound:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Error'

--- a/pepper-apis/docs/specification/src/endpoints/post-password-reset.yml
+++ b/pepper-apis/docs/specification/src/endpoints/post-password-reset.yml
@@ -1,0 +1,64 @@
+get:
+  operationId: getPostPasswordReset
+  tags:
+    - Other
+  summary: Post Password Reset
+  description: |
+    This API may be used in the Auth0 Password Reset Flow. Clients should not
+    call this directly, but rather configure their flow such that Auth0 calls
+    this API after user finishes password reset. This API will then call the
+    configured client application URL using a 302 redirect.
+
+    The redirect will provide the following query parameters:
+    - `errorCode` (string): will be set to `PASSWORD_RESET_LINK_EXPIRED` if
+      password reset flow failed
+  parameters:
+    - in: query
+      name: clientId
+      required: true
+      description: the auth0 client id
+      schema:
+        type: string
+    - in: query
+      name: domain
+      required: false
+      description: the auth0 client domain
+      schema:
+        type: string
+    - in: query
+      name: success
+      required: true
+      description: whether password reset succeeded or not, should be provided by auth0
+      schema:
+        type: boolean
+  responses:
+    302:
+      description: password reset is successful
+    400:
+      description: client id  is not provided or not unique
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../pepper.yml#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    enum:
+                      - BAD_PAYLOAD
+                      - REQUIRED_PARAMETER_MISSING
+    404:
+      description: client is not found
+      content:
+        application/json:
+          schema:
+            $ref: '../pepper.yml#/components/schemas/Error.NotFound'
+    422:
+      description: client is revoked or no application URL is configured
+      content:
+        application/json:
+          schema:
+            $ref: '../pepper.yml#/components/schemas/Error.OperationNotAllowed'
+    default:
+      $ref: '../pepper.yml#/components/responses/ErrorResponse'

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers: []
 info:
   description: 'Pepper API specification'
-  version: 1.9.0
+  version: 1.9.1
   title: Pepper
   contact:
     email: info@datadonationplatform.org
@@ -122,6 +122,8 @@ paths:
     $ref: 'endpoints/cancers.yml'
   /autocomplete/institution:
     $ref: 'endpoints/autocomplete.institution.yml'
+  /post-password-reset:
+    $ref: 'endpoints/post-password-reset.yml'
 components:
   parameters:
     $ref: 'components/parameters.yml'

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
@@ -185,7 +185,6 @@ public class RouteConstants {
         public static final String IRB_PASSWORD = "irbPassword";
         public static final String AUTH0_CLIENT_ID  = "clientId";
         public static final String AUTH0_DOMAIN  = "domain";
-        public static final String EMAIL  = "email";
         public static final String SUCCESS  = "success";
         public static final String UMBRELLA = "umbrella";
         public static final String TYPEAHEAD_QUERY = "q";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PostPasswordResetRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PostPasswordResetRoute.java
@@ -3,11 +3,9 @@ package org.broadinstitute.ddp.route;
 import java.util.Optional;
 
 import okhttp3.HttpUrl;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.QueryParam;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -15,10 +13,8 @@ import org.broadinstitute.ddp.db.dao.JdbiClient;
 import org.broadinstitute.ddp.db.dto.ClientDto;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.util.ResponseUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -35,13 +31,12 @@ public class PostPasswordResetRoute implements Route {
     public Object handle(Request request, Response response) throws Exception {
         String auth0ClientId = request.queryParams(QueryParam.AUTH0_CLIENT_ID);
         String auth0Domain = request.queryParams(QueryParam.AUTH0_DOMAIN);
-        String email = request.queryParams(QueryParam.EMAIL);
         String auth0Success = request.queryParams(QueryParam.SUCCESS);
 
-        if (StringUtils.isBlank(auth0ClientId) || StringUtils.isBlank(email)) {
-            String errMsg = "auth0ClientId and email query string parameters are mandatory";
+        if (StringUtils.isBlank(auth0ClientId)) {
+            String errMsg = "auth0ClientId query string parameter is mandatory";
             LOG.warn(errMsg);
-            ResponseUtil.haltError(response, HttpStatus.SC_BAD_REQUEST, new ApiError(ErrorCodes.REQUIRED_PARAMETER_MISSING, errMsg));
+            throw ResponseUtil.haltError(response, HttpStatus.SC_BAD_REQUEST, new ApiError(ErrorCodes.REQUIRED_PARAMETER_MISSING, errMsg));
         }
 
         HttpUrl clientPwdResetUrl = null;
@@ -67,7 +62,6 @@ public class PostPasswordResetRoute implements Route {
         }
 
         HttpUrl.Builder urlBuilder = clientPwdResetUrl.newBuilder();
-        urlBuilder.addQueryParameter(QueryParam.EMAIL, email);
 
         if (!Boolean.valueOf(auth0Success)) {
             String errMsg = "success parameter is FALSE, which means that the Auth0 link has expired";

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PostPasswordResetRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PostPasswordResetRouteTest.java
@@ -8,10 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import okhttp3.HttpUrl;
-
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
-
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.API;
@@ -26,9 +24,7 @@ import org.broadinstitute.ddp.security.EncryptionKey;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.broadinstitute.ddp.util.TestDataSetupUtil.GeneratedTestData;
 import org.broadinstitute.ddp.util.TestUtil;
-
 import org.hamcrest.Matchers;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -41,7 +37,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
     private static String auth0Domain;
     private static final String testEmail = "test_user@datadonationplatform.org";
     private static final String testRedirectUrl = "http://www.datadonationplatform.org/default-password-reset-page/";
-    private static final String testRedirectUrlWithEmail = testRedirectUrl + "?" + QueryParam.EMAIL + "=" + testEmail;
 
     @BeforeClass
     public static void setup() {
@@ -63,13 +58,12 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
                 .when().get(fullUrl.toString()).then().assertThat()
                 .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
-                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrlWithEmail));
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
     }
 
     @Test
@@ -77,7 +71,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, nonExistentAuth0Client);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -93,7 +86,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -105,23 +97,10 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
     }
 
     @Test
-    public void test_WhenRouteIsCalledWithEmptyEmail_ItRespondsWithBadRequest() {
-        Map<String, String> queryParams = new HashMap<>();
-        queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
-        queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, "");
-        queryParams.put(QueryParam.SUCCESS, "true");
-        HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
-        given().when().get(fullUrl.toString()).then().assertThat()
-                .statusCode(HttpStatus.SC_BAD_REQUEST);
-    }
-
-    @Test
     public void test_WhenRouteIsCalledWithEmptyClientId_ItRespondsWithBadRequest() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, "");
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -133,13 +112,12 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, "");
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
                 .when().get(fullUrl.toString()).then().assertThat()
                 .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
-                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrlWithEmail));
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
     }
 
     @Test
@@ -182,7 +160,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
             Map<String, String> queryParams = new HashMap<>();
             queryParams.put(QueryParam.AUTH0_CLIENT_ID, duplicatedAuth0ClientId);
             queryParams.put(QueryParam.AUTH0_DOMAIN, "");
-            queryParams.put(QueryParam.EMAIL, testEmail);
             queryParams.put(QueryParam.SUCCESS, "true");
             HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
             given().when().get(fullUrl.toString()).then().assertThat()
@@ -206,7 +183,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "false");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
@@ -224,7 +200,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -244,7 +219,6 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
-        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()


### PR DESCRIPTION
## Context

Removing the requirement on `email` query parameter in the post-password-reset API, since that is not used by downstream clients and is causing issues in TestBoston.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have updated existing tests

## Release

- [x] These changes require no special release procedures--just code!

