### PR TITLE
Check for nulls when removing answers from cache

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/AnswerCachedDao.java
@@ -203,15 +203,20 @@ public class AnswerCachedDao extends SQLObjectWrapper<AnswerDao> implements Answ
     }
 
     private void removeFromCache(Long id) {
-        if (!isNullCache(idToAnswerCache)) {
+        if (!isNullCache(idToAnswerCache) && id != null) {
             Answer answerFromCache = idToAnswerCache.remove(id);
             String cacheKey = buildKey(answerFromCache);
             if (cacheKey != null) {
                 activityInstanceGuidAndQuestionKeyToAnswerIdCache.remove(cacheKey);
             }
             if (answerFromCache instanceof CompositeAnswer) {
-                ((CompositeAnswer)answerFromCache).getValue().forEach(
-                        row -> row.getValues().forEach(val -> removeFromCache(val.getAnswerId())));
+                ((CompositeAnswer) answerFromCache).getValue().forEach(row ->
+                        row.getValues().forEach(val -> {
+                            if (val != null) {
+                                removeFromCache(val.getAnswerId());
+                            }
+                        })
+                );
             }
         }
     }


### PR DESCRIPTION
## Context

Fix null pointer error in Slack prod-alerts. Not sure if this should be a hotfix but have labeled it as such.
Checked logs going back one week and this error has only happened once. Was while entering a testboston activity answer.


## Checklist

- [ X] I have labeled the type of changes involved using the `C-*` labels.
- [ X] I have assessed potential risks and labeled using the `R-*` labels.
- [ X] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ X] I have considered security and privacy, and added `I-*` labels as needed
- [X ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ X] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ X] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [X ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?
 The correct situation with Composite answers would need to be setup. Not sure exactly how.
cumented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing
I have not done additional testing. Just adds null checks.
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [X ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

