### PR TITLE
DDP 5322 elastic changes

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1091,6 +1091,12 @@ PicklistOption:
       type: string
     exclusive:
       type: boolean
+    nestedOptionsLabel:
+      type: string
+    nestedOptions:
+        type: array
+        items:
+          $ref: '../pepper.yml#/components/schemas/PicklistOption'
 PrequalifierModel:
   type: object
   required:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -411,7 +411,9 @@ public interface AnswerDao extends SqlObject {
                             new PicklistAnswer(answerId, questionStableId, answerGuid, new ArrayList<>(), actInstanceGuid));
                     var optionStableId = view.getColumn("pa_option_stable_id", String.class);
                     if (optionStableId != null) {
-                        var option = new SelectedPicklistOption(optionStableId, view.getColumn("pa_detail_text", String.class));
+                        var option = new SelectedPicklistOption(optionStableId,
+                                view.getColumn("pa_parent_option_stable_id", String.class),
+                                view.getColumn("pa_detail_text", String.class));
                         ((PicklistAnswer) answer).getValue().add(option);
                     }
                     break;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -16,7 +16,7 @@ import org.broadinstitute.ddp.model.activity.types.QuestionType;
 public final class PicklistQuestionRecord extends QuestionRecord {
 
     @SerializedName("answer")
-    private List<Object> selected = new ArrayList<>();
+    private List<String> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
     @SerializedName("nestedOptions")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -2,21 +2,25 @@ package org.broadinstitute.ddp.export.json.structured;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
 public final class PicklistQuestionRecord extends QuestionRecord {
 
     @SerializedName("answer")
-    private List<String> selected = new ArrayList<>();
+    private List<Object> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
+    @SerializedName("nestedOptions")
+    private Map<String, List<String>> nestedOptions = new HashMap<>();
 
     public PicklistQuestionRecord(String stableId, List<SelectedPicklistOption> answer) {
         super(QuestionType.PICKLIST, stableId);
@@ -24,7 +28,12 @@ public final class PicklistQuestionRecord extends QuestionRecord {
             List<SelectedPicklistOption> selected = new ArrayList<>(answer);
             selected.sort(Comparator.comparing(SelectedPicklistOption::getStableId));
             for (SelectedPicklistOption option : selected) {
-                this.selected.add(option.getStableId());
+                if (StringUtils.isNotBlank(option.getParentStableId())) {
+                    String parentStableId = option.getParentStableId();
+                    nestedOptions.computeIfAbsent(parentStableId, id -> new ArrayList<>()).add(option.getStableId());
+                } else {
+                    this.selected.add(option.getStableId());
+                }
                 if (option.getDetailText() != null) {
                     Map<String, String> details = new LinkedHashMap<>();
                     details.put("option", option.getStableId());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/SelectedPicklistOption.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/SelectedPicklistOption.java
@@ -17,12 +17,20 @@ public class SelectedPicklistOption implements Serializable {
     @SerializedName("detail")
     private String detailText;
 
+    private transient  String parentStableId;
+
     public SelectedPicklistOption(String stableId) {
         this(stableId, null);
     }
 
     public SelectedPicklistOption(String stableId, String detailText) {
         this.stableId = MiscUtil.checkNotBlank(stableId, "stableId");
+        this.detailText = detailText;
+    }
+
+    public SelectedPicklistOption(String stableId, String parentStableId, String detailText) {
+        this.stableId = MiscUtil.checkNotBlank(stableId, "stableId");
+        this.parentStableId = parentStableId;
         this.detailText = detailText;
     }
 
@@ -33,4 +41,9 @@ public class SelectedPicklistOption implements Serializable {
     public String getDetailText() {
         return detailText;
     }
+
+    public String getParentStableId() {
+        return parentStableId;
+    }
+
 }

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -38,8 +38,9 @@ select ai.activity_instance_id   as a_instance_id,
        da.day    as da_day,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
-       po.picklist_option_stable_id as pa_option_stable_id,
-       pa.detail_text               as pa_detail_text,
+       po.picklist_option_stable_id  as pa_option_stable_id,
+       ppo.picklist_option_stable_id as pa_parent_option_stable_id,
+       pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,
        ca.child_answer_id  as ca_child_answer_id,
@@ -66,6 +67,8 @@ select ai.activity_instance_id   as a_instance_id,
   left join numeric_answer as na on na.answer_id = ans.answer_id
   left join picklist_option__answer as pa on pa.answer_id = ans.answer_id
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
+  left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
+  left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -14,6 +14,7 @@ select ans.answer_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id as pa_option_stable_id,
+       ppo.picklist_option_stable_id as pa_parent_option_stable_id,
        pa.detail_text               as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,
@@ -40,6 +41,8 @@ select ans.answer_id,
   left join numeric_answer as na on na.answer_id = ans.answer_id
   left join picklist_option__answer as pa on pa.answer_id = ans.answer_id
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
+  left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
+  left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-5322
Add nested picklist options to participant_structured elastic index .
Changes is needed for DSM to show nested options in POSTCONSENT: RACE question of Brain Pediatrics
nested options already exists in activity_definition but DSM prefers it in  participant_structured index along with answers for ease of displaying them.

Added nestedOptions API doc changes