### PR TITLE
DDP-5175 support copying answers from previous instance

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -177,6 +177,18 @@ public interface ActivityInstanceDao extends SqlObject {
             + " where ai.participant_id = :userId and sa.study_id = :studyId")
     Set<Long> findAllInstanceIdsByUserIdAndStudyId(@Bind("userId") long userId, @Bind("studyId") long studyId);
 
+    @SqlQuery("select activity_instance_id"
+            + "  from activity_instance as ai"
+            + "  join (select participant_id, study_activity_id, created_at"
+            + "          from activity_instance where activity_instance_id = :instanceId)"
+            + "       as ai2 on ai.participant_id = ai2.participant_id"
+            + "       and ai.study_activity_id = ai2.study_activity_id"
+            + "       and ai.created_at <= ai2.created_at"
+            + " where ai.activity_instance_id != :instanceId"
+            + " order by ai.created_at desc"
+            + " limit 1")
+    Optional<Long> findMostRecentInstanceBeforeCurrent(@Bind("instanceId") long currentInstanceId);
+
     /**
      * Helper that only deletes an activity instance and its associated status(es).
      */

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.java
@@ -31,7 +31,7 @@ public interface CopyConfigurationDao extends SqlObject {
     CopyConfigurationSql getCopyConfigurationSql();
 
     default CopyConfiguration createCopyConfig(CopyConfiguration config) {
-        long configId = getCopyConfigurationSql().insertCopyConfig(config.getStudyId());
+        long configId = getCopyConfigurationSql().insertCopyConfig(config.getStudyId(), config.shouldCopyFromPreviousInstance());
         int order = 1;
         for (var pair : config.getPairs()) {
             pair.setOrder(order);
@@ -116,13 +116,14 @@ public interface CopyConfigurationDao extends SqlObject {
             CopyConfiguration config = container
                     .computeIfAbsent(id, key -> view.getRow(CopyConfiguration.class));
 
-            long pairId = view.getColumn("copy_configuration_pair_id", Long.class);
-            CopyLocation source = reduceLocation(view, "source");
-            CopyLocation target = reduceLocation(view, "target");
-            int order = view.getColumn("execution_order", Integer.class);
-            var pair = new CopyConfigurationPair(pairId, source, target, order);
-
-            config.addPairs(List.of(pair));
+            Long pairId = view.getColumn("copy_configuration_pair_id", Long.class);
+            if (pairId != null) {
+                CopyLocation source = reduceLocation(view, "source");
+                CopyLocation target = reduceLocation(view, "target");
+                int order = view.getColumn("execution_order", Integer.class);
+                var pair = new CopyConfigurationPair(pairId, source, target, order);
+                config.addPairs(List.of(pair));
+            }
         }
 
         private CopyLocation reduceLocation(RowView view, String prefix) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationSql.java
@@ -13,8 +13,8 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface CopyConfigurationSql extends SqlObject {
 
     @GetGeneratedKeys
-    @SqlUpdate("insert into copy_configuration (study_id) values (:studyId)")
-    long insertCopyConfig(@Bind("studyId") long studyId);
+    @SqlUpdate("insert into copy_configuration (study_id, copy_from_previous_instance) values (:studyId, :copyFromPreviousInstance)")
+    long insertCopyConfig(@Bind("studyId") long studyId, @Bind("copyFromPreviousInstance") boolean copyFromPreviousInstance);
 
     @GetGeneratedKeys
     @SqlUpdate("insert into copy_location (copy_location_type_id)"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/copy/CopyConfiguration.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/copy/CopyConfiguration.java
@@ -10,16 +10,22 @@ public class CopyConfiguration {
 
     private long id;
     private long studyId;
+    private boolean copyFromPreviousInstance;
     private List<CopyConfigurationPair> pairs = new ArrayList<>();
 
     @JdbiConstructor
-    public CopyConfiguration(@ColumnName("copy_configuration_id") long id, @ColumnName("study_id") long studyId) {
+    public CopyConfiguration(
+            @ColumnName("copy_configuration_id") long id,
+            @ColumnName("study_id") long studyId,
+            @ColumnName("copy_from_previous_instance") boolean copyFromPreviousInstance) {
         this.id = id;
         this.studyId = studyId;
+        this.copyFromPreviousInstance = copyFromPreviousInstance;
     }
 
-    public CopyConfiguration(long studyId, List<CopyConfigurationPair> pairs) {
+    public CopyConfiguration(long studyId, boolean copyFromPreviousInstance, List<CopyConfigurationPair> pairs) {
         this.studyId = studyId;
+        this.copyFromPreviousInstance = copyFromPreviousInstance;
         addPairs(pairs);
     }
 
@@ -29,6 +35,10 @@ public class CopyConfiguration {
 
     public long getStudyId() {
         return studyId;
+    }
+
+    public boolean shouldCopyFromPreviousInstance() {
+        return copyFromPreviousInstance;
     }
 
     public List<CopyConfigurationPair> getPairs() {

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -236,4 +236,5 @@
     <include file="db-changes/schema/DDP-5183-drop-initial-kit-record.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5194-picklist-nested-options.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/add-participant-list-workflow-state-type.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5175-copy-from-previous-instance.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5175-copy-from-previous-instance.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5175-copy-from-previous-instance.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20201029-copy-from-previous-instance-column">
+        <addColumn tableName="copy_configuration">
+            <column name="copy_from_previous_instance" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.sql.stg
@@ -3,6 +3,7 @@ group CopyConfigurationDao;
 all_configs_select() ::= <<
 select cfg.copy_configuration_id,
        cfg.study_id,
+       cfg.copy_from_previous_instance,
        pair.copy_configuration_pair_id,
        pair.execution_order,
        src.copy_location_id as source_copy_location_id,
@@ -22,9 +23,9 @@ select cfg.copy_configuration_id,
          where question_stable_code_id = tgt_ans.question_stable_code_id
        ) as target_question_stable_id
   from copy_configuration as cfg
-  join copy_configuration_pair as pair on pair.copy_configuration_id = cfg.copy_configuration_id
-  join copy_location as src on src.copy_location_id = pair.source_location_id
-  join copy_location as tgt on tgt.copy_location_id = pair.target_location_id
+  left join copy_configuration_pair as pair on pair.copy_configuration_id = cfg.copy_configuration_id
+  left join copy_location as src on src.copy_location_id = pair.source_location_id
+  left join copy_location as tgt on tgt.copy_location_id = pair.target_location_id
   left join copy_answer_location as src_ans on src_ans.copy_location_id = src.copy_location_id
   left join copy_answer_location as tgt_ans on tgt_ans.copy_location_id = tgt.copy_location_id
 >>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/copy/CopyExecutorTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/copy/CopyExecutorTest.java
@@ -12,8 +12,14 @@ import org.broadinstitute.ddp.db.dao.AnswerDao;
 import org.broadinstitute.ddp.db.dao.CopyConfigurationDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.model.activity.definition.question.NumericQuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.template.Template;
 import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
+import org.broadinstitute.ddp.model.activity.instance.answer.CompositeAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.NumericIntegerAnswer;
 import org.broadinstitute.ddp.model.activity.instance.answer.TextAnswer;
+import org.broadinstitute.ddp.model.activity.types.NumericType;
+import org.broadinstitute.ddp.model.activity.types.QuestionType;
 import org.broadinstitute.ddp.model.copy.CopyAnswerLocation;
 import org.broadinstitute.ddp.model.copy.CopyConfiguration;
 import org.broadinstitute.ddp.model.copy.CopyConfigurationPair;
@@ -46,7 +52,7 @@ public class CopyExecutorTest extends TxnAwareBaseTest {
             var answer = new TextAnswer(null, act.getTextQuestion().getStableId(), null, "new-first-name");
             handle.attach(AnswerDao.class).createAnswer(testData.getUserId(), instanceId, answer);
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                     new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_FIRST_NAME))));
             config = handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
@@ -76,7 +82,7 @@ public class CopyExecutorTest extends TxnAwareBaseTest {
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
             long instance2Id = createInstance(handle, act2.getDef().getActivityId()).getId();
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act1.getTextQuestion().getStableId()),
                     new CopyAnswerLocation(act2.getTextQuestion().getStableId()))));
             config = handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
@@ -89,6 +95,57 @@ public class CopyExecutorTest extends TxnAwareBaseTest {
             assertNotNull(actual);
             assertNotNull(actual.getAnswerGuid());
             assertEquals("source-text", ((TextAnswer) actual).getValue());
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void testExecute_copyFromPreviousInstance() {
+        TransactionWrapper.useTxn(handle -> {
+            TestFormActivity act = TestFormActivity.builder()
+                    .withTextQuestion(true)
+                    .withCompositeQuestion(true, NumericQuestionDef
+                            .builder(NumericType.INTEGER, "child-num", Template.text("child-num-prompt"))
+                            .build())
+                    .build(handle, testData.getUserId(), testData.getStudyGuid());
+            long instance1Id = createInstance(handle, act.getDef().getActivityId()).getId();
+
+            AnswerDao answerDao = handle.attach(AnswerDao.class);
+            var answer = new TextAnswer(null, act.getTextQuestion().getStableId(), null, "prev-text");
+            answerDao.createAnswer(testData.getUserId(), instance1Id, answer);
+
+            var compAnswer = new CompositeAnswer(null, act.getCompositeQuestion().getStableId(), null);
+            compAnswer.addRowOfChildAnswers(new NumericIntegerAnswer(null, "child-num", null, 1L));
+            compAnswer.addRowOfChildAnswers(new NumericIntegerAnswer(null, "child-num", null, 25L));
+            answerDao.createAnswer(testData.getUserId(), instance1Id, compAnswer);
+
+            var config = new CopyConfiguration(testData.getStudyId(), true, List.of());
+            config = handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
+
+            long instance2Id = createInstance(handle, act.getDef().getActivityId()).getId();
+            new CopyExecutor()
+                    .withTriggeredInstanceId(instance2Id)
+                    .execute(handle, testData.getUserId(), testData.getUserId(), config);
+
+            var actual = handle.attach(ActivityInstanceDao.class)
+                    .findFormResponseWithAnswersByInstanceId(instance2Id)
+                    .orElse(null);
+            assertNotNull(actual);
+            assertEquals(2, actual.getAnswers().size());
+
+            var actualAnswer = actual.getAnswer(act.getTextQuestion().getStableId());
+            assertNotNull(actualAnswer);
+            assertEquals(QuestionType.TEXT, actualAnswer.getQuestionType());
+            assertEquals("prev-text", ((TextAnswer) actualAnswer).getValue());
+
+            actualAnswer = actual.getAnswer(act.getCompositeQuestion().getStableId());
+            assertNotNull(actualAnswer);
+            assertEquals(QuestionType.COMPOSITE, actualAnswer.getQuestionType());
+            var actualCompAnswer = (CompositeAnswer) actualAnswer;
+            assertEquals(2, actualCompAnswer.getValue().size());
+            assertEquals(1L, actualCompAnswer.getValue().get(0).getValues().get(0).getValue());
+            assertEquals(25L, actualCompAnswer.getValue().get(1).getValues().get(0).getValue());
 
             handle.rollback();
         });

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDaoTest.java
@@ -47,7 +47,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
         thrown.expect(DaoException.class);
         thrown.expectMessage(containsString("answer source locations"));
         TransactionWrapper.useTxn(handle -> {
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_FIRST_NAME),
                     new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_LAST_NAME))));
             handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
@@ -64,7 +64,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
                     .withBoolQuestion(true)
                     .withTextQuestion(true)
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act.getBoolQuestion().getStableId()),
                     new CopyAnswerLocation(act.getTextQuestion().getStableId()))));
             handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
@@ -80,7 +80,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
             TestFormActivity act = TestFormActivity.builder()
                     .withCompositeQuestion(true, TextQuestionDef.builder(TextInputType.TEXT, "c1", Template.text("child")).build())
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act.getCompositeQuestion().getStableId()),
                     new CopyAnswerLocation(act.getCompositeQuestion().getStableId()))));
             handle.attach(CopyConfigurationDao.class).createCopyConfig(config);
@@ -95,7 +95,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
                     .withTextQuestion(true)
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                     new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_FIRST_NAME))));
 
@@ -129,7 +129,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
                     .withTextQuestion(true)
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(
                     new CopyConfigurationPair(
                             new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                             new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_FIRST_NAME)),
@@ -168,7 +168,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
                             TextQuestionDef.builder(TextInputType.TEXT, "c2b", Template.text("")).build())
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(
                     new CopyConfigurationPair(new CopyAnswerLocation("c1a"), new CopyAnswerLocation("c1b")),
                     new CopyConfigurationPair(new CopyAnswerLocation("c2a"), new CopyAnswerLocation("c2b"))));
 
@@ -207,7 +207,7 @@ public class CopyConfigurationDaoTest extends TxnAwareBaseTest {
                     .withTextQuestion(true)
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(new CopyConfigurationPair(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(new CopyConfigurationPair(
                     new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                     new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_FIRST_NAME))));
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CopyAnswerEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CopyAnswerEventActionTest.java
@@ -71,7 +71,7 @@ public class CopyAnswerEventActionTest extends TxnAwareBaseTest {
             answerDao.createAnswer(testData.getUserId(), instanceId,
                     new TextAnswer(null, act.getTextQuestion().getStableId(), null, "new-last-name"));
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(
                     new CopyConfigurationPair(
                             new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                             new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_LAST_NAME)),
@@ -120,7 +120,7 @@ public class CopyAnswerEventActionTest extends TxnAwareBaseTest {
             handle.attach(ActivityInstanceDao.class)
                     .insertInstance(act.getDef().getActivityId(), testData.getUserGuid());
 
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(
                     new CopyConfigurationPair(
                             new CopyAnswerLocation(act.getTextQuestion().getStableId()),
                             new CopyLocation(CopyLocationType.PARTICIPANT_PROFILE_LAST_NAME)),
@@ -209,7 +209,7 @@ public class CopyAnswerEventActionTest extends TxnAwareBaseTest {
             instanceDao.insertInstance(act2.getDef().getActivityId(), testData.getUserGuid());
 
             // Setup event configuration
-            var config = new CopyConfiguration(testData.getStudyId(), List.of(
+            var config = new CopyConfiguration(testData.getStudyId(), false, List.of(
                     // Target profile
                     new CopyConfigurationPair(
                             new CopyAnswerLocation(act1.getTextQuestion().getStableId()),

--- a/study-builder/studies/study-example.conf
+++ b/study-builder/studies/study-example.conf
@@ -678,6 +678,12 @@
     {
       "action": {
         "type": "COPY_ANSWER",
+        # When true, answers from the most recent previous instance will be copied to the current instance,
+        # so this needs to be paired with the ACTIVITY_STATUS trigger when true. This copying will be executed
+        # before the copy source/target pairs below.
+        #
+        # Defauls to false.
+        "copyFromPreviousInstance": "bool"
         # List of copy configuration source/target pairs, each specifying where to copy data from/to.
         "copyConfigPairs": [
           {


### PR DESCRIPTION
## Context

This is one of the features needed for the A-T study. The `COPY_ANSWERS` event action can now be configured to copy answers from a previous instance of the same activity.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

