### PR TITLE
Update Redisson to latest version

### DIFF
--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -449,7 +449,7 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
-            <version>3.13.1</version>
+            <version>3.13.4</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
## Context

Trying to resolve issues with timeouts reported in error logs.
Yesterday tried updating nettyThreads as recommended by website FAQ.
https://github.com/redisson/redisson/wiki/16.-FAQ#q-i-saw-a-redistimeoutexception-what-does-it-mean-what-shall-i-do-can-redisson-team-fix-it
Now trying latest version of Redisson. There was a very similar issue that was resolved that they claim has been fixed in latest:
https://github.com/redisson/redisson/issues/2902#issuecomment-685331362

I don't know if this will fix problem but we can try it on dev and see what happens. Should not break anything (unless new version has new bugs).
