### PR TITLE
Prion: DDP-5256: Internationalized password strength text

### DIFF
--- a/study-builder/tenants/prion/loginPage.html
+++ b/study-builder/tenants/prion/loginPage.html
@@ -919,6 +919,9 @@
             'lock.fallback': 'We\'re sorry, something went wrong when attempting to log in.',
             'lock.invalid_email_password': 'Wrong email or password.',
             'lock.network': 'We could not reach the server. Please check your connection and try again.'
+        },
+        passwordStrength: {
+            lengthAtLeast: 'At least %d characters in length'
         }
     };
 
@@ -977,6 +980,9 @@
             'lock.fallback': '(es) We\'re sorry, something went wrong when attempting to log in.',
             'lock.invalid_email_password': '(es) Wrong email or password.',
             'lock.network': '(es) We could not reach the server. Please check your connection and try again.'
+        },
+        passwordStrength: {
+            lengthAtLeast: '(es)At least %d characters in length'
         }
     };
     dictionaries['he'] = {
@@ -1034,6 +1040,9 @@
             'lock.fallback': '(he) We\'re sorry, something went wrong when attempting to log in.',
             'lock.invalid_email_password': '(he) Wrong email or password.',
             'lock.network': '(he) We could not reach the server. Please check your connection and try again.'
+        },
+        passwordStrength: {
+            lengthAtLeast: '(he)At least %d characters in length'
         }
     };
     dictionaries['zh'] = {
@@ -1091,6 +1100,9 @@
             'lock.fallback': '(zh) We\'re sorry, something went wrong when attempting to log in.',
             'lock.invalid_email_password': '(zh) Wrong email or password.',
             'lock.network': '(zh) We could not reach the server. Please check your connection and try again.'
+        },
+        passwordStrength: {
+            lengthAtLeast: '(zh)At least %d characters in length'
         }
     };
     if ('en' !== languageCode && 'es' !== languageCode && 'he' !== languageCode && 'zh' !== languageCode) {


### PR DESCRIPTION
## Context

See DDP-5256: this just adds the password validation popup text to the language dictionaries for internationalization purposes.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

