### PR TITLE
DDP-5019 pex: default isStatus() to false

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
@@ -260,14 +260,9 @@ public class TreeWalkInterpreter implements PexInterpreter {
                         }
                     })
                     .collect(Collectors.toList());
-
             return fetcher.findLatestActivityInstanceStatus(ictx, studyGuid, activityCode)
-                    .map(latestStatus -> expectedStatuses.contains(latestStatus))
-                    .orElseThrow(() -> {
-                        String msg = String.format("No activity instance of form %s found for user %s and study %s",
-                                activityCode, ictx.getUserGuid(), studyGuid);
-                        return new PexFetchException(new NoSuchElementException(msg));
-                    });
+                    .map(expectedStatuses::contains)
+                    .orElse(false);
         } else if (predCtx instanceof PexParser.HasInstancePredicateContext) {
             return fetcher.findLatestActivityInstanceStatus(ictx, studyGuid, activityCode).isPresent();
         } else {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/pex/TreeWalkInterpreterTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/pex/TreeWalkInterpreterTest.java
@@ -3,7 +3,6 @@ package org.broadinstitute.ddp.pex;
 import static org.broadinstitute.ddp.pex.RetrievedActivityInstanceType.LATEST;
 import static org.broadinstitute.ddp.pex.RetrievedActivityInstanceType.SPECIFIC;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -17,7 +16,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
@@ -697,8 +695,6 @@ public class TreeWalkInterpreterTest extends TxnAwareBaseTest {
 
     @Test
     public void testEval_formQuery_userDoesNotHaveInstance() {
-        thrown.expect(PexFetchException.class);
-        thrown.expectCause(instanceOf(NoSuchElementException.class));
         TransactionWrapper.useTxn(handle -> {
             FormActivityDef form = FormActivityDef.generalFormBuilder("PEX_ANOTHER_ACT", "v1", studyGuid)
                     .addName(new Translation("en", "another pex test activity"))
@@ -709,8 +705,7 @@ public class TreeWalkInterpreterTest extends TxnAwareBaseTest {
             String expr = String.format(
                     "user.studies[\"%s\"].forms[\"%s\"].isStatus(\"CREATED\")",
                     studyGuid, form.getActivityCode());
-            run(handle, expr);
-            fail("Expected exception was not thrown");
+            assertFalse(run(handle, expr));
         });
     }
 

--- a/study-builder/studies/angio/about-you.conf
+++ b/study-builder/studies/angio/about-you.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "PREQUALIFIER",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/angio/consent.conf
+++ b/study-builder/studies/angio/consent.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "CONSENT",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/angio/followup-consent.conf
+++ b/study-builder/studies/angio/followup-consent.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "CONSENT",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/angio/loved-one.conf
+++ b/study-builder/studies/angio/loved-one.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "GENERAL",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/angio/prequal.conf
+++ b/study-builder/studies/angio/prequal.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "GENERAL",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/angio/release.conf
+++ b/study-builder/studies/angio/release.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "GENERAL",
   "studyGuid": "ANGIO",

--- a/study-builder/studies/brain/about-you.conf
+++ b/study-builder/studies/brain/about-you.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "formType": "GENERAL",
   "listStyleHint": "NUMBER",
   "introduction": {

--- a/study-builder/studies/brain/consent.conf
+++ b/study-builder/studies/brain/consent.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "CONSENT",
   "studyGuid": "cmi-brain",

--- a/study-builder/studies/brain/post-consent.conf
+++ b/study-builder/studies/brain/post-consent.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "formType": "GENERAL",
   "listStyleHint": "NUMBER",
   "introduction": {

--- a/study-builder/studies/brain/prequal.conf
+++ b/study-builder/studies/brain/prequal.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "GENERAL",
   "studyGuid": "cmi-brain",

--- a/study-builder/studies/brain/release.conf
+++ b/study-builder/studies/brain/release.conf
@@ -1,4 +1,5 @@
 {
+  include required("../snippets/activity-general-form.conf"),
   "activityType": "FORMS",
   "formType": "GENERAL",
   "studyGuid": "cmi-brain",


### PR DESCRIPTION
## Context

This PR changes the behavior of the `isStatus()` query in PEX so that it returns `false` instead of throwing exception when instance is not found.

I have looked through the configurations for existing studies (Angio, Brain, MBC, Osteo), and have walked through the studies locally to ensure that they work as expected.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

