### PR TITLE
DDP-5442 - fix event persist: do not save with already existing log_id

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/Auth0LogEventService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/Auth0LogEventService.java
@@ -45,6 +45,8 @@ public class Auth0LogEventService {
 
     private static final Logger LOG = getLogger(Auth0LogEventService.class);
 
+    public static final String AUTH0_LOG_EVENT_TITLE = "SAVE Auth0LogEvent";
+
     /**
      * List of Auth0 Log Event JSON node names which to read (recursively)
      */
@@ -83,7 +85,7 @@ public class Auth0LogEventService {
     public void logAuth0LogEvent(Auth0LogEvent logEvent) {
         if (LOG.isDebugEnabled() || LOG.isTraceEnabled()) {
             LOG.debug(
-                    "AUTH0-LOG-EVENT[{}]: type={} ({}), date={}, log_id={}\n"
+                    AUTH0_LOG_EVENT_TITLE + "[{}]: type={} ({}), date={}, log_id={}\n"
                             + "\tclient_id={}, connection_id={}, user_id={}\n"
                             + "\tuser_agent={}\n"
                             + "\tip={}, email={}\n"
@@ -101,7 +103,7 @@ public class Auth0LogEventService {
                     logEvent.getEmail(),
                     logEvent.getData());
         } else {
-            LOG.info("AUTH0-LOG-EVENT[{}]: type={} ({}), date={}, user_id={}, log_id={}",
+            LOG.info(AUTH0_LOG_EVENT_TITLE + "[{}]: type={} ({}), date={}, user_id={}, log_id={}",
                     logEvent.getTenant(),
                     logEvent.getType(),
                     getTypeDescription(logEvent),


### PR DESCRIPTION

## Context

It looks like Auth0 can resend log event with log_id already persisted into DB. In such case we need to just ignore the new copy of the same event. 
In this PR implemented a fix which checks type of exception which happened during data persisting: if it is of type SQLIntegrityConstraintViolationException and message contains name of unique constraing (tenant+log_id) "auth0_log_event_tenant_log_id_uk", then ignore such error (not return an exception in response).

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

