### PR TITLE
DDP-5187 Housekeeping sends 12+ kit delivery emails by accident to participants

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -253,16 +254,23 @@ public class Housekeeping {
         //loop to pickup pending events on main DB API and create messages to send over to Housekeeping
         while (!stop) {
             try {
-                int numEventsProcessed = TransactionWrapper.withTxn(TransactionWrapper.DB.APIS, apisHandle -> {
+                // in one transaction, query the list of events to consider dispatching
+                final List<QueuedEventDto> pendingEvents = new ArrayList<>();
+                TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, apisHandle -> {
                     EventDao eventDao = apisHandle.attach(EventDao.class);
-                    JdbiQueuedEvent queuedEventDao = apisHandle.attach(JdbiQueuedEvent.class);
                     // first query the full list of pending events, shuffled to avoid event starvation
                     LOG.info("Querying pending events");
-                    List<QueuedEventDto> pendingEvents = eventDao.findPublishableQueuedEvents();
+                    pendingEvents.addAll(eventDao.findPublishableQueuedEvents());
                     LOG.info("Found {} events that may be publishable", pendingEvents.size());
                     Collections.shuffle(pendingEvents);
+                });
 
-                    for (QueuedEventDto pendingEvent : pendingEvents) {
+                for (QueuedEventDto pendingEvent : pendingEvents) {
+                    // for each event we are considering, handle it in its own transaction
+                    TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, apisHandle -> {
+                        boolean shouldSkipEvent = false;
+                        JdbiQueuedEvent queuedEventDao = apisHandle.attach(JdbiQueuedEvent.class);
+                        EventDao eventDao = apisHandle.attach(EventDao.class);
                         if (pendingEvent.getParticipantGuid() != null) {
                             User participant = apisHandle.attach(UserDao.class)
                                     .findUserByGuid(pendingEvent.getParticipantGuid())
@@ -270,143 +278,152 @@ public class Housekeeping {
                             if (participant == null) {
                                 LOG.error("Could not find participant {} for publishing queued event {}, skipping",
                                         pendingEvent.getParticipantGuid(), pendingEvent.getQueuedEventId());
-                                continue;
+                                shouldSkipEvent = true;
                             } else if (participant.isTemporary()) {
                                 LOG.warn("Participant {} for queued event {} is a temporary user, skipping",
                                         pendingEvent.getParticipantGuid(), pendingEvent.getQueuedEventId());
-                                continue;
+                                shouldSkipEvent = true;
                             }
                         }
 
-                        String pendingEventId = pendingEvent.getDdpEventId();
-                        boolean shouldCancel = false;
-                        if (StringUtils.isNotBlank(pendingEvent.getCancelCondition())) {
-                            try {
-                                shouldCancel = pexInterpreter.eval(pendingEvent.getCancelCondition(),
-                                        apisHandle,
-                                        pendingEvent.getParticipantGuid(),
-                                        null);
-                            } catch (PexException e) {
-                                LOG.warn("Failed to evaluate cancelCondition pex, defaulting to false: `{}`",
-                                        pendingEvent.getCancelCondition(), e);
-                                shouldCancel = false;
-                            }
-                        }
-                        if (shouldCancel) {
-                            LOG.info("Deleting queued event {} because its cancel condition has been met", pendingEvent
-                                    .getQueuedEventId());
-                            int rowsDeleted = queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
-                            if (rowsDeleted != 1) {
-                                throw new DDPException("Deleted " + rowsDeleted + " rows for queued event "
-                                        + pendingEvent.getQueuedEventId() + " after hitting cancel "
-                                        + "condition "
-                                        + pendingEvent.getCancelCondition());
-                            }
-                        } else {
-                            boolean hasMetPrecondition = true;
-                            if (StringUtils.isNotBlank(pendingEvent.getPrecondition())) {
+                        if (!shouldSkipEvent) {
+                            String pendingEventId = pendingEvent.getDdpEventId();
+                            boolean shouldCancel = false;
+                            if (StringUtils.isNotBlank(pendingEvent.getCancelCondition())) {
                                 try {
-                                    hasMetPrecondition = pexInterpreter.eval(pendingEvent.getPrecondition(),
+                                    shouldCancel = pexInterpreter.eval(pendingEvent.getCancelCondition(),
                                             apisHandle,
                                             pendingEvent.getParticipantGuid(),
                                             null);
                                 } catch (PexException e) {
-                                    LOG.warn("Failed to evaluate precondition pex, defaulting to false: `{}`",
-                                            pendingEvent.getPrecondition(), e);
-                                    hasMetPrecondition = false;
+                                    LOG.warn("Failed to evaluate cancelCondition pex, defaulting to false: `{}`",
+                                            pendingEvent.getCancelCondition(), e);
+                                    shouldCancel = false;
                                 }
                             }
-
-                            if (hasMetPrecondition) {
-                                if (pendingEvent.getActionType() == EventActionType.ACTIVITY_INSTANCE_CREATION) {
-                                    Optional<EventConfigurationDto> eventConfOptDto =
-                                            eventDao.getEventConfigurationDtoById(pendingEvent.getEventConfigurationId());
-                                    if (!eventConfOptDto.isPresent()) {
-                                        LOG.error("No event configuration found for ID: {} . skipping queued event : {} ",
-                                                pendingEvent.getEventConfigurationId(), pendingEvent.getQueuedEventId());
-                                    } else {
-                                        createActivityInstance(apisHandle, eventConfOptDto.get(), pendingEvent);
-                                        queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
-                                        continue;
+                            if (shouldCancel) {
+                                LOG.info("Deleting queued event {} because its cancel condition has been met", pendingEvent
+                                        .getQueuedEventId());
+                                int rowsDeleted = queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
+                                if (rowsDeleted != 1) {
+                                    throw new DDPException("Deleted " + rowsDeleted + " rows for queued event "
+                                            + pendingEvent.getQueuedEventId() + " after hitting cancel "
+                                            + "condition "
+                                            + pendingEvent.getCancelCondition());
+                                }
+                            } else {
+                                boolean hasMetPrecondition = true;
+                                if (StringUtils.isNotBlank(pendingEvent.getPrecondition())) {
+                                    try {
+                                        hasMetPrecondition = pexInterpreter.eval(pendingEvent.getPrecondition(),
+                                                apisHandle,
+                                                pendingEvent.getParticipantGuid(),
+                                                null);
+                                    } catch (PexException e) {
+                                        LOG.warn("Failed to evaluate precondition pex, defaulting to false: `{}`",
+                                                pendingEvent.getPrecondition(), e);
+                                        hasMetPrecondition = false;
                                     }
                                 }
-                                TransactionWrapper.useTxn(TransactionWrapper.DB.HOUSEKEEPING, housekeepingHandle -> {
-                                    JdbiEvent jdbiEvent = housekeepingHandle.attach(JdbiEvent.class);
-                                    JdbiMessage jdbiMessage = housekeepingHandle.attach(JdbiMessage.class);
-                                    if (jdbiEvent.shouldHandleEvent(
-                                            pendingEventId,
-                                            pendingEvent.getActionType().name(),
-                                            pendingEvent.getMaxOccurrencesPerUser())) {
-                                        String ddpMessageId = Long.toString(jdbiMessage.insertMessageForEvent(
-                                                pendingEventId));
-                                        LOG.info("Publishing queued event {}", pendingEvent.getQueuedEventId());
-                                        PubsubMessage message = null;
-                                        try {
-                                            message = messageBuilder.createMessage(ddpMessageId, pendingEvent, apisHandle);
-                                        } catch (NoSendableEmailAddressException e) {
-                                            boolean shouldDeleteEvent = apisHandle.attach(StudyDao.class)
-                                                    .findSettings(pendingEvent.getStudyGuid())
-                                                    .map(StudySettings::shouldDeleteUnsendableEmails)
-                                                    .orElse(false);
-                                            if (shouldDeleteEvent) {
-                                                LOG.warn("Unable to create message for event with queued_event_id={}, proceeding to delete",
-                                                        pendingEvent.getQueuedEventId(), e);
-                                                queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
-                                                return; // Exit out of transaction wrapper and move on to next event.
-                                            } else {
-                                                LOG.error("Could not create message for event with queued_event_id={}"
-                                                        + " because there is no email address to sent to",
-                                                        pendingEvent.getQueuedEventId(), e);
-                                            }
-                                        } catch (MessageBuilderException e) {
-                                            LOG.error("Could not create message for queued event "
-                                                    + pendingEvent.getQueuedEventId(), e);
-                                        }
 
-                                        if (message != null) {
-                                            // publish the message and delete it from the queue when published
-                                            Publisher publisher = null;
-                                            // todo arz cache publishers, creating them is expensive
-                                            try {
-                                                publisher = pubsubConnectionManager.createPublisher(ProjectTopicName.of(
-                                                        pubSubProject, pendingEvent.getPubSubTopic()));
-                                            } catch (IOException e) {
-                                                throw new DDPException("Could not create publisher for " + pendingEvent
-                                                        .getPubSubTopic(), e);
-                                            }
-                                            ApiFuture<String> publishResult = publisher.publish(message);
-
-                                            int numRowsUpdated = queuedEventDao.markPending(pendingEvent.getQueuedEventId());
-                                            LOG.info("Marked queued event {} as pending", pendingEvent.getQueuedEventId());
-                                            if (numRowsUpdated != 1) {
-                                                throw new DaoException("Marked " + numRowsUpdated + " rows as pending for "
-
-                                                        + "queued event " + pendingEventId);
-                                            }
-                                            setPostPublishingCallbacks(publishResult, pendingEvent.getQueuedEventId());
+                                if (hasMetPrecondition) {
+                                    if (pendingEvent.getActionType() == EventActionType.ACTIVITY_INSTANCE_CREATION) {
+                                        Optional<EventConfigurationDto> eventConfOptDto =
+                                                eventDao.getEventConfigurationDtoById(pendingEvent.getEventConfigurationId());
+                                        if (!eventConfOptDto.isPresent()) {
+                                            LOG.error("No event configuration found for ID: {} . skipping queued event : {} ",
+                                                    pendingEvent.getEventConfigurationId(), pendingEvent.getQueuedEventId());
                                         } else {
-                                            LOG.error("null message for " + pendingEvent.getQueuedEventId());
+                                            createActivityInstance(apisHandle, eventConfOptDto.get(), pendingEvent);
+                                            queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
+                                            shouldSkipEvent = true;
                                         }
-                                    } else {
-                                        LOG.info(IGNORE_EVENT_LOG_MESSAGE + "{}", pendingEvent
-                                                .getEventConfigurationId());
-                                        synchronized (afterHandlerGuard) {
-                                            if (afterHandling != null) {
-                                                String eventIdStr = Long.toString(pendingEvent.getEventConfigurationId());
-                                                afterHandling.eventIgnored(eventIdStr);
-                                            }
-                                        }
-                                        queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
                                     }
-                                });
-                            } else {
-                                LOG.info("Skipping event {} because its precondition has not been met", pendingEvent
-                                        .getQueuedEventId());
+
+                                    if (!shouldSkipEvent) {
+                                        TransactionWrapper.useTxn(TransactionWrapper.DB.HOUSEKEEPING, housekeepingHandle -> {
+                                            JdbiEvent jdbiEvent = housekeepingHandle.attach(JdbiEvent.class);
+                                            JdbiMessage jdbiMessage = housekeepingHandle.attach(JdbiMessage.class);
+                                            if (jdbiEvent.shouldHandleEvent(
+                                                    pendingEventId,
+                                                    pendingEvent.getActionType().name(),
+                                                    pendingEvent.getMaxOccurrencesPerUser())) {
+                                                String ddpMessageId = Long.toString(jdbiMessage.insertMessageForEvent(
+                                                        pendingEventId));
+                                                LOG.info("Publishing queued event {}", pendingEvent.getQueuedEventId());
+                                                PubsubMessage message = null;
+                                                try {
+                                                    message = messageBuilder.createMessage(ddpMessageId, pendingEvent,
+                                                            apisHandle);
+                                                } catch (NoSendableEmailAddressException e) {
+                                                    boolean shouldDeleteEvent = apisHandle.attach(StudyDao.class)
+                                                            .findSettings(pendingEvent.getStudyGuid())
+                                                            .map(StudySettings::shouldDeleteUnsendableEmails)
+                                                            .orElse(false);
+                                                    if (shouldDeleteEvent) {
+                                                        LOG.warn("Unable to create message for event with "
+                                                                + "queued_event_id={}, proceeding to delete",
+                                                                pendingEvent.getQueuedEventId(), e);
+                                                        queuedEventDao.deleteAllByQueuedEventId(
+                                                                pendingEvent.getQueuedEventId());
+                                                        return; // Exit out of transaction wrapper and move on to next
+                                                        // event.
+                                                    } else {
+                                                        LOG.error("Could not create message for event with "
+                                                                + "queued_event_id={}"
+                                                                + " because there is no email address to sent to",
+                                                                pendingEvent.getQueuedEventId(), e);
+                                                    }
+                                                } catch (MessageBuilderException e) {
+                                                    LOG.error("Could not create message for queued event "
+                                                            + pendingEvent.getQueuedEventId(), e);
+                                                }
+
+                                                if (message != null) {
+                                                    // publish the message and delete it from the queue when published
+                                                    Publisher publisher = null;
+                                                    // todo arz cache publishers, creating them is expensive
+                                                    try {
+                                                        publisher = pubsubConnectionManager.createPublisher(ProjectTopicName.of(
+                                                                pubSubProject, pendingEvent.getPubSubTopic()));
+                                                    } catch (IOException e) {
+                                                        throw new DDPException("Could not create publisher for " + pendingEvent
+                                                                .getPubSubTopic(), e);
+                                                    }
+                                                    ApiFuture<String> publishResult = publisher.publish(message);
+
+                                                    int numRowsUpdated = queuedEventDao.markPending(pendingEvent.getQueuedEventId());
+                                                    LOG.info("Marked queued event {} as pending", pendingEvent.getQueuedEventId());
+                                                    if (numRowsUpdated != 1) {
+                                                        throw new DaoException("Marked " + numRowsUpdated + " rows as pending for "
+
+                                                                + "queued event " + pendingEventId);
+                                                    }
+                                                    setPostPublishingCallbacks(publishResult, pendingEvent.getQueuedEventId());
+                                                } else {
+                                                    LOG.error("null message for " + pendingEvent.getQueuedEventId());
+                                                }
+                                            } else {
+                                                LOG.info(IGNORE_EVENT_LOG_MESSAGE + "{}", pendingEvent
+                                                        .getEventConfigurationId());
+                                                synchronized (afterHandlerGuard) {
+                                                    if (afterHandling != null) {
+                                                        String eventIdStr = Long.toString(pendingEvent.getEventConfigurationId());
+                                                        afterHandling.eventIgnored(eventIdStr);
+                                                    }
+                                                }
+                                                queuedEventDao.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
+                                            }
+                                        });
+                                    }
+                                } else {
+                                    LOG.info("Skipping event {} because its precondition has not been met", pendingEvent
+                                            .getQueuedEventId());
+                                }
                             }
                         }
-                    }
-                    return pendingEvents.size();
-                });
+                    });
+                }
 
             } catch (Exception e) {
                 logException(e);
@@ -517,20 +534,8 @@ public class Housekeeping {
         return Instant.now().toEpochMilli() - lastLogTime > ERROR_LOG_QUIET_TIME;
     }
 
-    private static boolean shouldLog(Exception e) {
-        boolean shouldLog = true;
-        if (lastLogTimeForException.containsKey(e)) {
-            long lastLogTime = lastLogTimeForException.get(e);
-            shouldLog = isTimeForLogging(lastLogTime);
-        }
-        return shouldLog;
-    }
-
     private static void logException(Exception e) {
-        if (shouldLog(e)) {
-            LOG.error("Housekeeping error", e);
-            lastLogTimeForException.replace(e, Instant.now().toEpochMilli());
-        }
+        LOG.error("Housekeeping error", e);
     }
 
     public static void stop() {


### PR DESCRIPTION
## Context

DDP-5187.  A single failure during housekeeping event processing could result in *all* pending events being published repeatedly to pubsub.  The approach here is to grab the full list of events in one transaction, but then process each one in its own transaction (allowing for two connections open to housekeeping and apis at the same time).  Sidebar: now that we are on one database instance, we should ponder how to simplify the whole two connection pool thing--some other time.

Along the way, I ripped out the logic for selectively muting error logging.  Now that we pay more attention to GCP error logging, we don't need this muting, and in fact it may have made it harder for us to see this error happening in real time.

Since I'm on a laptop that is incapable of running a substantial app locally, I will need help in getting this running somewhere to verify correctness.

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [x ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

