### PR TITLE
Increase netty thread redisson config to max value recommended. Tryin…

### DIFF
--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -20,7 +20,7 @@ singleServerConfig:
   dnsMonitoringInterval: 5000
   pingConnectionInterval: 3000
 threads: 16
-nettyThreads: 128
+nettyThreads: 256
 codec: !<org.redisson.codec.FstCodec> {}
 transportMode: "NIO"
 {{end}}


### PR DESCRIPTION
Problem with timeouts still showing up in dev alerts even after previous tweaks to configuration.

`Unable to send PING command over channel: [id: 0x4a9f46d4, L:/169.254.8.1:45548 - R:/10.248.94.251:6379] Command execution timeout for command: (PING), params: [], Redis client: [addr=redis://10.248.94.251:6379]
`
Going to try to go with the max value recommended to fix this problem based on this FAQ for Redisson library:
https://github.com/redisson/redisson/wiki/16.-FAQ