### PR TITLE
DDP-4927 allow configuring exclude_status_icon_from_display

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -230,6 +230,7 @@ Activity.Summary:
       description: a Base64 encoded png or jpg image
       example: YW55IGN...BwbGVhc3VyZQ==
       type: string
+      nullable: true
     instanceGuid:
       example: 6B03213FD0
       type: string

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
@@ -81,6 +81,7 @@ public class SqlConstants {
         public static final String IS_WRITE_ONCE = "is_write_once";
         public static final String ALLOW_ONDEMAND_TRIGGER = "allow_ondemand_trigger";
         public static final String EXCLUDE_FROM_DISPLAY = "exclude_from_display";
+        public static final String EXCLUDE_STATUS_ICON_FROM_DISPLAY = "exclude_status_icon_from_display";
         public static final String ALLOW_UNAUTHENTICATED = "allow_unauthenticated";
         public static final String IS_FOLLOWUP = "is_followup";
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
@@ -293,7 +293,8 @@ public class ActivityInstanceDao {
                     String statusTypeCode =
                             rs.getString(SqlConstants.ActivityInstanceStatusTypeTable.ACTIVITY_STATUS_TYPE_CODE);
                     FormType formType = formTypeCode != null ? FormType.valueOf(formTypeCode) : null;
-                    Blob iconBlob = formTypeAndStatusTypeToIcon.get(formType + "-" + statusTypeCode);
+                    boolean excludeStatusIconFromDisplay = rs.getBoolean(SqlConstants.StudyActivityTable.EXCLUDE_STATUS_ICON_FROM_DISPLAY);
+                    Blob iconBlob = excludeStatusIconFromDisplay ? null : formTypeAndStatusTypeToIcon.get(formType + "-" + statusTypeCode);
                     String iconBase64 = iconBlob != null
                             ? Base64.getEncoder().encodeToString(iconBlob.getBytes(1, (int) iconBlob.length())) : null;
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -76,8 +76,8 @@ public interface FormActivityDao extends SqlObject {
 
         long activityId = jdbiActivity.insertActivity(activityTypeId, studyId, activity.getActivityCode(),
                 activity.getMaxInstancesPerUser(), activity.getDisplayOrder(), activity.isWriteOnce(), activity.getEditTimeoutSec(),
-                activity.isOndemandTriggerAllowed(), activity.isExcludeFromDisplay(), activity.isAllowUnauthenticated(),
-                activity.isFollowup());
+                activity.isOndemandTriggerAllowed(), activity.isExcludeFromDisplay(), activity.isExcludeStatusIconFromDisplay(),
+                activity.isAllowUnauthenticated(), activity.isFollowup());
         activity.setActivityId(activityId);
 
         long versionId = jdbiVersion.insert(activity.getActivityId(), activity.getVersionTag(), revisionId);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -27,10 +27,10 @@ public interface JdbiActivity extends SqlObject {
     @SqlUpdate("insert into study_activity"
             + " (activity_type_id,study_id,study_activity_code,max_instances_per_user,display_order,"
             + "is_write_once, instantiate_upon_registration,edit_timeout_sec,allow_ondemand_trigger,"
-            + "exclude_from_display, allow_unauthenticated, is_followup)"
+            + "exclude_from_display, exclude_status_icon_from_display, allow_unauthenticated, is_followup)"
             + " values(:activityTypeId,:studyId,:activityCode,"
             + ":maxInstancesPerUser,:displayOrder,:writeOnce,0,:editTimeoutSec,:allowOndemandTrigger,"
-            + ":excludeFromDisplay, :allowUnauthenticated, :isFollowup)")
+            + ":excludeFromDisplay, :excludeStatusIconFromDisplay, :allowUnauthenticated, :isFollowup)")
     @GetGeneratedKeys()
     long insertActivity(
             @Bind("activityTypeId") long activityTypeId,
@@ -42,6 +42,7 @@ public interface JdbiActivity extends SqlObject {
             @Bind("editTimeoutSec") Long editTimeoutSec,
             @Bind("allowOndemandTrigger") boolean allowOndemandTrigger,
             @Bind("excludeFromDisplay") boolean excludeFromDisplay,
+            @Bind("excludeStatusIconFromDisplay") boolean excludeStatusIconFromDisplay,
             @Bind("allowUnauthenticated") boolean allowUnauthenticated,
             @Bind("isFollowup") boolean isFollowup
     );

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
@@ -57,6 +57,9 @@ public abstract class ActivityDef {
     @SerializedName("excludeFromDisplay")
     protected boolean excludeFromDisplay;
 
+    @SerializedName("excludeStatusIconFromDisplay")
+    protected boolean excludeStatusIconFromDisplay;
+
     @SerializedName("allowUnauthenticated")
     protected boolean allowUnauthenticated;
 
@@ -224,6 +227,10 @@ public abstract class ActivityDef {
         return excludeFromDisplay;
     }
 
+    public boolean isExcludeStatusIconFromDisplay() {
+        return excludeStatusIconFromDisplay;
+    }
+
     public boolean isAllowUnauthenticated() {
         return allowUnauthenticated;
     }
@@ -250,6 +257,7 @@ public abstract class ActivityDef {
         protected Long editTimeoutSec = null;
         protected boolean allowOndemandTrigger = false;
         protected boolean excludeFromDisplay = false;
+        protected boolean excludeStatusIconFromDisplay = false;
         protected boolean allowUnauthenticated = false;
         protected List<Translation> names = new ArrayList<>();
         protected List<Translation> titles = new ArrayList<>();
@@ -275,6 +283,7 @@ public abstract class ActivityDef {
             activity.editTimeoutSec = editTimeoutSec;
             activity.allowOndemandTrigger = allowOndemandTrigger;
             activity.excludeFromDisplay = excludeFromDisplay;
+            activity.excludeStatusIconFromDisplay = excludeStatusIconFromDisplay;
             activity.allowUnauthenticated = allowUnauthenticated;
             activity.readonlyHintTemplate = readonlyHintTemplate;
             activity.isFollowup = isFollowup;
@@ -332,6 +341,11 @@ public abstract class ActivityDef {
 
         public T setExcludeFromDisplay(boolean excludeFromDisplay) {
             this.excludeFromDisplay = excludeFromDisplay;
+            return self();
+        }
+
+        public T setExcludeStatusIconFromDisplay(boolean excludeStatusIconFromDisplay) {
+            this.excludeStatusIconFromDisplay = excludeStatusIconFromDisplay;
             return self();
         }
 

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -226,4 +226,5 @@
     <include file="db-changes/schema/DDP-4876-mailing-address-component-required-flags.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4854-increase-i18nstudyactivity-title-len.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/testboston-delivered.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-4927-exclude-status-icon-from-display.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-4927-exclude-status-icon-from-display.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-4927-exclude-status-icon-from-display.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200910-exclude-status-icon-from-display-column">
+        <addColumn tableName="study_activity">
+            <column name="exclude_status_icon_from_display" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/sql.conf
+++ b/pepper-apis/src/main/resources/sql.conf
@@ -8,6 +8,7 @@
         act.edit_timeout_sec,
         act.is_write_once,
         act.exclude_from_display,
+        act.exclude_status_icon_from_display,
         act.is_followup,
         actv.version_tag,
         actv.revision_id,

--- a/study-builder/studies/snippets/activity-general-form.conf
+++ b/study-builder/studies/snippets/activity-general-form.conf
@@ -6,9 +6,13 @@
   "creationExpr": null,
   "maxInstancesPerUser": null,
   "allowOndemandTrigger": false,
-  "excludeFromDisplay": false,
   "allowUnauthenticated": false,
   "listStyleHint": "NONE",
+
+  # Should activity instances be excluded when listing user's activity instances? Optional, defaults to false.
+  "excludeFromDisplay": false,
+  # Should the status icon be excluded when listing the activity instances? Optional, defaults to false.
+  "excludeStatusIconFromDisplay": false,
 
   # Should a snapshot of activity substitution values be saved on the first submit?
   #


### PR DESCRIPTION
## Context

Allow configuring whether to exclude the status icon when listing activity instances.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!
