### PR TITLE
DDP-5225 testboston: baseline_symptom no longer write-once

### DIFF
--- a/study-builder/studies/testboston/baseline-symptom.conf
+++ b/study-builder/studies/testboston/baseline-symptom.conf
@@ -4,7 +4,7 @@
   "activityCode": ${id.act.baseline_symptom},
   "versionTag": "v1",
   "displayOrder": 4,
-  "writeOnce": true,
+  "writeOnce": false,
   "maxInstancesPerUser": 1,
   "translatedNames": [
     { "language": "en", "text": ${i18n.en.baseline_symptom.name} },

--- a/study-builder/studies/testboston/study-events.conf
+++ b/study-builder/studies/testboston/study-events.conf
@@ -219,6 +219,7 @@
       },
       # If there is already a Baseline Symptom survey, then this is after the initial kit.
       "cancelExpr": """user.studies["testboston"].forms["BASELINE_SYMPTOM"].hasInstance()""",
+      "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1
     },
@@ -467,7 +468,7 @@
       },
       "action": {
         "type": "MARK_ACTIVITIES_READ_ONLY",
-        "activityCodes": [${id.act.baseline_covid}, ${id.act.baseline_symptom}, ${id.act.longitudinal}]
+        "activityCodes": [${id.act.baseline_covid}]
       },
       "dispatchToHousekeeping": false,
       "order": 1


### PR DESCRIPTION
## Context

This PR outlines the study configuration change we want to make to TestBoston so that the symptom surveys have different read-only behavior.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

