### PR TITLE
DDP-5312 handle empty set when bulk querying substitutions

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -247,7 +247,8 @@ public interface ActivityInstanceDao extends SqlObject {
 
     @SqlQuery("select * from activity_instance_substitution where activity_instance_id in (<instanceIds>)")
     @UseRowReducer(BulkFindSubstitutionsReducer.class)
-    Stream<SubstitutionsWrapper> bulkFindSubstitutions(@BindList("instanceIds") Set<Long> instanceIds);
+    Stream<SubstitutionsWrapper> bulkFindSubstitutions(
+            @BindList(value = "instanceIds", onEmpty = EmptyHandling.NULL) Set<Long> instanceIds);
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryBaseResponsesByInstanceId")

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDaoTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -189,6 +190,17 @@ public class ActivityInstanceDaoTest extends TxnAwareBaseTest {
             assertEquals(answer.getAnswerGuid(), resp.getAnswers().get(0).getAnswerGuid());
 
             handle.rollback();
+        });
+    }
+
+    @Test
+    public void testBulkFindSubstitutions() {
+        TransactionWrapper.useTxn(handle -> {
+            var dao = handle.attach(ActivityInstanceDao.class);
+            try (var stream = dao.bulkFindSubstitutions(Collections.emptySet())) {
+                var result = stream.collect(Collectors.toList());
+                assertTrue("should return empty list", result.isEmpty());
+            }
         });
     }
 }


### PR DESCRIPTION
Fixes bug seen in `pepper-dev-alerts` channel:

```
[export] failed to export participant G3538UQV2545HGE2LI5Z for study testboston, continuing argument is empty; emptiness was explicitly forbidden on this instance of BindList
```