### PR TITLE
DDP-5337 testboston: remove longitudinal survey edit timeout

### DIFF
--- a/study-builder/studies/testboston/longitudinal-covid.conf
+++ b/study-builder/studies/testboston/longitudinal-covid.conf
@@ -5,7 +5,7 @@
   "versionTag": "v1",
   "displayOrder": 2,
   "writeOnce": false,
-  "editTimeoutSec": 604800,   # 7 days
+  "editTimeoutSec": null,
   "maxInstancesPerUser": 5,
   "translatedNames": [
     { "language": "en", "text": ${i18n.en.longitudinal.name} },


### PR DESCRIPTION
Saving TestBoston configuration change that's already made in production. See ticket and [Slack thread](https://broadinstitute.slack.com/archives/G012Y2S45KN/p1605815556179600).