### PR TITLE
DDP-5349 Allow usage of variables in i18n substitutions

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
@@ -289,7 +289,15 @@ public class I18nContentRenderer {
         VelocityContext ctx = new VelocityContext(context);
         StringWriter writer = new StringWriter();
         engine.evaluate(ctx, writer, TEMPLATE_NAME, template);
-        return writer.toString();
+        String result = writer.toString();
+        if (result.contains("$")) {
+            // Here we have a second pass in case of variables in the substitution values,
+            // e.g. participantName() with locale-dependent position in the sentence.
+            writer = new StringWriter();
+            engine.evaluate(ctx, writer, TEMPLATE_NAME, result);
+            result = writer.toString();
+        }
+        return result;
     }
 
     private String convertToString(Object obj) {


### PR DESCRIPTION
Currently it is not supported to have tags like $ddp.participantName() in the substitutions, they won't be processed during rendering.
However, for different languages, name etc. could be at different positions in the sentence.
Therefore, it is necessary to have second level of template processing in order to support i18n.