### PR TITLE
DDP-5020: Prion: Added second names to surveys

### DIFF
--- a/study-builder/studies/prion/consent.conf
+++ b/study-builder/studies/prion/consent.conf
@@ -29,6 +29,7 @@
       "text": ${i18n.zh.consentName}
     }
   ],
+  "translatedSecondNames": [],
   "translatedSubtitles": [],
   "translatedTitles": [
     {

--- a/study-builder/studies/prion/consent.conf
+++ b/study-builder/studies/prion/consent.conf
@@ -1,16 +1,12 @@
 {
-  "activityType": "FORMS",
+  include required("../snippets/activity-general-form.conf"),
   "formType": "CONSENT",
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
   "studyGuid": "PRION",
   "activityCode": "PRIONCONSENT",
   "versionTag": "v1",
   "displayOrder": 1,
-  "writeOnce": true,
-  "editTimeoutSec": null,
-  "creationExpr": null,
-  "maxInstancesPerUser": 1,
-  "allowOndemandTrigger": false,
-  "listStyleHint": "NONE",
   "translatedNames": [
     {
       "language": "en",
@@ -29,8 +25,6 @@
       "text": ${i18n.zh.consentName}
     }
   ],
-  "translatedSecondNames": [],
-  "translatedSubtitles": [],
   "translatedTitles": [
     {
       "language": "en",
@@ -49,7 +43,6 @@
       "text": ${i18n.zh.consentTitle}
     }
   ],
-  "translatedDescriptions": [],
   "translatedSummaries": [
     {
       "statusCode": "CREATED",
@@ -1951,12 +1944,8 @@
           "shownExpr": null
         },
         {
-          "question": {
-            "hideNumber": true,
-            "questionType": "AGREEMENT",
+          "question": { include required("./snippets/agreement.conf") } {
             "stableId": "prion_consent_s7_age",
-            "isRestricted": false,
-            "isDeprecated": false,
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="LegalAgePrompt">$prion_consent_s7_age_prompt</p>""",
@@ -2018,8 +2007,8 @@
           "shownExpr": null
         },
         {
-          "question": {
-            "hideNumber": true,
+          "question": { include required("./snippets/boolean.conf") } {
+            "stableId": "prion_consent_s7_participation_options",
             "trueTemplate": {
               "templateType": "TEXT",
               "templateText": "$prion_consent_s7_participation_options_yes",
@@ -2050,10 +2039,6 @@
                 }
               ]
             },
-            "questionType": "BOOLEAN",
-            "stableId": "prion_consent_s7_participation_options",
-            "isRestricted": false,
-            "isDeprecated": false,
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p>$prion_consent_s7_prompt_participation_options</p>""",
@@ -2115,11 +2100,8 @@
           "shownExpr": null,
         },
         {
-          "control": {
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "picklistLabelTemplate": null,
-            "groups": [],
+          "control": { include required("../snippets/picklist-question-single-list.conf") } {
+            "stableId": "prion_consent_s7_consent_type",
             "hideNumber": true,
             "picklistOptions": [
               {
@@ -2165,10 +2147,6 @@
                 "exclusive": false,
               }
             ],
-            "questionType": "PICKLIST",
-            "stableId": "prion_consent_s7_consent_type",
-            "isRestricted": false,
-            "isDeprecated": false,
             "validations": [
               {
                 "ruleType": "REQUIRED",
@@ -2226,15 +2204,8 @@
           },
           "nested": [
             {
-              "question": {
-                "questionType": "TEXT",
-                "inputType": "SIGNATURE",
-                "stableId": "prion_consent_s7_consent_fullname"
-                "isRestricted": false,
-                "isDeprecated": false,
-                "placeholderTemplate": null,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
+              "question": { include required("../snippets/text-question-signature-required.conf") } {
+                "stableId": "prion_consent_s7_consent_fullname",
                 "validations": [
                   {
                     "ruleType": "REQUIRED",
@@ -2277,15 +2248,8 @@
                   questions["prion_consent_s7_consent_type"].answers.hasOption("prion_consent_s7_INDEPENDENT_NO")"""
             },
             {
-              "question": {
-                "questionType": "TEXT",
-                "inputType": "TEXT",
+              "question": { include required("../snippets/text-question.conf") } {
                 "stableId": "prion_consent_s7_representative_fullname"
-                "isRestricted": false,
-                "isDeprecated": false,
-                "placeholderTemplate": null,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
                 "validations": [
                   {
                     "ruleType": "REQUIRED",
@@ -2327,15 +2291,8 @@
                   questions["prion_consent_s7_consent_type"].answers.hasOption("prion_consent_s7_INDEPENDENT_NO")"""
             },
             {
-              "question": {
-                "questionType": "TEXT",
-                "inputType": "TEXT",
+              "question": { include required("../snippets/text-question.conf") } {
                 "stableId": "prion_consent_s7_representative_authority"
-                "isRestricted": false,
-                "isDeprecated": false,
-                "placeholderTemplate": null,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
                 "validations": [
                   {
                     "ruleType": "REQUIRED",

--- a/study-builder/studies/prion/i18n/en.conf
+++ b/study-builder/studies/prion/i18n/en.conf
@@ -241,6 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Medical Questionnaire",
+    "medicalSecondName": """Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
     "medicalTitle": "Medical Questionnaire",
     "medicalCreated": "Please complete this Medical Questionnaire",
     "medicalInProgress": "Please complete this Medical Questionnaire",

--- a/study-builder/studies/prion/i18n/en.conf
+++ b/study-builder/studies/prion/i18n/en.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Medical Questionnaire",
-    "medicalSecondName": """Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
+    "medicalSecondName": """Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")}""",
     "medicalTitle": "Medical Questionnaire",
     "medicalCreated": "Please complete this Medical Questionnaire",
     "medicalInProgress": "Please complete this Medical Questionnaire",

--- a/study-builder/studies/prion/i18n/en.conf
+++ b/study-builder/studies/prion/i18n/en.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Medical Questionnaire",
-    "medicalSecondName": """Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
+    "medicalSecondName": """Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
     "medicalTitle": "Medical Questionnaire",
     "medicalCreated": "Please complete this Medical Questionnaire",
     "medicalInProgress": "Please complete this Medical Questionnaire",

--- a/study-builder/studies/prion/i18n/es.conf
+++ b/study-builder/studies/prion/i18n/es.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Cuestionario médico",
-    "medicalSecondName": """(es)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
+    "medicalSecondName": """(es)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
     "medicalTitle": "Cuestionario médico",
     "medicalCreated": "Complete este cuestionario médico",
     "medicalInProgress": "Complete este cuestionario médico",

--- a/study-builder/studies/prion/i18n/es.conf
+++ b/study-builder/studies/prion/i18n/es.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Cuestionario médico",
-    "medicalSecondName": """(es)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
+    "medicalSecondName": """(es)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")}""",
     "medicalTitle": "Cuestionario médico",
     "medicalCreated": "Complete este cuestionario médico",
     "medicalInProgress": "Complete este cuestionario médico",

--- a/study-builder/studies/prion/i18n/es.conf
+++ b/study-builder/studies/prion/i18n/es.conf
@@ -241,6 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "Cuestionario médico",
+    "medicalSecondName": """(es)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
     "medicalTitle": "Cuestionario médico",
     "medicalCreated": "Complete este cuestionario médico",
     "medicalInProgress": "Complete este cuestionario médico",

--- a/study-builder/studies/prion/i18n/he.conf
+++ b/study-builder/studies/prion/i18n/he.conf
@@ -243,6 +243,7 @@
 
     //Medical questionnaire
     "medicalName": "שאלון רפואי",
+    "medicalSecondName": """(he)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
     "medicalTitle": "שאלון רפואי",
     "medicalCreated": "אנא מלא את שאלון רפואי זה",
     "medicalInProgress": "אנא מלא את שאלון רפואי זה",

--- a/study-builder/studies/prion/i18n/he.conf
+++ b/study-builder/studies/prion/i18n/he.conf
@@ -243,7 +243,7 @@
 
     //Medical questionnaire
     "medicalName": "שאלון רפואי",
-    "medicalSecondName": """(he)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
+    "medicalSecondName": """(he)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")}""",
     "medicalTitle": "שאלון רפואי",
     "medicalCreated": "אנא מלא את שאלון רפואי זה",
     "medicalInProgress": "אנא מלא את שאלון רפואי זה",

--- a/study-builder/studies/prion/i18n/he.conf
+++ b/study-builder/studies/prion/i18n/he.conf
@@ -243,7 +243,7 @@
 
     //Medical questionnaire
     "medicalName": "שאלון רפואי",
-    "medicalSecondName": """(he)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
+    "medicalSecondName": """(he)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
     "medicalTitle": "שאלון רפואי",
     "medicalCreated": "אנא מלא את שאלון רפואי זה",
     "medicalInProgress": "אנא מלא את שאלון רפואי זה",

--- a/study-builder/studies/prion/i18n/zh.conf
+++ b/study-builder/studies/prion/i18n/zh.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "医学问卷",
-    "medicalSecondName": """(zh)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
+    "medicalSecondName": """(zh)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")}""",
     "medicalTitle": "医学问卷",
     "medicalCreated": "请填写此医学问卷",
     "medicalInProgress": "请填写此医学问卷",

--- a/study-builder/studies/prion/i18n/zh.conf
+++ b/study-builder/studies/prion/i18n/zh.conf
@@ -241,6 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "医学问卷",
+    "medicalSecondName": """(zh)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
     "medicalTitle": "医学问卷",
     "medicalCreated": "请填写此医学问卷",
     "medicalInProgress": "请填写此医学问卷",

--- a/study-builder/studies/prion/i18n/zh.conf
+++ b/study-builder/studies/prion/i18n/zh.conf
@@ -241,7 +241,7 @@
 
     //Medical questionnaire
     "medicalName": "医学问卷",
-    "medicalSecondName": """(zh)Medical Questionnaire Update ${ddp.activityInstanceNumberDisplay(1, 2, "#")""",
+    "medicalSecondName": """(zh)Medical Questionnaire Update${ddp.activityInstanceNumberDisplay(1, 2, " #")""",
     "medicalTitle": "医学问卷",
     "medicalCreated": "请填写此医学问卷",
     "medicalInProgress": "请填写此医学问卷",

--- a/study-builder/studies/prion/medical.conf
+++ b/study-builder/studies/prion/medical.conf
@@ -29,6 +29,24 @@
       "text": ${i18n.zh.medicalName}
     }
   ],
+  "translatedSecondNames": [
+    {
+      "language": "en",
+      "text": ${i18n.en.medicalSecondName}
+    },
+    {
+      "language": "es",
+      "text": ${i18n.es.medicalSecondName}
+    },
+    {
+      "language": "he",
+      "text": ${i18n.he.medicalSecondName}
+    },
+    {
+      "language": "zh",
+      "text": ${i18n.zh.medicalSecondName}
+    }
+  ]
   "translatedSubtitles": [],
   "translatedTitles": [
     {

--- a/study-builder/studies/prion/medical.conf
+++ b/study-builder/studies/prion/medical.conf
@@ -1,16 +1,11 @@
 {
-  "activityType": "FORMS",
-  "formType": "GENERAL",
+  include required("../snippets/activity-general-form.conf"),
+  "writeOnce": true,
+  "allowOndemandTrigger": true,
   "studyGuid": "PRION",
   "activityCode": "PRIONMEDICAL",
   "versionTag": "v1",
   "displayOrder": 2,
-  "writeOnce": true,
-  "editTimeoutSec": null,
-  "creationExpr": null,
-  "maxInstancesPerUser": null,
-  "allowOndemandTrigger": true,
-  "listStyleHint": "NONE",
   "translatedNames": [
     {
       "language": "en",
@@ -47,7 +42,6 @@
       "text": ${i18n.zh.medicalSecondName}
     }
   ]
-  "translatedSubtitles": [],
   "translatedTitles": [
     {
       "language": "en",
@@ -66,7 +60,6 @@
       "text": ${i18n.zh.medicalTitle}
     }
   ],
-  "translatedDescriptions": [],
   "translatedSummaries": [
     {
       "statusCode": "CREATED",
@@ -180,18 +173,9 @@
         {
           "blockType": "QUESTION",
           "shownExpr": null,
-          "question": {
+          "question": { include required("../snippets/text-question.conf") } {
             "stableId": "prion_medical_birth_year",
-            "questionType": "TEXT",
-            "inputType": "TEXT",
-            "renderMode": "TEXT",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistConfig": null,
             "placeholderTemplate": {
               "templateType": "TEXT",
               "templateText": "$prion_medical_birth_year_placeholder",
@@ -236,19 +220,9 @@
         {
           "blockType": "QUESTION",
           "shownExpr": null,
-          "question": {
+          "question": { include required("../snippets/picklist-question-single-list.conf") } {
             "stableId": "prion_medical_gender",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_gender</p>""",
@@ -354,11 +328,8 @@
             },
             "children": [
               {
+                include required("../snippets/text-question.conf"),
                 "stableId": "prion_medical_city",
-                "questionType": "TEXT",
-                "inputType": "TEXT",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
                 "placeholderTemplate": {
                   "templateType": "TEXT",
@@ -375,11 +346,6 @@
                     }
                   ],
                 },
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "suggestionType": "NONE",
-                "suggestions": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_city</label>""",
@@ -397,11 +363,8 @@
                 }
               },
               {
+                include required("../snippets/text-question.conf"),
                 "stableId": "prion_medical_state",
-                "questionType": "TEXT",
-                "inputType": "TEXT",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
                 "placeholderTemplate": {
                   "templateType": "TEXT",
@@ -418,11 +381,6 @@
                     }
                   ],
                 },
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "suggestionType": "NONE",
-                "suggestions": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_state</label>""",
@@ -440,11 +398,8 @@
                 }
               },
               {
+                include required("../snippets/text-question.conf"),
                 "stableId": "prion_medical_postal",
-                "questionType": "TEXT",
-                "inputType": "TEXT",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
                 "placeholderTemplate": {
                   "templateType": "TEXT",
@@ -461,11 +416,6 @@
                     }
                   ],
                 },
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "suggestionType": "NONE",
-                "suggestions": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_postal</label>""",
@@ -483,14 +433,8 @@
                 }
               },
               {
+                include required("./snippets/country.conf"),
                 "stableId": "prion_medical_country",
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "DROPDOWN",
-                "isRestricted": false,
-                "isDeprecated": false,
-                "hideNumber": true,
-                "validations": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<label class="Input-label SubLabel">$prion_medical_prompt_country</label>""",
@@ -506,8 +450,6 @@
                     }
                   ]
                 },
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
                 "picklistLabelTemplate": {
                   "templateType": "TEXT",
                   "templateCode": null,
@@ -524,7 +466,6 @@
                     }
                   ]
                 },
-                "groups": [],
                 "picklistOptions": [
                   {
                     "stableId": "AW",
@@ -6003,19 +5944,9 @@
         {
           "blockType": "QUESTION",
           "shownExpr": null,
-          "question": {
+          "question": { include required("../snippets/picklist-question-single-list.conf") } {
             "stableId": "prion_medical_disease_status"
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_disease_status</p>""",
@@ -6134,17 +6065,9 @@
             },
             "children": [
               {
+                include required("../snippets/text-question.conf"),
                 "stableId": "prion_medical_earliest_symptom",
-                "questionType": "TEXT",
-                "inputType": "TEXT",
-                "renderMode": "TEXT",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "picklistConfig": null,
                 "placeholderTemplate": {
                   "templateType": "TEXT",
                   "templateText": "$prion_medical_earliest_symptom_placeholder",
@@ -6177,17 +6100,8 @@
                 }
               },
               {
+                include required("../snippets/picklist-question-single-checklist.conf"),
                 "stableId": "prion_medical_earliest_symptom_est",
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "CHECKBOX_LIST",
-                "picklistLabelTemplate": null,
-                "groups": [],
-                "isRestricted": false,
-                "isDeprecated": false,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
                 "hideNumber": true,
                 "promptTemplate": {
                   "templateType": "HTML",
@@ -6233,17 +6147,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "control": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_doctor_diagnosed",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST"
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "groups": []
-            "validations": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_doctor_diagnosed</p>""",
@@ -6321,17 +6227,9 @@
                 },
                 "children": [
                   {
+                    include required("../snippets/text-question.conf"),
                     "stableId": "prion_medical_diagnosis_location_hospital",
-                    "questionType": "TEXT",
-                    "inputType": "TEXT",
-                    "isRestricted": false,
-                    "isDeprecated": false,
                     "hideNumber": true,
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
-                    "validations": [],
-                    "suggestionType": "NONE",
-                    "suggestions": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label UnorderedItem SubLabel">$prompt_prion_medical_diagnosis_location_hospital</label>""",
@@ -6364,17 +6262,9 @@
                     },
                   },
                   {
+                    include required("../snippets/text-question.conf"),
                     "stableId": "prion_medical_diagnosis_location_city",
-                    "questionType": "TEXT",
-                    "inputType": "TEXT",
-                    "isRestricted": false,
-                    "isDeprecated": false,
                     "hideNumber": true,
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
-                    "validations": [],
-                    "suggestionType": "NONE",
-                    "suggestions": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_diagnosis_location_city</label>""",
@@ -6407,17 +6297,9 @@
                     },
                   },
                   {
+                    include required("../snippets/text-question.conf"),
                     "stableId": "prion_medical_diagnosis_location_state",
-                    "questionType": "TEXT",
-                    "inputType": "TEXT",
-                    "isRestricted": false,
-                    "isDeprecated": false,
                     "hideNumber": true,
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
-                    "validations": [],
-                    "suggestionType": "NONE",
-                    "suggestions": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_diagnosis_location_state</label>""",
@@ -6450,17 +6332,9 @@
                     },
                   },
                   {
+                    include required("../snippets/text-question.conf"),
                     "stableId": "prion_medical_diagnosis_location_zip",
-                    "questionType": "TEXT",
-                    "inputType": "TEXT",
-                    "isRestricted": false,
-                    "isDeprecated": false,
                     "hideNumber": true,
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
-                    "validations": [],
-                    "suggestionType": "NONE",
-                    "suggestions": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_diagnosis_location_zip</label>""",
@@ -6493,14 +6367,8 @@
                     },
                   },
                   {
+                    include required("./snippets/country.conf"),
                     "stableId": "prion_medical_diagnosis_location_country",
-                    "questionType": "PICKLIST",
-                    "selectMode": "SINGLE",
-                    "renderMode": "DROPDOWN",
-                    "isRestricted": false,
-                    "isDeprecated": false,
-                    "hideNumber": true,
-                    "validations": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label SubLabel">$prion_medical_prompt_country</label>""",
@@ -6516,8 +6384,6 @@
                         }
                       ]
                     },
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
                     "picklistLabelTemplate": {
                       "templateType": "TEXT",
                       "templateCode": null,
@@ -6534,7 +6400,6 @@
                         }
                       ]
                     },
-                    "groups": [],
                     "picklistOptions": [
                       {
                         "stableId": "AW",
@@ -12024,17 +11889,9 @@
                 },
                 "children": [
                   {
+                    include required("../snippets/text-question.conf"),
                     "stableId": "prion_medical_diagnosis_date_date",
-                    "questionType": "TEXT",
-                    "inputType": "TEXT",
-                    "isRestricted": false,
-                    "isDeprecated": false,
                     "hideNumber": true,
-                    "additionalInfoHeaderTemplate": null,
-                    "additionalInfoFooterTemplate": null,
-                    "validations": [],
-                    "suggestionType": "NONE",
-                    "suggestions": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": """<label class="Input-label SubLabel">$prompt_prion_medical_diagnosis_date_date</label>""",
@@ -12083,16 +11940,9 @@
                     }
                   },
                   {
+                    include required("../snippets/picklist-question-single-checklist.conf"),
                     "stableId": "prion_medical_diagnosis_date_estimated",
-                    "questionType": "PICKLIST",
                     "hideNumber": true,
-                    "isRestricted": false,
-                    "isDeprecated": false,
-                    "validations": [],
-                    "selectMode": "SINGLE",
-                    "renderMode": "CHECKBOX_LIST",
-                    "picklistLabelTemplate": null,
-                    "groups": [],
                     "promptTemplate": {
                       "templateType": "HTML",
                       "templateText": "$prompt_prion_medical_diagnosis_date_estimated",
@@ -12138,17 +11988,9 @@
             {
               "blockType": "QUESTION",
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_doctor_diagnosed"].answers.hasOption("DIAGNOSED_YES")""",
-              "question": {
-                "questionType": "PICKLIST",
+              "question": { include required("../snippets/picklist-question-single-list.conf") } {
                 "stableId": "prion_medical_subtype",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "validations": [],
-                "selectMode": "SINGLE",
-                "renderMode": "LIST",
-                "groups": [],
-                "picklistLabelTemplate": null,
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_subtype</p>""",
@@ -12339,17 +12181,9 @@
             {
               "blockType": "QUESTION",
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_doctor_diagnosed"].answers.hasOption("DIAGNOSED_NO")""",
-              "question": {
+              "question": { include required("../snippets/picklist-question-single-list.conf") } {
                 "stableId": "prion_medical_participant_belief",
                 "hideNumber": true,
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "LIST",
-                "isRestricted": false,
-                "isDeprecated": false,
-                "validations": [],
-                "picklistLabelTemplate": null,
-                "groups": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_participant_belief</p>""",
@@ -12411,18 +12245,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].answers.hasOption("AT_RISK")""",
           "blockType": "CONDITIONAL",
           "control": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_disease_risk",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_disease_risk</p>""",
@@ -12606,19 +12431,9 @@
               "blockType": "QUESTION",
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_risk"].answers.hasOption("PARTICIPANT_TESTED")
               || user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_risk"].answers.hasOption("RELATIVE_TESTED")""",
-              "question": {
+              "question": { include required("../snippets/picklist-question-single-list.conf") } {
                 "stableId": "prion_medical_known_mutation",
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "LIST",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "picklistLabelTemplate": null,
-                "groups": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_known_mutation</p>""",
@@ -12686,17 +12501,9 @@
               "blockType": "QUESTION",
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_known_mutation"].answers.hasOption("KNOWN_MUTATION_YES") && (user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_risk"].answers.hasOption("PARTICIPANT_TESTED")
               || user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_risk"].answers.hasOption("RELATIVE_TESTED"))""",
-              "question": {
+              "question": { include required("../snippets/text-question.conf") } {
                 "stableId": "prion_medical_specific_mutation",
-                "questionType": "TEXT",
-                "inputType": "TEXT",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "picklistConfig": null,
                 "placeholderTemplate": {
                   "templateType": "TEXT",
                   "templateText": "$prion_medical_specific_mutation_placeholder",
@@ -12732,19 +12539,9 @@
             {
               "blockType": "QUESTION",
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_risk"].answers.hasOption("MEDICAL_INFORMED")""",
-              "question": {
+              "question": { include required("../snippets/picklist-question-single-list.conf") } {
                 "stableId": "prion_medical_procedure",
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "LIST",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "picklistLabelTemplate": null,
-                "groups": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_procedure</p>""",
@@ -12915,19 +12712,9 @@
         {
           "blockType": "QUESTION",
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].answers.hasOption("AT_RISK")""",
-          "question": {
+          "question": { include required("../snippets/picklist-question-single-list.conf") } {
             "stableId": "prion_medical_risk_subtype",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin30">$prompt_prion_medical_risk_subtype</p>""",
@@ -13137,19 +12924,9 @@
           "blockType": "QUESTION",
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
-          "question": {
+          "question": { include required("../snippets/picklist-question-single-list.conf") } {
             "stableId": "prion_medical_family_history",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_family_history</p>""",
@@ -13210,18 +12987,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "control": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_genetic_testing",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin20">$prompt_prion_medical_genetic_testing</p>""",
@@ -13303,18 +13071,9 @@
               "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC") && user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_genetic_testing"].answers.hasOption("KNOWN")""",
               "question": {
+                include required("../snippets/picklist-question-single-list.conf"),
                 "stableId": "prion_medical_mutation_identified",
-                "questionType": "PICKLIST",
-                "selectMode": "SINGLE",
-                "renderMode": "LIST",
-                "isRestricted": false,
-                "isDeprecated": false,
                 "hideNumber": true,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
-                "validations": [],
-                "picklistLabelTemplate": null,
-                "groups": [],
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateText": """<p class="Medium UnorderedItem BulletItem Margin10">$prompt_prion_medical_mutation_identified</p>""",
@@ -13395,18 +13154,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "question": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_move_ability",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem BottomMargin10">$prompt_prion_medical_move_ability</p>""",
@@ -13485,18 +13235,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "question": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_cognitive_ability",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin30 BottomMargin10">$prompt_prion_medical_cognitive_ability</p>""",
@@ -13575,18 +13316,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "question": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_eat_ability",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin30 BottomMargin10">$prompt_prion_medical_eat_ability</p>""",
@@ -13665,18 +13397,9 @@
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].
               answers.hasOption("SYMPTOMATIC")""",
           "question": {
+            include required("../snippets/picklist-question-single-list.conf"),
             "stableId": "prion_medical_travel_ability",
-            "questionType": "PICKLIST",
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin30 BottomMargin10">$prompt_prion_medical_travel_ability</p>""",
@@ -13770,18 +13493,9 @@
           "blockType": "QUESTION",
           "shownExpr": """user.studies["PRION"].forms["PRIONMEDICAL"].questions["prion_medical_disease_status"].answers.hasOption("CONTROL")""",
           "question": {
+            include required("../snippets/picklist-question-multi-list.conf"),
             "stableId": "prion_medical_control_reason",
-            "questionType": "PICKLIST",
-            "selectMode": "MULTIPLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem">$prompt_prion_medical_control_reason <span class="Italic">$prompt_prion_medical_control_select</span></p>""",
@@ -13886,18 +13600,9 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "question": {
+            include required("../snippets/picklist-question-multi-list.conf"),
             "stableId": "prion_medical_research",
-            "questionType": "PICKLIST",
-            "selectMode": "MULTIPLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin10">$prompt_prion_medical_research <span class="Italic">$prompt_prion_medical_research_select</span></p>""",
@@ -14002,18 +13707,9 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "question": {
+            include required("../snippets/picklist-question-multi-list.conf"),
             "stableId": "prion_medical_previous_research",
-            "questionType": "PICKLIST",
-            "selectMode": "MULTIPLE",
-            "renderMode": "LIST",
-            "isRestricted": false,
-            "isDeprecated": false,
             "hideNumber": true,
-            "additionalInfoHeaderTemplate": null,
-            "additionalInfoFooterTemplate": null,
-            "validations": [],
-            "picklistLabelTemplate": null,
-            "groups": [],
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": """<p class="Medium UnorderedItem BulletItem Margin20">$prompt_prion_medical_previous_research <span class="Italic">$prompt_prion_medical_previous_research_select</span></p>""",

--- a/study-builder/studies/prion/request.conf
+++ b/study-builder/studies/prion/request.conf
@@ -1,17 +1,11 @@
 {
-  "activityType": "FORMS",
-  "formType": "GENERAL",
+  include required("../snippets/activity-general-form.conf"),
+  "writeOnce": true,
+  "excludeFromDisplay": true,
   "studyGuid": "PRION",
   "activityCode": "PRIONREQUEST",
   "versionTag": "v1",
   "displayOrder": 1,
-  "excludeFromDisplay": true,
-  "writeOnce": true,
-  "editTimeoutSec": null,
-  "creationExpr": null,
-  "maxInstancesPerUser": null,
-  "allowOndemandTrigger": false,
-  "listStyleHint": "NONE",
   "translatedNames": [
     {
       "language": "en",
@@ -30,7 +24,6 @@
       "text": ${i18n.zh.requestName}
     }
   ],
-  "translatedSecondNames": [],
   "translatedTitles": [
     {
       "language": "en",
@@ -49,9 +42,7 @@
       "text": ${i18n.zh.requestTitle}
     }
   ],
-  "translatedSubtitles": [],
-  "translatedDescriptions": [],
-  "translatedSummaries": [],
+  "introduction": null,
   "closing": null,
   "sections": [
     {
@@ -59,15 +50,8 @@
       "icons": [],
       "blocks": [
         {
-          "control": {
-            "questionType": "PICKLIST",
+          "control": { include required("../snippets/picklist-question-single-list.conf") } {
             "stableId": "DATA_REQUEST_QUESTION",
-            "isRestricted": false,
-            "isDeprecated": false,
-            "selectMode": "SINGLE",
-            "renderMode": "LIST",
-            "picklistLabelTemplate": null,
-            "groups": [],
             "hideNumber": true,
             "promptTemplate": {
               "templateType": "HTML",
@@ -197,15 +181,9 @@
               "shownExpr": """user.studies["PRION"].forms["PRIONREQUEST"].
                   questions["DATA_REQUEST_QUESTION"].answers.hasOption("OTHER") && user.studies["PRION"].forms["PRIONREQUEST"].
                   questions["DATA_REQUEST_QUESTION"].isAnswered()""",
-              "question": {
-                "questionType": "TEXT",
+              "question": { include required("../snippets/text-question.conf") } {
+                "stableId": "REQUEST_QUESTION_OTHER_DETAILS",
                 "inputType": "ESSAY",
-                "stableId": "REQUEST_QUESTION_OTHER_DETAILS"
-                "isRestricted": false,
-                "isDeprecated": false,
-                "placeholderTemplate": null,
-                "additionalInfoHeaderTemplate": null,
-                "additionalInfoFooterTemplate": null,
                 "promptTemplate": {
                   "templateType": "TEXT",
                   "templateText": "",

--- a/study-builder/studies/prion/request.conf
+++ b/study-builder/studies/prion/request.conf
@@ -30,6 +30,7 @@
       "text": ${i18n.zh.requestName}
     }
   ],
+  "translatedSecondNames": [],
   "translatedTitles": [
     {
       "language": "en",

--- a/study-builder/studies/prion/snippets/agreement.conf
+++ b/study-builder/studies/prion/snippets/agreement.conf
@@ -1,0 +1,7 @@
+{
+  "questionType": "AGREEMENT",
+  "isRestricted": false,
+  "isDeprecated": false,
+  "hideNumber": true,
+  "validations": []
+}

--- a/study-builder/studies/prion/snippets/boolean.conf
+++ b/study-builder/studies/prion/snippets/boolean.conf
@@ -1,0 +1,9 @@
+{
+  "questionType": "BOOLEAN",
+  "isRestricted": false,
+  "isDeprecated": false,
+  "hideNumber": true,
+  "additionalInfoHeaderTemplate": null,
+  "additionalInfoFooterTemplate": null,
+  "validations": []
+}

--- a/study-builder/studies/prion/snippets/country.conf
+++ b/study-builder/studies/prion/snippets/country.conf
@@ -1,0 +1,13 @@
+{
+  # Ideally the prompt template, picklist label template, and picklist options would be here but HOCON complains
+  "questionType": "PICKLIST",
+  "selectMode": "SINGLE",
+  "renderMode": "DROPDOWN",
+  "isRestricted": false,
+  "isDeprecated": false,
+  "hideNumber": true,
+  "additionalInfoHeaderTemplate": null,
+  "additionalInfoFooterTemplate": null,
+  "validations": [],
+  "groups": []
+}

--- a/study-builder/studies/snippets/picklist-question-single-checklist.conf
+++ b/study-builder/studies/snippets/picklist-question-single-checklist.conf
@@ -1,0 +1,14 @@
+{
+  "questionType": "PICKLIST",
+  "selectMode": "SINGLE",
+  "renderMode": "CHECKBOX_LIST",
+  "isRestricted": false,
+  "isDeprecated": false,
+  "hideNumber": false,
+  "additionalInfoHeaderTemplate": null,
+  "additionalInfoFooterTemplate": null,
+  "validations": [],
+  "picklistLabelTemplate": null,
+  "groups": [],
+  "picklistOptions": []
+}


### PR DESCRIPTION
## Context

See DDP-5020 and DDP-5013.  This does two things: first, it makes it so Prion's study configuration files work again.  Second, it updates the naming of triggered additional instances of the medical questionnaire.  Not sure if there's a better way to handle minor Prion-specific changes.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document