### PR TITLE
Close all JDBI streams

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
@@ -424,8 +424,8 @@ public class ActivityInstanceDao {
         var instanceDao = handle.attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class);
         Map<Long, Map<String, String>> substitutions;
         try (var substitionStream = instanceDao.bulkFindSubstitutions(instanceIds)) {
-             substitutions = substitionStream.
-                     collect(Collectors.toMap(wrapper -> wrapper.getActivityInstanceId(), wrapper -> wrapper.unwrap()));
+            substitutions = substitionStream
+                    .collect(Collectors.toMap(wrapper -> wrapper.getActivityInstanceId(), wrapper -> wrapper.unwrap()));
         }
         var sharedSnapshot = I18nContentRenderer
                 .newValueProviderBuilder(handle, userId)
@@ -468,10 +468,10 @@ public class ActivityInstanceDao {
     /**
      * Given a user, return a collection of activity instance summaries.
      *
-     * @param handle          JDBC handle
-     * @param userGuid        GUID of the user
-     * @param studyGuid       GUID of the study
-     * @param instanceGuid    GUID of the activity instance
+     * @param handle       JDBC handle
+     * @param userGuid     GUID of the user
+     * @param studyGuid    GUID of the study
+     * @param instanceGuid GUID of the activity instance
      * @return A size of sections for activity instance
      */
     public int getActivityInstanceSectionsSize(Handle handle,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityInstanceDao.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.typesafe.config.Config;
 import org.apache.commons.lang3.StringUtils;
@@ -371,10 +372,12 @@ public class ActivityInstanceDao {
         Set<String> instanceGuids = activitySummaries.stream()
                 .map(ActivityInstanceSummary::getActivityInstanceGuid)
                 .collect(Collectors.toSet());
-        Map<String, FormResponse> instanceResponses = handle
+        Map<String, FormResponse> instanceResponses;
+        try (Stream<FormResponse> responseStream = handle
                 .attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class)
-                .findFormResponsesWithAnswersByInstanceGuids(instanceGuids)
-                .collect(Collectors.toMap(ActivityResponse::getGuid, Function.identity()));
+                .findFormResponsesWithAnswersByInstanceGuids(instanceGuids)) {
+            instanceResponses = responseStream.collect(Collectors.toMap(ActivityResponse::getGuid, Function.identity()));
+        }
 
         for (var summary : activitySummaries) {
             if (ActivityType.valueOf(summary.getActivityType()) == FORMS) {
@@ -419,8 +422,11 @@ public class ActivityInstanceDao {
 
         Set<Long> instanceIds = summaries.stream().map(ActivityInstanceSummary::getActivityInstanceId).collect(Collectors.toSet());
         var instanceDao = handle.attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class);
-        var substitutions = instanceDao.bulkFindSubstitutions(instanceIds)
-                .collect(Collectors.toMap(wrapper -> wrapper.getActivityInstanceId(), wrapper -> wrapper.unwrap()));
+        Map<Long, Map<String, String>> substitutions;
+        try (var substitionStream = instanceDao.bulkFindSubstitutions(instanceIds)) {
+             substitutions = substitionStream.
+                     collect(Collectors.toMap(wrapper -> wrapper.getActivityInstanceId(), wrapper -> wrapper.unwrap()));
+        }
         var sharedSnapshot = I18nContentRenderer
                 .newValueProviderBuilder(handle, userId)
                 .build().getSnapshot();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityDao.java
@@ -2,7 +2,6 @@ package org.broadinstitute.ddp.db.dao;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.db.DaoException;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityDao.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.db.dao;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 
@@ -144,5 +145,5 @@ public interface ActivityDao extends SqlObject {
             + "  join activity_mapping_type as mtype on mapping.activity_mapping_type_id = mtype.activity_mapping_type_id"
             + " where study.umbrella_study_id = :studyId and mtype.activity_mapping_code = :type")
     @RegisterConstructorMapper(ActivityMapping.class)
-    Stream<ActivityMapping> findActivityMappings(@Bind("studyId") long studyId, @Bind("type") ActivityMappingType type);
+    List<ActivityMapping> findActivityMappings(@Bind("studyId") long studyId, @Bind("type") ActivityMappingType type);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -253,11 +253,15 @@ public interface ActivityInstanceDao extends SqlObject {
             @BindList(value = "activityIds", onEmpty = BindList.EmptyHandling.NULL) Set<Long> activityIds);
 
     default Optional<FormResponse> findFormResponseWithAnswersByInstanceId(long instanceId) {
-        return findFormResponsesWithAnswersByInstanceIds(Set.of(instanceId)).findFirst();
+        try (var responseStream = findFormResponsesWithAnswersByInstanceIds(Set.of(instanceId))) {
+            return responseStream.findFirst();
+        }
     }
 
     default Optional<FormResponse> findFormResponseWithAnswersByInstanceGuid(String instanceGuid) {
-        return findFormResponsesWithAnswersByInstanceGuids(Set.of(instanceGuid)).findFirst();
+        try (var responseStream = findFormResponsesWithAnswersByInstanceGuids(Set.of(instanceGuid))) {
+            return responseStream.findFirst();
+        }
     }
 
     default Stream<FormResponse> findFormResponsesWithAnswersByInstanceIds(Set<Long> instanceIds) {
@@ -292,10 +296,6 @@ public interface ActivityInstanceDao extends SqlObject {
         return getActivityInstanceSql()
                 .findFormResponsesWithAnswersByUsersAndActivityIds(
                         false, null, userGuids, activityIds);
-    }
-
-    default Stream<FormResponse> findFormResponsesSubsetWithAnswersByUserGuid(String userGuid, Set<Long> activityIds) {
-        return findFormResponsesSubsetWithAnswersByUserGuids(Set.of(userGuid), activityIds);
     }
 
     default Stream<FormResponse> findFormResponsesSubsetWithAnswersByUserIds(Set<Long> userIds, Set<Long> activityIds) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaCached.java
@@ -52,7 +52,9 @@ public class JdbiUmbrellaCached extends SQLObjectWrapper<JdbiUmbrella> implement
         if (isUsingNullCache()) {
             return delegate.findAll();
         } else {
-            return streamAll().collect(Collectors.toList());
+            try (var allStream = streamAll()) {
+                return allStream.collect(Collectors.toList());
+            }
         }
     }
 
@@ -61,7 +63,9 @@ public class JdbiUmbrellaCached extends SQLObjectWrapper<JdbiUmbrella> implement
         if (isUsingNullCache()) {
             return delegate.findIdByName(umbrellaName);
         } else {
-            return streamAll().filter(umbrella -> umbrella.getName().equals(umbrellaName)).findAny().map(dto -> dto.getId());
+            try (var allStream = streamAll()) {
+                return allStream.filter(umbrella -> umbrella.getName().equals(umbrellaName)).findAny().map(dto -> dto.getId());
+            }
         }
     }
 
@@ -70,7 +74,9 @@ public class JdbiUmbrellaCached extends SQLObjectWrapper<JdbiUmbrella> implement
         if (isUsingNullCache()) {
             return delegate.findByGuid(umbrellaGuid);
         } else {
-            return streamAll().filter(umbrella -> umbrella.getGuid().equals(umbrellaGuid)).findAny();
+            try (var allStream = streamAll()) {
+                return allStream.filter(umbrella -> umbrella.getGuid().equals(umbrellaGuid)).findAny();
+            }
         }
     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/StudyGovernanceDao.java
@@ -17,6 +17,7 @@ import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.FetchSize;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.UseRowReducer;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
@@ -99,6 +100,7 @@ public interface StudyGovernanceDao extends SqlObject {
     @UseStringTemplateSqlLocator
     @SqlQuery("queryAllAgeUpCandidatesByStudyId")
     @RegisterConstructorMapper(AgeUpCandidate.class)
+    @FetchSize(300)
     Stream<AgeUpCandidate> findAllAgeUpCandidatesByStudyId(@Bind("studyId") long studyId);
 
     @UseStringTemplateSqlLocator

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -224,7 +224,7 @@ public class DataExporter {
             }
             return extractParticipantsFromResultSet(handle, studyDto, resultset);
         } finally {
-            if(resultset != null) {
+            if (resultset != null) {
                 resultset.close();
             }
         }
@@ -429,17 +429,18 @@ public class DataExporter {
             }
             participants = extractParticipantsFromResultSet(handle, studyDto, resultset);
         } finally {
-            if(resultset != null) {
+            if (resultset != null) {
                 resultset.close();
             }
         }
+
 
         //load governances and build data structures to get proxies and governedUsers
         Map<String, Set<String>> proxiesMap = new HashMap<>();
         Map<String, Set<String>> governedUsersMap = new HashMap<>();
         Set<String> operatorGuids = new HashSet<>();
         UserGovernanceDao userGovernanceDao = handle.attach(UserGovernanceDao.class);
-        try(Stream<Governance> allGovernances = userGovernanceDao.findActiveGovernancesByStudyGuid(studyDto.getGuid())) {
+        try (Stream<Governance> allGovernances = userGovernanceDao.findActiveGovernancesByStudyGuid(studyDto.getGuid())) {
             allGovernances.forEach(governance -> {
                 String proxyGuid = governance.getProxyUserGuid();
                 String governedUserGuid = governance.getGovernedUserGuid();
@@ -462,7 +463,7 @@ public class DataExporter {
         });
 
         //load operators
-        try(Stream<User> users = handle.attach(UserDao.class).findUsersAndProfilesByGuids(operatorGuids)) {
+        try (Stream<User> users = handle.attach(UserDao.class).findUsersAndProfilesByGuids(operatorGuids)) {
             List<User> operators = extractUsersFromResultSet(handle, studyDto, users);
             operators.forEach(user -> {
                 if (allUsers.containsKey(user.getGuid())) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -215,23 +215,35 @@ public class DataExporter {
     }
 
     public List<Participant> extractParticipantDataSetByIds(Handle handle, StudyDto studyDto, Set<Long> userIds) {
-        Stream<Participant> resultset;
-        if (userIds == null) {
-            resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullData(studyDto.getId());
-        } else {
-            resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullDataByUserIds(studyDto.getId(), userIds);
+        Stream<Participant> resultset = null;
+        try {
+            if (userIds == null) {
+                resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullData(studyDto.getId());
+            } else {
+                resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullDataByUserIds(studyDto.getId(), userIds);
+            }
+            return extractParticipantsFromResultSet(handle, studyDto, resultset);
+        } finally {
+            if(resultset != null) {
+                resultset.close();
+            }
         }
-        return extractParticipantsFromResultSet(handle, studyDto, resultset);
     }
 
     public List<Participant> extractParticipantDataSetByGuids(Handle handle, StudyDto studyDto, Set<String> userGuids) {
-        Stream<Participant> resultset;
-        if (userGuids == null) {
-            resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullData(studyDto.getId());
-        } else {
-            resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullDataByUserGuids(studyDto.getId(), userGuids);
+        Stream<Participant> resultset = null;
+        try {
+            if (userGuids == null) {
+                resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullData(studyDto.getId());
+            } else {
+                resultset = handle.attach(ParticipantDao.class).findParticipantsWithFullDataByUserGuids(studyDto.getId(), userGuids);
+            }
+            return extractParticipantsFromResultSet(handle, studyDto, resultset);
+        } finally {
+            if (resultset != null) {
+                resultset.close();
+            }
         }
-        return extractParticipantsFromResultSet(handle, studyDto, resultset);
     }
 
     private List<Participant> extractParticipantsFromResultSet(Handle handle, StudyDto studyDto, Stream<Participant> resultset) {
@@ -405,35 +417,42 @@ public class DataExporter {
     public void exportUsersToElasticsearch(Handle handle, StudyDto studyDto, Set<Long> userIds) {
 
         //load participants
-        Stream<Participant> resultset;
-        if (userIds != null) {
-            resultset = handle.attach(ParticipantDao.class).findParticipantsWithUserProfileByStudyIdAndUserIds(
-                    studyDto.getId(), userIds);
-        } else {
-            resultset = handle.attach(ParticipantDao.class)
-                    .findParticipantsWithUserProfileByStudyId(studyDto.getId());
+        Stream<Participant> resultset = null;
+        List<Participant> participants;
+        try {
+            if (userIds != null) {
+                resultset = handle.attach(ParticipantDao.class).findParticipantsWithUserProfileByStudyIdAndUserIds(
+                        studyDto.getId(), userIds);
+            } else {
+                resultset = handle.attach(ParticipantDao.class)
+                        .findParticipantsWithUserProfileByStudyId(studyDto.getId());
+            }
+            participants = extractParticipantsFromResultSet(handle, studyDto, resultset);
+        } finally {
+            if(resultset != null) {
+                resultset.close();
+            }
         }
-        List<Participant> participants = extractParticipantsFromResultSet(handle, studyDto, resultset);
 
         //load governances and build data structures to get proxies and governedUsers
-        UserGovernanceDao userGovernanceDao = handle.attach(UserGovernanceDao.class);
-        Stream<Governance> allGovernances = userGovernanceDao.findActiveGovernancesByStudyGuid(studyDto.getGuid());
         Map<String, Set<String>> proxiesMap = new HashMap<>();
         Map<String, Set<String>> governedUsersMap = new HashMap<>();
         Set<String> operatorGuids = new HashSet<>();
-
-        allGovernances.forEach(governance -> {
-            String proxyGuid = governance.getProxyUserGuid();
-            String governedUserGuid = governance.getGovernedUserGuid();
-            Long governedUserId = governance.getGovernedUserId();
-            governedUsersMap.computeIfAbsent(governedUserGuid, key -> new HashSet<>());
-            governedUsersMap.get(governedUserGuid).add(proxyGuid);
-            proxiesMap.computeIfAbsent(proxyGuid, key -> new HashSet<>());
-            proxiesMap.get(proxyGuid).add(governedUserGuid);
-            if (userIds == null || userIds.contains(governedUserId)) {
-                operatorGuids.add(proxyGuid);
-            }
-        });
+        UserGovernanceDao userGovernanceDao = handle.attach(UserGovernanceDao.class);
+        try(Stream<Governance> allGovernances = userGovernanceDao.findActiveGovernancesByStudyGuid(studyDto.getGuid())) {
+            allGovernances.forEach(governance -> {
+                String proxyGuid = governance.getProxyUserGuid();
+                String governedUserGuid = governance.getGovernedUserGuid();
+                Long governedUserId = governance.getGovernedUserId();
+                governedUsersMap.computeIfAbsent(governedUserGuid, key -> new HashSet<>());
+                governedUsersMap.get(governedUserGuid).add(proxyGuid);
+                proxiesMap.computeIfAbsent(proxyGuid, key -> new HashSet<>());
+                proxiesMap.get(proxyGuid).add(governedUserGuid);
+                if (userIds == null || userIds.contains(governedUserId)) {
+                    operatorGuids.add(proxyGuid);
+                }
+            });
+        }
 
         Map<String, Object> allUsers = new HashMap<>();
         //load participants
@@ -443,15 +462,16 @@ public class DataExporter {
         });
 
         //load operators
-        Stream<User> users = handle.attach(UserDao.class).findUsersAndProfilesByGuids(operatorGuids);
-        List<User> operators = extractUsersFromResultSet(handle, studyDto, users);
-        operators.forEach(user -> {
-            if (allUsers.containsKey(user.getGuid())) {
-                //operator/user is also a participant... skip
-                return;
-            }
-            allUsers.put(user.getGuid(), createUserRecord(user, proxiesMap, governedUsersMap));
-        });
+        try(Stream<User> users = handle.attach(UserDao.class).findUsersAndProfilesByGuids(operatorGuids)) {
+            List<User> operators = extractUsersFromResultSet(handle, studyDto, users);
+            operators.forEach(user -> {
+                if (allUsers.containsKey(user.getGuid())) {
+                    //operator/user is also a participant... skip
+                    return;
+                }
+                allUsers.put(user.getGuid(), createUserRecord(user, proxiesMap, governedUsersMap));
+            });
+        }
 
         String index = ElasticsearchServiceUtil.getIndexForStudy(
                 handle,
@@ -547,9 +567,11 @@ public class DataExporter {
         }
 
         //load proxies
-        Map<String, List<Governance>> userProxies = handle.attach(UserGovernanceDao.class)
-                .findActiveGovernancesByStudyGuid(studyDto.getGuid())
-                .collect(Collectors.groupingBy(Governance::getGovernedUserGuid));
+        Map<String, List<Governance>> userProxies;
+        try (Stream<Governance> governanceStream =
+                     handle.attach(UserGovernanceDao.class).findActiveGovernancesByStudyGuid(studyDto.getGuid())) {
+            userProxies = governanceStream.collect(Collectors.groupingBy(Governance::getGovernedUserGuid));
+        }
 
         Map<String, List<String>> participantProxyGuids = new HashMap<>();
         if (!userProxies.isEmpty()) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/AnnouncementEventAction.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/AnnouncementEventAction.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.model.event;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.db.dao.UserAnnouncementDao;
 import org.broadinstitute.ddp.db.dao.UserGovernanceDao;
@@ -40,9 +41,11 @@ public class AnnouncementEventAction extends EventAction {
 
         try {
             if (createForProxies) {
-                List<Governance> governances = handle.attach(UserGovernanceDao.class)
-                        .findActiveGovernancesByParticipantAndStudyIds(participantId, studyId)
-                        .collect(Collectors.toList());
+                List<Governance> governances;
+                try (Stream<Governance> governanceStream = handle.attach(UserGovernanceDao.class)
+                        .findActiveGovernancesByParticipantAndStudyIds(participantId, studyId)) {
+                    governances = governanceStream.collect(Collectors.toList());
+                }
                 if (!governances.isEmpty()) {
                     for (var governance : governances) {
                         long id = announcementDao.insert(governance.getProxyUserId(), studyId, messageTemplateId, isPermanent);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetGovernedStudyParticipantsRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetGovernedStudyParticipantsRoute.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.route;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.constants.ErrorCodes;
@@ -12,6 +13,7 @@ import org.broadinstitute.ddp.db.dao.UserGovernanceDao;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.json.GovernedParticipant;
 import org.broadinstitute.ddp.json.errors.ApiError;
+import org.broadinstitute.ddp.model.governance.Governance;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
 import org.slf4j.Logger;
@@ -37,10 +39,11 @@ public class GetGovernedStudyParticipantsRoute implements Route {
                 LOG.warn(err.getMessage());
                 throw ResponseUtil.haltError(response, HttpStatus.SC_NOT_FOUND, err);
             }
-            return handle.attach(UserGovernanceDao.class)
-                    .findActiveGovernancesByProxyAndStudyGuids(operatorGuid, studyGuid)
-                    .map(governed -> new GovernedParticipant(governed.getGovernedUserGuid(), governed.getAlias()))
-                    .collect(Collectors.toList());
+            try (Stream<Governance> govStream = handle.attach(UserGovernanceDao.class)
+                    .findActiveGovernancesByProxyAndStudyGuids(operatorGuid, studyGuid)) {
+                return govStream.map(governed -> new GovernedParticipant(governed.getGovernedUserGuid(), governed.getAlias()))
+                        .collect(Collectors.toList());
+            }
         });
 
         LOG.info("Found {} governed study participants for operator {} in study {}", participants.size(), operatorGuid, studyGuid);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetUserAnnouncementsRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetUserAnnouncementsRoute.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
 
@@ -72,9 +73,11 @@ public class GetUserAnnouncementsRoute implements Route {
 
             UserAnnouncementDao announcementDao = handle.attach(UserAnnouncementDao.class);
 
-            List<UserAnnouncement> announcements = announcementDao
-                    .findAllForUserAndStudy(user.getId(), studyDto.getId())
-                    .collect(Collectors.toList());
+            List<UserAnnouncement> announcements;
+            try (Stream<UserAnnouncement> annStream = announcementDao
+                    .findAllForUserAndStudy(user.getId(), studyDto.getId())) {
+                announcements = annStream.collect(Collectors.toList());
+            }
 
             LOG.info("Found {} announcements for user {} and study {}", announcements.size(), userGuid, studyGuid);
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
@@ -322,9 +323,11 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
 
         if (status == null) {
             // Find if user is a proxy of any other user in the study, whether active or not.
-            long numGovernances = handle.attach(UserGovernanceDao.class)
-                    .findGovernancesByProxyAndStudyGuids(user.getGuid(), study.getGuid())
-                    .count();
+            long numGovernances;
+            try (Stream<Governance> govStream = handle.attach(UserGovernanceDao.class)
+                    .findGovernancesByProxyAndStudyGuids(user.getGuid(), study.getGuid())) {
+                numGovernances = govStream.count();
+            }
             if (numGovernances > 0) {
                 LOG.info("Existing user {} is a proxy of {} users in study {}", user.getGuid(), numGovernances, study.getGuid());
                 return user.getGuid();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.InvitationDao;
@@ -59,9 +60,10 @@ public class AgeUpService {
         InvitationDao invitationDao = handle.attach(InvitationDao.class);
         JdbiUserStudyEnrollment jdbiEnrollment = handle.attach(JdbiUserStudyEnrollment.class);
 
-        List<AgeUpCandidate> potentialCandidates = studyGovernanceDao
-                .findAllAgeUpCandidatesByStudyId(policy.getStudyId())
-                .collect(Collectors.toList());
+        List<AgeUpCandidate> potentialCandidates;
+        try(Stream<AgeUpCandidate> governanceStream = studyGovernanceDao.findAllAgeUpCandidatesByStudyId(policy.getStudyId())) {
+            potentialCandidates = governanceStream.collect(Collectors.toList());
+        }
         Collections.shuffle(potentialCandidates);
 
         String studyGuid = policy.getStudyGuid();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -61,7 +61,7 @@ public class AgeUpService {
         JdbiUserStudyEnrollment jdbiEnrollment = handle.attach(JdbiUserStudyEnrollment.class);
 
         List<AgeUpCandidate> potentialCandidates;
-        try(Stream<AgeUpCandidate> governanceStream = studyGovernanceDao.findAllAgeUpCandidatesByStudyId(policy.getStudyId())) {
+        try (Stream<AgeUpCandidate> governanceStream = studyGovernanceDao.findAllAgeUpCandidatesByStudyId(policy.getStudyId())) {
             potentialCandidates = governanceStream.collect(Collectors.toList());
         }
         Collections.shuffle(potentialCandidates);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -140,7 +140,7 @@ public class KitCheckService {
         Map<String, List<PendingScheduleRecord>> groupByStudyBatch = new HashMap<>();
         var currentBatchSize = new AtomicInteger(0);
 
-        try(Stream<PendingScheduleRecord> records = kitScheduleDao.findAllEligibleRecordsWaitingForKitStatus()) {
+        try (Stream<PendingScheduleRecord> records = kitScheduleDao.findAllEligibleRecordsWaitingForKitStatus()) {
             records.forEach(pending -> {
                 groupByStudyBatch.computeIfAbsent(pending.getStudyGuid(), key -> new ArrayList<>()).add(pending);
                 currentBatchSize.incrementAndGet();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/MedicalRecordService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/MedicalRecordService.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
@@ -49,17 +50,20 @@ public class MedicalRecordService {
 
         Map<Long, ActivityMapping> mappings = handle.attach(ActivityDao.class)
                 .findActivityMappings(studyId, ActivityMappingType.DATE_OF_DIAGNOSIS)
+                .stream()
                 .collect(Collectors.toMap(ActivityMapping::getActivityId, Function.identity()));
 
-        return handle.attach(ActivityInstanceDao.class)
-                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, mappings.keySet())
-                .filter(instance -> instance.getFirstCompletedAt() != null)
-                .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
-                .flatMap(instance -> answerSql
-                        .findLatestDateValueByQuestionStableIdAndUserId(
-                                mappings.get(instance.getActivityId()).getSubActivityStableId(), participantUserId, studyId)
-                        .stream()
-                ).findFirst();
+
+        try (Stream<ActivityResponse> responseStream = handle.attach(ActivityInstanceDao.class)
+                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, mappings.keySet())) {
+            return responseStream.filter(instance -> instance.getFirstCompletedAt() != null)
+                    .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
+                    .flatMap(instance -> answerSql
+                            .findLatestDateValueByQuestionStableIdAndUserId(
+                                    mappings.get(instance.getActivityId()).getSubActivityStableId(), participantUserId, studyId)
+                            .stream()
+                    ).findFirst();
+        }
     }
 
     /**
@@ -76,17 +80,20 @@ public class MedicalRecordService {
 
         Map<Long, ActivityMapping> mappings = handle.attach(ActivityDao.class)
                 .findActivityMappings(studyId, ActivityMappingType.DATE_OF_BIRTH)
+                .stream()
                 .collect(Collectors.toMap(ActivityMapping::getActivityId, Function.identity()));
 
-        return handle.attach(ActivityInstanceDao.class)
-                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, mappings.keySet())
-                .filter(instance -> instance.getFirstCompletedAt() != null)
-                .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
-                .flatMap(instance -> answerSql
-                        .findLatestDateValueByQuestionStableIdAndUserId(
-                                mappings.get(instance.getActivityId()).getSubActivityStableId(), participantUserId, studyId)
-                        .stream()
-                ).findFirst();
+        try (Stream<ActivityResponse> responseStream = handle.attach(ActivityInstanceDao.class)
+                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, mappings.keySet())) {
+            return responseStream
+                    .filter(instance -> instance.getFirstCompletedAt() != null)
+                    .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
+                    .flatMap(instance -> answerSql
+                            .findLatestDateValueByQuestionStableIdAndUserId(
+                                    mappings.get(instance.getActivityId()).getSubActivityStableId(), participantUserId, studyId)
+                            .stream()
+                    ).findFirst();
+        }
     }
 
     /**
@@ -105,20 +112,25 @@ public class MedicalRecordService {
         var activityDao = handle.attach(ActivityDao.class);
         Map<Long, ActivityMapping> bloodMappings = activityDao
                 .findActivityMappings(studyId, ActivityMappingType.BLOOD)
+                .stream()
                 .collect(Collectors.toMap(ActivityMapping::getActivityId, Function.identity()));
         Map<Long, ActivityMapping> tissueMappings = activityDao
                 .findActivityMappings(studyId, ActivityMappingType.TISSUE)
+                .stream()
                 .collect(Collectors.toMap(ActivityMapping::getActivityId, Function.identity()));
 
         Set<Long> activityIds = new HashSet<>();
         activityIds.addAll(bloodMappings.keySet());
         activityIds.addAll(tissueMappings.keySet());
 
-        List<ActivityResponse> sortedSubmittedInstances = handle.attach(ActivityInstanceDao.class)
-                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, activityIds)
-                .filter(instance -> instance.getFirstCompletedAt() != null)
-                .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
-                .collect(Collectors.toList());
+        List<ActivityResponse> sortedSubmittedInstances;
+        try (Stream<ActivityResponse> responseStream = handle.attach(ActivityInstanceDao.class)
+                .findBaseResponsesByStudyAndUserIds(studyId, Set.of(participantUserId), true, activityIds)) {
+            sortedSubmittedInstances = responseStream
+                    .filter(instance -> instance.getFirstCompletedAt() != null)
+                    .sorted(Comparator.comparing(ActivityResponse::getFirstCompletedAt).reversed())
+                    .collect(Collectors.toList());
+        }
 
         boolean hasConsentedToBloodDraw = determineElectionStatus(handle, participantGuid, studyGuid,
                 ActivityMappingType.BLOOD, bloodMappings, sortedSubmittedInstances);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -109,9 +109,10 @@ public class PdfGenerationService {
                                                        Handle handle) throws IOException {
         byte[] unflattenedPdf = generatePdfForConfiguration(configuration, userGuid, handle);
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             PdfWriter tempWriter = new PdfWriter(baos);
-             PdfDocument flattenedDoc = new PdfDocument(new PdfReader(new ByteArrayInputStream(unflattenedPdf)), tempWriter)) {
+        try (
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                PdfWriter tempWriter = new PdfWriter(baos);
+                PdfDocument flattenedDoc = new PdfDocument(new PdfReader(new ByteArrayInputStream(unflattenedPdf)), tempWriter);) {
 
             PdfAcroForm form = PdfAcroForm.getAcroForm(flattenedDoc, false);
             form.flattenFields();
@@ -169,9 +170,10 @@ public class PdfGenerationService {
         }
         checkForErrors(errors, userGuid);
 
-        try (ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
-             PdfWriter pdfWriter = new PdfWriter(renderedStream);
-             PdfDocument mergedDoc = new PdfDocument(pdfWriter)) {
+        try (
+                ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
+                PdfWriter pdfWriter = new PdfWriter(renderedStream);
+                PdfDocument mergedDoc = new PdfDocument(pdfWriter)) {
             // concatenate each rendered doc to a master doc
 
             int counter = 0;
@@ -446,8 +448,9 @@ public class PdfGenerationService {
                                                   String pdfConfigurationName,
                                                   List<String> errors) throws IOException {
 
-        try (ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
-             PdfDocument renderedPdf = new PdfDocument(new PdfReader(inputStream), new PdfWriter(renderedStream))) {
+        try (
+                ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
+                PdfDocument renderedPdf = new PdfDocument(new PdfReader(inputStream), new PdfWriter(renderedStream))) {
 
             PdfAcroForm form = PdfAcroForm.getAcroForm(renderedPdf, true);
             form.setGenerateAppearance(true);
@@ -545,8 +548,9 @@ public class PdfGenerationService {
                              String pdfConfigurationName,
                              Participant participant, Map<Long, ActivityResponse> instances, List<String> errors) throws IOException {
         InputStream templateStream = template.asByteStream();
-        try (ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
-             PdfDocument renderedPdf = new PdfDocument(new PdfReader(templateStream), new PdfWriter(renderedStream))) {
+        try (
+                ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
+                PdfDocument renderedPdf = new PdfDocument(new PdfReader(templateStream), new PdfWriter(renderedStream))) {
 
             PdfAcroForm form = PdfAcroForm.getAcroForm(renderedPdf, true);
             form.setGenerateAppearance(true);
@@ -808,9 +812,10 @@ public class PdfGenerationService {
     private byte[] renderCompositePdf(AnswerRow answerRow, CompositeAnswerSubstitution compositeSubstitution,
                                       CustomTemplate template, List<String> errors) throws IOException {
 
-        try (ByteArrayOutputStream renderedCompositeStream = new ByteArrayOutputStream();
-             PdfDocument renderedCompositePdf = new PdfDocument(
-                     new PdfReader(template.asByteStream()), new PdfWriter(renderedCompositeStream))) {
+        try (
+                ByteArrayOutputStream renderedCompositeStream = new ByteArrayOutputStream();
+                PdfDocument renderedCompositePdf = new PdfDocument(new PdfReader(template.asByteStream()),
+                        new PdfWriter(renderedCompositeStream))) {
 
             PdfAcroForm compositeForm = PdfAcroForm.getAcroForm(renderedCompositePdf, true);
             compositeForm.setGenerateAppearance(true);
@@ -837,8 +842,9 @@ public class PdfGenerationService {
                                             List<String> errors, String studyGuid, Handle handle) throws IOException {
 
         InputStream templateStream = template.asByteStream();
-        try (ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
-             PdfDocument renderedPdf = new PdfDocument(new PdfReader(templateStream), new PdfWriter(renderedStream))) {
+        try (
+                ByteArrayOutputStream renderedStream = new ByteArrayOutputStream();
+                PdfDocument renderedPdf = new PdfDocument(new PdfReader(templateStream), new PdfWriter(renderedStream))) {
 
             PdfAcroForm form = PdfAcroForm.getAcroForm(renderedPdf, true);
             form.setGenerateAppearance(true);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDaoTest.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -133,9 +134,11 @@ public class ActivityInstanceDaoTest extends TxnAwareBaseTest {
                     .createAnswer(testData.getUserId(), instanceDto.getId(), answer)
                     .getAnswerGuid();
 
-            List<FormResponse> actual = dao
-                    .findFormResponsesWithAnswersByUserGuids(testData.getStudyId(), new HashSet<>(singletonList(testData.getUserGuid())))
-                    .collect(Collectors.toList());
+            List<FormResponse> actual;
+            try (Stream<FormResponse> responseStream = dao
+                    .findFormResponsesWithAnswersByUserGuids(testData.getStudyId(), new HashSet<>(singletonList(testData.getUserGuid())))) {
+                actual = responseStream.collect(Collectors.toList());
+            }
 
             assertEquals(1, actual.size());
             assertEquals(1, actual.get(0).getAnswers().size());


### PR DESCRIPTION
Continuing to try to find source of memory leaks in housekeeping I kept finding JDBC objects in heap dumps.

Looking at the docs below, it appears that we might have been mishandling JDBI result streams:

Found this interesting tidbit in JDBI docs: https://jdbi.org/#__sqlquery
<img width="804" alt="Screen Shot 2020-10-27 at 10 32 43 PM" src="https://user-images.githubusercontent.com/29984380/97383676-85988300-18a4-11eb-8e3d-b7534563affc.png">

I tried to find every place where we generate a stream of JDBI results and make sure it is closed.

To be clear: I don't know if this the root cause of our memory leak, but it appears to be a problem.

