### PR TITLE
legacy_altpid size extension

### DIFF
--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -237,4 +237,5 @@
     <include file="db-changes/schema/DDP-5194-picklist-nested-options.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/add-participant-list-workflow-state-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5175-copy-from-previous-instance.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/user_legacy_altpid_change_limit_size.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/user_legacy_altpid_change_limit_size.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/user_legacy_altpid_change_limit_size.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="20200618-user-legacy-altpid-change-limit-size" author="m.mamytov">
+
+        <modifyDataType  columnName="legacy_altpid"
+                         newDataType="varchar(70)"
+                         tableName="user"/>
+
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
legacy altpid size was 60, changed to 70 to fit altpid size which comes from legacy app
