### PR TITLE
DDP-5161 invitation already accepted as `info` instead of `error`

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/AdminCreateStudyParticipantRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/AdminCreateStudyParticipantRoute.java
@@ -75,7 +75,7 @@ public class AdminCreateStudyParticipantRoute extends ValidatedJsonInputRoute<Cr
                 throw ResponseUtil.haltError(HttpStatus.SC_BAD_REQUEST, new ApiError(ErrorCodes.INVALID_INVITATION, msg));
             } else if (invitation.isAccepted()) {
                 String msg = String.format("Invitation %s has already been accepted", invitationGuid);
-                LOG.error(msg);
+                LOG.info(msg);
                 throw ResponseUtil.haltError(HttpStatus.SC_BAD_REQUEST, new ApiError(ErrorCodes.INVALID_INVITATION, msg));
             } else if (invitation.getUserId() != null) {
                 String msg = String.format("Invitation %s has already been assigned to another user", invitationGuid);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
@@ -118,7 +118,7 @@ public class InvitationCheckStatusRoute extends ValidatedJsonInputRoute<Invitati
             LOG.error("Invitation {} is voided", invitationGuid);
             return new ApiError(ErrorCodes.INVALID_INVITATION, getInviteErrorMessage(handle, studyDto.getId(), langCode));
         } else if (invitation.isAccepted()) {
-            LOG.error("Invitation {} has already been accepted", invitationGuid);
+            LOG.info("Invitation {} has already been accepted", invitationGuid);
             return new ApiError(ErrorCodes.INVALID_INVITATION, getInviteErrorMessage(handle, studyDto.getId(), langCode));
         } else {
             LOG.info("Invitation {} is valid", invitationGuid);


### PR DESCRIPTION

## Context
DDP-5161: attempting to use an invitation more than once is interesting, but not something we need to be aware of immediately as an `error()`.

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.

Just grab an invitation that's already been accepted, plug it into the tbos project, and see the message as `info` instead of `error`.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

