### PR TITLE
mark old mpc followup as not on-demand activity

### DIFF
--- a/study-builder/studies/mpc/followup-consent.conf
+++ b/study-builder/studies/mpc/followup-consent.conf
@@ -8,7 +8,7 @@
   "writeOnce": true,
   "maxInstancesPerUser": null,
   "isFollowup": true,
-  "allowOndemandTrigger": true,
+  "allowOndemandTrigger": false,
   "translatedNames": [
     {
       "language": "en",


### PR DESCRIPTION
mark old followup MPC as not on-demand activity so that this activity options doesn't show up in DSM followup activities that are on-demand trigger activities.
change was made part of prod deploy, just pushing up the change.