### PR TITLE
Revert SlackAppender changes

### DIFF
--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.github.seratch</groupId>
             <artifactId>jslack</artifactId>
-            <version>3.4.2</version>
+            <version>1.0.26</version>
         </dependency>
 
         <dependency>

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/log/SlackAppender.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/log/SlackAppender.java
@@ -133,12 +133,7 @@ public class SlackAppender<E> extends AppenderBase<ILoggingEvent> {
                 logBreadCrumb = e.getMDCPropertyMap().get(MDCLogBreadCrumbFilter.LOG_BREADCRUMB);
             }
             if (StringUtils.isNotBlank(logBreadCrumb)) {
-                var attachment = Attachment.builder().text("grep for `" + logBreadCrumb + "`")
-                        .appUnfurl(false)
-                        .msgUnfurl(false)
-                        .replyUnfurl(false)
-                        .threadRootUnfurl(false).build();
-                attachments.add(attachment);
+                attachments.add(Attachment.builder().text("grep for `" + logBreadCrumb + "`").build());
             }
 
             Payload messagePayload = Payload.builder()


### PR DESCRIPTION
## Context
The problem came up with running tests.
The main symptom was that routes did not properly urldecode query params.
So the URLS coming into the server looked like this:
```
http://localhost:5556/pepper/v1/post-password-resetclientId=ohaL5lylXNKGlZqvDfDv85jLTblqhNRw&success=true&domain=https%3A%2F%2Fddp-dev.auth0.com%2F&email=test_user%40datadonationplatform.org
```
And code in route would try to extract the domain param like so:
```
request.getParam("domain")
```
This method call should return the URL decoded value `https://ddp-dev.auth0.com/`
but instead it was returning the undecoded string `https%3A%2F%2Fddp-dev.auth0.com%2F`

By process of elimination found that the updated `jslack` dependency introduced this behavior into system.
A bit puzzling because I did not find any dependencies that would overwrite any of ours. Maybe included in jar itself?

