### PR TITLE
Add cleanup to a test

### DIFF
--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/DsmTriggerOnDemandActivityRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/DsmTriggerOnDemandActivityRouteTest.java
@@ -29,6 +29,7 @@ import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
 import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
 import org.jdbi.v3.core.Handle;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -58,6 +59,15 @@ public class DsmTriggerOnDemandActivityRouteTest extends DsmRouteTest {
         handle.attach(ActivityDao.class).insertActivity(activity, RevisionMetadata.now(generatedTestData.getUserId(), "test"));
         assertNotNull(activity.getActivityId());
         return activity;
+    }
+
+    @AfterClass
+    public static void testDataCleanup() {
+        TransactionWrapper.useTxn(handle -> {
+            assertEquals(1, handle.createUpdate("update user set legacy_altpid = null where guid = :guid")
+                    .bind("guid", userGuid)
+                    .execute());
+        });
     }
 
     @After


### PR DESCRIPTION
Once in a while, I'll see a particular test fail in CircleCI, such as [this one](https://app.circleci.com/pipelines/github/broadinstitute/ddp-study-server/3688/workflows/e96e3921-02cf-4004-8884-cc5755ef064c/jobs/6393). I think this is because we didn't cleanup data properly in the tests, so added the necessary cleanup.