### PR TITLE
testboston: occupation other specify

### DIFF
--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -270,6 +270,7 @@
     "female": "Female",
     "other": "Other",
     "other_details": "Please provide details",
+    "other_specify": "Please specify",
     "man": "Man",
     "woman": "Woman",
     "transgender": "Transgender",

--- a/study-builder/studies/testboston/i18n/es.conf
+++ b/study-builder/studies/testboston/i18n/es.conf
@@ -270,6 +270,7 @@
     "female": "Femenino",
     "other": "Otro",
     "other_details": "Por favor proporcione detalles",
+    "other_specify": "por favor especificar",
     "man": "Hombre",
     "woman": "Mujer",
     "transgender": "Transgénero",

--- a/study-builder/studies/testboston/i18n/ht.conf
+++ b/study-builder/studies/testboston/i18n/ht.conf
@@ -270,6 +270,7 @@
     "female": "[HT] Female",
     "other": "[HT] Other",
     "other_details": "[HT] Please provide details",
+    "other_specify": "Tanpri presize",
     "man": "[HT] Man",
     "woman": "[HT] Woman",
     "transgender": "[HT] Transgender",

--- a/study-builder/studies/testboston/snippets/question-occupation.conf
+++ b/study-builder/studies/testboston/snippets/question-occupation.conf
@@ -465,14 +465,14 @@
       "detailLabelTemplate": {
         "templateType": "TEXT",
         "templateCode": null,
-        "templateText": "$occupation_other_details",
+        "templateText": "$occupation_other_specify",
         "variables": [
           {
-            "name": "occupation_other_details",
+            "name": "occupation_other_specify",
             "translations": [
-              { "language": "en", "text": ${i18n.en.option.other_details} },
-              { "language": "es", "text": ${i18n.es.option.other_details} },
-              { "language": "ht", "text": ${i18n.ht.option.other_details} }
+              { "language": "en", "text": ${i18n.en.option.other_specify} },
+              { "language": "es", "text": ${i18n.es.option.other_specify} },
+              { "language": "ht", "text": ${i18n.ht.option.other_specify} }
             ]
           }
         ]


### PR DESCRIPTION
Another text change for TestBoston, per https://broadinstitute.atlassian.net/browse/DDP-5032.