### PR TITLE
DDP-5010 testboston: update activity naming details

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nDao.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.db.dao;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -32,6 +33,15 @@ public interface ActivityI18nDao extends SqlObject {
         long[] ids = getActivityI18nSql().bulkInsertSummaries(activityId, summaries);
         DBUtils.checkInsert(summaries.size(), ids.length);
         return ids;
+    }
+
+    //
+    // updates
+    //
+
+    default void updateDetails(List<ActivityI18nDetail> details) {
+        int[] updatedCounts = getActivityI18nSql().bulkUpdateDetails(details);
+        DBUtils.checkUpdate(details.size(), Arrays.stream(updatedCounts).sum());
     }
 
     //

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nSql.java
@@ -77,4 +77,16 @@ public interface ActivityI18nSql extends SqlObject {
     long[] bulkInsertSummaries(
             @Bind("activityId") long activityId,
             @BindMethods("s") Iterable<SummaryTranslation> summaries);
+
+    //
+    // updates
+    //
+
+    @SqlBatch("update i18n_study_activity"
+            + "   set name = :d.getName,"
+            + "       title = :d.getTitle,"
+            + "       subtitle = :d.getSubtitle,"
+            + "       description = :d.getDescription"
+            + " where i18n_study_activity_id = :d.getId")
+    int[] bulkUpdateDetails(@BindMethods("d") Iterable<ActivityI18nDetail> details);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/i18n/ActivityI18nDetail.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/i18n/ActivityI18nDetail.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.ddp.model.activity.definition.i18n;
 
+import java.util.Objects;
+
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
@@ -76,5 +78,29 @@ public class ActivityI18nDetail {
 
     public String getDescription() {
         return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ActivityI18nDetail that = (ActivityI18nDetail) o;
+        return id == that.id
+                && activityId == that.activityId
+                && langCodeId == that.langCodeId
+                && Objects.equals(isoLangCode, that.isoLangCode)
+                && Objects.equals(name, that.name)
+                && Objects.equals(title, that.title)
+                && Objects.equals(subtitle, that.subtitle)
+                && Objects.equals(description, that.description);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, activityId, langCodeId, isoLangCode, name, title, subtitle, description);
     }
 }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Functions;
@@ -102,7 +101,7 @@ public class UpdateActivityNamingDetails implements CustomTask {
                     titles.getOrDefault(language, null),
                     subtitles.getOrDefault(language, null),
                     descriptions.getOrDefault(language, null));
-            if (isAnyTextDifferent(current, latest)) {
+            if (!current.equals(latest)) {
                 newDetails.add(latest);
             }
         }
@@ -131,13 +130,5 @@ public class UpdateActivityNamingDetails implements CustomTask {
             }
         }
         return newDetails;
-    }
-
-    private boolean isAnyTextDifferent(ActivityI18nDetail current, ActivityI18nDetail latest) {
-        return hash(current) != hash(latest);
-    }
-
-    private int hash(ActivityI18nDetail detail) {
-        return Objects.hash(detail.getName(), detail.getTitle(), detail.getSubtitle(), detail.getDescription());
     }
 }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
@@ -1,0 +1,143 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.google.common.base.Functions;
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.db.dao.ActivityI18nDao;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.model.activity.definition.i18n.ActivityI18nDetail;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * General task to help update activity naming details such as name, title, subtitle, and description. The activity
+ * definition will be read to lookup the latest text to update to. If new text in a new language is added, those will be
+ * inserted as well. This task will do this for all activities in the study.
+ */
+public class UpdateActivityNamingDetails implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateActivityNamingDetails.class);
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyCfg.getString("study.guid"));
+        User admin = handle.attach(UserDao.class).findUserByGuid(studyCfg.getString("adminUser.guid")).get();
+        var activityBuilder = new ActivityBuilder(cfgPath.getParent(), studyCfg, varsCfg, studyDto, admin.getId());
+
+        for (Config activityCfg : studyCfg.getConfigList("activities")) {
+            Config definition = activityBuilder.readDefinitionConfig(activityCfg.getString("filepath"));
+            String activityCode = definition.getString("activityCode");
+            long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
+            LOG.info("Working on activity {}...", activityCode);
+
+            var activityI18nDao = handle.attach(ActivityI18nDao.class);
+            Map<String, ActivityI18nDetail> currentDetails = activityI18nDao
+                    .findDetailsByActivityId(activityId)
+                    .stream()
+                    .collect(Collectors.toMap(ActivityI18nDetail::getIsoLangCode, Functions.identity()));
+
+            Map<String, String> names = collectTranslatedText(definition, "translatedNames");
+            Map<String, String> titles = collectTranslatedText(definition, "translatedTitles");
+            Map<String, String> subtitles = collectTranslatedText(definition, "translatedSubtitles");
+            Map<String, String> descriptions = collectTranslatedText(definition, "translatedDescriptions");
+
+            var newDetails = buildDetailsForUpdate(currentDetails, names, titles, subtitles, descriptions);
+            activityI18nDao.updateDetails(newDetails);
+            LOG.info("Updated for {} languages: {}", newDetails.size(),
+                    newDetails.stream().map(ActivityI18nDetail::getIsoLangCode).collect(Collectors.toList()));
+
+            newDetails = buildDetailsForInsert(activityId, currentDetails, names, titles, subtitles, descriptions);
+            activityI18nDao.insertDetails(newDetails);
+            LOG.info("Created for {} languages: {}", newDetails.size(),
+                    newDetails.stream().map(ActivityI18nDetail::getIsoLangCode).collect(Collectors.toList()));
+        }
+    }
+
+    private Map<String, String> collectTranslatedText(Config activityCfg, String key) {
+        Map<String, String> container = new HashMap<>();
+        for (Config textCfg : activityCfg.getConfigList(key)) {
+            container.put(textCfg.getString("language"), textCfg.getString("text"));
+        }
+        return container;
+    }
+
+    private List<ActivityI18nDetail> buildDetailsForUpdate(
+            Map<String, ActivityI18nDetail> currentDetails,
+            Map<String, String> names,
+            Map<String, String> titles,
+            Map<String, String> subtitles,
+            Map<String, String> descriptions) {
+        List<ActivityI18nDetail> newDetails = new ArrayList<>();
+        for (String language : currentDetails.keySet()) {
+            ActivityI18nDetail current = currentDetails.get(language);
+            ActivityI18nDetail latest = new ActivityI18nDetail(
+                    current.getId(),
+                    current.getActivityId(),
+                    current.getLangCodeId(),
+                    current.getIsoLangCode(),
+                    names.get(language),
+                    titles.getOrDefault(language, null),
+                    subtitles.getOrDefault(language, null),
+                    descriptions.getOrDefault(language, null));
+            if (isAnyTextDifferent(current, latest)) {
+                newDetails.add(latest);
+            }
+        }
+        return newDetails;
+    }
+
+    private List<ActivityI18nDetail> buildDetailsForInsert(
+            long activityId,
+            Map<String, ActivityI18nDetail> currentDetails,
+            Map<String, String> names,
+            Map<String, String> titles,
+            Map<String, String> subtitles,
+            Map<String, String> descriptions) {
+        List<ActivityI18nDetail> newDetails = new ArrayList<>();
+        // Adding something (like a title) without adding a name in that language doesn't make sense,
+        // so keying off of the name is the way to go, and name is also required.
+        for (String language : names.keySet()) {
+            if (!currentDetails.containsKey(language)) {
+                newDetails.add(new ActivityI18nDetail(
+                        activityId,
+                        language,
+                        names.get(language),
+                        titles.getOrDefault(language, null),
+                        subtitles.getOrDefault(language, null),
+                        descriptions.getOrDefault(language, null)));
+            }
+        }
+        return newDetails;
+    }
+
+    private boolean isAnyTextDifferent(ActivityI18nDetail current, ActivityI18nDetail latest) {
+        return hash(current) != hash(latest);
+    }
+
+    private int hash(ActivityI18nDetail detail) {
+        return Objects.hash(detail.getName(), detail.getTitle(), detail.getSubtitle(), detail.getDescription());
+    }
+}

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -148,7 +148,7 @@
     "s4_date": "Date"
   },
   "baseline_covid": {
-    "name": "Covid Survey",
+    "name": "Introductory Survey",
     "title": "<span>Covid-19 Survey <span class=\"activity-header__text\">Please tell us about your experience with COVID-19</span></span>"
   },
   "address": {
@@ -169,7 +169,7 @@
     "title": "Monthly COVID-19 Survey"
   },
   "result_report": {
-    "name": "Covid-19 Test Results",
+    "name": "COVID-19 Test Results",
     "title": "SARS CoV-2 Test Results",
     "label_id": "TestBoston Study ID:",
     "label_dob": "Date of Birth:",

--- a/study-builder/studies/testboston/i18n/es.conf
+++ b/study-builder/studies/testboston/i18n/es.conf
@@ -148,7 +148,7 @@
     "s4_date": "Fecha"
   },
   "baseline_covid": {
-    "name": "Encuesta sobre COVID-19",
+    "name": "[ES] Introductory Survey",
     "title": "<span>Encuesta sobre COVID-19 <span class=\"activity-header__text\">Cuéntenos su experiencia con COVID-19</span></span>"
   },
   "address": {
@@ -169,7 +169,7 @@
     "title": "[ES] Monthly COVID-19 Survey"
   },
   "result_report": {
-    "name": "[ES] Covid-19 Test Results",
+    "name": "[ES] COVID-19 Test Results",
     "title": "[ES] SARS CoV-2 Test Results",
     "label_id": "[ES] TestBoston Study ID:",
     "label_dob": "[ES] Date of Birth:",

--- a/study-builder/studies/testboston/i18n/ht.conf
+++ b/study-builder/studies/testboston/i18n/ht.conf
@@ -148,7 +148,7 @@
     "s4_date": "Dat"
   },
   "baseline_covid": {
-    "name": "Sondaj sou covid",
+    "name": "[HT] Introductory Survey",
     "title": "<span>Sondaj covid-19 <span class=\"activity-header__text\">Tanpri, pale nou de eksperyans ou avèk COVID-19</span></span>"
   },
   "address": {
@@ -169,7 +169,7 @@
     "title": "[HT] Monthly COVID-19 Survey"
   },
   "result_report": {
-    "name": "[HT] Covid-19 Test Results",
+    "name": "[HT] COVID-19 Test Results",
     "title": "[HT] SARS CoV-2 Test Results",
     "label_id": "[HT] TestBoston Study ID:",
     "label_dob": "[HT] Date of Birth:",


### PR DESCRIPTION
## Context

Update activity names for TestBoston. I have added a "general study-builder task" that can update all activity naming details for all activities in a study to their latest text. So we can just run the `UpdateActivityNamingDetails` task instead of having to destroy-and-recreate the study!

On production, we'll run the `UpdateActivityNamingDetails` task once for TestBoston.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] Getting dev into a state where this is user-visible requires some tech fiddling.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

