### PR TITLE
DDP-4934 support events based on corrected status of test result

### DIFF
--- a/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
+++ b/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
@@ -27,6 +27,7 @@ query
   | 'user' '.' study '.' form '.' question '.' 'answers' '.' predicate                   # DefaultLatestAnswerQuery
   | 'user' '.' study '.' form '.' instance '.' question '.' 'answers' '.' predicate      # AnswerQuery
   | 'user' '.' 'profile' '.' profileDataQuery   # ProfileQuery
+  | 'user' '.' 'event' '.' 'testResult' '.' testResultQuery   # EventTestResultQuery
   ;
 
 study : 'studies' '[' STR ']' ;
@@ -71,6 +72,12 @@ predicate
 // Queries to pull out various pieces of profile data
 profileDataQuery
   : 'birthDate' '(' ')'   # ProfileBirthDateQuery
+  ;
+
+// Queries for current test result event.
+testResultQuery
+  : 'isCorrected' '(' ')'   # IsCorrectedTestResultQuery
+  | 'isPositive' '(' ')'    # IsPositiveTestResultQuery
   ;
 
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.model.dsm.TestResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -94,9 +95,9 @@ public class RenderValueProvider {
         if (StringUtils.isBlank(testResultCode)) {
             return null;
         }
-        if ("POSITIVE".equals(testResultCode)) {
+        if (TestResult.POSITIVE_CODE.equals(testResultCode)) {
             return posText;
-        } else if ("NEGATIVE".equals(testResultCode)) {
+        } else if (TestResult.NEGATIVE_CODE.equals(testResultCode)) {
             return negText;
         } else {
             return otherText;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/TestResult.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/TestResult.java
@@ -10,18 +10,25 @@ import org.broadinstitute.ddp.transformers.InstantToIsoDateTimeUtcStrAdapter;
 
 public class TestResult {
 
+    public static final String NEGATIVE_CODE = "NEGATIVE";
+    public static final String POSITIVE_CODE = "POSITIVE";
+
     @NotBlank
     @SerializedName("result")
-    private String result;
+    private final String result;
 
     @NotNull
     @SerializedName("timeCompleted")
     @JsonAdapter(InstantToIsoDateTimeUtcStrAdapter.class)
-    private Instant timeCompleted;
+    private final Instant timeCompleted;
 
-    public TestResult(String result, Instant timeCompleted) {
+    @SerializedName("isCorrected")
+    private final boolean isCorrected;
+
+    public TestResult(String result, Instant timeCompleted, boolean isCorrected) {
         this.result = result;
         this.timeCompleted = timeCompleted;
+        this.isCorrected = isCorrected;
     }
 
     public String getResult() {
@@ -31,9 +38,9 @@ public class TestResult {
     public String getNormalizedResult() {
         String res = result.toUpperCase();
         if ("NEG".equals(res)) {
-            return "NEGATIVE";
+            return NEGATIVE_CODE;
         } else if ("POS".equals(res)) {
-            return "POSITIVE";
+            return POSITIVE_CODE;
         } else {
             return res;
         }
@@ -41,5 +48,9 @@ public class TestResult {
 
     public Instant getTimeCompleted() {
         return timeCompleted;
+    }
+
+    public boolean isCorrected() {
+        return isCorrected;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/InterpreterContext.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/InterpreterContext.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.pex;
 
 import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
+import org.broadinstitute.ddp.model.event.EventSignal;
 import org.jdbi.v3.core.Handle;
 
 /**
@@ -13,20 +14,16 @@ class InterpreterContext {
     private final Handle handle;
     private final String userGuid;
     private final String activityInstanceGuid;
-    private UserActivityInstanceSummary activityInstanceSummary;
+    private final UserActivityInstanceSummary activityInstanceSummary;
+    private final EventSignal eventSignal;
 
-    // enum for whether ai guid is relevant
-
-    InterpreterContext(Handle handle, String userGuid, String activityInstanceGuid) {
+    InterpreterContext(Handle handle, String userGuid, String activityInstanceGuid,
+                       UserActivityInstanceSummary activityInstanceSummary, EventSignal eventSignal) {
         this.handle = handle;
         this.userGuid = userGuid;
         this.activityInstanceGuid = activityInstanceGuid;
-    }
-
-    InterpreterContext(Handle handle, String userGuid, String activityInstanceGuid,
-                       UserActivityInstanceSummary activityInstanceSummary) {
-        this(handle, userGuid, activityInstanceGuid);
         this.activityInstanceSummary = activityInstanceSummary;
+        this.eventSignal = eventSignal;
     }
 
     public Handle getHandle() {
@@ -43,5 +40,9 @@ class InterpreterContext {
 
     public UserActivityInstanceSummary getActivityInstanceSummary() {
         return activityInstanceSummary;
+    }
+
+    public EventSignal getEventSignal() {
+        return eventSignal;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/PexInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/PexInterpreter.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.pex;
 
 import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
+import org.broadinstitute.ddp.model.event.EventSignal;
 import org.jdbi.v3.core.Handle;
 
 /**
@@ -26,4 +27,6 @@ public interface PexInterpreter {
     boolean eval(String expression, Handle handle, String userGuid, String activityInstanceGuid,
                  UserActivityInstanceSummary activityInstanceSummary);
 
+    boolean eval(String expression, Handle handle, String userGuid, String activityInstanceGuid,
+                 UserActivityInstanceSummary activityInstanceSummary, EventSignal signal);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/EventService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/EventService.java
@@ -70,7 +70,7 @@ public class EventService {
                         cancelExpr, eventConfig.getEventConfigurationId());
                 try {
                     boolean shouldCancel = pexInterpreter.eval(cancelExpr, handle, eventSignal.getParticipantGuid(),
-                            null);
+                            null, null, eventSignal);
                     if (shouldCancel) {
                         LOG.info("Cancel expression `{}` evaluated to TRUE, skipping the configuration", cancelExpr);
                         return;
@@ -89,7 +89,7 @@ public class EventService {
             );
             try {
                 if (precondExpr != null && !pexInterpreter.eval(precondExpr, handle,
-                        eventSignal.getParticipantGuid(), null)) {
+                        eventSignal.getParticipantGuid(), null, null, eventSignal)) {
                     LOG.info("Precondition expression {} evaluated to FALSE, skipping the configuration", precondExpr);
                     return;
                 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
@@ -255,7 +255,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
         });
 
         var payload = new DsmNotificationPayload(null, TEST_RESULT.name(), 1L);
-        var result = new TestResult("NEGATIVE", Instant.now());
+        var result = new TestResult("NEGATIVE", Instant.now(), false);
         payload.setEventData(GsonUtil.standardGson().toJsonTree(result));
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())

--- a/study-builder/studies/testboston/study-events.conf
+++ b/study-builder/studies/testboston/study-events.conf
@@ -370,6 +370,7 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": ${id.act.result_report}
       },
+      "cancelExpr": "user.event.testResult.isCorrected()",
       "dispatchToHousekeeping": false,
       "order": 1
     },


### PR DESCRIPTION
## Context

This PR adds support for events that depends on certain properties of a test result. Idea here is to add new queries in PEX that allows looking at the current event data provided in the current evaluation context. If there's no event data, we get a runtime error. This approach gives study configurations a lot of flexibility to define more complex logic.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [x] I have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

