### PR TITLE
DDP-5312 part 3: pass invite code substitution to study emails

### DIFF
--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilderTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilderTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.housekeeping;
 
 import static org.broadinstitute.ddp.Housekeeping.DDP_MESSAGE_ID;
 import static org.broadinstitute.ddp.Housekeeping.DDP_STUDY_GUID;
+import static org.broadinstitute.ddp.constants.NotificationTemplateVariables.DDP_INVITATION_ID;
 import static org.broadinstitute.ddp.constants.NotificationTemplateVariables.DDP_PROXY_FIRST_NAME;
 import static org.broadinstitute.ddp.constants.NotificationTemplateVariables.DDP_PROXY_LAST_NAME;
 import static org.junit.Assert.assertEquals;
@@ -14,6 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,9 +24,12 @@ import com.google.pubsub.v1.PubsubMessage;
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.InvitationDao;
+import org.broadinstitute.ddp.db.dao.InvitationFactory;
 import org.broadinstitute.ddp.db.dao.StudyDao;
 import org.broadinstitute.ddp.db.dao.UserDao;
 import org.broadinstitute.ddp.db.dao.UserGovernanceDao;
+import org.broadinstitute.ddp.db.dto.InvitationDto;
 import org.broadinstitute.ddp.db.dto.NotificationDetailsDto;
 import org.broadinstitute.ddp.db.dto.QueuedEventDto;
 import org.broadinstitute.ddp.db.dto.QueuedNotificationDto;
@@ -208,5 +213,42 @@ public class PubSubMessageBuilderTest extends TxnAwareBaseTest {
         assertNotNull(actual);
         assertEquals("t2", actual.getTemplateKey());
         assertEquals("fr", actual.getLanguageCode());
+    }
+
+    @Test
+    public void testCreateMessage_studyEmail() {
+        TransactionWrapper.useTxn(handle -> {
+            QueuedEventDto event = new QueuedNotificationDto(
+                    new QueuedEventDto(1L, testData.getUserId(), testData.getUserGuid(), testData.getUserHruid(),
+                            testData.getUserGuid(), 1L, EventTriggerType.ACTIVITY_STATUS, EventActionType.NOTIFICATION, null, null,
+                            "topic", null, null, testData.getStudyGuid()),
+                    new NotificationDetailsDto(NotificationType.STUDY_EMAIL, NotificationServiceType.SENDGRID,
+                            null, null, "url", "apiKey", "studyFromName", "studyFromEmail",
+                            "salutation", "first", "last"));
+
+            InvitationDto invite = handle.attach(InvitationFactory.class)
+                    .createRecruitmentInvitation(testData.getStudyId(), "dummy-invite-code");
+            handle.attach(InvitationDao.class)
+                    .assignAcceptingUser(invite.getInvitationId(), testData.getUserId(), Instant.now());
+
+            PubSubMessageBuilder builder = spy(new PubSubMessageBuilder(cfg));
+            doReturn(new NotificationTemplate(1L, "template", false, 1L, "en"))
+                    .when(builder).determineEmailTemplate(any(), anyLong(), any(), any());
+
+            PubsubMessage msg = builder.createMessage("test", event, handle);
+            assertEquals("test", msg.getAttributesOrThrow(DDP_MESSAGE_ID));
+            assertEquals(testData.getStudyGuid(), msg.getAttributesOrThrow(DDP_STUDY_GUID));
+
+            NotificationMessage content = gson.fromJson(msg.getData().toStringUtf8(), NotificationMessage.class);
+            assertEquals(1, content.getDistributionList().size());
+            assertEquals("the 'to' field should be directed to study's email",
+                    "studyFromEmail", content.getDistributionList().iterator().next());
+
+            Optional<String> inviteCode = content.getTemplateSubstitutionValue(DDP_INVITATION_ID);
+            assertTrue("email substitutions should have invite code", inviteCode.isPresent());
+            assertEquals(invite.getInvitationGuid(), inviteCode.get());
+
+            handle.rollback();
+        });
     }
 }


### PR DESCRIPTION
## Context

Part of DDP-5312 and DDP-5276. In TestBoston, we want to send study staff an email when participant submits the adhoc_symptom survey, and we want to include their invite code in the email. The TestBoston email and configuration changes will be in a followup PR.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

