### PR TITLE
Remove Slack appender from Redisson loggers

### DIFF
--- a/pepper-apis/src/main/resources/logback.xml
+++ b/pepper-apis/src/main/resources/logback.xml
@@ -20,13 +20,12 @@
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>
             <OnMismatch>DENY</OnMismatch>
-            <OnMatch>ALLOW</OnMatch>
+            <OnMatch>ACCEPT</OnMatch>
         </filter>
     </appender>
 
     <logger name="org.redisson" level="info">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="SLACK" />
         <appender-ref ref="REDISCONNVALIDATOR" />
     </logger>
 


### PR DESCRIPTION
Redis PING errors where overwhelming Slack pepper-**ENV**-alerts channels. One error per connection!
We will keep logging the errors but we won't send them to Slack anymore.


