### PR TITLE
DDP-5312 part 2: export kit-related activity attributes

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -196,6 +196,9 @@
               "ignore_malformed": false,
               "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
             },
+            "attributes": {
+              "type": "object"
+            },
             "questionsAnswers": {
               "type": "nested",
               "properties": {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nTemplateConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/I18nTemplateConstants.java
@@ -11,6 +11,7 @@ public class I18nTemplateConstants {
         public static final String PARTICIPANT_BIRTH_DATE = "DDP_PARTICIPANT_BIRTH_DATE";
         public static final String PARTICIPANT_TIME_ZONE = "DDP_PARTICIPANT_TIME_ZONE";
         public static final String DATE = "DDP_DATE";
+        public static final String KIT_REQUEST_ID = "DDP_KIT_REQUEST_ID";
         public static final String TEST_RESULT_CODE = "DDP_TEST_RESULT_CODE";
         public static final String TEST_RESULT_TIME_COMPLETED = "DDP_TEST_RESULT_TIME_COMPLETED";
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -26,6 +26,7 @@ public class RenderValueProvider {
     private LocalDate participantBirthDate;
     private ZoneId participantTimeZone;
     private LocalDate date;
+    private String kitRequestId;
     private String testResultCode;
     private Instant testResultTimeCompleted;
     private Integer activityInstanceNumber;
@@ -80,6 +81,13 @@ public class RenderValueProvider {
             LOG.warn("Error formatting date value '{}' using format '{}'", date, format, e);
             return date.toString();
         }
+    }
+
+    /**
+     * Returns the kit request id, if available.
+     */
+    public String kitRequestId() {
+        return kitRequestId;
     }
 
     /**
@@ -177,6 +185,9 @@ public class RenderValueProvider {
         if (date != null) {
             snapshot.put(I18nTemplateConstants.Snapshot.DATE, date.toString());
         }
+        if (kitRequestId != null) {
+            snapshot.put(I18nTemplateConstants.Snapshot.KIT_REQUEST_ID, kitRequestId);
+        }
         if (testResultCode != null) {
             snapshot.put(I18nTemplateConstants.Snapshot.TEST_RESULT_CODE, testResultCode);
         }
@@ -220,6 +231,11 @@ public class RenderValueProvider {
 
         public Builder setDate(LocalDate date) {
             provider.date = date;
+            return this;
+        }
+
+        public Builder setKitRequestId(String kitRequestId) {
+            provider.kitRequestId = kitRequestId;
             return this;
         }
 
@@ -269,6 +285,11 @@ public class RenderValueProvider {
                 provider.date = LocalDate.parse(value);
             }
 
+            value = snapshot.get(I18nTemplateConstants.Snapshot.KIT_REQUEST_ID);
+            if (value != null) {
+                provider.kitRequestId = value;
+            }
+
             value = snapshot.get(I18nTemplateConstants.Snapshot.TEST_RESULT_CODE);
             if (value != null) {
                 provider.testResultCode = value;
@@ -290,6 +311,7 @@ public class RenderValueProvider {
             copy.participantBirthDate = provider.participantBirthDate;
             copy.participantTimeZone = provider.participantTimeZone;
             copy.date = provider.date;
+            copy.kitRequestId = provider.kitRequestId;
             copy.testResultCode = provider.testResultCode;
             copy.testResultTimeCompleted = provider.testResultTimeCompleted;
             copy.activityInstanceNumber = provider.activityInstanceNumber;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ActivityInstanceRecord.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/json/structured/ActivityInstanceRecord.java
@@ -1,6 +1,8 @@
 package org.broadinstitute.ddp.export.json.structured;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
@@ -23,6 +25,8 @@ public class ActivityInstanceRecord {
     private Long lastUpdatedAtMillis;
     @SerializedName("questionsAnswers")
     private List<QuestionRecord> questionsAnswers;
+    @SerializedName("attributes")
+    private Map<String, String> attributes = new HashMap<>();
 
     public ActivityInstanceRecord(
             String versionTag,
@@ -42,5 +46,9 @@ public class ActivityInstanceRecord {
         this.completedAtMillis = completedAtMillis;
         this.lastUpdatedAtMillis = lastUpdatedAtMillis;
         this.questionsAnswers = questionsAnswers;
+    }
+
+    public void putAttribute(String name, String value) {
+        attributes.put(name, value);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/dsm/DsmNotificationPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/dsm/DsmNotificationPayload.java
@@ -14,6 +14,9 @@ public class DsmNotificationPayload {
     @SerializedName("eventType")
     private String eventType;
 
+    @SerializedName("kitRequestId")
+    private String kitRequestId;
+
     @SerializedName("kitReasonType")
     private KitReasonType kitReasonType;
 
@@ -26,12 +29,13 @@ public class DsmNotificationPayload {
     @SerializedName("eventDate")
     private long eventDate;
 
-    public DsmNotificationPayload(String eventType) {
-        this(eventType, KitReasonType.NORMAL);
+    public DsmNotificationPayload(String eventType, String kitRequestId) {
+        this(eventType, kitRequestId, KitReasonType.NORMAL);
     }
 
-    public DsmNotificationPayload(String eventType, KitReasonType kitReasonType) {
+    public DsmNotificationPayload(String eventType, String kitRequestId, KitReasonType kitReasonType) {
         this.eventType = eventType;
+        this.kitRequestId = kitRequestId;
         this.kitReasonType = kitReasonType;
     }
 
@@ -45,6 +49,10 @@ public class DsmNotificationPayload {
         } catch (Exception e) {
             return Optional.empty();
         }
+    }
+
+    public String getKitRequestId() {
+        return kitRequestId;
     }
 
     public KitReasonType getKitReasonType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/ActivityInstanceCreationEventAction.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/ActivityInstanceCreationEventAction.java
@@ -1,8 +1,10 @@
 package org.broadinstitute.ddp.model.event;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.content.RenderValueProvider;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
@@ -122,18 +124,21 @@ public class ActivityInstanceCreationEventAction extends EventAction {
 
         if (signal instanceof DsmNotificationSignal) {
             var dsmSignal = (DsmNotificationSignal) signal;
+            var builder = new RenderValueProvider.Builder();
+            if (StringUtils.isNotBlank(dsmSignal.getKitRequestId())) {
+                builder.setKitRequestId(dsmSignal.getKitRequestId());
+            }
             if (dsmSignal.getDsmEventType() == DsmNotificationEventType.TEST_RESULT) {
                 TestResult result = dsmSignal.getTestResult();
                 if (result != null) {
-                    var provider = new RenderValueProvider.Builder()
-                            .setTestResultCode(result.getNormalizedResult())
-                            .setTestResultTimeCompleted(result.getTimeCompleted())
-                            .build();
-                    handle.attach(ActivityInstanceDao.class).saveSubstitutions(
-                            newActivityInstanceId,
-                            provider.getSnapshot());
-                    LOG.info("Saved test result data as substitution snapshot for activity instance {}", newActivityInstanceId);
+                    builder.setTestResultCode(result.getNormalizedResult())
+                            .setTestResultTimeCompleted(result.getTimeCompleted());
                 }
+            }
+            Map<String, String> snapshot = builder.build().getSnapshot();
+            if (!snapshot.isEmpty()) {
+                handle.attach(ActivityInstanceDao.class).saveSubstitutions(newActivityInstanceId, snapshot);
+                LOG.info("Saved kit event data as substitution snapshot for activity instance {}", newActivityInstanceId);
             }
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/DsmNotificationSignal.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/DsmNotificationSignal.java
@@ -10,21 +10,27 @@ import org.broadinstitute.ddp.model.dsm.TestResult;
 public class DsmNotificationSignal extends EventSignal {
 
     private DsmNotificationEventType eventType;
+    private String kitRequestId;
     private KitReasonType kitReasonType;
     private TestResult testResult;
 
     public DsmNotificationSignal(long operatorId, long participantId, String participantGuid,
                                  String operatorGuid, long studyId, DsmNotificationEventType eventType,
-                                 KitReasonType kitReasonType,
+                                 @Nullable String kitRequestId, KitReasonType kitReasonType,
                                  @Nullable TestResult testResult) {
         super(operatorId, participantId, participantGuid, operatorGuid, studyId, EventTriggerType.DSM_NOTIFICATION);
         this.eventType = eventType;
+        this.kitRequestId = kitRequestId;
         this.kitReasonType = kitReasonType;
         this.testResult = testResult;
     }
 
     public DsmNotificationEventType getDsmEventType() {
         return eventType;
+    }
+
+    public String getKitRequestId() {
+        return kitRequestId;
     }
 
     public KitReasonType getKitReasonType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/study/Participant.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/study/Participant.java
@@ -23,6 +23,7 @@ public class Participant {
 
     private User user;
     private Map<String, List<ActivityResponse>> responses;
+    private Map<Long, Map<String, String>> activityInstanceSubstitutions;
 
     // todo: better models for status and medical providers
     private EnrollmentStatusDto status;
@@ -38,6 +39,7 @@ public class Participant {
         this.providers = new ArrayList<>();
         this.invitations = new ArrayList<>();
         this.responses = new HashMap<>();
+        this.activityInstanceSubstitutions = new HashMap<>();
     }
 
     public EnrollmentStatusDto getStatus() {
@@ -91,6 +93,14 @@ public class Participant {
         responses.computeIfAbsent(response.getActivityTag(), tag -> new ArrayList<>()).add(response);
     }
 
+    public Map<String, String> getActivityInstanceSubstitutions(long activityInstanceId) {
+        return activityInstanceSubstitutions.getOrDefault(activityInstanceId, new HashMap<>());
+    }
+
+    public void putActivityInstanceSubstitutions(long activityInstanceId, Map<String, String> substitutions) {
+        activityInstanceSubstitutions.put(activityInstanceId, substitutions);
+    }
+
     public LocalDate getDateOfMajority() {
         return dateOfMajority;
     }
@@ -98,7 +108,6 @@ public class Participant {
     public void setDateOfMajority(LocalDate dateOfMajority) {
         this.dateOfMajority = dateOfMajority;
     }
-
 
     public List<InvitationDto> getInvitations() {
         return invitations;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRoute.java
@@ -58,8 +58,8 @@ public class ReceiveDsmNotificationRoute extends ValidatedJsonInputRoute<DsmNoti
         String studyGuid = request.params(PathParam.STUDY_GUID);
         String participantGuidOrAltPid = request.params(PathParam.USER_GUID);
 
-        LOG.info("Received DSM notification event for userGuidOrAltPid={}, studyGuid={}, and eventType={}",
-                participantGuidOrAltPid, studyGuid, payload.getEventType());
+        LOG.info("Received DSM notification event for userGuidOrAltPid={}, studyGuid={}, eventType={}, kitRequestId={}, kitReasonType={}",
+                participantGuidOrAltPid, studyGuid, payload.getEventType(), payload.getKitRequestId(), payload.getKitReasonType());
 
         return TransactionWrapper.withTxn(handle -> {
             var found = RouteUtil.findPotentiallyLegacyUserAndStudyOrHalt(handle, participantGuidOrAltPid, studyGuid);
@@ -105,6 +105,7 @@ public class ReceiveDsmNotificationRoute extends ValidatedJsonInputRoute<DsmNoti
                     null,
                     studyDto.getId(),
                     eventType,
+                    payload.getKitRequestId(),
                     kitReasonType,
                     testResult);
             EventService.getInstance().processAllActionsForEventSignal(handle, signal);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExporterTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExporterTest.java
@@ -30,6 +30,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import com.opencsv.CSVReader;
 import org.broadinstitute.ddp.TxnAwareBaseTest;
+import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
@@ -553,6 +554,12 @@ public class DataExporterTest extends TxnAwareBaseTest {
         );
         assertEquals(1, result.size());
         assertTrue(result.get(TEST_USER_GUID).contains("invite123"));
+
+        // Check kit-related attributes.
+        assertTrue(result.get(TEST_USER_GUID).contains("\"attributes\""));
+        assertTrue(result.get(TEST_USER_GUID).contains("\"DDP_KIT_REQUEST_ID\":\"kit-1\""));
+        assertTrue(result.get(TEST_USER_GUID).contains("\"DDP_TEST_RESULT_CODE\":\"NEGATIVE\""));
+        assertTrue(result.get(TEST_USER_GUID).contains("\"DDP_TEST_RESULT_TIME_COMPLETED\":\"2018-10-18T20:18:01Z\""));
     }
 
     @Test
@@ -696,6 +703,12 @@ public class DataExporterTest extends TxnAwareBaseTest {
                 instance.putAnswer(new NumericIntegerAnswer(3L, "Q_NUMERIC", "guid", 25L));
                 instance.putAnswer(new DateAnswer(4L, "Q_BIRTHDAY", "guid", new DateValue(1978, 5, 16)));
                 participant.addResponse(instance);
+
+                Map<String, String> substitutions = Map.of(
+                        I18nTemplateConstants.Snapshot.KIT_REQUEST_ID, "kit-1",
+                        I18nTemplateConstants.Snapshot.TEST_RESULT_CODE, "NEGATIVE",
+                        I18nTemplateConstants.Snapshot.TEST_RESULT_TIME_COMPLETED, Instant.ofEpochMilli(timestamp).toString());
+                participant.putActivityInstanceSubstitutions(instance.getId(), substitutions);
             }
 
             participants = new ArrayList<>();

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/pex/TreeWalkInterpreterTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/pex/TreeWalkInterpreterTest.java
@@ -1338,6 +1338,7 @@ public class TreeWalkInterpreterTest extends TxnAwareBaseTest {
                 userGuid,
                 testData.getStudyId(),
                 DsmNotificationEventType.TEST_RESULT,
+                "dummy-kit-request-id",
                 kitReasonType,
                 testResult);
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
@@ -120,7 +120,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testStudyNotFound() {
-        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name());
+        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", "foobar")
                 .pathParam("user", testData.getUserGuid())
@@ -133,7 +133,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testUserNotFound() {
-        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name());
+        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", "foobar")
@@ -146,7 +146,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testNotificationEventTypeUnknown() {
-        var payload = new DsmNotificationPayload("foobar");
+        var payload = new DsmNotificationPayload("foobar", "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", testData.getUserGuid())
@@ -160,7 +160,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testNotificationEventTestResultMissingEventData() {
-        var payload = new DsmNotificationPayload(TEST_RESULT.name());
+        var payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", testData.getUserGuid())
@@ -174,7 +174,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testNotificationEventTestResultBadEventData() {
-        var payload = new DsmNotificationPayload(TEST_RESULT.name());
+        var payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-1");
         var result = new JsonObject();
         result.addProperty("result", "NEGATIVE");
         result.addProperty("reason", "the reason");
@@ -193,7 +193,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testNotificationEventTestResultInvalidEventData() {
-        var payload = new DsmNotificationPayload(TEST_RESULT.name());
+        var payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-1");
         var result = new JsonObject();
         result.addProperty("result", "NEGATIVE");
         result.addProperty("reason", "the reason");
@@ -212,7 +212,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testEvents_success() {
-        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name());
+        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", testData.getUserGuid())
@@ -225,7 +225,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testEvents_usingLegacyAltPid_success() {
-        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name());
+        var payload = new DsmNotificationPayload(SALIVA_RECEIVED.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", LEGACY_ALT_PID)
@@ -238,7 +238,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
 
     @Test
     public void testEvents_mismatchedDsmEventType() {
-        var payload = new DsmNotificationPayload(TESTBOSTON_RECEIVED.name());
+        var payload = new DsmNotificationPayload(TESTBOSTON_RECEIVED.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", testData.getStudyGuid())
                 .pathParam("user", LEGACY_ALT_PID)
@@ -270,7 +270,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
         });
 
         // This DSM event should be ignored because it's not replacement.
-        var payload = new DsmNotificationPayload(TEST_RESULT.name(), KitReasonType.NORMAL);
+        var payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-1", KitReasonType.NORMAL);
         var result = new TestResult("NEGATIVE", Instant.now(), false);
         payload.setEventData(GsonUtil.standardGson().toJsonTree(result));
         given().auth().oauth2(dsmClientAccessToken)
@@ -282,7 +282,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
                 .statusCode(200);
 
         // This DSM event should pass because it is replacement.
-        payload = new DsmNotificationPayload(TEST_RESULT.name(), KitReasonType.REPLACEMENT);
+        payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-2", KitReasonType.REPLACEMENT);
         var result2 = new TestResult("Positive", Instant.now(), false);
         payload.setEventData(GsonUtil.standardGson().toJsonTree(result2));
         given().auth().oauth2(dsmClientAccessToken)
@@ -303,6 +303,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
             ActivityResponse instance = instances.get(0);
             Map<String, String> substitutions = instanceDao.findSubstitutions(instance.getId());
             assertFalse(substitutions.isEmpty());
+            assertEquals("kit-2", substitutions.get(I18nTemplateConstants.Snapshot.KIT_REQUEST_ID));
             assertEquals("should be result of second request and should normalize result code",
                     "POSITIVE", substitutions.get(I18nTemplateConstants.Snapshot.TEST_RESULT_CODE));
             assertEquals(result2.getTimeCompleted().toString(),
@@ -329,7 +330,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
                     .createScheduleRecord(testData.getUserId(), configId);
         });
 
-        var payload = new DsmNotificationPayload(TESTBOSTON_SENT.name());
+        var payload = new DsmNotificationPayload(TESTBOSTON_SENT.name(), "kit-1");
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("study", study.getGuid())
                 .pathParam("user", testData.getUserGuid())


### PR DESCRIPTION
## Context

Part of DDP-5312. When we create an activity instance due to a kit event, we store the kit_request_id with the activity instance so we have some way to associate the two. We then export the kit-related data for an activity instance to Elasticsearch so DSM can leverage that (also exporting the test result data too so DSM can display that).

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling
    - Need to update Elasticsearch template and re-export data.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
    - Need to update Elasticsearch template and re-export data.

