### PR TITLE
Refactor housekeeping tasks receiver

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -48,7 +48,7 @@
     "pdfArchiveUseFilesystem": false,
     "pubsub": {
         "enableHousekeepingTasks": {{$conf.Data.pubsub.enableHousekeepingTasks}},
-        "housekeepingTasksTopic": "{{$conf.Data.pubsub.housekeepingTasksTopic}}",
+        "housekeepingTasksSubscription": "{{$conf.Data.pubsub.housekeepingTasksSubscription}}",
     },
     "studyExportBucket": "{{$conf.Data.studyExportBucket}}",
     "schedules": {

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -92,7 +92,7 @@
     "pdfArchiveUseFilesystem": true,
     "pubsub": {
         "enableHousekeepingTasks": false,
-        "housekeepingTasksTopic": "local-housekeeping-tasks",
+        "housekeepingTasksSubscription": "local-housekeeping-tasks-sub",
     },
     "studyExportBucket": "ddp-dev-study-exports-testing",
     "schedules": {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -22,8 +23,6 @@ import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Publisher;
 import com.google.cloud.pubsub.v1.Subscriber;
 import com.google.gson.Gson;
-import com.google.protobuf.Duration;
-import com.google.pubsub.v1.ExpirationPolicy;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.google.pubsub.v1.PubsubMessage;
@@ -89,7 +88,6 @@ import org.broadinstitute.ddp.service.PdfGenerationService;
 import org.broadinstitute.ddp.service.PdfService;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.ConfigUtil;
-import org.broadinstitute.ddp.util.GuidUtils;
 import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
 import org.jdbi.v3.core.Handle;
@@ -168,7 +166,7 @@ public class Housekeeping {
     private static AfterHandlerCallback afterHandling;
 
     private static Scheduler scheduler;
-    private static Subscriber eventSubscriber;
+    private static Subscriber taskSubscriber;
 
     public static void setAfterHandler(AfterHandlerCallback afterHandler) {
         synchronized (afterHandlerGuard) {
@@ -215,48 +213,10 @@ public class Housekeeping {
         }
         TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, LanguageStore::init);
 
+        setupScheduler(cfg);
+        setupTaskReceiver(cfg, pubSubProject);
+
         final PubSubConnectionManager pubsubConnectionManager = new PubSubConnectionManager(usePubSubEmulator);
-
-        boolean runScheduler = cfg.getBoolean(ConfigFile.RUN_SCHEDULER);
-        if (runScheduler) {
-            LOG.info("Booting job scheduler...");
-            scheduler = JobScheduler.initializeWith(cfg,
-                    CheckAgeUpJob::register,
-                    CheckKitsJob::register,
-                    DataSyncJob::register,
-                    DatabaseBackupJob::register,
-                    DatabaseBackupCheckJob::register,
-                    OnDemandExportJob::register,
-                    TemporaryUserCleanupJob::register,
-                    StudyDataExportJob::register);
-
-            if (cfg.getBoolean(ConfigFile.PUBSUB_ENABLE_HKEEP_TASKS)) {
-                var topicName = ProjectTopicName.of(pubSubProject, cfg.getString(ConfigFile.PUBSUB_HKEEP_TASKS_TOPIC));
-                pubsubConnectionManager.createTopicIfNotExists(topicName);
-
-                var subName = ProjectSubscriptionName.of(pubSubProject,
-                        String.format("%s-%s", topicName.getTopic(), GuidUtils.randomAlphaNumeric()));
-                pubsubConnectionManager.createSubscriptionIfNotExists(Subscription.newBuilder()
-                        .setName(subName.toString())
-                        .setTopic(topicName.toString())
-                        .setAckDeadlineSeconds(PubSubConnectionManager.ACK_DEADLINE_SECONDS)
-                        .setExpirationPolicy(ExpirationPolicy.newBuilder().setTtl(Duration.newBuilder()
-                                .setSeconds(PubSubConnectionManager.SUB_EXPIRATION_DAYS * 24 * 60 * 60)
-                                .build()).build())
-                        .build());
-                LOG.info("Created housekeeping tasks subscription {}", subName);
-
-                HousekeepingTaskReceiver receiver = new HousekeepingTaskReceiver(subName.getSubscription(), scheduler);
-                eventSubscriber = pubsubConnectionManager.subscribe(subName, receiver);
-                eventSubscriber.startAsync();
-                LOG.info("Started housekeeping tasks subscriber to subscription {}", subName);
-            } else {
-                LOG.warn("Housekeeping tasks is not enabled");
-            }
-        } else {
-            LOG.info("Housekeeping job scheduler is not set to run");
-        }
-
         TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, handle -> {
             JdbiMessageDestination messageDestinationDao = handle.attach(JdbiMessageDestination.class);
             for (String topicName : messageDestinationDao.getAllTopics()) {
@@ -461,13 +421,63 @@ public class Housekeeping {
             }
         }
         pubsubConnectionManager.close();
-        if (eventSubscriber != null) {
-            eventSubscriber.stopAsync();
+        if (taskSubscriber != null) {
+            taskSubscriber.stopAsync();
         }
         if (scheduler != null) {
             JobScheduler.shutdownScheduler(scheduler, true);
         }
         LOG.info("Housekeeping is shutting down");
+    }
+
+    private static void setupScheduler(Config cfg) {
+        boolean runScheduler = cfg.getBoolean(ConfigFile.RUN_SCHEDULER);
+        boolean enableHKeepTasks = cfg.getBoolean(ConfigFile.PUBSUB_ENABLE_HKEEP_TASKS);
+        if (runScheduler || enableHKeepTasks) {
+            LOG.info("Booting job scheduler...");
+            scheduler = JobScheduler.initializeWith(cfg);
+            try {
+                // Setup background jobs if scheduler is enabled.
+                if (runScheduler) {
+                    CheckAgeUpJob.register(scheduler, cfg);
+                    CheckKitsJob.register(scheduler, cfg);
+                    DataSyncJob.register(scheduler, cfg);
+                    DatabaseBackupJob.register(scheduler, cfg);
+                    DatabaseBackupCheckJob.register(scheduler, cfg);
+                    TemporaryUserCleanupJob.register(scheduler, cfg);
+                    StudyDataExportJob.register(scheduler, cfg);
+                }
+                // Setup jobs needed for housekeeping-tasks if that's enabled.
+                if (cfg.getBoolean(ConfigFile.PUBSUB_ENABLE_HKEEP_TASKS)) {
+                    OnDemandExportJob.register(scheduler, cfg);
+                    if (!scheduler.checkExists(TemporaryUserCleanupJob.getKey())) {
+                        TemporaryUserCleanupJob.register(scheduler, cfg);
+                    }
+                }
+            } catch (Exception e) {
+                JobScheduler.shutdownScheduler(scheduler, false);
+                throw new DDPException("Failed to setup scheduler jobs", e);
+            }
+        } else {
+            LOG.info("Housekeeping job scheduler is not set to run");
+        }
+    }
+
+    private static void setupTaskReceiver(Config cfg, String projectId) {
+        boolean enableHKeepTasks = cfg.getBoolean(ConfigFile.PUBSUB_ENABLE_HKEEP_TASKS);
+        if (enableHKeepTasks) {
+            var subName = ProjectSubscriptionName.of(projectId, cfg.getString(ConfigFile.PUBSUB_HKEEP_TASKS_SUB));
+            var receiver = new HousekeepingTaskReceiver(subName, scheduler);
+            taskSubscriber = Subscriber.newBuilder(subName, receiver).build();
+            try {
+                taskSubscriber.startAsync().awaitRunning(30L, TimeUnit.SECONDS);
+            } catch (TimeoutException e) {
+                throw new DDPException("Could not start housekeeping tasks subscriber", e);
+            }
+            LOG.info("Started housekeeping tasks subscriber to subscription {}", subName);
+        } else {
+            LOG.warn("Housekeeping tasks is not enabled");
+        }
     }
 
     private static void respondToGAEStartHook(String envPort) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -99,7 +99,7 @@ public class ConfigFile {
     public static final String BACKEND_AUTH0_TEST_SECRET2 = "backendTestSecret2";
     public static final String BACKEND_AUTH0_TEST_CLIENT_NAME2 = "backendTestClientName2";
     public static final String PUBSUB_ENABLE_HKEEP_TASKS = "pubsub.enableHousekeepingTasks";
-    public static final String PUBSUB_HKEEP_TASKS_TOPIC = "pubsub.housekeepingTasksTopic";
+    public static final String PUBSUB_HKEEP_TASKS_SUB = "pubsub.housekeepingTasksSubscription";
     public static final String SLACK_HOOK = "slack.hook";
     public static final String SLACK_CHANNEL = "slack.channel";
     public static final String TEST_USER_AUTH0_ID = "testUserAuth0Id";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
@@ -38,7 +38,6 @@ public class PubSubConnectionManager {
     private static final Logger LOG = LoggerFactory.getLogger(PubSubConnectionManager.class);
 
     public static final int ACK_DEADLINE_SECONDS = 60;
-    public static final long SUB_EXPIRATION_DAYS = 10L;
 
     private final boolean useEmulator;
 


### PR DESCRIPTION
## Context

Refactor the Housekeeping tasks receiver so we no longer need to provider the subscription to match on. There will only be one instance of Housekeeping and so we'll only setup one pubsub subscription for it. Before, it was a big hassle because you have to first go look for the subscription name before sending a task message to Housekeeping.

A new value needs to go into Vault, and we also need to setup the subscription, both of which I have already done on `dev` environment.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] Getting dev into a state where this is user-visible requires some tech fiddling, which I have done.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

