### PR TITLE
Add code to test redis connection when an exception has occurred

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,9 @@ commands:
             develop)
               DEPLOY_ENV=dev
             ;;
+            RedisConnectionHandling)
+              DEPLOY_ENV=dev
+            ;;
             test)
               DEPLOY_ENV=test
             ;;
@@ -824,6 +827,7 @@ workflows:
                 - develop
                 - &rc /^rc.*/
                 - &hotfix /^hotfix.*/
+                - RedisConnectionHandling
       - parallel-compile-and-test-job:
           parallelism: *test_parallelism
           <<: *compile_and_test_filters
@@ -834,6 +838,7 @@ workflows:
             branches:
               only:
                 - develop
+                - RedisConnectionHandling
           requires:
             - parallel-compile-and-test-job
             - compile-and-run-test-suite-job

--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -10,12 +10,12 @@ singleServerConfig:
   retryInterval: 1500
   password: null
   subscriptionsPerConnection: 5
-  clientName: null
+  clientName: pepper-backend
   address: "redis://{{$conf.Data.redis.host}}:{{$conf.Data.redis.port}}"
   subscriptionConnectionMinimumIdleSize: 1
   subscriptionConnectionPoolSize: 50
   connectionMinimumIdleSize: 24
-  connectionPoolSize: 86
+  connectionPoolSize: 64
   database: 0
   dnsMonitoringInterval: 5000
   pingConnectionInterval: 15000

--- a/pepper-apis/config/redisson-jcache.yaml.ctmpl
+++ b/pepper-apis/config/redisson-jcache.yaml.ctmpl
@@ -10,7 +10,7 @@ singleServerConfig:
   retryInterval: 1500
   password: null
   subscriptionsPerConnection: 5
-  clientName: pepper-backend
+  clientName: null
   address: "redis://{{$conf.Data.redis.host}}:{{$conf.Data.redis.port}}"
   subscriptionConnectionMinimumIdleSize: 1
   subscriptionConnectionPoolSize: 50

--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -452,6 +452,11 @@
             <version>3.13.4</version>
         </dependency>
         <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
             <version>4.1.50.Final</version>

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
@@ -7,6 +7,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
 import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
 import org.broadinstitute.ddp.model.activity.instance.answer.CompositeAnswer;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -104,6 +105,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + idToAnswerCache.getName() + " key lookedup:"
                         + answerId + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             Optional<Answer> optAnswer;
             if (answer == null) {
@@ -141,6 +143,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + activityInstanceGuidAndQuestionKeyToAnswerIdCache.getName()
                         + " key lookedup:" + key + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (answerId != null) {
                 try {
@@ -148,6 +151,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                 } catch (RedisException e) {
                     LOG.warn("Failed to retrieve value from Redis cache: " + idToAnswerCache.getName()
                             + " key lookedup:" + answerId + "Will try to retrieve from database", e);
+                    TestRedisConnection.doTest();
                 }
             }
             if (answer == null) {
@@ -171,6 +175,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                 idToAnswerCache.putAsync(answer.getAnswerId(), answer);
             } catch (RedisException e) {
                 LOG.warn("Failed to save to Redis cache: " + idToAnswerCache.getName() + " with key:" + answer.getAnswerId(), e);
+                TestRedisConnection.doTest();
             }
 
             String key = buildKey(answer);
@@ -179,6 +184,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                     activityInstanceGuidAndQuestionKeyToAnswerIdCache.putAsync(key, answer.getAnswerId());
                 } catch (RedisException e) {
                     LOG.warn("Failed to save to Redis cache: " + idToAnswerCache.getName() + " with key:" + key, e);
+                    TestRedisConnection.doTest();
                 }
             }
         }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
@@ -7,7 +7,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
 import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
 import org.broadinstitute.ddp.model.activity.instance.answer.CompositeAnswer;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -105,7 +105,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + idToAnswerCache.getName() + " key lookedup:"
                         + answerId + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             Optional<Answer> optAnswer;
             if (answer == null) {
@@ -143,7 +143,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + activityInstanceGuidAndQuestionKeyToAnswerIdCache.getName()
                         + " key lookedup:" + key + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (answerId != null) {
                 try {
@@ -151,7 +151,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                 } catch (RedisException e) {
                     LOG.warn("Failed to retrieve value from Redis cache: " + idToAnswerCache.getName()
                             + " key lookedup:" + answerId + "Will try to retrieve from database", e);
-                    TestRedisConnection.doTest();
+                    RedisConnectionValidator.doTest();
                 }
             }
             if (answer == null) {
@@ -175,7 +175,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                 idToAnswerCache.putAsync(answer.getAnswerId(), answer);
             } catch (RedisException e) {
                 LOG.warn("Failed to save to Redis cache: " + idToAnswerCache.getName() + " with key:" + answer.getAnswerId(), e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
 
             String key = buildKey(answer);
@@ -184,7 +184,7 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
                     activityInstanceGuidAndQuestionKeyToAnswerIdCache.putAsync(key, answer.getAnswerId());
                 } catch (RedisException e) {
                     LOG.warn("Failed to save to Redis cache: " + idToAnswerCache.getName() + " with key:" + key, e);
-                    TestRedisConnection.doTest();
+                    RedisConnectionValidator.doTest();
                 }
             }
         }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JbdiActivityInstanceStatusTypeCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JbdiActivityInstanceStatusTypeCached.java
@@ -6,7 +6,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceStatusType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
 import org.broadinstitute.ddp.route.GetActivityInstanceStatusTypeListRoute;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -50,7 +50,7 @@ public class JbdiActivityInstanceStatusTypeCached extends SQLObjectWrapper<JdbiA
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + languageCodeToActivityInstanceStatusType.getName()
                         + " key lookedup: " + isoLanguageCode + " Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (statusTypes == null) {
                 statusTypes = delegate.getActivityInstanceStatusTypes(isoLanguageCode);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JbdiActivityInstanceStatusTypeCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JbdiActivityInstanceStatusTypeCached.java
@@ -6,6 +6,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceStatusType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
 import org.broadinstitute.ddp.route.GetActivityInstanceStatusTypeListRoute;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -49,6 +50,7 @@ public class JbdiActivityInstanceStatusTypeCached extends SQLObjectWrapper<JdbiA
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + languageCodeToActivityInstanceStatusType.getName()
                         + " key lookedup: " + isoLanguageCode + " Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (statusTypes == null) {
                 statusTypes = delegate.getActivityInstanceStatusTypes(isoLanguageCode);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.QuestionDto;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -65,7 +65,7 @@ public class JdbiQuestionCached extends SQLObjectWrapper<JdbiQuestion> implement
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + questionKeyToQuestionDtosCache.getName() + " key lookedup:" + key
                         + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (cachedQuestionDtos == null) {
                 Map<String, List<QuestionDto>> mapOfDtos = cacheQuestionDtosForStudyActivity(activityInstance.getActivityId());
@@ -97,7 +97,7 @@ public class JdbiQuestionCached extends SQLObjectWrapper<JdbiQuestion> implement
             questionKeyToQuestionDtosCache.putAllAsync(dtoMap);
         } catch (RedisException e) {
             LOG.warn("Failed to store value from Redis cache: " + questionKeyToQuestionDtosCache.getName(), e);
-            TestRedisConnection.doTest();
+            RedisConnectionValidator.doTest();
         }
         return dtoMap;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
@@ -13,6 +13,7 @@ import java.util.stream.Stream;
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.QuestionDto;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -64,6 +65,7 @@ public class JdbiQuestionCached extends SQLObjectWrapper<JdbiQuestion> implement
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + questionKeyToQuestionDtosCache.getName() + " key lookedup:" + key
                         + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (cachedQuestionDtos == null) {
                 Map<String, List<QuestionDto>> mapOfDtos = cacheQuestionDtosForStudyActivity(activityInstance.getActivityId());
@@ -95,6 +97,7 @@ public class JdbiQuestionCached extends SQLObjectWrapper<JdbiQuestion> implement
             questionKeyToQuestionDtosCache.putAllAsync(dtoMap);
         } catch (RedisException e) {
             LOG.warn("Failed to store value from Redis cache: " + questionKeyToQuestionDtosCache.getName(), e);
+            TestRedisConnection.doTest();
         }
         return dtoMap;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionValidationCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionValidationCached.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.db.dto.QuestionDto;
 import org.broadinstitute.ddp.db.dto.validation.ValidationDto;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -59,7 +59,7 @@ public class JdbiQuestionValidationCached extends SQLObjectWrapper<JdbiQuestionV
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + questionIdToValidationsCache.getName() + " key lookedup:"
                         + questionDto.getId() + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (validations == null) {
                 Map<Long, List<ValidationDto>> data = cacheActivityValidations(questionDto.getActivityId());
@@ -75,7 +75,7 @@ public class JdbiQuestionValidationCached extends SQLObjectWrapper<JdbiQuestionV
             questionIdToValidationsCache.putAllAsync(dataToCache);
         } catch (RedisException e) {
             LOG.warn("Failed to cache data to Redis: " + questionIdToValidationsCache.getName() + " to key" + activityId, e);
-            TestRedisConnection.doTest();
+            RedisConnectionValidator.doTest();
         }
 
         return dataToCache;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionValidationCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionValidationCached.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.db.dto.QuestionDto;
 import org.broadinstitute.ddp.db.dto.validation.ValidationDto;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -58,6 +59,7 @@ public class JdbiQuestionValidationCached extends SQLObjectWrapper<JdbiQuestionV
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + questionIdToValidationsCache.getName() + " key lookedup:"
                         + questionDto.getId() + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (validations == null) {
                 Map<Long, List<ValidationDto>> data = cacheActivityValidations(questionDto.getActivityId());
@@ -73,6 +75,7 @@ public class JdbiQuestionValidationCached extends SQLObjectWrapper<JdbiQuestionV
             questionIdToValidationsCache.putAllAsync(dataToCache);
         } catch (RedisException e) {
             LOG.warn("Failed to cache data to Redis: " + questionIdToValidationsCache.getName() + " to key" + activityId, e);
+            TestRedisConnection.doTest();
         }
 
         return dataToCache;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
@@ -7,6 +7,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.cache.ModelChangeType;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.model.address.OLCPrecision;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -64,9 +65,9 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
             try {
                 id = studyGuidToIdCache.get(studyGuid);
             } catch (RedisException e) {
-                LOG.warn("Failed to retrieve value from Redis cache: " + studyGuidToIdCache.getName() + " key lookedup:" +  studyGuid
-                                + "Will try to retrieve from database",
-                        e);
+                LOG.warn("Failed to retrieve value from Redis cache: " + studyGuidToIdCache.getName() + " key lookedup:" + studyGuid
+                                + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (id == null) {
                 dto = delegate.findByStudyGuid(studyGuid);
@@ -87,7 +88,8 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
             try {
                 dto = idToStudyCache.get(studyId);
             } catch (RedisException e) {
-                LOG.warn("Failed to retrieve value from Redis cache: " + idToStudyCache.getName() + " key lookedup:" +  studyId, e);
+                LOG.warn("Failed to retrieve value from Redis cache: " + idToStudyCache.getName() + " key lookedup:" + studyId, e);
+                TestRedisConnection.doTest();
             }
             if (dto == null) {
                 dto = delegate.findById(studyId);
@@ -151,6 +153,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                 studyGuidToIdCache.removeAsync(dto.getGuid());
             } catch (RedisException e) {
                 LOG.warn("Failed to remove values from Redis caches", e);
+                TestRedisConnection.doTest();
             }
         }
     }
@@ -225,6 +228,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                 studyGuidToIdCache.put(dto.getGuid(), dto.getId());
             } catch (RedisException e) {
                 LOG.warn("Failed to store value to Redis cache", e);
+                TestRedisConnection.doTest();
             }
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
@@ -7,7 +7,7 @@ import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.cache.ModelChangeType;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.model.address.OLCPrecision;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -67,7 +67,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + studyGuidToIdCache.getName() + " key lookedup:" + studyGuid
                                 + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (id == null) {
                 dto = delegate.findByStudyGuid(studyGuid);
@@ -89,7 +89,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                 dto = idToStudyCache.get(studyId);
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + idToStudyCache.getName() + " key lookedup:" + studyId, e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (dto == null) {
                 dto = delegate.findById(studyId);
@@ -153,7 +153,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                 studyGuidToIdCache.removeAsync(dto.getGuid());
             } catch (RedisException e) {
                 LOG.warn("Failed to remove values from Redis caches", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
         }
     }
@@ -228,7 +228,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                 studyGuidToIdCache.put(dto.getGuid(), dto.getId());
             } catch (RedisException e) {
                 LOG.warn("Failed to store value to Redis cache", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyLanguageCachedDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyLanguageCachedDao.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.model.study.StudyLanguage;
-import org.broadinstitute.ddp.util.TestRedisConnection;
+import org.broadinstitute.ddp.util.RedisConnectionValidator;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -48,7 +48,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
             studyIdToLanguageCache.remove(umbrellaStudyId);
         } catch (RedisException e) {
             LOG.warn("Failed to remove values from Redis caches", e);
-            TestRedisConnection.doTest();
+            RedisConnectionValidator.doTest();
         }
         return delegate.insert(umbrellaStudyId, languageCodeId);
     }
@@ -98,7 +98,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + studyIdToLanguageCache.getName() + " key lookedup:"
                         + umbrellaStudyId + "Will try to retrieve from database", e);
-                TestRedisConnection.doTest();
+                RedisConnectionValidator.doTest();
             }
             if (result == null) {
                 result = delegate.findLanguages(umbrellaStudyId);
@@ -106,7 +106,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
                     studyIdToLanguageCache.putAsync(umbrellaStudyId, result);
                 } catch (RedisException e) {
                     LOG.warn("Failed to store value to Redis cache: " + studyIdToLanguageCache.getName() + " key " + umbrellaStudyId, e);
-                    TestRedisConnection.doTest();
+                    RedisConnectionValidator.doTest();
                 }
             }
             return result;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyLanguageCachedDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyLanguageCachedDao.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.broadinstitute.ddp.cache.CacheService;
 import org.broadinstitute.ddp.model.study.StudyLanguage;
+import org.broadinstitute.ddp.util.TestRedisConnection;
 import org.jdbi.v3.core.Handle;
 import org.redisson.api.RLocalCachedMap;
 import org.redisson.client.RedisException;
@@ -47,6 +48,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
             studyIdToLanguageCache.remove(umbrellaStudyId);
         } catch (RedisException e) {
             LOG.warn("Failed to remove values from Redis caches", e);
+            TestRedisConnection.doTest();
         }
         return delegate.insert(umbrellaStudyId, languageCodeId);
     }
@@ -96,6 +98,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
             } catch (RedisException e) {
                 LOG.warn("Failed to retrieve value from Redis cache: " + studyIdToLanguageCache.getName() + " key lookedup:"
                         + umbrellaStudyId + "Will try to retrieve from database", e);
+                TestRedisConnection.doTest();
             }
             if (result == null) {
                 result = delegate.findLanguages(umbrellaStudyId);
@@ -103,6 +106,7 @@ public class StudyLanguageCachedDao extends SQLObjectWrapper<StudyLanguageDao> i
                     studyIdToLanguageCache.putAsync(umbrellaStudyId, result);
                 } catch (RedisException e) {
                     LOG.warn("Failed to store value to Redis cache: " + studyIdToLanguageCache.getName() + " key " + umbrellaStudyId, e);
+                    TestRedisConnection.doTest();
                 }
             }
             return result;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/RedisConnectionValidator.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/RedisConnectionValidator.java
@@ -6,8 +6,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 
-public class TestRedisConnection {
-    private static final Logger LOG = LoggerFactory.getLogger(TestRedisConnection.class);
+public class RedisConnectionValidator {
+    private static final Logger LOG = LoggerFactory.getLogger(RedisConnectionValidator.class);
 
     public static void doTest() {
         String redisAddress = ConfigManager.getInstance().getConfig().getString(ConfigFile.REDIS_SERVER_ADDRESS);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/TestRedisConnection.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/TestRedisConnection.java
@@ -1,0 +1,37 @@
+package org.broadinstitute.ddp.util;
+
+import org.apache.commons.lang.StringUtils;
+import org.broadinstitute.ddp.constants.ConfigFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+public class TestRedisConnection {
+    private static final Logger LOG = LoggerFactory.getLogger(TestRedisConnection.class);
+
+    public static void doTest() {
+        String redisAddress = ConfigManager.getInstance().getConfig().getString(ConfigFile.REDIS_SERVER_ADDRESS);
+        String host = StringUtils.substringBetween(redisAddress, "//", ":");
+        String portString = StringUtils.substringAfterLast(redisAddress, ":");
+        doTest(host, Integer.parseInt(portString));
+    }
+
+    public static void doTest(String host, int port) {
+        String testHash = "testhash";
+        String valToWrite = Math.random() + "";
+        try (var jedis = new Jedis(host, port)) {
+            jedis.hset(testHash, "hello", valToWrite);
+
+            String valRead = jedis.hget(testHash, "hello");
+            if (valToWrite.equals(valRead)) {
+                LOG.info("Redis is fine");
+            }
+        } catch (RuntimeException e) {
+            LOG.error("There was a problem reading/writing to Redis", e);
+        }
+    }
+
+    public static void main(String[] args) {
+        doTest("localhost", 6379);
+    }
+}


### PR DESCRIPTION
## Context

Two things:
First, we were using 2 different configuration for caches. And one of them was using a very long timeout (30s) which has been causing problems in production.
So one change makes sure we use the same settings for all Redis caches.

Second, going through logs, it appears frequently when a Redis problem occurs, there are other errors in the logs that suggest we have network connectivity issues; have seen Redis errors coinciding with tcell not being able to read from its own servers and logback logging not being able to contact Slack.

Wherever we detect a RedisException we try to run a simple test: using a completely different Redis library, we try to read and write a value.

If a RedisException occurs, but we have connectivity, then we can't blame the VPC or any other networking system.

Code is self-explanatory.
