### PR TITLE
Prion: DDP-5241, auth0 validation fix: added validation messages to p…

### DIFF
--- a/study-builder/tenants/prion/loginPage.html
+++ b/study-builder/tenants/prion/loginPage.html
@@ -231,10 +231,6 @@
         color: #82B547;
     }
 
-    .auth0-lock-password-strength {
-        display: none;
-    }
-
     .auth0-lock.auth0-lock .auth0-lock-form .auth0-lock-alternative .auth0-lock-alternative-link {
         color: #717174;
         font-size: 0.75rem;
@@ -258,8 +254,7 @@
         text-align: left !important;
     }
 
-    .auth0-lock-input-block.auth0-lock-input-show-password .auth0-lock-input-block.auth0-lock-input-password.auth0-lock-error::after {
-        content: unset;
+    .auth0-lock-input-block.auth0-lock-input-password.auth0-lock-error {
         font-family: 'Raleway', sans-serif;
         font-size: 12px;
         color: #f00;
@@ -1249,6 +1244,31 @@
                     console.log('appending password hint');
                     passwordBlock.insertBefore(passwordHint, passwordBlock.childNodes[0]);
                 }
+            }
+            if (!document.getElementById('auth0-lock-error-msg-password') && document.getElementsByClassName('auth0-lock-input-block auth0-lock-input-password auth0-lock-error')[0]) {
+                //If the password is invalid but we haven't added the error message, set it
+                var passwordError = document.getElementsByClassName('auth0-lock-input-block auth0-lock-input-password auth0-lock-error')[0];
+                var errorText = languageDictionary.invalidErrorHint;
+
+                // If the password field isn't empty but is invalid, make that the error message
+                var inputElements = passwordError ? passwordError.getElementsByTagName('input') : null;
+                var value = inputElements && inputElements[0] ? inputElements[0].value : null;
+                if (value.length === 0) {
+                    errorText = languageDictionary.blankErrorHint;
+                }
+
+                var passwordErrorMessage = document.createElement('div');
+                passwordErrorMessage.innerHTML = `<span>${errorText}</span>`;
+                passwordErrorMessage.setAttribute('role', 'alert');
+                passwordErrorMessage.setAttribute('id', 'auth0-lock-error-msg-password');
+                passwordErrorMessage.setAttribute('class', 'auth0-lock-error-msg');
+                console.log('appending password error message');
+                passwordError.appendChild(passwordErrorMessage);
+            }
+            if (document.getElementById('auth0-lock-error-msg-password') && !document.getElementsByClassName('auth0-lock-input-block auth0-lock-input-password auth0-lock-error')[0]){
+                //If we're still showing the error message for the password field even though the field is now valid, get rid of the error message
+                var errorMsg = document.getElementById('auth0-lock-error-msg-password');
+                errorMsg.parentElement.removeChild(errorMsg);
             }
             if (!document.getElementById('ddp-email-prompt')) {
                 // If we are logging in, add some instructions


### PR DESCRIPTION
…assword field of join us page

## Context

See DDP-5241.  After I changed the password requirements to make sure the length is at least 8 characters, I never re-added the validation for the password field, which means that users could try to submit with an invalid password and it wouldn't go through but they also wouldn't get an error message.  This adds the error message at the bottom of the field that the other fields have and adds back the Auth0 popup with password requirements.  

This does involve adding an additional element in the JavaScript for the Auth0 universal login page, which results in a visible delay in showing this specific error message of maybe a few seconds, but I'm not sure there's a better way to do it given that we are pretty far away from the intended use of the Auth0 universal login feature.  The tradeoff seems worth it because participants would be more confused if they weren't sure why they couldn't submit the form.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

