### PR TITLE
DDP-4910 make email optional in post-password-reset

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/post-password-reset.yml
+++ b/pepper-apis/docs/specification/src/endpoints/post-password-reset.yml
@@ -10,6 +10,7 @@ get:
     configured client application URL using a 302 redirect.
 
     The redirect will provide the following query parameters:
+    - `email` (string): if provided by auth0
     - `errorCode` (string): will be set to `PASSWORD_RESET_LINK_EXPIRED` if
       password reset flow failed
   parameters:
@@ -23,6 +24,12 @@ get:
       name: domain
       required: false
       description: the auth0 client domain
+      schema:
+        type: string
+    - in: query
+      name: email
+      required: false
+      description: the user's email, should be provided by auth0
       schema:
         type: string
     - in: query

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
@@ -185,6 +185,7 @@ public class RouteConstants {
         public static final String IRB_PASSWORD = "irbPassword";
         public static final String AUTH0_CLIENT_ID  = "clientId";
         public static final String AUTH0_DOMAIN  = "domain";
+        public static final String EMAIL = "email";
         public static final String SUCCESS  = "success";
         public static final String UMBRELLA = "umbrella";
         public static final String TYPEAHEAD_QUERY = "q";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PostPasswordResetRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PostPasswordResetRoute.java
@@ -31,6 +31,7 @@ public class PostPasswordResetRoute implements Route {
     public Object handle(Request request, Response response) throws Exception {
         String auth0ClientId = request.queryParams(QueryParam.AUTH0_CLIENT_ID);
         String auth0Domain = request.queryParams(QueryParam.AUTH0_DOMAIN);
+        String email = request.queryParams(QueryParam.EMAIL);
         String auth0Success = request.queryParams(QueryParam.SUCCESS);
 
         if (StringUtils.isBlank(auth0ClientId)) {
@@ -62,6 +63,9 @@ public class PostPasswordResetRoute implements Route {
         }
 
         HttpUrl.Builder urlBuilder = clientPwdResetUrl.newBuilder();
+        if (StringUtils.isNotBlank(email)) {
+            urlBuilder.addQueryParameter(QueryParam.EMAIL, email);
+        }
 
         if (!Boolean.valueOf(auth0Success)) {
             String errMsg = "success parameter is FALSE, which means that the Auth0 link has expired";

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PostPasswordResetRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PostPasswordResetRouteTest.java
@@ -37,6 +37,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
     private static String auth0Domain;
     private static final String testEmail = "test_user@datadonationplatform.org";
     private static final String testRedirectUrl = "http://www.datadonationplatform.org/default-password-reset-page/";
+    private static final String testRedirectUrlWithEmail = testRedirectUrl + "?" + QueryParam.EMAIL + "=" + testEmail;
 
     @BeforeClass
     public static void setup() {
@@ -58,12 +59,13 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
                 .when().get(fullUrl.toString()).then().assertThat()
                 .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
-                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrlWithEmail));
     }
 
     @Test
@@ -71,6 +73,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, nonExistentAuth0Client);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -86,6 +89,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -97,10 +101,38 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
     }
 
     @Test
+    public void test_WhenRouteIsCalledWithEmptyEmail_ItRedirectsWithoutEmail() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
+        queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, "");
+        queryParams.put(QueryParam.SUCCESS, "true");
+        HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
+        given(TestUtil.RestAssured.nonFollowingRequestSpec())
+                .when().get(fullUrl.toString()).then().assertThat()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
+    }
+
+    @Test
+    public void test_WhenRouteIsCalledWithoutEmail_ItRedirectsWithoutEmail() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
+        queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.SUCCESS, "true");
+        HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
+        given(TestUtil.RestAssured.nonFollowingRequestSpec())
+                .when().get(fullUrl.toString()).then().assertThat()
+                .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
+    }
+
+    @Test
     public void test_WhenRouteIsCalledWithEmptyClientId_ItRespondsWithBadRequest() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, "");
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -112,12 +144,13 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, "");
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
                 .when().get(fullUrl.toString()).then().assertThat()
                 .statusCode(HttpStatus.SC_MOVED_TEMPORARILY)
-                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrl));
+                .header(HttpHeaders.LOCATION, equalTo(testRedirectUrlWithEmail));
     }
 
     @Test
@@ -160,6 +193,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
             Map<String, String> queryParams = new HashMap<>();
             queryParams.put(QueryParam.AUTH0_CLIENT_ID, duplicatedAuth0ClientId);
             queryParams.put(QueryParam.AUTH0_DOMAIN, "");
+            queryParams.put(QueryParam.EMAIL, testEmail);
             queryParams.put(QueryParam.SUCCESS, "true");
             HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
             given().when().get(fullUrl.toString()).then().assertThat()
@@ -183,6 +217,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "false");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given(TestUtil.RestAssured.nonFollowingRequestSpec())
@@ -200,6 +235,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()
@@ -219,6 +255,7 @@ public class PostPasswordResetRouteTest extends IntegrationTestSuite.TestCase {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put(QueryParam.AUTH0_CLIENT_ID, auth0ClientId);
         queryParams.put(QueryParam.AUTH0_DOMAIN, auth0Domain);
+        queryParams.put(QueryParam.EMAIL, testEmail);
         queryParams.put(QueryParam.SUCCESS, "true");
         HttpUrl fullUrl = buildEncodedUrl(url, queryParams);
         given().when().get(fullUrl.toString()).then().assertThat()


### PR DESCRIPTION
## Context

Making `email` optional so existing apps continue with same behavior while fixing issue for TestBoston.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests

## Release

- [x] These changes require no special release procedures--just code!
