### PR TITLE
DDP 5342 - Add  picklist group to participant_structured elastic index

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -413,6 +413,7 @@ public interface AnswerDao extends SqlObject {
                     if (optionStableId != null) {
                         var option = new SelectedPicklistOption(optionStableId,
                                 view.getColumn("pa_parent_option_stable_id", String.class),
+                                view.getColumn("pa_group_stable_id", String.class),
                                 view.getColumn("pa_detail_text", String.class));
                         ((PicklistAnswer) answer).getValue().add(option);
                     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -19,8 +19,8 @@ public final class PicklistQuestionRecord extends QuestionRecord {
     private List<String> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
-    @SerializedName("groupOptions")
-    private Map<String, List<String>> groupOptions = new HashMap<>();
+    @SerializedName("groupedOptions")
+    private Map<String, List<String>> groupedOptions = new HashMap<>();
     @SerializedName("nestedOptions")
     private Map<String, List<String>> nestedOptions = new HashMap<>();
 
@@ -32,7 +32,7 @@ public final class PicklistQuestionRecord extends QuestionRecord {
             for (SelectedPicklistOption option : selected) {
                 if (StringUtils.isNotBlank(option.getGroupStableId())) {
                     String groupStableId = option.getGroupStableId();
-                    groupOptions.computeIfAbsent(groupStableId, id -> new ArrayList<>()).add(option.getStableId());
+                    groupedOptions.computeIfAbsent(groupStableId, id -> new ArrayList<>()).add(option.getStableId());
                 } else if (StringUtils.isNotBlank(option.getParentStableId())) {
                     String parentStableId = option.getParentStableId();
                     nestedOptions.computeIfAbsent(parentStableId, id -> new ArrayList<>()).add(option.getStableId());
@@ -46,8 +46,8 @@ public final class PicklistQuestionRecord extends QuestionRecord {
                     this.optionDetails.add(details);
                 }
             }
-            if (!groupOptions.isEmpty())  {
-                this.selected.addAll(groupOptions.keySet());
+            if (!groupedOptions.isEmpty())  {
+                this.selected.addAll(groupedOptions.keySet());
             }
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -16,7 +16,7 @@ import org.broadinstitute.ddp.model.activity.types.QuestionType;
 public final class PicklistQuestionRecord extends QuestionRecord {
 
     @SerializedName("answer")
-    private List<Object> selected = new ArrayList<>();
+    private List<String> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
     @SerializedName("groupOptions")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/PicklistQuestionRecord.java
@@ -16,9 +16,11 @@ import org.broadinstitute.ddp.model.activity.types.QuestionType;
 public final class PicklistQuestionRecord extends QuestionRecord {
 
     @SerializedName("answer")
-    private List<String> selected = new ArrayList<>();
+    private List<Object> selected = new ArrayList<>();
     @SerializedName("optionDetails")
     private List<Map<String, String>> optionDetails = new ArrayList<>();
+    @SerializedName("groupOptions")
+    private Map<String, List<String>> groupOptions = new HashMap<>();
     @SerializedName("nestedOptions")
     private Map<String, List<String>> nestedOptions = new HashMap<>();
 
@@ -28,7 +30,10 @@ public final class PicklistQuestionRecord extends QuestionRecord {
             List<SelectedPicklistOption> selected = new ArrayList<>(answer);
             selected.sort(Comparator.comparing(SelectedPicklistOption::getStableId));
             for (SelectedPicklistOption option : selected) {
-                if (StringUtils.isNotBlank(option.getParentStableId())) {
+                if (StringUtils.isNotBlank(option.getGroupStableId())) {
+                    String groupStableId = option.getGroupStableId();
+                    groupOptions.computeIfAbsent(groupStableId, id -> new ArrayList<>()).add(option.getStableId());
+                } else if (StringUtils.isNotBlank(option.getParentStableId())) {
                     String parentStableId = option.getParentStableId();
                     nestedOptions.computeIfAbsent(parentStableId, id -> new ArrayList<>()).add(option.getStableId());
                 } else {
@@ -40,6 +45,9 @@ public final class PicklistQuestionRecord extends QuestionRecord {
                     details.put("details", option.getDetailText());
                     this.optionDetails.add(details);
                 }
+            }
+            if (!groupOptions.isEmpty())  {
+                this.selected.addAll(groupOptions.keySet());
             }
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/SelectedPicklistOption.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/answer/SelectedPicklistOption.java
@@ -18,6 +18,7 @@ public class SelectedPicklistOption implements Serializable {
     private String detailText;
 
     private transient  String parentStableId;
+    private transient  String groupStableId;
 
     public SelectedPicklistOption(String stableId) {
         this(stableId, null);
@@ -28,8 +29,9 @@ public class SelectedPicklistOption implements Serializable {
         this.detailText = detailText;
     }
 
-    public SelectedPicklistOption(String stableId, String parentStableId, String detailText) {
+    public SelectedPicklistOption(String stableId, String parentStableId, String groupStableId, String detailText) {
         this.stableId = MiscUtil.checkNotBlank(stableId, "stableId");
+        this.groupStableId = groupStableId;
         this.parentStableId = parentStableId;
         this.detailText = detailText;
     }
@@ -46,4 +48,7 @@ public class SelectedPicklistOption implements Serializable {
         return parentStableId;
     }
 
+    public String getGroupStableId() {
+        return groupStableId;
+    }
 }

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -39,8 +39,8 @@ select ai.activity_instance_id   as a_instance_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id  as pa_option_stable_id,
-			 (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
-			   where ppo.picklist_option_id = npo.parent_option_id
+       (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
+         where ppo.picklist_option_id = npo.parent_option_id
          and npo.nested_option_id = pa.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -40,6 +40,7 @@ select ai.activity_instance_id   as a_instance_id,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id  as pa_option_stable_id,
        ppo.picklist_option_stable_id as pa_parent_option_stable_id,
+       plg.group_stable_id           as pa_group_stable_id,
        pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,
@@ -69,6 +70,8 @@ select ai.activity_instance_id   as a_instance_id,
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
   left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
   left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
+  left join picklist_grouped_option as gpo on gpo.picklist_option_id = pa.picklist_option_id
+  left join picklist_group as plg on plg.picklist_group_id = gpo.picklist_group_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -39,13 +39,13 @@ select ai.activity_instance_id   as a_instance_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id  as pa_option_stable_id,
-       (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
-         where ppo.picklist_option_id = npo.parent_option_id
-         and npo.nested_option_id = pa.picklist_option_id
+       (select ppo.picklist_option_stable_id from picklist_nested_option as pno join picklist_option as ppo
+         on ppo.picklist_option_id = pno.parent_option_id
+         where pno.nested_option_id = pa.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
-         where pgo.picklist_group_id = plg.picklist_group_id
-         and pgo.picklist_option_id = po.picklist_option_id
+         on pgo.picklist_group_id = plg.picklist_group_id
+         where pgo.picklist_option_id = po.picklist_option_id
        ) as pa_group_stable_id,
        pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -41,7 +41,7 @@ select ai.activity_instance_id   as a_instance_id,
        po.picklist_option_stable_id  as pa_option_stable_id,
        (select ppo.picklist_option_stable_id from picklist_nested_option as pno join picklist_option as ppo
          on ppo.picklist_option_id = pno.parent_option_id
-         where pno.nested_option_id = pa.picklist_option_id
+         where pno.nested_option_id = po.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
          on pgo.picklist_group_id = plg.picklist_group_id

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceSql.sql.stg
@@ -39,8 +39,14 @@ select ai.activity_instance_id   as a_instance_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id  as pa_option_stable_id,
-       ppo.picklist_option_stable_id as pa_parent_option_stable_id,
-       plg.group_stable_id           as pa_group_stable_id,
+			 (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
+			   where ppo.picklist_option_id = npo.parent_option_id
+         and npo.nested_option_id = pa.picklist_option_id
+       ) as pa_parent_option_stable_id,
+       (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
+         where pgo.picklist_group_id = plg.picklist_group_id
+         and pgo.picklist_option_id = po.picklist_option_id
+       ) as pa_group_stable_id,
        pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,
@@ -68,10 +74,6 @@ select ai.activity_instance_id   as a_instance_id,
   left join numeric_answer as na on na.answer_id = ans.answer_id
   left join picklist_option__answer as pa on pa.answer_id = ans.answer_id
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
-  left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
-  left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
-  left join picklist_grouped_option as gpo on gpo.picklist_option_id = pa.picklist_option_id
-  left join picklist_group as plg on plg.picklist_group_id = gpo.picklist_group_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -14,8 +14,8 @@ select ans.answer_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id as pa_option_stable_id,
-			 (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
-			   where ppo.picklist_option_id = npo.parent_option_id
+       (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
+         where ppo.picklist_option_id = npo.parent_option_id
          and npo.nested_option_id = pa.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -16,7 +16,7 @@ select ans.answer_id,
        po.picklist_option_stable_id as pa_option_stable_id,
        (select ppo.picklist_option_stable_id from picklist_nested_option as pno join picklist_option as ppo
          on ppo.picklist_option_id = pno.parent_option_id
-         where pno.nested_option_id = pa.picklist_option_id
+         where pno.nested_option_id = po.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
          on pgo.picklist_group_id = plg.picklist_group_id

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -14,8 +14,14 @@ select ans.answer_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id as pa_option_stable_id,
-       ppo.picklist_option_stable_id as pa_parent_option_stable_id,
-       plg.group_stable_id           as pa_group_stable_id,
+			 (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
+			   where ppo.picklist_option_id = npo.parent_option_id
+         and npo.nested_option_id = pa.picklist_option_id
+       ) as pa_parent_option_stable_id,
+       (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
+         where pgo.picklist_group_id = plg.picklist_group_id
+         and pgo.picklist_option_id = po.picklist_option_id
+       ) as pa_group_stable_id,
        pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -14,13 +14,13 @@ select ans.answer_id,
        nt.numeric_type_code as na_numeric_type,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id as pa_option_stable_id,
-       (select ppo.picklist_option_stable_id from picklist_nested_option as npo join picklist_option as ppo
-         where ppo.picklist_option_id = npo.parent_option_id
-         and npo.nested_option_id = pa.picklist_option_id
+       (select ppo.picklist_option_stable_id from picklist_nested_option as pno join picklist_option as ppo
+         on ppo.picklist_option_id = pno.parent_option_id
+         where pno.nested_option_id = pa.picklist_option_id
        ) as pa_parent_option_stable_id,
        (select plg.group_stable_id from picklist_grouped_option pgo join picklist_group plg
-         where pgo.picklist_group_id = plg.picklist_group_id
-         and pgo.picklist_option_id = po.picklist_option_id
+         on pgo.picklist_group_id = plg.picklist_group_id
+         where pgo.picklist_option_id = po.picklist_option_id
        ) as pa_group_stable_id,
        pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
@@ -50,8 +50,6 @@ select ans.answer_id,
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
   left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
   left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
-  left join picklist_grouped_option as gpo on gpo.picklist_option_id = pa.picklist_option_id
-  left join picklist_group as plg on plg.picklist_group_id = gpo.picklist_group_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/AnswerDao.sql.stg
@@ -15,7 +15,8 @@ select ans.answer_id,
        na.int_value         as na_int_value,
        po.picklist_option_stable_id as pa_option_stable_id,
        ppo.picklist_option_stable_id as pa_parent_option_stable_id,
-       pa.detail_text               as pa_detail_text,
+       plg.group_stable_id           as pa_group_stable_id,
+       pa.detail_text                as pa_detail_text,
        cq.allow_multiple   as ca_allow_multiple,
        cq.unwrap_on_export as ca_unwrap_on_export,
        ca.child_answer_id  as ca_child_answer_id,
@@ -43,6 +44,8 @@ select ans.answer_id,
   left join picklist_option as po on po.picklist_option_id = pa.picklist_option_id
   left join picklist_nested_option as npo on npo.nested_option_id = pa.picklist_option_id
   left join picklist_option as ppo on ppo.picklist_option_id = npo.parent_option_id
+  left join picklist_grouped_option as gpo on gpo.picklist_option_id = pa.picklist_option_id
+  left join picklist_group as plg on plg.picklist_group_id = gpo.picklist_group_id
   left join composite_answer_item as ca on ca.parent_answer_id = ans.answer_id
 >>
 


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-5342
Add  picklist group to participant_structured elastic index .
Group is needed for DSM to show group stableID in MPC (Prostate) about-you survey
group already exists in activity_definition but DSM prefers it in  participant_structured index along with answers for ease of displaying them.

Some SQL refactoring 
