### PR TITLE
DDP-5192: limit housekeeping pubsub subscriber threads

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
@@ -254,16 +254,15 @@ public class PubSubConnectionManager {
     }
 
     /**
-     * Creates a new subscriber
+     * Creates a new subscriber builder
      */
-    public Subscriber subscribe(ProjectSubscriptionName projectSubscriptionName, MessageReceiver receiver) {
+    public Subscriber.Builder subscribeBuilder(ProjectSubscriptionName projectSubscriptionName, MessageReceiver receiver) {
         if (useEmulator) {
             return Subscriber.newBuilder(projectSubscriptionName, receiver)
                     .setCredentialsProvider(pubsubCredsProvider)
-                    .setChannelProvider(channelProvider)
-                    .build();
+                    .setChannelProvider(channelProvider);
         } else {
-            return Subscriber.newBuilder(projectSubscriptionName, receiver).build();
+            return Subscriber.newBuilder(projectSubscriptionName, receiver);
         }
     }
 


### PR DESCRIPTION
## Context

Pubsub messages we handle are email and pdf generation messages, both of which has the potential to pull in large pdf objects. We limit the subscriber so we process pubsub messages one at a time, as a way of limiting memory usage.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

