### PR TITLE
DDP-5505 support text question institution suggestion type

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1470,8 +1470,9 @@ Question.Text:
         enum:
           - NONE
           - DRUG
-          - INCLUDED
           - CANCER
+          - INCLUDED
+          - INSTITUTION
       suggestions:
         description: 'If the suggestionType is INCLUDED, then this is the list of suggestions to use'
         type: array

--- a/pepper-apis/docs/specification/src/endpoints/autocomplete.institution.yml
+++ b/pepper-apis/docs/specification/src/endpoints/autocomplete.institution.yml
@@ -9,6 +9,12 @@ get:
       description: the substring to filter on
       schema:
         type: string
+    - in: query
+      name: limit
+      description: maximum number of suggestions to return
+      schema:
+        type: integer
+        minimum: 0
   responses:
     200:
       $ref: '../pepper.yml#/components/responses/InstitutionSuggestion'

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 servers: []
 info:
   description: 'Pepper API specification'
-  version: 1.9.5
+  version: 1.9.8
   title: Pepper
   contact:
     email: info@datadonationplatform.org

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/SuggestionType.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/SuggestionType.java
@@ -4,5 +4,6 @@ public enum SuggestionType {
     NONE,
     DRUG,
     CANCER,
-    INCLUDED
+    INCLUDED,
+    INSTITUTION
 }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -243,4 +243,5 @@
     <include file="db-changes/seed/add-languages-de-hi-it-ja-pl-tr.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5277-revision-activity-naming-details.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5509-copy-previous-instance-filter.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/DDP-5505-text-question-institution-suggestion-type.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/DDP-5505-text-question-institution-suggestion-type.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/DDP-5505-text-question-institution-suggestion-type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210108-text-question-institution-suggestion-type">
+        <insert tableName="suggestion_type">
+            <column name="suggestion_type_code" value="INSTITUTION"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetInstitutionSuggestionsRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetInstitutionSuggestionsRouteTest.java
@@ -136,11 +136,19 @@ public class GetInstitutionSuggestionsRouteTest extends IntegrationTestSuite.Tes
     }
 
     @Test
-    public void testResultsAreLimited() throws IOException {
+    public void testResultsAreLimited_defaultLimit() throws IOException {
         String url = endpoint + "?namePattern=limit";
         List<InstitutionSuggestion> suggestions = executeGetRequestAndGetResponseBody(token, url);
         Assert.assertNotNull(suggestions);
         Assert.assertEquals(GetInstitutionSuggestionsRoute.LIMIT, suggestions.size());
+    }
+
+    @Test
+    public void testResultsAreLimited_customLimit() throws IOException {
+        String url = endpoint + "?namePattern=limit&limit=10";
+        List<InstitutionSuggestion> suggestions = executeGetRequestAndGetResponseBody(token, url);
+        Assert.assertNotNull(suggestions);
+        Assert.assertEquals(10, suggestions.size());
     }
 
     private static class NewInstitutionTestData {

--- a/study-builder/studies/testboston/snippets/question-hospital-name.conf
+++ b/study-builder/studies/testboston/snippets/question-hospital-name.conf
@@ -1,7 +1,7 @@
 {
   include required("../../snippets/text-question.conf"),
   "stableId": ${id.q.longitudinal_hospital_name},
-  // todo: institution autocompletion configuration
+  "suggestionType": "INSTITUTION",
   "promptTemplate": {
     "templateType": "HTML",
     "templateText": "$longitudinal_hospital_name_prompt"


### PR DESCRIPTION
## Context

Implements server-side of DDP-5505. We add the `INSTITUTION` suggestion type for `TEXT` questions. Most of the heavy-lifting of autocompletion in on client-side in https://github.com/broadinstitute/ddp-angular/pull/404. I also went ahead and added support for taking `limit` query param in the Institution Suggestion API.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

