### PR TITLE
testboston: hide adhoc_symptom

### DIFF
--- a/study-builder/studies/testboston/adhoc-symptom.conf
+++ b/study-builder/studies/testboston/adhoc-symptom.conf
@@ -7,6 +7,7 @@
   "writeOnce": true,
   "maxInstancesPerUser": null,
   "allowOndemandTrigger": true,
+  "excludeFromDisplay": true,
   "hideExistingInstancesOnCreation": true,
   "translatedNames": [
     { "language": "en", "text": ${i18n.en.adhoc_symptom.name} },


### PR DESCRIPTION
Per study staff request, we're not hiding the adhoc_symptom survey in TestBoston. Saving that change to our configuration files so it won't get overwritten or "reset" later.