### PR TITLE
Remove Xms param from Housekeeping java startup command

### DIFF
--- a/pepper-apis/config/Housekeeping.yaml.ctmpl
+++ b/pepper-apis/config/Housekeeping.yaml.ctmpl
@@ -12,9 +12,9 @@ manual_scaling:
 # todo arz give housekeeping and backends different app names for tcell
 
 {{if and (or (eq $environment "prod") (eq $environment "staging") (eq $environment "dev") (eq $environment "test")) (eq $gae "true") }}
-entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xms1340m -Xmx1340m -jar Housekeeping.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1340m -jar Housekeeping.jar
 {{else}}
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xms1640m -Xmx1640m -jar Housekeeping.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xmx1640m -jar Housekeeping.jar
 {{end}}
 
 # GAE does not like the "=" character in entrypoint and does not support "." in environment variables


### PR DESCRIPTION
## Context
A new possible scenario for how we could be running out of memory: amount of heap space allocated for Java is more than enough, but there is not enough memory available for non-heap space Java memory and whatever else can reside in the 2048mb that we supposedly have available in GAE instances,

I did a test in dev with the headergrabber app, setting only the -Xmx flag (no Xms flag) just high enough for the simple operations and artificially created an OutOfMemoryError by allocating lots of objects to overwhelm Xmx setting.
The OutOfMemory error was actually reported in GAE logs before it died.

By contrast we have yet to see an OutOfMemory error in GAE (housekeeping or pepper-backend).

So it is possible that housekeeping Xmx heap max is never reached, but since we have been setting Xms to same value, only room for non-heap memory in 
GAE instance is  =2048m - Xms
and it is the non-heap (Java or non-Java. I don't know) that GAE is detecting and using as reason to kill instance.

This is a no risk change: at worst it will be some additional memory management CPU cycles trying to handle the necessary memory allocations.
