### PR TITLE
DDP-5254 testboston: add sample collect message to symptom surveys

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/TestBostonAddSampleCollectMessage.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/TestBostonAddSampleCollectMessage.java
@@ -1,0 +1,105 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
+import org.broadinstitute.ddp.db.dao.JdbiFormActivityFormSection;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.SectionBlockDao;
+import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.ContentBlockDef;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.broadinstitute.ddp.util.GsonPojoValidator;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.broadinstitute.ddp.util.JsonValidationError;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestBostonAddSampleCollectMessage implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestBostonAddSampleCollectMessage.class);
+    private static final String DATA_FILE = "patches/sample-collect-message.conf";
+    private static final String STUDY_GUID = "testboston";
+
+    private Config varsCfg;
+    private Config dataCfg;
+    private Gson gson;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        File file = cfgPath.getParent().resolve(DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        dataCfg = ConfigFactory.parseFile(file);
+        dataCfg = dataCfg.resolveWith(varsCfg);
+
+        if (!studyCfg.getString("study.guid").equals(STUDY_GUID)) {
+            throw new DDPException("This task is only for the " + STUDY_GUID + " study!");
+        }
+
+        this.varsCfg = varsCfg;
+        this.gson = GsonUtil.standardGson();
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(STUDY_GUID);
+
+        Config blockCfg = dataCfg.getConfig("block");
+        validateBlockDef(blockCfg);
+
+        String activityCode = varsCfg.getString("id.act.baseline_symptom");
+        prependNewBlockInPlace(handle, studyDto.getId(), activityCode, blockCfg);
+
+        activityCode = varsCfg.getString("id.act.longitudinal");
+        prependNewBlockInPlace(handle, studyDto.getId(), activityCode, blockCfg);
+    }
+
+    private void validateBlockDef(Config blockCfg) {
+        var validator = new GsonPojoValidator();
+        var def = gson.fromJson(ConfigUtil.toJson(blockCfg), ContentBlockDef.class);
+        List<JsonValidationError> errors = validator.validateAsJson(def);
+        if (!errors.isEmpty()) {
+            String msg = errors.stream()
+                    .map(JsonValidationError::toDisplayMessage)
+                    .collect(Collectors.joining(", "));
+            throw new DDPException("Block definition has validation errors: " + msg);
+        }
+    }
+
+    private void prependNewBlockInPlace(Handle handle, long studyId, String activityCode, Config blockCfg) {
+        long activityId = ActivityBuilder.findActivityId(handle, studyId, activityCode);
+        LOG.info("Prepending block for activity {}...", activityCode);
+
+        ActivityVersionDto versionDto = handle.attach(JdbiActivityVersion.class)
+                .getActiveVersion(activityId)
+                .orElseThrow(() -> new DDPException("Could not find latest version for activity " + activityCode));
+
+        long timestamp = versionDto.getRevStart();
+        List<Long> sectionIds = handle.attach(JdbiFormActivityFormSection.class)
+                .findOrderedSectionIdsByActivityIdAndTimestamp(activityId, timestamp);
+        if (sectionIds.isEmpty()) {
+            throw new DDPException("Could not find sections for activity " + activityCode);
+        }
+
+        long sectionId = sectionIds.get(0);
+        long revisionId = versionDto.getRevId();
+        int displayOrder = SectionBlockDao.DISPLAY_ORDER_GAP / 2; // Current first block starts at this gap, so use something smaller.
+        var block = gson.fromJson(ConfigUtil.toJson(blockCfg), ContentBlockDef.class);
+
+        handle.attach(SectionBlockDao.class).insertBlockForSection(activityId, sectionId, displayOrder, block, revisionId);
+        LOG.info("Inserted new {} block with id={}, displayOrder={} for activityCode={}, sectionId={}",
+                block.getBlockType(), block.getBlockId(), displayOrder, activityCode, sectionId);
+    }
+}

--- a/study-builder/studies/testboston/baseline-symptom.conf
+++ b/study-builder/studies/testboston/baseline-symptom.conf
@@ -34,6 +34,30 @@
       "icons": [],
       "blocks": [
         {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "$tb_sample_collect_msg",
+            "variables": [
+              {
+                "name": "tb_sample_collect_msg",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.baseline_symptom.sample_collect_msg} },
+                  { "language": "es", "text": ${i18n.es.baseline_symptom.sample_collect_msg} },
+                  { "language": "ht", "text": ${i18n.ht.baseline_symptom.sample_collect_msg} },
+                  { "language": "ar", "text": ${i18n.ar.baseline_symptom.sample_collect_msg} },
+                  { "language": "fr", "text": ${i18n.fr.baseline_symptom.sample_collect_msg} },
+                  { "language": "pt", "text": ${i18n.pt.baseline_symptom.sample_collect_msg} },
+                  { "language": "ru", "text": ${i18n.ru.baseline_symptom.sample_collect_msg} },
+                  { "language": "vi", "text": ${i18n.vi.baseline_symptom.sample_collect_msg} },
+                  { "language": "zh", "text": ${i18n.zh.baseline_symptom.sample_collect_msg} }
+                ]
+              }
+            ]
+          },
+          "blockType": "CONTENT"
+        },
+        {
           "control": ${_includes.baseline_symptom.baseline_symptoms},
           "nested": [
             {

--- a/study-builder/studies/testboston/i18n/ar.conf
+++ b/study-builder/studies/testboston/i18n/ar.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "استبيان الأعراض",
-    "title": "<span>تحري أعراض الإصابة بفيروس Covid-19، <span class=\"activity-header__text\">يُرجى إخبارنا بما كنت تشعر به في الوقت الذي أخذت فيه عينة اختبار الكشف عن فيروس COVID-19</span></span>"
+    "title": "<span>تحري أعراض الإصابة بفيروس Covid-19، <span class=\"activity-header__text\">يُرجى إخبارنا بما كنت تشعر به في الوقت الذي أخذت فيه عينة اختبار الكشف عن فيروس COVID-19</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "الإبلاغ عن الأعراض في أي وقت!",

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -158,7 +158,7 @@
   "baseline_symptom": {
     "name": "Symptom Survey",
     "title": "<span>Covid-19 Symptom Check <span class=\"activity-header__text\">Please tell us how you’re feeling as close as possible to the time you collect your COVID-19 test sample</span></span>",
-    "sample_collect_msg": "<p class=\"infobox no-margin\"><strong>STOP! Do not collect your sample or take this survey on Friday, Saturday, or Sunday.</strong> Take this survey Monday through Thursday, the SAME DAY you take and ship your test.</p>"
+    "sample_collect_msg": "<p class=\"infobox no-margin\"><span class=\"RedMessage\"><strong>STOP! Do not collect your sample or take this survey on Friday, Saturday, or Sunday.</strong></span> Take this survey Monday through Thursday, the SAME DAY you take and ship your test.</p>"
   },
   "adhoc_symptom": {
     "name": "Report Symptoms Anytime!",

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Symptom Survey",
-    "title": "<span>Covid-19 Symptom Check <span class=\"activity-header__text\">Please tell us how you’re feeling as close as possible to the time you collect your COVID-19 test sample</span></span>"
+    "title": "<span>Covid-19 Symptom Check <span class=\"activity-header__text\">Please tell us how you’re feeling as close as possible to the time you collect your COVID-19 test sample</span></span>",
+    "sample_collect_msg": "<p class=\"infobox no-margin\"><strong>STOP! Do not collect your sample or take this survey on Friday, Saturday, or Sunday.</strong> Take this survey Monday through Thursday, the SAME DAY you take and ship your test.</p>"
   },
   "adhoc_symptom": {
     "name": "Report Symptoms Anytime!",

--- a/study-builder/studies/testboston/i18n/en.conf
+++ b/study-builder/studies/testboston/i18n/en.conf
@@ -158,7 +158,7 @@
   "baseline_symptom": {
     "name": "Symptom Survey",
     "title": "<span>Covid-19 Symptom Check <span class=\"activity-header__text\">Please tell us how you’re feeling as close as possible to the time you collect your COVID-19 test sample</span></span>",
-    "sample_collect_msg": "<p class=\"infobox no-margin\"><span class=\"RedMessage\"><strong>STOP! Do not collect your sample or take this survey on Friday, Saturday, or Sunday.</strong></span> Take this survey Monday through Thursday, the SAME DAY you take and ship your test.</p>"
+    "sample_collect_msg": "<p class=\"infobox no-margin\"><span class=\"ErrorMessage\"><strong>STOP! Do not collect your sample or take this survey on Friday, Saturday, or Sunday.</strong></span><br/>Take this survey Monday through Thursday, the SAME DAY you take and ship your test.</p>"
   },
   "adhoc_symptom": {
     "name": "Report Symptoms Anytime!",

--- a/study-builder/studies/testboston/i18n/es.conf
+++ b/study-builder/studies/testboston/i18n/es.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Encuesta sobre Síntomas",
-    "title": "<span>Comprobación de Síntomas de COVID-19<span class=\"activity-header__text\">Por favor comuníquenos cómo se siente lo más próximo posible del momento en el cual se recolecta su muestra para el examen de detección de COVID-19</span></span>"
+    "title": "<span>Comprobación de Síntomas de COVID-19<span class=\"activity-header__text\">Por favor comuníquenos cómo se siente lo más próximo posible del momento en el cual se recolecta su muestra para el examen de detección de COVID-19</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "¡Reporte los síntomas en cualquier momento!",

--- a/study-builder/studies/testboston/i18n/fr.conf
+++ b/study-builder/studies/testboston/i18n/fr.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Enquête sur les symptômes",
-    "title": "<span>Vérification des symptômes Covid-19 <span class=\"activity-header__text\">Veuillez décrire comment vous vous sentez au moment le plus proche possible du prélèvement dʼéchantillon pour le dépistage COVID-19</span></span>"
+    "title": "<span>Vérification des symptômes Covid-19 <span class=\"activity-header__text\">Veuillez décrire comment vous vous sentez au moment le plus proche possible du prélèvement dʼéchantillon pour le dépistage COVID-19</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "Signalez vos symptômes à tout moment !",

--- a/study-builder/studies/testboston/i18n/ht.conf
+++ b/study-builder/studies/testboston/i18n/ht.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Apantaj sou sentòm",
-    "title": "<span>Covid-19 Sentòm Tcheke <span class=\"activity-header__text\">Tanpri, di nou ki jan ou te  santi ou o tan ké posib nan tan ou te kolekte echantiyon tès COVID-19 ou an</span></span>"
+    "title": "<span>Covid-19 Sentòm Tcheke <span class=\"activity-header__text\">Tanpri, di nou ki jan ou te  santi ou o tan ké posib nan tan ou te kolekte echantiyon tès COVID-19 ou an</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "Rapò sou sentòm yo a nenpòt ki  lè!",

--- a/study-builder/studies/testboston/i18n/pt.conf
+++ b/study-builder/studies/testboston/i18n/pt.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Questionário sobre sintomas",
-    "title": "<span>Verificação de sintomas da Covid-19  <span class=\"activity-header__text\">Diga-nos como se sente o mais próximo possível da hora de colheita da sua amostra do teste para a COVID-19 </span></span>"
+    "title": "<span>Verificação de sintomas da Covid-19  <span class=\"activity-header__text\">Diga-nos como se sente o mais próximo possível da hora de colheita da sua amostra do teste para a COVID-19 </span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "Notifique os sintomas a qualquer momento!",

--- a/study-builder/studies/testboston/i18n/ru.conf
+++ b/study-builder/studies/testboston/i18n/ru.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Опрос на наличие симптомов",
-    "title": "<span>Проверка симптомов Covid-19 <span class=\"activity-header__text\">Расскажите о своем самочувствии как можно ближе ко времени взятия образца для анализа на COVID-19.</span></span>"
+    "title": "<span>Проверка симптомов Covid-19 <span class=\"activity-header__text\">Расскажите о своем самочувствии как можно ближе ко времени взятия образца для анализа на COVID-19.</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "Сообщайте о симптомах в любое время!",

--- a/study-builder/studies/testboston/i18n/vi.conf
+++ b/study-builder/studies/testboston/i18n/vi.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "Khảo sát triệu chứng",
-    "title": "<span>Kiểm tra triệu chứng Covid-19 <span class=\"activity-header__text\">Vui lòng cho chúng tôi biết cảm giác gần nhất của quý vị về thời điểm quý vị lấy mẫu xét nghiệm COVID-19 của mình</span></span>"
+    "title": "<span>Kiểm tra triệu chứng Covid-19 <span class=\"activity-header__text\">Vui lòng cho chúng tôi biết cảm giác gần nhất của quý vị về thời điểm quý vị lấy mẫu xét nghiệm COVID-19 của mình</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "Báo cáo các triệu chứng bất cứ lúc nào!",

--- a/study-builder/studies/testboston/i18n/zh.conf
+++ b/study-builder/studies/testboston/i18n/zh.conf
@@ -157,7 +157,8 @@
   },
   "baseline_symptom": {
     "name": "症状调查",
-    "title": "<span>COVID-19 症状检查 <span class=\"activity-header__text\">请尽可能告诉我们，在您采集 COVID-19 测试样本时感觉如何</span></span>"
+    "title": "<span>COVID-19 症状检查 <span class=\"activity-header__text\">请尽可能告诉我们，在您采集 COVID-19 测试样本时感觉如何</span></span>",
+    "sample_collect_msg": ""
   },
   "adhoc_symptom": {
     "name": "随时报告症状！",

--- a/study-builder/studies/testboston/longitudinal-covid.conf
+++ b/study-builder/studies/testboston/longitudinal-covid.conf
@@ -35,6 +35,30 @@
       "icons": [],
       "blocks": [
         {
+          "titleTemplate": null,
+          "bodyTemplate": {
+            "templateType": "HTML",
+            "templateText": "$tb_sample_collect_msg",
+            "variables": [
+              {
+                "name": "tb_sample_collect_msg",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.baseline_symptom.sample_collect_msg} },
+                  { "language": "es", "text": ${i18n.es.baseline_symptom.sample_collect_msg} },
+                  { "language": "ht", "text": ${i18n.ht.baseline_symptom.sample_collect_msg} },
+                  { "language": "ar", "text": ${i18n.ar.baseline_symptom.sample_collect_msg} },
+                  { "language": "fr", "text": ${i18n.fr.baseline_symptom.sample_collect_msg} },
+                  { "language": "pt", "text": ${i18n.pt.baseline_symptom.sample_collect_msg} },
+                  { "language": "ru", "text": ${i18n.ru.baseline_symptom.sample_collect_msg} },
+                  { "language": "vi", "text": ${i18n.vi.baseline_symptom.sample_collect_msg} },
+                  { "language": "zh", "text": ${i18n.zh.baseline_symptom.sample_collect_msg} }
+                ]
+              }
+            ]
+          },
+          "blockType": "CONTENT"
+        },
+        {
           # NOTE: Using HOCON object concatenation here to override just a few things on the included object,
           # so we can leverage re-use since it's mostly the same questions.
           "control": ${_includes.baseline_covid.covid_been_tested} {

--- a/study-builder/studies/testboston/patches/sample-collect-message.conf
+++ b/study-builder/studies/testboston/patches/sample-collect-message.conf
@@ -1,0 +1,26 @@
+{
+  "block": {
+    "titleTemplate": null,
+    "bodyTemplate": {
+      "templateType": "HTML",
+      "templateText": "$tb_sample_collect_msg",
+      "variables": [
+        {
+          "name": "tb_sample_collect_msg",
+          "translations": [
+            { "language": "en", "text": ${i18n.en.baseline_symptom.sample_collect_msg} },
+            { "language": "es", "text": ${i18n.es.baseline_symptom.sample_collect_msg} },
+            { "language": "ht", "text": ${i18n.ht.baseline_symptom.sample_collect_msg} },
+            { "language": "ar", "text": ${i18n.ar.baseline_symptom.sample_collect_msg} },
+            { "language": "fr", "text": ${i18n.fr.baseline_symptom.sample_collect_msg} },
+            { "language": "pt", "text": ${i18n.pt.baseline_symptom.sample_collect_msg} },
+            { "language": "ru", "text": ${i18n.ru.baseline_symptom.sample_collect_msg} },
+            { "language": "vi", "text": ${i18n.vi.baseline_symptom.sample_collect_msg} },
+            { "language": "zh", "text": ${i18n.zh.baseline_symptom.sample_collect_msg} }
+          ]
+        }
+      ]
+    },
+    "blockType": "CONTENT"
+  }
+}


### PR DESCRIPTION
Add configuration and study-builder code to add a "sample collect message" to the symptom surveys. Although there is study-builder code, this is purely a study configuration change, so does not need to follow regular release schedule.

I have updated the existing activity definitions, so that local development is much easier (just run regular study-builder, nothing else needed). For deployed environments, we will run the new `TestBostonAddSampleCollectMessage` task, which is a once-per-environment operation.