### PR TITLE
Redisson reversing netty thread increase

### DIFF
--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -20,7 +20,7 @@ singleServerConfig:
   dnsMonitoringInterval: 5000
   pingConnectionInterval: 3000
 threads: 16
-nettyThreads: 128
+nettyThreads: 256
 codec: !<org.redisson.codec.FstCodec> {}
 transportMode: "NIO"
 {{end}}

--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -7,7 +7,7 @@ singleServerConfig:
   connectTimeout: 10000
   timeout: 3000
   retryAttempts: 3
-  retryInterval: 1500
+  retryInterval: 3000
   password: null
   subscriptionsPerConnection: 5
   clientName: null
@@ -15,7 +15,7 @@ singleServerConfig:
   subscriptionConnectionMinimumIdleSize: 1
   subscriptionConnectionPoolSize: 50
   connectionMinimumIdleSize: 24
-  connectionPoolSize: 64
+  connectionPoolSize: 86
   database: 0
   dnsMonitoringInterval: 5000
   pingConnectionInterval: 3000

--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -20,7 +20,7 @@ singleServerConfig:
   dnsMonitoringInterval: 5000
   pingConnectionInterval: 3000
 threads: 16
-nettyThreads: 256
+nettyThreads: 128
 codec: !<org.redisson.codec.FstCodec> {}
 transportMode: "NIO"
 {{end}}


### PR DESCRIPTION
Turning up to nettyThreads to 256 appears to have made matters worse. Going back to 128. Will have to investigate other solutions here.
Going back to recommendations here https://github.com/redisson/redisson/wiki/16.-FAQ#q-i-saw-a-redistimeoutexception-what-does-it-mean-what-shall-i-do-can-redisson-team-fix-it

and reading the actual source, there is a good chance that the reason for the timeout is that there is no connection available to execute PING.

So increasing the connection pool size and retry interval. 