### PR TITLE
Brain project name fix

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainPrequalV2.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainPrequalV2.java
@@ -98,7 +98,7 @@ public class BrainPrequalV2 implements CustomTask {
         RevisionMetadata meta = new RevisionMetadata(timestamp.toEpochMilli(), adminUser.getUserId(), reason);
         SqlHelper helper = handle.attach(SqlHelper.class);
         String selfOptionText = "I have been diagnosed with brain cancer.";
-        String promptText = "First, how will you be participating in the Brain Tumor Project? ";
+        String promptText = "First, how will you be participating in the Brain Cancer Project? ";
 
         //load new activity def/conf
         ActivityDef def = GsonUtil.standardGson().fromJson(ConfigUtil.toJson(dataCfg), ActivityDef.class);

--- a/study-builder/studies/brain/patches/prequal-v2.conf
+++ b/study-builder/studies/brain/patches/prequal-v2.conf
@@ -39,7 +39,7 @@
                   "translations": [
                     {
                       "language": "en",
-                      "text": "First, how will you be participating in the Brain Tumor Project?"
+                      "text": "First, how will you be participating in the Brain Cancer Project?"
                     }
                   ]
                 }

--- a/study-builder/studies/brain/patches/prequal-validations.conf
+++ b/study-builder/studies/brain/patches/prequal-validations.conf
@@ -15,7 +15,7 @@
                   {
                     "language": "en",
                     "text": """
-                      Currently, the Brain Tumor Project is open only to patients in the United States or Canada.
+                      Currently, the Brain Cancer Project is open only to patients in the United States or Canada.
                       If you do live or are treated in the United States or Canada, please reach out to us at
                       <a href="mailto:info@braincancerproject.org" class="Link">info@braincancerproject.org</a>.
                     """
@@ -44,7 +44,7 @@
                   {
                     "language": "en",
                     "text": """
-                      Currently, the Brain Tumor Project is open only to patients in the United States or Canada.
+                      Currently, the Brain Cancer Project is open only to patients in the United States or Canada.
                       If your child does live or is treated in the United States or Canada, please reach out to us at
                       <a href="mailto:info@braincancerproject.org" class="Link">info@braincancerproject.org</a>.
                     """

--- a/study-builder/studies/brain/sendgrid_emails.conf
+++ b/study-builder/studies/brain/sendgrid_emails.conf
@@ -147,7 +147,7 @@
     {
       "key": "parentalBloodSent",
       "name": "BRAIN_PARENTAL_BLOOD_SENT",
-      "subject": "Brain Tumor Project Check-In",
+      "subject": "Brain Cancer Project Check-In",
       "filepath": "emails/parental_blood_sent.html",
       "render": true,
       "isDynamic": true
@@ -155,7 +155,7 @@
     {
       "key": "parentalBloodSentReminder",
       "name": "BRAIN_PARENTAL_BLOOD_SENT_REMINDER",
-      "subject": "Brain Tumor Project Check-In",
+      "subject": "Brain Cancer Project Check-In",
       "filepath": "emails/parental_blood_sent_reminder.html",
       "render": true,
       "isDynamic": true
@@ -163,7 +163,7 @@
     {
       "key": "parentalConsent1wkReminder",
       "name": "BRAIN_PARENTAL_CONSENT_1WK_REMINDER",
-      "subject": "Reminder: Please sign the Brain Tumor Project Consent form",
+      "subject": "Reminder: Please sign the Brain Cancer Project Consent form",
       "filepath": "emails/parental_consent_1wk_reminder.html",
       "render": true,
       "isDynamic": true
@@ -171,7 +171,7 @@
     {
       "key": "parentalConsent2wkReminder",
       "name": "BRAIN_PARENTAL_CONSENT_2WK_REMINDER",
-      "subject": "Reminder: Please sign the Brain Tumor Project Consent form",
+      "subject": "Reminder: Please sign the Brain Cancer Project Consent form",
       "filepath": "emails/parental_consent_2wk_reminder.html",
       "render": true,
       "isDynamic": true
@@ -179,7 +179,7 @@
     {
       "key": "parentalConsent3wkReminder",
       "name": "BRAIN_PARENTAL_CONSENT_3WK_REMINDER",
-      "subject": "Reminder: Please sign the Brain Tumor Project Consent form",
+      "subject": "Reminder: Please sign the Brain Cancer Project Consent form",
       "filepath": "emails/parental_consent_3wk_reminder.html",
       "render": true,
       "isDynamic": true
@@ -259,7 +259,7 @@
     {
       "key": "reconsentEmailVerification",
       "name": "BRAIN_RECONSENT_EMAIL_VERIFICATION",
-      "subject": "Brain Tumor Project - Email Verification & Consent",
+      "subject": "Brain Cancer Project - Email Verification & Consent",
       "filepath": "emails/reconsent_email_verification.html",
       "render": true,
       "isDynamic": true
@@ -267,7 +267,7 @@
     {
       "key": "reconsentNextSteps",
       "name": "BRAIN_RECONSENT_NEXT_STEPS",
-      "subject": "Brain Tumor Project - Consent for Research",
+      "subject": "Brain Cancer Project - Consent for Research",
       "filepath": "emails/reconsent_next_steps.html",
       "render": true,
       "isDynamic": true

--- a/study-builder/studies/brain/snippets/consent-minors-section1-preamble.conf
+++ b/study-builder/studies/brain/snippets/consent-minors-section1-preamble.conf
@@ -10,7 +10,7 @@
           {
             "language": "en",
             "text": """
-              "The Brain Tumor Project" is a patient-driven movement that empowers Brain Tumor patients and their families
+              "The Brain Cancer Project" is a patient-driven movement that empowers Brain Cancer patients and their families
               to directly transform research and treatment of disease by sharing copies of their medical records and
               tissue and/or blood samples with researchers in order to accelerate the pace of discovery. Because
               we are enrolling participants across the country regardless of where they are being treated, this study

--- a/study-builder/studies/brain/snippets/consent-minors-section1-purpose.conf
+++ b/study-builder/studies/brain/snippets/consent-minors-section1-purpose.conf
@@ -24,7 +24,7 @@
           {
             "language": "en",
             "text": """
-              We want to understand Brain Tumor better so that we can develop more effective therapies. By
+              We want to understand Brain Cancer better so that we can develop more effective therapies. By
               partnering directly with patients and their families, we are able to study many more aspects of cancer than would
               otherwise be possible."""
           }

--- a/study-builder/studies/brain/snippets/consent-minors-section2-intro.conf
+++ b/study-builder/studies/brain/snippets/consent-minors-section2-intro.conf
@@ -32,8 +32,8 @@
             "language": "en",
             "text": """
               You are being invited to enroll your child in a research study that will collect and analyze samples and
-              health information of patients with Brain Tumor. This study will help doctors and researchers better
-              understand why Brain Tumor occurs and develop ways to better treat and prevent it."""
+              health information of patients with Brain Cancer. This study will help doctors and researchers better
+              understand why Brain Cancer occurs and develop ways to better treat and prevent it."""
           }
         ]
       },
@@ -84,7 +84,7 @@
           {
             "language": "en",
             "text": """
-              You are being asked to have your child participate in the study because your child has Brain Tumor. Other than providing
+              You are being asked to have your child participate in the study because your child has Brain Cancer. Other than providing
               your child's saliva samples and, if you elect to, your child's blood sample(s) (1 tube or 2 teaspoons per sample), participating
               in the study involves no additional tests or procedures."""
           }

--- a/study-builder/studies/brain/snippets/former-proxy-announcement-msg.conf
+++ b/study-builder/studies/brain/snippets/former-proxy-announcement-msg.conf
@@ -11,7 +11,7 @@
       "translations": [
         {
           "language": "en",
-          "text": "A Message from the Brain Tumor Project"
+          "text": "A Message from the Brain Cancer Project"
         }
       ]
     },
@@ -21,7 +21,7 @@
         {
           "language": "en",
           "text": """
-            Your child has reached the age of consenting for themselves in order to continue their participation in the Brain Tumor Project.
+            Your child has reached the age of consenting for themselves in order to continue their participation in the Brain Cancer Project.
             Because of this, access and control of their information related to this project has shifted to their account."""
         }
       ]
@@ -32,7 +32,7 @@
         {
           "language": "en",
           "text": """
-            Thank you for your support of the Brain Tumor Project, if you have any questions about this change or other topics,
+            Thank you for your support of the Brain Cancer Project, if you have any questions about this change or other topics,
             email us at <a class="Link" href="mailto:info@braincancerproject.org">info@braincancerproject.org</a>
             or call <a class="Link" href="tel:651-229-3480">651-229-3480</a>."""
         }

--- a/study-builder/studies/brain/snippets/thank-you-announcement-msg.conf
+++ b/study-builder/studies/brain/snippets/thank-you-announcement-msg.conf
@@ -13,7 +13,7 @@
       "translations": [
         {
           "language": "en",
-          "text": "A Message from the Brain Tumor Project"
+          "text": "A Message from the Brain Cancer Project"
         }
       ]
     },


### PR DESCRIPTION
While we wait for IRB approval: revert the project name to "Brain Cancer Project" from new "Brain Tumor Project". 
Kit rule expr update to handle pediatrics