### PR TITLE
DDP-5013 testboston: reorder activities

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
@@ -67,11 +67,6 @@ public class SqlConstants {
         public static final String TABLE_NAME = "study_activity";
         public static final String ID = "study_activity_id";
         public static final String CODE = "study_activity_code";
-        public static final String ACTIVITY_TYPE_ID = "activity_type_id";
-        public static final String STUDY_ID = "study_id";
-        public static final String DISPLAY_ORDER = "display_order";
-        public static final String INSTANTIATE_UPON_REGISTRATION = "instantiate_upon_registration";
-        public static final String MAX_INSTANCES_PER_USER = "max_instances_per_user";
         public static final String NAME_TRANS = "activity_name_trans";
         public static final String TITLE_TRANS = "activity_title_trans";
         public static final String SUBTITLE_TRANS = "activity_subtitle_trans";
@@ -79,12 +74,10 @@ public class SqlConstants {
         public static final String SUMMARY_TRANS = "activity_summary_trans";
         public static final String EDIT_TIMEOUT_SEC = "edit_timeout_sec";
         public static final String IS_WRITE_ONCE = "is_write_once";
-        public static final String ALLOW_ONDEMAND_TRIGGER = "allow_ondemand_trigger";
         public static final String EXCLUDE_FROM_DISPLAY = "exclude_from_display";
         public static final String EXCLUDE_STATUS_ICON_FROM_DISPLAY = "exclude_status_icon_from_display";
         public static final String ALLOW_UNAUTHENTICATED = "allow_unauthenticated";
         public static final String IS_FOLLOWUP = "is_followup";
-        public static final String HIDE_INSTANCES = "hide_existing_instances_on_creation";
     }
 
     public static final class ActivityVersionTable {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -13,7 +13,7 @@ import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.FormType;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.SqlObject;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -49,6 +49,34 @@ public interface JdbiActivity extends SqlObject {
             @Bind("hideExistingInstancesOnCreation") boolean hideExistingInstancesOnCreation
     );
 
+    @SqlUpdate("update study_activity"
+            + "    set display_order = :displayOrder,"
+            + "        is_write_once = :writeOnce,"
+            + "        instantiate_upon_registration = :instantiate,"
+            + "        max_instances_per_user = :maxInstancesPerUser,"
+            + "        edit_timeout_sec = :editTimeoutSec,"
+            + "        allow_ondemand_trigger = :allowOndemandTrigger,"
+            + "        exclude_from_display = :excludeFromDisplay,"
+            + "        allow_unauthenticated = :allowUnauthenticated,"
+            + "        is_followup = :isFollowup,"
+            + "        exclude_status_icon_from_display = :excludeStatusIconFromDisplay,"
+            + "        hide_existing_instances_on_creation = :hideExistingInstancesOnCreation"
+            + "  where study_activity_id = :activityId")
+    int updateActivity(
+            @Bind("activityId") long activityId,
+            @Bind("displayOrder") int displayOrder,
+            @Bind("writeOnce") boolean writeOnce,
+            @Bind("instantiate") boolean instantiateUponRegistration,
+            @Bind("maxInstancesPerUser") Integer maxInstancesPerUser,
+            @Bind("editTimeoutSec") Long editTimeoutSec,
+            @Bind("allowOndemandTrigger") boolean allowOndemandTrigger,
+            @Bind("excludeFromDisplay") boolean excludeFromDisplay,
+            @Bind("allowUnauthenticated") boolean allowUnauthenticated,
+            @Bind("isFollowup") boolean isFollowup,
+            @Bind("excludeStatusIconFromDisplay") boolean excludeStatusIconFromDisplay,
+            @Bind("hideExistingInstancesOnCreation") boolean hideExistingInstancesOnCreation
+    );
+
     @SqlUpdate("insert into form_activity(study_activity_id,form_type_id) values(?,?)")
     int insertFormActivity(long studyActivityId, long formTypeId);
 
@@ -77,20 +105,20 @@ public interface JdbiActivity extends SqlObject {
     Optional<Long> findIdByStudyIdAndCode(@Bind("studyId") long studyId, @Bind("code") String activityCode);
 
     @SqlQuery("select * from study_activity where study_id = :studyId and study_activity_code = :code")
-    @RegisterRowMapper(ActivityDto.ActivityRowMapper.class)
+    @RegisterConstructorMapper(ActivityDto.class)
     Optional<ActivityDto> findActivityByStudyIdAndCode(@Bind("studyId") long studyId, @Bind("code") String activityCode);
 
     @SqlQuery("select * from study_activity where study_id = (select umbrella_study_id from umbrella_study where guid = :studyGuid) "
             + "and study_activity_code = :code")
-    @RegisterRowMapper(ActivityDto.ActivityRowMapper.class)
+    @RegisterConstructorMapper(ActivityDto.class)
     Optional<ActivityDto> findActivityByStudyGuidAndCode(@Bind("studyGuid") String studyGuid, @Bind("code") String activityCode);
 
     @SqlQuery("select * from study_activity where study_id = :studyId order by display_order asc")
-    @RegisterRowMapper(ActivityDto.ActivityRowMapper.class)
+    @RegisterConstructorMapper(ActivityDto.class)
     List<ActivityDto> findOrderedDtosByStudyId(@Bind("studyId") long studyId);
 
     @SqlQuery("select * from study_activity where study_activity_id = ?")
-    @RegisterRowMapper(ActivityDto.ActivityRowMapper.class)
+    @RegisterConstructorMapper(ActivityDto.class)
     ActivityDto queryActivityById(long studyActivityId);
 
     @SqlUpdate("update study_activity set edit_timeout_sec = :editTimeoutSec where study_id = :studyId and study_activity_code = :code")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
@@ -1,76 +1,65 @@
 package org.broadinstitute.ddp.db.dto;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.util.Objects;
 
-import org.broadinstitute.ddp.constants.SqlConstants;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 public class ActivityDto {
 
+    private final long activityId;
     private final long activityTypeId;
     private final long studyId;
+    private final int displayOrder;
+    private final boolean writeOnce;
     private final boolean instantiateUponRegistration;
+    private final Integer maxInstancesPerUser;
+    private final Long editTimeoutSec;
+    private final boolean allowOndemandTrigger;
+    private final boolean excludeFromDisplay;
+    private final boolean allowUnauthenticated;
+    private final boolean isFollowup;
+    private final boolean excludeStatusIconFromDisplay;
+    private final boolean hideExistingInstancesOnCreation;
     private String activityCode;
-    private long activityId;
-    private int displayOrder;
-    private Integer maxInstancesPerUser;
-    private Long editTimeoutSec;
-    private boolean writeOnce;
-    private boolean allowOndemandTrigger;
-    private boolean isFollowup;
-    private boolean hideExistingInstancesOnCreation;
 
-    /**
-     * Instantiate an ActivityDto object.
-     */
+    @JdbiConstructor
     public ActivityDto(
-            long activityId,
-            String activityCode,
-            long activityTypeId,
-            long studyId,
-            int displayOrder,
-            boolean instantiateUponRegistration,
-            Integer maxInstancesPerUser,
-            Long editTimeoutSec,
-            boolean writeOnce,
-            boolean allowOndemandTrigger,
-            boolean isFollowup,
-            boolean hideExistingInstancesOnCreation
+            @ColumnName("study_activity_id") long activityId,
+            @ColumnName("activity_type_id") long activityTypeId,
+            @ColumnName("study_id") long studyId,
+            @ColumnName("study_activity_code") String activityCode,
+            @ColumnName("display_order") int displayOrder,
+            @ColumnName("is_write_once") boolean writeOnce,
+            @ColumnName("instantiate_upon_registration") boolean instantiateUponRegistration,
+            @ColumnName("max_instances_per_user") Integer maxInstancesPerUser,
+            @ColumnName("edit_timeout_sec") Long editTimeoutSec,
+            @ColumnName("allow_ondemand_trigger") boolean allowOndemandTrigger,
+            @ColumnName("exclude_from_display") boolean excludeFromDisplay,
+            @ColumnName("allow_unauthenticated") boolean allowUnauthenticated,
+            @ColumnName("is_followup") boolean isFollowup,
+            @ColumnName("exclude_status_icon_from_display") boolean excludeStatusIconFromDisplay,
+            @ColumnName("hide_existing_instances_on_creation") boolean hideExistingInstancesOnCreation
     ) {
         this.activityId = activityId;
-        this.activityCode = activityCode;
         this.activityTypeId = activityTypeId;
         this.studyId = studyId;
+        this.activityCode = activityCode;
         this.displayOrder = displayOrder;
+        this.writeOnce = writeOnce;
         this.instantiateUponRegistration = instantiateUponRegistration;
         this.maxInstancesPerUser = maxInstancesPerUser;
         this.editTimeoutSec = editTimeoutSec;
-        this.writeOnce = writeOnce;
         this.allowOndemandTrigger = allowOndemandTrigger;
+        this.excludeFromDisplay = excludeFromDisplay;
+        this.allowUnauthenticated = allowUnauthenticated;
         this.isFollowup = isFollowup;
+        this.excludeStatusIconFromDisplay = excludeStatusIconFromDisplay;
         this.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
-    }
-
-    public String getActivityCode() {
-        return activityCode;
-    }
-
-    public void setActivityCode(String activityCode) {
-        this.activityCode = activityCode;
     }
 
     public long getActivityId() {
         return activityId;
-    }
-
-    public int getDisplayOrder() {
-        return displayOrder;
-    }
-
-    public Integer getMaxInstancesPerUser() {
-        return maxInstancesPerUser;
     }
 
     public long getActivityTypeId() {
@@ -81,41 +70,101 @@ public class ActivityDto {
         return studyId;
     }
 
-    public boolean isInstantiateUponRegistration() {
-        return instantiateUponRegistration;
+    public String getActivityCode() {
+        return activityCode;
     }
 
-    public Long getEditTimeoutSec() {
-        return editTimeoutSec;
+    public void setActivityCode(String activityCode) {
+        this.activityCode = activityCode;
+    }
+
+    public int getDisplayOrder() {
+        return displayOrder;
     }
 
     public boolean isWriteOnce() {
         return writeOnce;
     }
 
+    public boolean isInstantiateUponRegistration() {
+        return instantiateUponRegistration;
+    }
+
+    public Integer getMaxInstancesPerUser() {
+        return maxInstancesPerUser;
+    }
+
+    public Long getEditTimeoutSec() {
+        return editTimeoutSec;
+    }
+
     public boolean isOndemandTriggerAllowed() {
         return allowOndemandTrigger;
+    }
+
+    public boolean shouldExcludeFromDisplay() {
+        return excludeFromDisplay;
+    }
+
+    public boolean isUnauthenticatedAllowed() {
+        return allowUnauthenticated;
+    }
+
+    public boolean isFollowup() {
+        return isFollowup;
+    }
+
+    public boolean shouldExcludeStatusIconFromDisplay() {
+        return excludeStatusIconFromDisplay;
     }
 
     public boolean isHideExistingInstancesOnCreation() {
         return hideExistingInstancesOnCreation;
     }
 
-    public static class ActivityRowMapper implements RowMapper<ActivityDto> {
-        @Override
-        public ActivityDto map(ResultSet rs, StatementContext ctx) throws SQLException {
-            return new ActivityDto(rs.getLong(SqlConstants.StudyActivityTable.ID),
-                    rs.getString(SqlConstants.StudyActivityTable.CODE),
-                    rs.getLong(SqlConstants.StudyActivityTable.ACTIVITY_TYPE_ID),
-                    rs.getLong(SqlConstants.StudyActivityTable.STUDY_ID),
-                    rs.getInt(SqlConstants.StudyActivityTable.DISPLAY_ORDER),
-                    rs.getBoolean(SqlConstants.StudyActivityTable.INSTANTIATE_UPON_REGISTRATION),
-                    (Integer) rs.getObject(SqlConstants.StudyActivityTable.MAX_INSTANCES_PER_USER),
-                    (Long) rs.getObject(SqlConstants.StudyActivityTable.EDIT_TIMEOUT_SEC),
-                    rs.getBoolean(SqlConstants.StudyActivityTable.IS_WRITE_ONCE),
-                    rs.getBoolean(SqlConstants.StudyActivityTable.ALLOW_ONDEMAND_TRIGGER),
-                    rs.getBoolean(SqlConstants.StudyActivityTable.IS_FOLLOWUP),
-                    rs.getBoolean(SqlConstants.StudyActivityTable.HIDE_INSTANCES));
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
         }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ActivityDto that = (ActivityDto) o;
+        return activityId == that.activityId
+                && activityTypeId == that.activityTypeId
+                && studyId == that.studyId
+                && Objects.equals(activityCode, that.activityCode)
+                && displayOrder == that.displayOrder
+                && writeOnce == that.writeOnce
+                && instantiateUponRegistration == that.instantiateUponRegistration
+                && Objects.equals(maxInstancesPerUser, that.maxInstancesPerUser)
+                && Objects.equals(editTimeoutSec, that.editTimeoutSec)
+                && allowOndemandTrigger == that.allowOndemandTrigger
+                && excludeFromDisplay == that.excludeFromDisplay
+                && allowUnauthenticated == that.allowUnauthenticated
+                && isFollowup == that.isFollowup
+                && excludeStatusIconFromDisplay == that.excludeStatusIconFromDisplay
+                && hideExistingInstancesOnCreation == that.hideExistingInstancesOnCreation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                activityId,
+                activityTypeId,
+                studyId,
+                activityCode,
+                displayOrder,
+                writeOnce,
+                instantiateUponRegistration,
+                maxInstancesPerUser,
+                editTimeoutSec,
+                allowOndemandTrigger,
+                excludeFromDisplay,
+                allowUnauthenticated,
+                isFollowup,
+                excludeStatusIconFromDisplay,
+                hideExistingInstancesOnCreation);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
@@ -39,6 +39,13 @@ public class ConfigUtil {
     }
 
     /**
+     * Get value as long if the key is present and value is not null.
+     */
+    public static Long getLongIfPresent(Config cfg, String key) {
+        return cfg.hasPath(key) ? cfg.getLong(key) : null;
+    }
+
+    /**
      * Get value as boolean if the key is present and value is not null.
      */
     public static Boolean getBoolIfPresent(Config cfg, String key) {

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
@@ -1,0 +1,86 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.db.dao.JdbiActivity;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.ActivityDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * General task to update basic activity configuration such as display order, max instances per user, and other flags.
+ */
+public class UpdateActivityBaseSettings implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateActivityBaseSettings.class);
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyCfg.getString("study.guid"));
+        User admin = handle.attach(UserDao.class).findUserByGuid(studyCfg.getString("adminUser.guid")).get();
+        var activityBuilder = new ActivityBuilder(cfgPath.getParent(), studyCfg, varsCfg, studyDto, admin.getId());
+
+        for (Config activityCfg : studyCfg.getConfigList("activities")) {
+            Config definition = activityBuilder.readDefinitionConfig(activityCfg.getString("filepath"));
+            String activityCode = definition.getString("activityCode");
+            long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
+
+            var jdbiActivity = handle.attach(JdbiActivity.class);
+            ActivityDto currentDto = jdbiActivity.queryActivityById(activityId);
+            ActivityDto latestDto = new ActivityDto(
+                    currentDto.getActivityId(),
+                    currentDto.getActivityTypeId(),
+                    currentDto.getStudyId(),
+                    currentDto.getActivityCode(),
+                    definition.getInt("displayOrder"),
+                    definition.getBoolean("writeOnce"),
+                    false,  // instantiate_upon_registration not supported anymore!
+                    ConfigUtil.getIntIfPresent(definition, "maxInstancesPerUser"),
+                    ConfigUtil.getLongIfPresent(definition, "editTimeoutSec"),
+                    definition.getBoolean("allowOndemandTrigger"),
+                    definition.getBoolean("excludeFromDisplay"),
+                    definition.getBoolean("allowUnauthenticated"),
+                    definition.getBoolean("isFollowup"),
+                    definition.getBoolean("excludeStatusIconFromDisplay"),
+                    definition.getBoolean("hideExistingInstancesOnCreation"));
+
+            if (!currentDto.equals(latestDto)) {
+                LOG.info("{} changed, updating...", activityCode);
+                jdbiActivity.updateActivity(
+                        latestDto.getActivityId(),
+                        latestDto.getDisplayOrder(),
+                        latestDto.isWriteOnce(),
+                        latestDto.isInstantiateUponRegistration(),
+                        latestDto.getMaxInstancesPerUser(),
+                        latestDto.getEditTimeoutSec(),
+                        latestDto.isOndemandTriggerAllowed(),
+                        latestDto.shouldExcludeFromDisplay(),
+                        latestDto.isUnauthenticatedAllowed(),
+                        latestDto.isFollowup(),
+                        latestDto.shouldExcludeStatusIconFromDisplay(),
+                        latestDto.isHideExistingInstancesOnCreation());
+            } else {
+                LOG.info("No changes for {}, skipping...", activityCode);
+            }
+        }
+    }
+}

--- a/study-builder/studies/snippets/activity-general-form.conf
+++ b/study-builder/studies/snippets/activity-general-form.conf
@@ -7,6 +7,8 @@
   "maxInstancesPerUser": null,
   "allowOndemandTrigger": false,
   "allowUnauthenticated": false,
+  "isFollowup": false,
+  "hideExistingInstancesOnCreation": false,
   "listStyleHint": "NONE",
 
   # Should activity instances be excluded when listing user's activity instances? Optional, defaults to false.

--- a/study-builder/studies/testboston/address.conf
+++ b/study-builder/studies/testboston/address.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.address},
   "versionTag": "v1",
-  "displayOrder": 3,
+  "displayOrder": 5,
   "writeOnce": false,
   "maxInstancesPerUser": 1,
   "translatedNames": [

--- a/study-builder/studies/testboston/adhoc-symptom.conf
+++ b/study-builder/studies/testboston/adhoc-symptom.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.adhoc_symptom},
   "versionTag": "v1",
-  "displayOrder": 5,
+  "displayOrder": 3,
   "writeOnce": true,
   "maxInstancesPerUser": null,
   "allowOndemandTrigger": true,

--- a/study-builder/studies/testboston/baseline-covid.conf
+++ b/study-builder/studies/testboston/baseline-covid.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.baseline_covid},
   "versionTag": "v1",
-  "displayOrder": 2,
+  "displayOrder": 6,
   "writeOnce": false,
   "editTimeoutSec": 604800,   # 7 days
   "maxInstancesPerUser": 1,

--- a/study-builder/studies/testboston/consent.conf
+++ b/study-builder/studies/testboston/consent.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.consent},
   "versionTag": "v1",
-  "displayOrder": 1,
+  "displayOrder": 7,
   "writeOnce": true,
   "snapshotSubstitutionsOnSubmit": true,
   "maxInstancesPerUser": 1,

--- a/study-builder/studies/testboston/longitudinal-covid.conf
+++ b/study-builder/studies/testboston/longitudinal-covid.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.longitudinal},
   "versionTag": "v1",
-  "displayOrder": 6,
+  "displayOrder": 2,
   "writeOnce": false,
   "editTimeoutSec": 604800,   # 7 days
   "maxInstancesPerUser": 5,

--- a/study-builder/studies/testboston/result-report.conf
+++ b/study-builder/studies/testboston/result-report.conf
@@ -3,7 +3,7 @@
   "studyGuid": ${id.study},
   "activityCode": ${id.act.result_report},
   "versionTag": "v1",
-  "displayOrder": 7,
+  "displayOrder": 1,
   "writeOnce": true,
   "maxInstancesPerUser": null,
   "excludeStatusIconFromDisplay": true,

--- a/study-builder/studies/testboston/study-activities.conf
+++ b/study-builder/studies/testboston/study-activities.conf
@@ -36,12 +36,12 @@
       "validations": []
     },
     {
-      "filepath": "longitudinal-covid.conf",
+      "filepath": "adhoc-symptom.conf",
       "mappings": [],
       "validations": []
-    }
+    },
     {
-      "filepath": "adhoc-symptom.conf",
+      "filepath": "longitudinal-covid.conf",
       "mappings": [],
       "validations": []
     },


### PR DESCRIPTION
## Context

This PR updates the display order of TestBoston's activities to better match what's IRB-approved. This is done using the new `UpdateActivityBaseSettings` task, which is a general task that will update "basic settings" for all activities in the study.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] Getting dev into a state where this is user-visible requires some tech fiddling. Need to run the task.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

