### PR TITLE
testboston: base skeleton study

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/ActivityBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/ActivityBuilder.java
@@ -105,6 +105,9 @@ public class ActivityBuilder {
     }
 
     private void insertActivities(Handle handle) {
+        if (!cfg.hasPath("activities")) {
+            return;
+        }
         Instant timestamp = ConfigUtil.getInstantIfPresent(cfg, "activityTimestamp");
         for (Config activityCfg : cfg.getConfigList("activities")) {
             Config definitionCfg = readDefinitionConfig(activityCfg.getString("filepath"));
@@ -201,6 +204,10 @@ public class ActivityBuilder {
     }
 
     private void insertActivityStatusIcons(Handle handle) {
+        if (!cfg.hasPath("activityStatusIcons")) {
+            return;
+        }
+
         JdbiFormTypeActivityInstanceStatusType jdbiStatusIcon = handle.attach(JdbiFormTypeActivityInstanceStatusType.class);
 
         String reason = String.format("Create activity status icons for study=%s", studyDto.getGuid());

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -64,6 +64,9 @@ public class EventBuilder {
     }
 
     private void insertEvents(Handle handle) {
+        if (!cfg.hasPath("events")) {
+            return;
+        }
         for (Config eventCfg : cfg.getConfigList("events")) {
             insertEvent(handle, eventCfg);
         }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/PdfBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/PdfBuilder.java
@@ -135,6 +135,9 @@ public class PdfBuilder {
     }
 
     void run(Handle handle) {
+        if (!cfg.hasPath("pdfs")) {
+            return;
+        }
         for (Config pdfCfg : cfg.getConfigList("pdfs")) {
             insertPdfConfig(handle, pdfCfg);
         }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
@@ -33,6 +33,9 @@ public class WorkflowBuilder {
     }
 
     private void insertTransitions(Handle handle) {
+        if (!cfg.hasPath("workflowTransitions")) {
+            return;
+        }
         for (Config transitionCfg : cfg.getConfigList("workflowTransitions")) {
             insertTransitionSet(handle, transitionCfg);
         }

--- a/study-builder/studies/testboston/study-base.conf
+++ b/study-builder/studies/testboston/study-base.conf
@@ -1,0 +1,57 @@
+{
+  "tenant": {
+    "domain": ${auth0.domain},
+    "mgmtClientId": ${auth0.mgmtClientId},
+    "mgmtSecret": ${auth0.mgmtClientSecret}
+  },
+
+  "umbrella": {
+    "name": "TestBoston",
+    "guid": ${id.study}
+  },
+
+  "study": {
+    "name": "TestBoston",
+    "guid": ${id.study},
+    "studyEmail": ${contact.email},
+    "baseWebUrl": ${baseWebUrl},
+    "irbPassword": ${irbPassword},
+    "recaptchaSiteKey": ${recaptchaSiteKey},
+    "plusCodePrecision": null,
+    "shareParticipantLocation": false,
+  },
+
+  "clients": [
+    {
+      "id": ${auth0.appClientId},
+      "secret": ${auth0.appClientSecret},
+      "passwordRedirectUrl": ${passwordRedirectUrl}
+    },
+    {
+      "id": ${auth0.crcClientId},
+      "secret": ${auth0.crcClientSecret},
+      "passwordRedirectUrl": null
+    },
+  ],
+
+  "adminUser": {
+    "guid": "TESTBOSTONADMINUSER1"
+  },
+
+  "supportedLanguages": [
+    {
+      "language": "en",
+      "name": "English",
+      "isDefault": true
+    },
+    {
+      "language": "es",
+      "name": "Español"
+    },
+    {
+      "language": "ht",
+      "name": "Kreyòl"
+    }
+  ],
+
+}

--- a/study-builder/studies/testboston/study.conf
+++ b/study-builder/studies/testboston/study.conf
@@ -1,42 +1,5 @@
 {
-  "tenant": {
-    "domain": ${auth0.domain},
-    "mgmtClientId": ${auth0.mgmtClientId},
-    "mgmtSecret": ${auth0.mgmtClientSecret}
-  },
-
-  "umbrella": {
-    "name": "TestBoston",
-    "guid": ${id.study}
-  },
-
-  "study": {
-    "name": "TestBoston",
-    "guid": ${id.study},
-    "studyEmail": ${contact.email},
-    "baseWebUrl": ${baseWebUrl},
-    "irbPassword": ${irbPassword},
-    "recaptchaSiteKey": ${recaptchaSiteKey},
-    "plusCodePrecision": null,
-    "shareParticipantLocation": false,
-  },
-
-  "clients": [
-    {
-      "id": ${auth0.appClientId},
-      "secret": ${auth0.appClientSecret},
-      "passwordRedirectUrl": ${passwordRedirectUrl}
-    },
-    {
-      "id": ${auth0.crcClientId},
-      "secret": ${auth0.crcClientSecret},
-      "passwordRedirectUrl": null
-    },
-  ],
-
-  "adminUser": {
-    "guid": "TESTBOSTONADMINUSER1"
-  },
+  include required("study-base.conf"),
 
   "studyDetails": [
     {
@@ -53,22 +16,6 @@
       "language": "ht",
       "name": "TestBoston",
       "summary": null
-    }
-  ],
-
-  "supportedLanguages": [
-    {
-      "language": "en",
-      "name": "English",
-      "isDefault": true
-    },
-    {
-      "language": "es",
-      "name": "Español"
-    },
-    {
-      "language": "ht",
-      "name": "Kreyòl"
     }
   ],
 


### PR DESCRIPTION
We can setup skeleton study without changing code, but I'll rather not have to fiddle with anything when doing a prod deploy. I pulled out the minimal set of configs out to a `study-base.conf` file that we can run to setup TestBoston skeleton. With this change, we can just run a single command for the skeleton:

```
java -Dconfig.file=output-config/application.conf -jar target/StudyBuilder.jar \
    --vars output-config/testboston-vars.conf \
    --substitutions studies/testboston/subs.conf \
    studies/testboston/study-base.conf
```