### PR TITLE
Increase Java Heap and turn on profiling for housekeeping in prod

### DIFF
--- a/pepper-apis/config/Housekeeping.yaml.ctmpl
+++ b/pepper-apis/config/Housekeeping.yaml.ctmpl
@@ -10,10 +10,10 @@ vpc_access_connector:
 manual_scaling:
   instances: 1
 # todo arz give housekeeping and backends different app names for tcell
-{{if and (or (eq $environment "dev") (eq $environment "test")) (eq $gae "true") }}
-entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true -Xms820m -Xmx820m -jar Housekeeping.jar
+{{if and (or (eq $environment "prod") (eq $environment "dev") (eq $environment "test")) (eq $gae "true") }}
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true -Xms1640m -Xmx1640m -jar Housekeeping.jar
 {{else}}
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xms820m -Xmx820m -jar Housekeeping.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xms1640m -Xmx1640m -jar Housekeeping.jar
 {{end}}
 
 # GAE does not like the "=" character in entrypoint and does not support "." in environment variables


### PR DESCRIPTION
In case we want to pursue this angle further, I have created this PR.

There might be a memory leak rearing its head in prod.
Turn on GCP profiler to investigate.
Also memory setting was way low. Increased to match settings used in pepper-backend.