### PR TITLE
circleci: skip job if no meaningful changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ commands:
 
             # untarring will create a "tcell" dir
             tar --no-same-owner -xvf $TAR_FILE_PATH
+
   build-jar:
     description: Build jar
     parameters:
@@ -104,6 +105,7 @@ commands:
           name: Run maven package
           command: |
             mvn package -DskipTests -file << parameters.pom_file >> -Dcheckstyle.skip -Dmaven.repo.local=<< parameters.m2_repo >>
+
   setup-shared-env:
     description: "Setup shared ENV vars used by multiple scripts"
     steps:
@@ -261,6 +263,7 @@ commands:
             mkdir -p $(dirname $JAR_FILE_PATH)
             gsutil cp  $JAR_FILE_URL $JAR_FILE_PATH
             echo ""
+
   deploy-jar:
     parameters:
       jar_base_name:
@@ -665,14 +668,47 @@ commands:
           path: <<parameters.ddp_cache_md5_file>>
           destination: ddp-cache-md5.txt
 
+  match-file-patterns-or-halt:
+    parameters:
+      file_patterns:
+        type: string
+        default: "pepper-apis"
+    steps:
+      - run:
+          name: Check git changes and stop the job early if certain files did not change
+          command: |
+            file_patterns='<<parameters.file_patterns>>'
+            echo "Checking file patterns: $file_patterns"
+            matched=false
+            for pattern in $(echo "$file_patterns"); do
+              if git diff --name-only origin/develop "$CIRCLE_BRANCH" | grep -e "$pattern" > /dev/null; then
+                echo "Matched pattern: $pattern"
+                matched=true
+                break
+              fi
+            done
+            if [[ "$matched" == 'false' ]]; then
+              echo "No file patterns matched, skipping job"
+              circleci step halt
+            fi
+
 jobs:
   build-api-docs-job:
     executor:
       name: build-deploy-executor
     working_directory: *api-spec-path
+    parameters:
+      allow_skip_job:
+        type: boolean
+        default: false
     steps:
       - checkout:
           path: *repo_path
+      - when:
+          condition: << parameters.allow_skip_job >>
+          steps:
+            - match-file-patterns-or-halt:
+                file_patterns: "pepper-apis/docs/specification"
       - run:
           name: Build docs
           command: ./build.sh documentation
@@ -681,12 +717,28 @@ jobs:
     executor:
       name: test-executor
     working_directory: *pepper_apis_path
+    parameters:
+      allow_skip_job:
+        type: boolean
+        default: false
     steps:
       - checkout:
           path: *repo_path
+      # When any code or configuration changes, run compile step below.
+      - when:
+          condition: << parameters.allow_skip_job >>
+          steps:
+            - match-file-patterns-or-halt:
+                file_patterns: "pepper-apis/config pepper-apis/src study-builder/src pom.xml checkstyle.xml"
       - setup-shared-env
       - compile-all-jars:
           restore_m2_cache: true
+      # When only pepper code or configuration changes, run the standalone tests.
+      - when:
+          condition: << parameters.allow_skip_job >>
+          steps:
+            - match-file-patterns-or-halt:
+                file_patterns: "pepper-apis/config pepper-apis/src pepper-apis/.*pom.xml"
       - render-configs
       - create-test-dbs
       - restore-ddp-cache
@@ -705,11 +757,19 @@ jobs:
     parallelism: <<parameters.parallelism>>
     parameters:
       parallelism:
-        default: 2
         type: integer
+        default: 2
+      allow_skip_job:
+        type: boolean
+        default: false
     steps:
       - checkout:
           path: *repo_path
+      - when:
+          condition: << parameters.allow_skip_job >>
+          steps:
+            - match-file-patterns-or-halt:
+                file_patterns: "pepper-apis/config pepper-apis/src pepper-apis/.*pom.xml"
       - setup-shared-env
       - run-maven-with-pepper-options:
           phase: process-test-classes
@@ -867,10 +927,13 @@ workflows:
   run-tests-on-demand-workflow:
     when: << pipeline.parameters.on_demand >>
     jobs:
-      - compile-and-run-test-suite-job
+      - compile-and-run-test-suite-job:
+          allow_skip_job: true
       - parallel-compile-and-test-job:
           parallelism: *test_parallelism
-      - build-api-docs-job
+          allow_skip_job: true
+      - build-api-docs-job:
+          allow_skip_job: true
 
   deploy-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,6 +678,7 @@ commands:
           name: Check git changes and stop the job early if certain files did not change
           command: |
             file_patterns='<<parameters.file_patterns>>'
+            file_patterns+=' .circleci/config.yml'
             echo "Checking file patterns: $file_patterns"
             matched=false
             for pattern in $(echo "$file_patterns"); do


### PR DESCRIPTION
Updated our CircleCI pipeline configuration to allow skipping jobs. Skipping is based on matching file patterns: if there's a match we'll continue, otherwise the job exits early with a success status. Skipping is only allowed on the "on-demand" workflow, so that we can skip for PRs but continue to run everything for the `develop` / RC / hotfix branches.

Even though we're skipping things, we're still incurring a wait time of about 2 minutes. This is because CircleCI has to setup the docker environment for the job (which takes forever, especially the parallel job) before checking the files. I haven't found a way to conditionally spin up jobs yet (I don't think CircleCI supports it..).

Despite that, PRs that only changed study configuration files should be less painful now since wait time is a bit lower and PR won't be affected by flaky tests.