### PR TITLE
DDP-5012 support activity second names

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
@@ -68,6 +68,7 @@ public class SqlConstants {
         public static final String ID = "study_activity_id";
         public static final String CODE = "study_activity_code";
         public static final String NAME_TRANS = "activity_name_trans";
+        public static final String SECOND_NAME_TRANS = "activity_second_name_trans";
         public static final String TITLE_TRANS = "activity_title_trans";
         public static final String SUBTITLE_TRANS = "activity_subtitle_trans";
         public static final String DESCRIPTION_TRANS = "activity_description_trans";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -28,6 +28,7 @@ public class RenderValueProvider {
     private LocalDate date;
     private String testResultCode;
     private Instant testResultTimeCompleted;
+    private Integer activityInstanceNumber;
 
     private RenderValueProvider() {
         // Use builder.
@@ -120,6 +121,17 @@ public class RenderValueProvider {
         }
     }
 
+    /**
+     * Returns the activity instance number, if available.
+     */
+    public String activityInstanceNumber() {
+        if (activityInstanceNumber == null) {
+            return null;
+        } else {
+            return String.valueOf(activityInstanceNumber);
+        }
+    }
+
     // Get provided values as a map to save as snapshot. Should not be called within templates.
     public Map<String, String> getSnapshot() {
         var snapshot = new HashMap<String, String>();
@@ -197,6 +209,11 @@ public class RenderValueProvider {
             return this;
         }
 
+        public Builder setActivityInstanceNumber(Integer activityInstanceNumber) {
+            provider.activityInstanceNumber = activityInstanceNumber;
+            return this;
+        }
+
         public Builder withSnapshot(Map<String, String> snapshot) {
             String value = snapshot.get(I18nTemplateConstants.Snapshot.PARTICIPANT_GUID);
             if (value != null) {
@@ -251,6 +268,7 @@ public class RenderValueProvider {
             copy.date = provider.date;
             copy.testResultCode = provider.testResultCode;
             copy.testResultTimeCompleted = provider.testResultTimeCompleted;
+            copy.activityInstanceNumber = provider.activityInstanceNumber;
             return copy;
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -132,6 +132,30 @@ public class RenderValueProvider {
         }
     }
 
+    /**
+     * Provides more flexibility for how to display an activity instance number, if available. The activity instance
+     * number will first be adjusted by subtracting the given offset. Then, if the adjusted number is less than the
+     * given cutoff number, then no number will be displayed. The cutoff number effectively serves as the first number
+     * to be displayed after the offset adjustment. The prefix is useful for optionally adding additional text when a
+     * number is displayed (e.g. prepending a space or a "#" symbol).
+     *
+     * @param offsetToSubtract subtract this amount from the number
+     * @param numberCutoff     if adjusted number is less than this cutoff number, no number will be displayed
+     * @param prefix           a prefix to prepend
+     * @return adjusted number
+     */
+    public String activityInstanceNumberDisplay(int offsetToSubtract, int numberCutoff, String prefix) {
+        if (activityInstanceNumber == null) {
+            return null;
+        }
+        int adjustedNumber = activityInstanceNumber - offsetToSubtract;
+        if (adjustedNumber < numberCutoff) {
+            return "";
+        } else {
+            return prefix + adjustedNumber;
+        }
+    }
+
     // Get provided values as a map to save as snapshot. Should not be called within templates.
     public Map<String, String> getSnapshot() {
         var snapshot = new HashMap<String, String>();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityI18nSql.java
@@ -17,31 +17,33 @@ public interface ActivityI18nSql extends SqlObject {
     //
 
     @GetGeneratedKeys
-    @SqlUpdate("insert into i18n_study_activity (study_activity_id, language_code_id, name, title, subtitle, description)"
-            + " values (:activityId, :langId, :name, :title, :subtitle, :description)")
+    @SqlUpdate("insert into i18n_study_activity (study_activity_id, language_code_id, name, second_name, title, subtitle, description)"
+            + " values (:activityId, :langId, :name, :secondName, :title, :subtitle, :description)")
     long insertDetail(
             @Bind("activityId") long activityId,
             @Bind("langId") long languageCodeId,
             @Bind("name") String name,
+            @Bind("secondName") String secondName,
             @Bind("title") String title,
             @Bind("subtitle") String subtitle,
             @Bind("description") String description);
 
     @GetGeneratedKeys
-    @SqlUpdate("insert into i18n_study_activity (study_activity_id, language_code_id, name, title, subtitle, description)"
-            + " select :activityId, language_code_id, :name, :title, :subtitle, :description"
+    @SqlUpdate("insert into i18n_study_activity (study_activity_id, language_code_id, name, second_name, title, subtitle, description)"
+            + " select :activityId, language_code_id, :name, :secondName, :title, :subtitle, :description"
             + "   from language_code where iso_language_code = :isoLangCode")
     long insertDetail(
             @Bind("activityId") long activityId,
             @Bind("isoLangCode") String isoLangCode,
             @Bind("name") String name,
+            @Bind("secondName") String secondName,
             @Bind("title") String title,
             @Bind("subtitle") String subtitle,
             @Bind("description") String description);
 
     @GetGeneratedKeys
-    @SqlBatch("insert into i18n_study_activity (study_activity_id, language_code_id, name, title, subtitle, description)"
-            + "select :d.getActivityId, language_code_id, :d.getName, :d.getTitle, :d.getSubtitle, :d.getDescription"
+    @SqlBatch("insert into i18n_study_activity (study_activity_id, language_code_id, name, second_name, title, subtitle, description)"
+            + "select :d.getActivityId, language_code_id, :d.getName, :d.getSecondName, :d.getTitle, :d.getSubtitle, :d.getDescription"
             + "  from language_code where iso_language_code = :d.getIsoLangCode")
     long[] bulkInsertDetails(@BindMethods("d") Iterable<ActivityI18nDetail> details);
 
@@ -84,6 +86,7 @@ public interface ActivityI18nSql extends SqlObject {
 
     @SqlBatch("update i18n_study_activity"
             + "   set name = :d.getName,"
+            + "       second_name = :d.getSecondName,"
             + "       title = :d.getTitle,"
             + "       subtitle = :d.getSubtitle,"
             + "       description = :d.getDescription"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -85,6 +85,8 @@ public interface FormActivityDao extends SqlObject {
 
         Map<String, String> names = activity.getTranslatedNames().stream()
                 .collect(Collectors.toMap(Translation::getLanguageCode, Translation::getText));
+        Map<String, String> secondNames = activity.getTranslatedSecondNames().stream()
+                .collect(Collectors.toMap(Translation::getLanguageCode, Translation::getText));
         Map<String, String> titles = activity.getTranslatedTitles().stream()
                 .collect(Collectors.toMap(Translation::getLanguageCode, Translation::getText));
         Map<String, String> subtitles = activity.getTranslatedSubtitles().stream()
@@ -100,6 +102,7 @@ public interface FormActivityDao extends SqlObject {
                     activityId,
                     isoLangCode,
                     name,
+                    secondNames.getOrDefault(isoLangCode, null),
                     titles.getOrDefault(isoLangCode, null),
                     subtitles.getOrDefault(isoLangCode, null),
                     descriptions.getOrDefault(isoLangCode, null)

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
@@ -60,6 +60,8 @@ public class ActivityInstanceSummary implements TranslatedSummary {
     private transient String activityTypeName;
     private transient boolean excludeFromDisplay;
     private transient boolean isHidden;
+    private transient String activitySecondName;
+    private transient int instanceNumber;
 
     /**
      * Instantiates ActivityInstanceSummary object.
@@ -69,6 +71,7 @@ public class ActivityInstanceSummary implements TranslatedSummary {
             long activityInstanceId,
             String activityInstanceGuid,
             String activityName,
+            String activitySecondName,
             String activityTitle,
             String activitySubtitle,
             String activityDescription,
@@ -89,6 +92,7 @@ public class ActivityInstanceSummary implements TranslatedSummary {
         this.activityInstanceId = activityInstanceId;
         this.activityInstanceGuid = activityInstanceGuid;
         this.activityName = activityName;
+        this.activitySecondName = activitySecondName;
         this.activityTitle = activityTitle;
         this.activitySubtitle = activitySubtitle;
         this.activityDescription = activityDescription;
@@ -127,6 +131,10 @@ public class ActivityInstanceSummary implements TranslatedSummary {
 
     public void setActivityName(String activityName) {
         this.activityName = activityName;
+    }
+
+    public String getActivitySecondName() {
+        return activitySecondName;
     }
 
     public String getActivityTitle() {
@@ -208,5 +216,13 @@ public class ActivityInstanceSummary implements TranslatedSummary {
 
     public void setNumQuestionsAnswered(int numQuestionsAnswered) {
         this.numQuestionsAnswered = numQuestionsAnswered;
+    }
+
+    public int getInstanceNumber() {
+        return instanceNumber;
+    }
+
+    public void setInstanceNumber(int instanceNumber) {
+        this.instanceNumber = instanceNumber;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
@@ -71,6 +71,10 @@ public abstract class ActivityDef {
     protected List<@Valid @NotNull Translation> translatedNames;
 
     @NotNull
+    @SerializedName("translatedSecondNames")
+    protected List<@Valid @NotNull Translation> translatedSecondNames;
+
+    @NotNull
     @SerializedName("translatedTitles")
     protected List<@Valid @NotNull Translation> translatedTitles;
 
@@ -125,6 +129,7 @@ public abstract class ActivityDef {
         } else {
             throw new IllegalArgumentException("Need at least one name translation");
         }
+        this.translatedSecondNames = new ArrayList<>();
         this.translatedTitles = translatedTitles;
         this.translatedSubtitles = translatedSubtitles;
         this.translatedDescriptions = translatedDescriptions;
@@ -185,6 +190,10 @@ public abstract class ActivityDef {
 
     public List<Translation> getTranslatedNames() {
         return translatedNames;
+    }
+
+    public List<Translation> getTranslatedSecondNames() {
+        return translatedSecondNames;
     }
 
     public List<Translation> getTranslatedTitles() {
@@ -269,6 +278,7 @@ public abstract class ActivityDef {
         protected boolean excludeStatusIconFromDisplay = false;
         protected boolean allowUnauthenticated = false;
         protected List<Translation> names = new ArrayList<>();
+        protected List<Translation> secondNames = new ArrayList<>();
         protected List<Translation> titles = new ArrayList<>();
         protected List<Translation> subtitles = new ArrayList<>();
         protected List<Translation> descriptions = new ArrayList<>();
@@ -298,6 +308,7 @@ public abstract class ActivityDef {
             activity.readonlyHintTemplate = readonlyHintTemplate;
             activity.isFollowup = isFollowup;
             activity.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
+            activity.translatedSecondNames.addAll(secondNames);
         }
 
         public T setActivityCode(String activityCode) {
@@ -377,6 +388,21 @@ public abstract class ActivityDef {
 
         public T clearNames() {
             this.names.clear();
+            return self();
+        }
+
+        public T addSecondName(Translation secondName) {
+            this.secondNames.add(secondName);
+            return self();
+        }
+
+        public T addSecondNames(Collection<Translation> secondNames) {
+            this.secondNames.addAll(secondNames);
+            return self();
+        }
+
+        public T clearSecondNames() {
+            this.secondNames.clear();
             return self();
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/i18n/ActivityI18nDetail.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/i18n/ActivityI18nDetail.java
@@ -12,6 +12,7 @@ public class ActivityI18nDetail {
     private final long langCodeId;
     private final String isoLangCode;
     private final String name;
+    private final String secondName;
     private final String title;
     private final String subtitle;
     private final String description;
@@ -23,6 +24,7 @@ public class ActivityI18nDetail {
             @ColumnName("language_code_id") long langCodeId,
             @ColumnName("iso_language_code") String isoLangCode,
             @ColumnName("name") String name,
+            @ColumnName("second_name") String secondName,
             @ColumnName("title") String title,
             @ColumnName("subtitle") String subtitle,
             @ColumnName("description") String description) {
@@ -31,18 +33,21 @@ public class ActivityI18nDetail {
         this.langCodeId = langCodeId;
         this.isoLangCode = isoLangCode;
         this.name = name;
+        this.secondName = secondName;
         this.title = title;
         this.subtitle = subtitle;
         this.description = description;
     }
 
     // For inserting new activity details.
-    public ActivityI18nDetail(long activityId, String isoLangCode, String name, String title, String subtitle, String description) {
+    public ActivityI18nDetail(long activityId, String isoLangCode, String name, String secondName,
+                              String title, String subtitle, String description) {
         this.id = 0L;
         this.activityId = activityId;
         this.langCodeId = 0L;
         this.isoLangCode = isoLangCode;
         this.name = name;
+        this.secondName = secondName;
         this.title = title;
         this.subtitle = subtitle;
         this.description = description;
@@ -66,6 +71,10 @@ public class ActivityI18nDetail {
 
     public String getName() {
         return name;
+    }
+
+    public String getSecondName() {
+        return secondName;
     }
 
     public String getTitle() {
@@ -94,6 +103,7 @@ public class ActivityI18nDetail {
                 && langCodeId == that.langCodeId
                 && Objects.equals(isoLangCode, that.isoLangCode)
                 && Objects.equals(name, that.name)
+                && Objects.equals(secondName, that.secondName)
                 && Objects.equals(title, that.title)
                 && Objects.equals(subtitle, that.subtitle)
                 && Objects.equals(description, that.description);
@@ -101,6 +111,6 @@ public class ActivityI18nDetail {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, activityId, langCodeId, isoLangCode, name, title, subtitle, description);
+        return Objects.hash(id, activityId, langCodeId, isoLangCode, name, secondName, title, subtitle, description);
     }
 }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -230,5 +230,5 @@
     <include file="db-changes/seed/DDP-4911-test-result-event.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4842-pdf-composite-answer-substitution.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-4931-activity-hide-instances.xml" relativeToChangelogFile="true"/>
-
+    <include file="db-changes/schema/DDP-5012-activity-second-name.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5012-activity-second-name.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5012-activity-second-name.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20200922-add-activity-second-name">
+        <addColumn tableName="i18n_study_activity">
+            <column name="second_name" type="varchar(500)" afterColumn="name">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/sql.conf
+++ b/pepper-apis/src/main/resources/sql.conf
@@ -20,6 +20,7 @@
         ai.is_hidden,
         (SELECT activity_type_code FROM activity_type WHERE activity_type_id = act.activity_type_id) AS activity_type_code,
         i18n_act.name        AS activity_name_trans,
+        i18n_act.second_name AS activity_second_name_trans,
         i18n_act.title       AS activity_title_trans,
         i18n_act.subtitle    AS activity_subtitle_trans,
         i18n_act.description AS activity_description_trans,

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityNamingDetails.java
@@ -59,16 +59,17 @@ public class UpdateActivityNamingDetails implements CustomTask {
                     .collect(Collectors.toMap(ActivityI18nDetail::getIsoLangCode, Functions.identity()));
 
             Map<String, String> names = collectTranslatedText(definition, "translatedNames");
+            Map<String, String> secondNames = collectTranslatedText(definition, "translatedSecondNames");
             Map<String, String> titles = collectTranslatedText(definition, "translatedTitles");
             Map<String, String> subtitles = collectTranslatedText(definition, "translatedSubtitles");
             Map<String, String> descriptions = collectTranslatedText(definition, "translatedDescriptions");
 
-            var newDetails = buildDetailsForUpdate(currentDetails, names, titles, subtitles, descriptions);
+            var newDetails = buildDetailsForUpdate(currentDetails, names, secondNames, titles, subtitles, descriptions);
             activityI18nDao.updateDetails(newDetails);
             LOG.info("Updated for {} languages: {}", newDetails.size(),
                     newDetails.stream().map(ActivityI18nDetail::getIsoLangCode).collect(Collectors.toList()));
 
-            newDetails = buildDetailsForInsert(activityId, currentDetails, names, titles, subtitles, descriptions);
+            newDetails = buildDetailsForInsert(activityId, currentDetails, names, secondNames, titles, subtitles, descriptions);
             activityI18nDao.insertDetails(newDetails);
             LOG.info("Created for {} languages: {}", newDetails.size(),
                     newDetails.stream().map(ActivityI18nDetail::getIsoLangCode).collect(Collectors.toList()));
@@ -86,6 +87,7 @@ public class UpdateActivityNamingDetails implements CustomTask {
     private List<ActivityI18nDetail> buildDetailsForUpdate(
             Map<String, ActivityI18nDetail> currentDetails,
             Map<String, String> names,
+            Map<String, String> secondNames,
             Map<String, String> titles,
             Map<String, String> subtitles,
             Map<String, String> descriptions) {
@@ -98,6 +100,7 @@ public class UpdateActivityNamingDetails implements CustomTask {
                     current.getLangCodeId(),
                     current.getIsoLangCode(),
                     names.get(language),
+                    secondNames.getOrDefault(language, null),
                     titles.getOrDefault(language, null),
                     subtitles.getOrDefault(language, null),
                     descriptions.getOrDefault(language, null));
@@ -112,6 +115,7 @@ public class UpdateActivityNamingDetails implements CustomTask {
             long activityId,
             Map<String, ActivityI18nDetail> currentDetails,
             Map<String, String> names,
+            Map<String, String> secondNames,
             Map<String, String> titles,
             Map<String, String> subtitles,
             Map<String, String> descriptions) {
@@ -124,6 +128,7 @@ public class UpdateActivityNamingDetails implements CustomTask {
                         activityId,
                         language,
                         names.get(language),
+                        secondNames.getOrDefault(language, null),
                         titles.getOrDefault(language, null),
                         subtitles.getOrDefault(language, null),
                         descriptions.getOrDefault(language, null)));

--- a/study-builder/studies/snippets/activity-general-form.conf
+++ b/study-builder/studies/snippets/activity-general-form.conf
@@ -25,6 +25,10 @@
   # Shows up in places like the dashboard and DSM listing.
   "translatedNames": [],
 
+  # A second name to use for activity.
+  # Used for render the name for the second activity and beyond.
+  "translatedSecondNames": [],
+
   # Title of the activity.
   # Shows up when viewing/editing the activity.
   "translatedTitles": [],

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -170,6 +170,7 @@
   },
   "result_report": {
     "name": "COVID-19 Test Results",
+    "second_name": "COVID-19 Test Results Month $ddp.activityInstanceNumber()",
     "title": "SARS CoV-2 Test Results",
     "label_id": "TestBoston Study ID:",
     "label_dob": "Date of Birth:",

--- a/study-builder/studies/testboston/i18n/es.conf
+++ b/study-builder/studies/testboston/i18n/es.conf
@@ -170,6 +170,7 @@
   },
   "result_report": {
     "name": "[ES] COVID-19 Test Results",
+    "second_name": "[ES] COVID-19 Test Results Month $ddp.activityInstanceNumber()",
     "title": "[ES] SARS CoV-2 Test Results",
     "label_id": "[ES] TestBoston Study ID:",
     "label_dob": "[ES] Date of Birth:",

--- a/study-builder/studies/testboston/i18n/ht.conf
+++ b/study-builder/studies/testboston/i18n/ht.conf
@@ -170,6 +170,7 @@
   },
   "result_report": {
     "name": "[HT] COVID-19 Test Results",
+    "second_name": "[HT] COVID-19 Test Results Month $ddp.activityInstanceNumber()",
     "title": "[HT] SARS CoV-2 Test Results",
     "label_id": "[HT] TestBoston Study ID:",
     "label_dob": "[HT] Date of Birth:",

--- a/study-builder/studies/testboston/result-report.conf
+++ b/study-builder/studies/testboston/result-report.conf
@@ -12,6 +12,11 @@
     { "language": "es", "text": ${i18n.es.result_report.name} },
     { "language": "ht", "text": ${i18n.ht.result_report.name} }
   ],
+  "translatedSecondNames": [
+    { "language": "en", "text": ${i18n.en.result_report.second_name} },
+    { "language": "es", "text": ${i18n.es.result_report.second_name} },
+    { "language": "ht", "text": ${i18n.ht.result_report.second_name} }
+  ],
   "translatedTitles": [
     { "language": "en", "text": ${i18n.en.result_report.title} },
     { "language": "es", "text": ${i18n.es.result_report.title} },


### PR DESCRIPTION
## Context

Adds support for configuring the name of activity instances. The `name` can now be rendered using "content substitutions" allow for more customization. We also add a "second name" that can be used for the second instance and newer.

Included in this PR is adding a "second name" for the `result_report` activity for TestBoston.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] Getting dev into a state where this is user-visible requires some tech fiddling. For TestBoston.

## Testing

- [x] I have written automated positive tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

