### PR TITLE
Reset instance of ServiceLocator if needed, like when running tests part 2

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
@@ -124,6 +124,9 @@ public class LiquibaseUtil implements  AutoCloseable {
     private void runMigrations(String changelogFile) throws LiquibaseException, SQLException {
         Liquibase liquibase = null;
         String tag = null;
+        if (ServiceLocator.getInstance() == null) {
+            ServiceLocator.reset();
+        }
         try {
             liquibase = new Liquibase(changelogFile, new ClassLoaderResourceAccessor(), new JdbcConnection(dataSource.getConnection()));
             logLocks(liquibase.listLocks());


### PR DESCRIPTION
Previous PR broke tests setup that try to use Liquibase after we have disabled it.