### PR TITLE
DDP-5259 should not fetch child composite answers

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -293,6 +293,7 @@ public interface AnswerDao extends SqlObject {
         }
 
         // Child answers are deleted separately, so remove any potential ones from the set of top-level answer ids.
+        answerIds = new HashSet<>(answerIds);
         answerIds.removeAll(childAnswerIds);
 
         // Delete parent answers first so it de-references the child answers

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -145,6 +145,7 @@ public interface AnswerDao extends SqlObject {
     private void createAnswerPicklistValue(long answerId, PicklistAnswer answer, PicklistQuestionDef questionDef) {
         getPicklistAnswerDao().assignOptionsToAnswerId(answerId, answer.getValue(), questionDef);
     }
+
     //
     // updates
     //
@@ -290,6 +291,9 @@ public interface AnswerDao extends SqlObject {
                         .forEach(child -> childAnswerIds.add(child.getId()));
             }
         }
+
+        // Child answers are deleted separately, so remove any potential ones from the set of top-level answer ids.
+        answerIds.removeAll(childAnswerIds);
 
         // Delete parent answers first so it de-references the child answers
         DBUtils.checkDelete(answerIds.size(), answerSql.bulkDeleteAnswersById(answerIds));

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
@@ -342,7 +342,7 @@ public interface QuestionDao extends SqlObject {
                 break;
             case COMPOSITE:
                 question = getCompositeQuestion((CompositeQuestionDto) dto,
-                        activityInstanceGuid, answerIds, untypedRules, retrieveAnswers, langCodeId);
+                        activityInstanceGuid, answerIds, untypedRules, langCodeId);
                 break;
             default:
                 throw new DaoException("Unknown question type: " + dto.getType());
@@ -657,7 +657,6 @@ public interface QuestionDao extends SqlObject {
                                                    String activityInstanceGuid,
                                                    List<Long> answerIds,
                                                    List<Rule> untypedRules,
-                                                   boolean retrieveAnswers,
                                                    long langCodeId) {
         JdbiQuestion jdbiQuestion = getJdbiQuestion();
         List<Long> childIds = jdbiQuestion.findCompositeChildIdsByParentId(dto.getId());
@@ -665,7 +664,7 @@ public interface QuestionDao extends SqlObject {
         try (var stream = jdbiQuestion.findQuestionDtosByIds(childIds)) {
             childQuestions = stream
                     .map(childQuestionDto ->
-                            getQuestionByActivityInstanceAndDto(childQuestionDto, activityInstanceGuid, retrieveAnswers, langCodeId))
+                            getQuestionByActivityInstanceAndDto(childQuestionDto, activityInstanceGuid, false, langCodeId))
                     .collect(toList());
         }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/QuestionDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/QuestionDaoTest.java
@@ -1591,7 +1591,6 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     activityInstanceDto.getGuid(),
                     List.of(ans.getAnswerId()),
                     Collections.emptyList(),
-                    true,
                     langCodeId);
             assertEquals(QuestionType.COMPOSITE, question.getQuestionType());
             assertEquals(prompt.getTemplateId(), (Long) question.getPromptTemplateId());


### PR DESCRIPTION
## Context

Fixes DDP-5259. I noticed that the GetActivityInstance endpoint was returning child composite answers in addition to the parent composite answer (which already contains the child answers!). This is confusing and redundant, so removing it.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

