### PR TITLE
DDP-5455 fix read-only calculation in Patch Answers

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -124,6 +124,9 @@ public interface JdbiActivity extends SqlObject {
     @SqlUpdate("update study_activity set edit_timeout_sec = :editTimeoutSec where study_id = :studyId and study_activity_code = :code")
     int updateEditTimeoutSecByCode(Long editTimeoutSec, String code, long studyId);
 
+    @SqlUpdate("update study_activity set is_write_once = :isWriteOnce where study_activity_id = :id")
+    int updateWriteOnceById(@Bind("id") long studyActivityId, @Bind("isWriteOnce") boolean isWriteOnce);
+
     @SqlUpdate("update study_activity set instantiate_upon_registration = :autoInstantiate"
             + " where study_activity_id = :studyActivityId")
     int updateAutoInstantiateById(long studyActivityId, boolean autoInstantiate);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceDto.java
@@ -1,10 +1,7 @@
 package org.broadinstitute.ddp.db.dto;
 
-import java.util.Optional;
-
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
-
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceDto.java
@@ -95,10 +95,6 @@ public class ActivityInstanceDto {
         return firstCompletedAt;
     }
 
-    public boolean isReadonly() {
-        return Optional.ofNullable(isReadonly).orElse(false);
-    }
-
     public Boolean getReadonly() {
         return isReadonly;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -169,9 +169,8 @@ public class PatchFormAnswersRoute implements Route {
             }
 
             if (ActivityInstanceUtil.isReadonly(formActivityDef.getEditTimeoutSec(), instanceDto.getCreatedAtMillis(),
-                    instanceDto.getStatusType().name(), formActivityDef.isWriteOnce(), instanceDto.isReadonly())) {
-                String msg = "Activity instance with GUID " + instanceGuid
-                        + " is read-only, cannot submit answer(s) for it";
+                    instanceDto.getStatusType().name(), formActivityDef.isWriteOnce(), instanceDto.getReadonly())) {
+                String msg = "Activity instance with GUID " + instanceGuid + " is read-only, cannot submit answer(s) for it";
                 LOG.info(msg);
                 throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
             }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
@@ -205,7 +205,7 @@ public class CreateInvitationEventActionTest extends TxnAwareBaseTest {
 
             // do it for real
             action.doAction(null, handle, signal);
-            assertTrue(handle.attach(JdbiActivityInstance.class).getByActivityInstanceId(instance1.getId()).get().isReadonly());
+            assertTrue(handle.attach(JdbiActivityInstance.class).getByActivityInstanceId(instance1.getId()).get().getReadonly());
 
             handle.rollback();
         });

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/MarkActivitiesReadOnlyEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/MarkActivitiesReadOnlyEventActionTest.java
@@ -62,8 +62,8 @@ public class MarkActivitiesReadOnlyEventActionTest extends TxnAwareBaseTest {
             action.doAction(null, handle, signal);
 
             var jdbiInstance = handle.attach(JdbiActivityInstance.class);
-            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().isReadonly());
-            assertTrue(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().isReadonly());
+            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().getReadonly());
+            assertTrue(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().getReadonly());
 
             handle.rollback();
         });
@@ -84,8 +84,8 @@ public class MarkActivitiesReadOnlyEventActionTest extends TxnAwareBaseTest {
             action.doAction(null, handle, signal);
 
             var jdbiInstance = handle.attach(JdbiActivityInstance.class);
-            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().isReadonly());
-            assertTrue(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().isReadonly());
+            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().getReadonly());
+            assertTrue(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().getReadonly());
 
             handle.rollback();
         });
@@ -107,8 +107,8 @@ public class MarkActivitiesReadOnlyEventActionTest extends TxnAwareBaseTest {
             action.doAction(null, handle, signal);
 
             var jdbiInstance = handle.attach(JdbiActivityInstance.class);
-            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().isReadonly());
-            assertFalse(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().isReadonly());
+            assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().getReadonly());
+            assertFalse(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().getReadonly());
 
             handle.rollback();
         });

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/MarkActivitiesReadOnlyEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/MarkActivitiesReadOnlyEventActionTest.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.model.event;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
@@ -108,7 +108,7 @@ public class MarkActivitiesReadOnlyEventActionTest extends TxnAwareBaseTest {
 
             var jdbiInstance = handle.attach(JdbiActivityInstance.class);
             assertTrue(jdbiInstance.getByActivityInstanceId(instance1.getId()).get().getReadonly());
-            assertFalse(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().getReadonly());
+            assertNull(jdbiInstance.getByActivityInstanceId(instance2.getId()).get().getReadonly());
 
             handle.rollback();
         });

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
@@ -423,6 +423,9 @@ public class PatchFormAnswersRouteStandaloneTest {
                     instanceGuid, InstanceStatusType.COMPLETE, Instant.now().toEpochMilli(), testData.getUserGuid());
         });
 
+        // Activity definition is cached! Clear cache since we made change to definition.
+        ActivityDefStore.getInstance().clear();
+
         AnswerSubmission submission = new AnswerSubmission(numericIntegerSid, null, gson.toJsonTree(10));
         PatchAnswerPayload data = new PatchAnswerPayload(List.of(submission));
 
@@ -430,6 +433,7 @@ public class PatchFormAnswersRouteStandaloneTest {
             givenAnswerPatchRequest(instanceGuid, data)
                     .then().assertThat()
                     .statusCode(422).contentType(ContentType.JSON)
+                    .log().all()
                     .body("code", equalTo(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY))
                     .body("message", containsString(instanceGuid))
                     .body("message", containsString("read-only"));
@@ -437,6 +441,7 @@ public class PatchFormAnswersRouteStandaloneTest {
             TransactionWrapper.useTxn(handle -> {
                 assertEquals(1, handle.attach(JdbiActivity.class).updateWriteOnceById(activity.getActivityId(), oldWriteOnce.get()));
             });
+            ActivityDefStore.getInstance().clear();
         }
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
@@ -149,7 +149,7 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
             assertEquals(EnrollmentStatusType.CONSENT_SUSPENDED, status.get());
 
             assertTrue("activity instance should have been made read-only", handle.attach(JdbiActivityInstance.class)
-                    .getByActivityInstanceId(instanceDto.getId()).get().isReadonly());
+                    .getByActivityInstanceId(instanceDto.getId()).get().getReadonly());
 
             handle.rollback();
         });
@@ -181,7 +181,7 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
             assertTrue(candidates.get(0).hasInitiatedPrep());
 
             assertTrue("activity instance should have been made read-only", handle.attach(JdbiActivityInstance.class)
-                    .getByActivityInstanceId(instanceDto.getId()).get().isReadonly());
+                    .getByActivityInstanceId(instanceDto.getId()).get().getReadonly());
 
             handle.rollback();
         });


### PR DESCRIPTION
## Context

Fixes DDP-5455.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

