### PR TITLE
[DDP-3709] part 1: file upload support and API

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -53,6 +53,12 @@
     "restrictAuth0LogEventRoute": {{$conf.Data.restrictAuth0LogEventRoute}},
     "requireDefaultGcpCredentials": {{$conf.Data.requireDefaultGcpCredentials}},
     "googleProjectId": "{{$conf.Data.googleProjectId}}",
+    "fileUploads": {
+        "uploadsBucket": "{{$conf.Data.fileUploads.uploadsBucket}}",
+        "maxFileSizeBytes": {{$conf.Data.fileUploads.maxFileSizeBytes}},
+        "maxSignedUrlMins": {{$conf.Data.fileUploads.maxSignedUrlMins}},
+        "signerServiceAccount": {{$conf.Data.fileUploads.signerServiceAccount | toJSONPretty}}
+    },
     "pdfArchiveBucket": "{{$conf.Data.pdfArchiveBucket}}",
     "pdfArchiveUseFilesystem": false,
     "pubsub": {

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -4,11 +4,11 @@
 {{with $environment := env "ENVIRONMENT"}}
 {{with $version := env "VERSION"}}
 {{with $gae := env "GAE"}}
-{{with $conf := vault (printf "secret/pepper/%s/%s/conf" $environment $version)}}
 {{with $testingConf := vault (printf "secret/pepper/%s/%s/testing" $environment $version)}}
 {{with $auth0 := index $testingConf.Data "auth0"}}
 {{with $testingAuth := index $testingConf.Data "auth0"}}
-{{with $elasticsearchConf := vault (printf "secret/pepper/%s/%s/elasticsearch" $environment $version)}}
+{{with $conf := vault (printf "secret/pepper/%s/%s/conf" $environment $version)}}
+{{with $fileUploads := index $conf.Data "fileUploads"}}
 
 {
     {{if eq $gae "true"}}
@@ -96,7 +96,7 @@
         "uploadsBucket": "ddp-local-file-uploads",
         "maxFileSizeBytes": 2000000,
         "maxSignedUrlMins": 5,
-        "signerServiceAccount": {{$conf.Data.fileUploads.signerServiceAccount | toJSONPretty}}
+        "signerServiceAccount": {{$fileUploads.signerServiceAccount | toJSONPretty}}
     },
     "pdfArchiveBucket": "pepper-pdf-dev",
     "pdfArchiveUseFilesystem": true,

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -4,6 +4,7 @@
 {{with $environment := env "ENVIRONMENT"}}
 {{with $version := env "VERSION"}}
 {{with $gae := env "GAE"}}
+{{with $conf := vault (printf "secret/pepper/%s/%s/conf" $environment $version)}}
 {{with $testingConf := vault (printf "secret/pepper/%s/%s/testing" $environment $version)}}
 {{with $auth0 := index $testingConf.Data "auth0"}}
 {{with $testingAuth := index $testingConf.Data "auth0"}}
@@ -91,6 +92,12 @@
     "sendMetrics": false,
     "requireDefaultGcpCredentials": false,
     "googleProjectId": "broad-ddp-dev",
+    "fileUploads": {
+        "uploadsBucket": "ddp-local-file-uploads",
+        "maxFileSizeBytes": 2000000,
+        "maxSignedUrlMins": 5,
+        "signerServiceAccount": {{$conf.Data.fileUploads.signerServiceAccount | toJSONPretty}}
+    },
     "pdfArchiveBucket": "pepper-pdf-dev",
     "pdfArchiveUseFilesystem": true,
     "pubsub": {
@@ -182,6 +189,7 @@
     }
 }
 
+{{end}}
 {{end}}
 {{end}}
 {{end}}

--- a/pepper-apis/docs/specification/src/components/parameters.yml
+++ b/pepper-apis/docs/specification/src/components/parameters.yml
@@ -12,3 +12,10 @@ userGuid:
   description: the user's guid
   schema:
     type: string
+instanceGuid:
+  in: path
+  name: instance
+  required: true
+  description: the activity instance guid
+  schema:
+    type: string

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1054,6 +1054,18 @@ Error.UserStudyActivityNotFound:
             - ACTIVITY_NOT_FOUND
             - STUDY_NOT_FOUND
             - USER_NOT_FOUND
+Error.UserStudyActivityQuestionNotFound:
+  allOf:
+    - $ref: '../pepper.yml#/components/schemas/Error'
+    - type: object
+      properties:
+        code:
+          type: string
+          enum:
+            - ACTIVITY_NOT_FOUND
+            - QUESTION_NOT_FOUND
+            - STUDY_NOT_FOUND
+            - USER_NOT_FOUND
 Image:
   type: object
   required:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.uploads.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.uploads.yml
@@ -1,0 +1,104 @@
+parameters:
+  - $ref: '../pepper.yml#/components/parameters/studyGuid'
+  - $ref: '../pepper.yml#/components/parameters/userGuid'
+  - $ref: '../pepper.yml#/components/parameters/instanceGuid'
+
+post:
+  operationId: postActivityUploads
+  tags:
+    - Activities
+  summary: create an authorized file upload
+  description: |
+    Request for a new URL for file upload. Link is accessible for limited
+    period of time (e.g. 5 mins). Resumable uploads are supported. With
+    information in response body, client will be able to upload the file
+    directly to a Google Bucket. If resumable=true is specified in request,
+    client will assume responsibility for creating the session URI with
+    provided URL in addition to follow up requests that contain the file
+    contents (see [documentation][doc]).
+
+    **Study Admins**
+
+    Activity file upload is not supported if activity instance/question is
+    read-only or otherwise inaccessible, unless operator is a study admin.
+
+    **Temporary Users**
+
+    This API endpoint does not allow access by temporary users.
+
+    [doc]: https://cloud.google.com/storage/docs/performing-resumable-uploads
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - questionStableId
+            - fileName
+            - fileSize
+            - resumable
+          properties:
+            questionStableId:
+              type: string
+              description: The question identifier
+            fileName:
+              type: string
+              maxLength: 100
+              description: Name of file to be uploaded
+            fileSize:
+              type: integer
+              description: Size of the file, in bytes (subject to a limit such as 2MB)
+            mimeType:
+              type: string
+              default: application/octet-stream
+              description: MIME type, if not specified will default to `application/octet-stream`
+            resumable:
+              type: boolean
+              description: Whether URL should support resumable upload
+  responses:
+    201:
+      description: authorized file upload
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - uploadGuid
+              - uploadUrl
+            properties:
+              uploadGuid:
+                type: string
+                description: Unique identifier for file upload
+              uploadUrl:
+                type: string
+                description: Signed URL which can be used to upload file contents
+    400:
+      description: invalid request or bad inputs
+      content:
+        application/json:
+          schema:
+            $ref: '../pepper.yml#/components/schemas/Error.BadPayload'
+    404:
+      description: user, study, instance or question is not found
+      content:
+        application/json:
+          schema:
+            $ref: '../pepper.yml#/components/schemas/Error.UserStudyActivityQuestionNotFound'
+    422:
+      description: file upload is not allowed or not supported
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '../pepper.yml#/components/schemas/Error'
+              - type: object
+                properties:
+                  code:
+                    type: string
+                    enum:
+                      - ACTIVITY_INSTANCE_IS_READONLY
+                      - QUESTION_IS_READONLY
+                      - NOT_SUPPORTED
+    default:
+      $ref: '../pepper.yml#/components/responses/ErrorResponse'

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -102,6 +102,8 @@ paths:
     $ref: 'endpoints/user.studies.activity.yml'
   /user/{user}/studies/{study}/activities/{instance}/answers:
     $ref: 'endpoints/user.studies.activity.answers.yml'
+  /user/{user}/studies/{study}/activities/{instance}/uploads:
+    $ref: 'endpoints/user.studies.activity.uploads.yml'
   /user/{user}/studies/{study}/consents:
     $ref: 'endpoints/user.studies.consents.yml'
   /user/{user}/studies/{study}/consents/{instance}:

--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.48.0</version>
+            <version>1.69.0</version>
         </dependency>
 
         <dependency>

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -77,6 +77,7 @@ import org.broadinstitute.ddp.route.CheckIrbPasswordRoute;
 import org.broadinstitute.ddp.route.CreateActivityInstanceRoute;
 import org.broadinstitute.ddp.route.CreateMailAddressRoute;
 import org.broadinstitute.ddp.route.CreateTemporaryUserRoute;
+import org.broadinstitute.ddp.route.CreateUserActivityUploadRoute;
 import org.broadinstitute.ddp.route.DeleteMailAddressRoute;
 import org.broadinstitute.ddp.route.DeleteMedicalProviderRoute;
 import org.broadinstitute.ddp.route.DeleteTempMailingAddressRoute;
@@ -156,6 +157,7 @@ import org.broadinstitute.ddp.service.ActivityValidationService;
 import org.broadinstitute.ddp.service.AddressService;
 import org.broadinstitute.ddp.service.CancerService;
 import org.broadinstitute.ddp.service.ConsentService;
+import org.broadinstitute.ddp.service.FileUploadService;
 import org.broadinstitute.ddp.service.FormActivityService;
 import org.broadinstitute.ddp.service.MedicalRecordService;
 import org.broadinstitute.ddp.service.PdfBucketService;
@@ -468,6 +470,9 @@ public class DataDonationPlatform {
                 new PutFormAnswersRoute(workflowService, activityValidationService, formInstanceDao, interpreter),
                 responseSerializer
         );
+
+        var fileUploadService = FileUploadService.fromConfig(cfg);
+        post(API.USER_ACTIVITY_UPLOADS, new CreateUserActivityUploadRoute(fileUploadService), responseSerializer);
 
         // User study invitations
         get(API.USER_STUDY_INVITES, new ListUserStudyInvitationsRoute(), jsonSerializer);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -192,4 +192,11 @@ public class ConfigFile {
     public static class Auth0LogEvents {
         public static final String AUTH0_LOG_EVENTS_TOKEN = "auth0LogEvents.token";
     }
+
+    public static class FileUploads {
+        public static final String UPLOADS_BUCKET = "fileUploads.uploadsBucket";
+        public static final String MAX_FILE_SIZE_BYTES = "fileUploads.maxFileSizeBytes";
+        public static final String MAX_SIGNED_URL_MINS = "fileUploads.maxSignedUrlMins";
+        public static final String SIGNER_SERVICE_ACCOUNT = "fileUploads.signerServiceAccount";
+    }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
@@ -91,6 +91,8 @@ public class RouteConstants {
                 PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
         public static final String USER_ACTIVITY_ANSWERS = fmt(BASE + "/user/%s/studies/%s/activities/%s/answers",
                 PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
+        public static final String USER_ACTIVITY_UPLOADS = fmt(BASE + "/user/%s/studies/%s/activities/%s/uploads",
+                PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
         public static final String USER_MEDICAL_PROVIDERS = fmt(
                 BASE + "/user/%s/studies/%s/medical-providers/%s",
                 PathParam.USER_GUID,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
@@ -1,0 +1,45 @@
+package org.broadinstitute.ddp.db.dao;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.broadinstitute.ddp.model.files.FileUploadStatus;
+import org.jdbi.v3.sqlobject.CreateSqlObject;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+public interface FileUploadDao extends SqlObject {
+
+    @CreateSqlObject
+    FileUploadSql getFileUploadSql();
+
+    default FileUpload createAuthorized(String guid, String blobName, String mimeType, String fileName,
+                                        int fileSize, long operatorUserId, long participantUserId) {
+        Instant now = Instant.now();
+        long id = getFileUploadSql().insert(
+                guid, blobName, mimeType, fileName, fileSize,
+                operatorUserId, participantUserId,
+                FileUploadStatus.AUTHORIZED, now);
+        return new FileUpload(
+                id, guid, blobName, mimeType, fileName, fileSize,
+                operatorUserId, participantUserId,
+                FileUploadStatus.AUTHORIZED, now, now, false);
+    }
+
+    @SqlQuery("select f.*, (select file_upload_status_code from file_upload_status"
+            + "       where file_upload_status_id = f.status_id) as status"
+            + "  from file_upload as f"
+            + " where f.file_upload_id = :id")
+    @RegisterConstructorMapper(FileUpload.class)
+    Optional<FileUpload> findById(@Bind("id") long fileUploadId);
+
+    @SqlQuery("select f.*, (select file_upload_status_code from file_upload_status"
+            + "       where file_upload_status_id = f.status_id) as status"
+            + "  from file_upload as f"
+            + " where f.file_upload_guid = :guid")
+    @RegisterConstructorMapper(FileUpload.class)
+    Optional<FileUpload> findByGuid(@Bind("guid") String fileUploadGuid);
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
@@ -1,0 +1,30 @@
+package org.broadinstitute.ddp.db.dao;
+
+import java.time.Instant;
+
+import org.broadinstitute.ddp.model.files.FileUploadStatus;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+public interface FileUploadSql extends SqlObject {
+
+    @GetGeneratedKeys
+    @SqlUpdate("insert into file_upload (file_upload_guid, blob_name, mime_type,"
+            + "        file_name, file_size, operator_user_id, participant_user_id,"
+            + "        status_id, status_changed_at, created_at, is_replaced)"
+            + " values (:guid, :blobName, :mimeType, :fileName, :fileSize, :operatorId, :participantId,"
+            + "        (select file_upload_status_id from file_upload_status where file_upload_status_code = :status),"
+            + "        :createdAt, :createdAt, false)")
+    long insert(
+            @Bind("guid") String fileUploadGuid,
+            @Bind("blobName") String blobName,
+            @Bind("mimeType") String mimeType,
+            @Bind("fileName") String fileName,
+            @Bind("fileSize") int fileSize,
+            @Bind("operatorId") long operatorUserId,
+            @Bind("participantId") long participantUserId,
+            @Bind("status") FileUploadStatus status,
+            @Bind("createdAt") Instant createdAt);
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/CreateUserActivityUploadPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/CreateUserActivityUploadPayload.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.ddp.json;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CreateUserActivityUploadPayload {
+
+    @NotBlank
+    @SerializedName("questionStableId")
+    private String questionStableId;
+
+    @NotBlank
+    @Size(max = 100)
+    @SerializedName("fileName")
+    private String fileName;
+
+    @Positive
+    @SerializedName("fileSize")
+    private int fileSize;
+
+    @SerializedName("mimeType")
+    private String mimeType;
+
+    @SerializedName("resumable")
+    private boolean resumable;
+
+    public CreateUserActivityUploadPayload(String questionStableId, String fileName, int fileSize, String mimeType, boolean resumable) {
+        this.questionStableId = questionStableId;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.mimeType = mimeType;
+        this.resumable = resumable;
+    }
+
+    public String getQuestionStableId() {
+        return questionStableId;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public int getFileSize() {
+        return fileSize;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public boolean isResumable() {
+        return resumable;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/CreateUserActivityUploadResponse.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/CreateUserActivityUploadResponse.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.ddp.json;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CreateUserActivityUploadResponse {
+
+    @SerializedName("uploadGuid")
+    private String uploadGuid;
+    @SerializedName("uploadUrl")
+    private String uploadUrl;
+
+    public CreateUserActivityUploadResponse(String uploadGuid, String uploadUrl) {
+        this.uploadGuid = uploadGuid;
+        this.uploadUrl = uploadUrl;
+    }
+
+    public String getUploadGuid() {
+        return uploadGuid;
+    }
+
+    public String getUploadUrl() {
+        return uploadUrl;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/files/FileUpload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/files/FileUpload.java
@@ -1,0 +1,133 @@
+package org.broadinstitute.ddp.model.files;
+
+import java.time.Instant;
+
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+public class FileUpload {
+
+    private final long id;
+    private final String guid;
+    private final String blobName;
+    private final String mimeType;
+    private final String fileName;
+    private final long fileSize;
+    private final long operatorUserId;
+    private final long participantUserId;
+    private final FileUploadStatus status;
+    private final Instant statusChangedAt;
+    private final Instant createdAt;
+    private final boolean isReplaced;
+
+    @JdbiConstructor
+    public FileUpload(@ColumnName("file_upload_id") long id,
+                      @ColumnName("file_upload_guid") String guid,
+                      @ColumnName("blob_name") String blobName,
+                      @ColumnName("mime_type") String mimeType,
+                      @ColumnName("file_name") String fileName,
+                      @ColumnName("file_size") long fileSize,
+                      @ColumnName("operator_user_id") long operatorUserId,
+                      @ColumnName("participant_user_id") long participantUserId,
+                      @ColumnName("status") FileUploadStatus status,
+                      @ColumnName("status_changed_at") Instant statusChangedAt,
+                      @ColumnName("created_at") Instant createdAt,
+                      @ColumnName("is_replaced") boolean isReplaced) {
+        this.id = id;
+        this.guid = guid;
+        this.blobName = blobName;
+        this.mimeType = mimeType;
+        this.fileName = fileName;
+        this.fileSize = fileSize;
+        this.operatorUserId = operatorUserId;
+        this.participantUserId = participantUserId;
+        this.status = status;
+        this.statusChangedAt = statusChangedAt;
+        this.createdAt = createdAt;
+        this.isReplaced = isReplaced;
+    }
+
+    /**
+     * Returns internal unique identifier.
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * Returns external unique identifier.
+     */
+    public String getGuid() {
+        return guid;
+    }
+
+    /**
+     * Returns bucket file name. This is the entire file path for the blob in the bucket.
+     */
+    public String getBlobName() {
+        return blobName;
+    }
+
+    /**
+     * Returns MIME type, such as `application/pdf`.
+     */
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    /**
+     * Returns user-provided name for the file being uploaded.
+     */
+    public String getFileName() {
+        return fileName;
+    }
+
+    /**
+     * Returns user-provided size of the file being uploaded, in bytes.
+     */
+    public long getFileSize() {
+        return fileSize;
+    }
+
+    /**
+     * Returns identifier of operator that initiated this file upload.
+     */
+    public long getOperatorUserId() {
+        return operatorUserId;
+    }
+
+    /**
+     * Returns identifier of participant that this file upload is for, e.g. the user that owns this file upload.
+     */
+    public long getParticipantUserId() {
+        return participantUserId;
+    }
+
+    /**
+     * Returns current status of the file upload.
+     */
+    public FileUploadStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Returns timestamp of the latest status change.
+     */
+    public Instant getStatusChangedAt() {
+        return statusChangedAt;
+    }
+
+    /**
+     * Returns timestamp of when file upload was first created and authorized.
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * Whether this file upload has been replaced by another upload. Replaced uploads should be removed.
+     */
+    public boolean isReplaced() {
+        return isReplaced;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/files/FileUploadStatus.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/files/FileUploadStatus.java
@@ -1,0 +1,23 @@
+package org.broadinstitute.ddp.model.files;
+
+public enum FileUploadStatus {
+    /**
+     * File upload has been authorized. This is the initial state.
+     */
+    AUTHORIZED,
+
+    /**
+     * File has been uploaded. File may not be safe to be operated on, and a scan is required/pending.
+     */
+    UPLOADED,
+
+    /**
+     * File upload has been scanned and found to be malicious. File has been moved to quarantine and should not be used.
+     */
+    QUARANTINED,
+
+    /**
+     * File upload may not be totally clean but is sufficiently safe. File is moved to safe storage and can be used.
+     */
+    SCANNED,
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
@@ -1,0 +1,121 @@
+package org.broadinstitute.ddp.route;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.ddp.constants.ErrorCodes;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.ActivityDefStore;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.ActivityDto;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.json.CreateUserActivityUploadPayload;
+import org.broadinstitute.ddp.json.CreateUserActivityUploadResponse;
+import org.broadinstitute.ddp.json.errors.ApiError;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.security.DDPAuth;
+import org.broadinstitute.ddp.service.FileUploadService;
+import org.broadinstitute.ddp.util.ActivityInstanceUtil;
+import org.broadinstitute.ddp.util.QuestionUtil;
+import org.broadinstitute.ddp.util.ResponseUtil;
+import org.broadinstitute.ddp.util.RouteUtil;
+import org.broadinstitute.ddp.util.ValidatedJsonInputRoute;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+
+public class CreateUserActivityUploadRoute extends ValidatedJsonInputRoute<CreateUserActivityUploadPayload> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CreateUserActivityUploadRoute.class);
+
+    private final FileUploadService service;
+
+    public CreateUserActivityUploadRoute(FileUploadService service) {
+        this.service = service;
+    }
+
+    @Override
+    protected int getValidationErrorStatus() {
+        return HttpStatus.SC_BAD_REQUEST;
+    }
+
+    @Override
+    public Object handle(Request request, Response response, CreateUserActivityUploadPayload payload) throws Exception {
+        String userGuid = request.params(RouteConstants.PathParam.USER_GUID);
+        String studyGuid = request.params(RouteConstants.PathParam.STUDY_GUID);
+        String instanceGuid = request.params(RouteConstants.PathParam.INSTANCE_GUID);
+
+        DDPAuth ddpAuth = RouteUtil.getDDPAuth(request);
+        String operatorGuid = StringUtils.defaultIfBlank(ddpAuth.getOperator(), userGuid);
+        boolean isStudyAdmin = ddpAuth.hasAdminAccessToStudy(studyGuid);
+
+        LOG.info("Authorizing file upload URL for user {}, operator {} (isStudyAdmin={}), activity instance {}, study {}",
+                userGuid, operatorGuid, isStudyAdmin, instanceGuid, studyGuid);
+
+        FileUploadService.AuthorizeResult result = TransactionWrapper.withTxn(handle -> {
+            ActivityInstanceDto instanceDto = RouteUtil.findAccessibleInstanceOrHalt(
+                    response, handle, userGuid, studyGuid, instanceGuid, isStudyAdmin);
+
+            ActivityDefStore activityStore = ActivityDefStore.getInstance();
+            ActivityDto activityDto = activityStore.findActivityDto(handle, instanceDto.getActivityId())
+                    .orElseThrow(() -> new DDPException("Could not find activity dto for instance " + instanceGuid));
+            ActivityVersionDto versionDto = activityStore
+                    .findVersionDto(handle, instanceDto.getActivityId(), instanceDto.getCreatedAtMillis())
+                    .orElseThrow(() -> new DDPException("Could not find activity version for instance " + instanceGuid));
+            FormActivityDef activityDef = activityStore.findActivityDef(handle, studyGuid, activityDto, versionDto)
+                    .orElseThrow(() -> new DDPException("Could not find activity definition for instance " + instanceGuid));
+
+            boolean isInstanceReadOnly = ActivityInstanceUtil.isReadonly(
+                    activityDef.getEditTimeoutSec(), instanceDto.getCreatedAtMillis(),
+                    instanceDto.getStatusType().name(), activityDef.isWriteOnce(), instanceDto.getReadonly());
+            if (!isStudyAdmin && isInstanceReadOnly) {
+                String msg = "Activity instance " + instanceGuid + " is read-only, no file upload will be authorized";
+                LOG.warn(msg);
+                throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+            }
+
+            String questionStableId = payload.getQuestionStableId();
+            QuestionDef questionDef = activityDef.getQuestionByStableId(questionStableId);
+            if (questionDef == null) {
+                String msg = "Could not find question with stable id " + questionStableId;
+                LOG.warn(msg);
+                throw ResponseUtil.haltError(response, 404, new ApiError(ErrorCodes.QUESTION_NOT_FOUND, msg));
+            }
+            // todo: check question type is FILE or halt
+
+            boolean isQuestionReadOnly = QuestionUtil.isReadonly(handle, questionDef, instanceDto);
+            if (!isStudyAdmin && isQuestionReadOnly) {
+                String msg = "Question " + questionStableId + " is read-only, no file upload will be authorized";
+                LOG.warn(msg);
+                throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.QUESTION_IS_READONLY, msg));
+            }
+
+            User operatorUser = handle.attach(UserDao.class).findUserByGuid(operatorGuid)
+                    .orElseThrow(() -> new DDPException("Could not find operator with guid " + operatorGuid));
+
+            String prefix = String.format("%s/%s/%s", studyGuid, userGuid, instanceDto.getActivityCode());
+            return service.authorizeUpload(
+                    handle, operatorUser.getId(), instanceDto.getParticipantId(), prefix,
+                    payload.getMimeType(), payload.getFileName(), payload.getFileSize(), payload.isResumable());
+        });
+
+        if (result.isExceededSize()) {
+            String msg = "File size exceeded maximum of " + service.getMaxFileSizeBytes() + " bytes";
+            LOG.warn(msg);
+            throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.NOT_SUPPORTED, msg));
+        }
+
+        FileUpload upload = result.getFileUpload();
+        LOG.info("Authorized file upload with id={} for bucket={} blobName={}",
+                upload.getId(), service.getBucketName(), upload.getBlobName());
+
+        response.status(HttpStatus.SC_CREATED);
+        return new CreateUserActivityUploadResponse(upload.getGuid(), result.getSignedUrl().toString());
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/FileUploadService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/FileUploadService.java
@@ -1,0 +1,137 @@
+package org.broadinstitute.ddp.service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.google.auth.ServiceAccountSigner;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.HttpMethod;
+import com.google.cloud.storage.Storage;
+import com.google.common.annotations.VisibleForTesting;
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.constants.ConfigFile;
+import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.broadinstitute.ddp.util.GoogleBucketUtil;
+import org.broadinstitute.ddp.util.GuidUtils;
+import org.jdbi.v3.core.Handle;
+
+public class FileUploadService {
+
+    public static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+
+    private final ServiceAccountSigner signer;
+    private final Storage storage;
+    private final String bucketName;
+    private final int maxFileSizeBytes;
+    private final int maxSignedUrlMins;
+
+    public static FileUploadService fromConfig(Config cfg) {
+        String signerJson = ConfigUtil.toJson(cfg.getConfig(ConfigFile.FileUploads.SIGNER_SERVICE_ACCOUNT));
+        InputStream signerStream = new ByteArrayInputStream(signerJson.getBytes(StandardCharsets.UTF_8));
+        ServiceAccountCredentials signerCredentials;
+        try {
+            signerCredentials = ServiceAccountCredentials.fromStream(signerStream);
+        } catch (IOException e) {
+            throw new DDPException("Could not get signer credentials", e);
+        }
+
+        GoogleCredentials bucketCredentials;
+        try {
+            bucketCredentials = GoogleCredentials.getApplicationDefault();
+        } catch (IOException e) {
+            throw new DDPException("Could not get bucket credentials", e);
+        }
+
+        String projectId = cfg.getString(ConfigFile.GOOGLE_PROJECT_ID);
+        Storage storage = GoogleBucketUtil.getStorage(bucketCredentials, projectId);
+
+        return new FileUploadService(
+                signerCredentials, storage,
+                cfg.getString(ConfigFile.FileUploads.UPLOADS_BUCKET),
+                cfg.getInt(ConfigFile.FileUploads.MAX_FILE_SIZE_BYTES),
+                cfg.getInt(ConfigFile.FileUploads.MAX_SIGNED_URL_MINS));
+    }
+
+    public FileUploadService(ServiceAccountSigner signer, Storage storage, String bucketName,
+                             int maxFileSizeBytes, int maxSignedUrlMins) {
+        this.signer = signer;
+        this.storage = storage;
+        this.bucketName = bucketName;
+        this.maxFileSizeBytes = maxFileSizeBytes;
+        this.maxSignedUrlMins = maxSignedUrlMins;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public int getMaxFileSizeBytes() {
+        return maxFileSizeBytes;
+    }
+
+    public AuthorizeResult authorizeUpload(Handle handle, long operatorUserId, long participantUserId,
+                                           String blobPrefix, String mimeType,
+                                           String fileName, int fileSize, boolean resumable) {
+        if (fileSize > maxFileSizeBytes) {
+            return new AuthorizeResult(true, null, null);
+        }
+
+        blobPrefix = blobPrefix != null ? blobPrefix + "/" : "";
+        mimeType = mimeType != null ? mimeType : DEFAULT_MIME_TYPE;
+        HttpMethod method = resumable ? HttpMethod.POST : HttpMethod.PUT;
+        String uploadGuid = GuidUtils.randomFileUploadGuid();
+        String blobName = blobPrefix + uploadGuid;
+
+        FileUpload upload = handle.attach(FileUploadDao.class).createAuthorized(
+                uploadGuid, blobName, mimeType, fileName, fileSize, operatorUserId, participantUserId);
+        URL signedURL = generateSignedUrl(blobName, mimeType, method);
+
+        return new AuthorizeResult(false, upload, signedURL);
+    }
+
+    @VisibleForTesting
+    URL generateSignedUrl(String blobName, String mimeType, HttpMethod method) {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, blobName)).build();
+        Map<String, String> headers = Map.of("Content-Type", mimeType);
+        return storage.signUrl(blobInfo, maxSignedUrlMins, TimeUnit.MINUTES,
+                Storage.SignUrlOption.signWith(signer),
+                Storage.SignUrlOption.withV4Signature(),
+                Storage.SignUrlOption.httpMethod(method),
+                Storage.SignUrlOption.withExtHeaders(headers));
+    }
+
+    public static class AuthorizeResult {
+        private boolean exceededSize;
+        private FileUpload fileUpload;
+        private URL signedUrl;
+
+        public AuthorizeResult(boolean exceededSize, FileUpload fileUpload, URL signedUrl) {
+            this.exceededSize = exceededSize;
+            this.fileUpload = fileUpload;
+            this.signedUrl = signedUrl;
+        }
+
+        public boolean isExceededSize() {
+            return exceededSize;
+        }
+
+        public FileUpload getFileUpload() {
+            return fileUpload;
+        }
+
+        public URL getSignedUrl() {
+            return signedUrl;
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/GuidUtils.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/GuidUtils.java
@@ -10,6 +10,7 @@ public final class GuidUtils {
     public static final int USER_HRUID_RANDOM_PART_LENGTH = 5;
     public static final int USER_GUID_LENGTH = 20;
     public static final int STANDARD_GUID_LENGTH = 10;
+    public static final int FILE_UPLOAD_GUID_LENGTH = 20;
     public static final char[] UPPER_ALPHA_NUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890".toCharArray();
     public static final char[] UPPER_ALPHA_NUMERIC_EXCLUDING_CONFUSING_CHAR = "ABCDEFGHJKLMNPQRTUVWXYZ2346789".toCharArray();
     public static final char[] ALPHA_NUMERIC = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".toCharArray();
@@ -70,6 +71,13 @@ public final class GuidUtils {
      */
     public static String randomUUID() {
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * Returns a random identifier for file uploads.
+     */
+    public static String randomFileUploadGuid() {
+        return NanoIdUtils.randomNanoId(NanoIdUtils.DEFAULT_NUMBER_GENERATOR, ALPHA_NUMERIC, FILE_UPLOAD_GUID_LENGTH);
     }
 
     /**

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -247,4 +247,6 @@
     <include file="db-changes/seed/DDP-5514-add-translations-de-hi-it-ja-pl-tr.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5442-auth0-log-event-code.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5442-auth0-log-event.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-3709-file-upload.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/DDP-3709-file-upload-status.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-3709-file-upload.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-3709-file-upload.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210126-file-upload-status-table">
+        <createTable tableName="file_upload_status">
+            <column name="file_upload_status_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="file_upload_status_pk"/>
+            </column>
+            <column name="file_upload_status_code" type="varchar(20)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="file_upload_status_code_uk"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="yufeng" id="20210126-file-upload-table">
+        <createTable tableName="file_upload">
+            <column name="file_upload_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="file_upload_pk"/>
+            </column>
+            <column name="file_upload_guid" type="varchar(20)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="file_upload_guid_uk"/>
+            </column>
+            <column name="blob_name" type="varchar(300)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="mime_type" type="varchar(50)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_name" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_size" type="int">
+                <constraints nullable="false"/>
+            </column>
+            <column name="operator_user_id" type="bigint">
+                <constraints nullable="false"
+                             references="user(user_id)"
+                             foreignKeyName="file_upload_operator_user_fk"/>
+            </column>
+            <column name="participant_user_id" type="bigint">
+                <constraints nullable="false"
+                             references="user(user_id)"
+                             foreignKeyName="file_upload_participant_user_fk"/>
+            </column>
+            <column name="status_id" type="bigint">
+                <constraints nullable="false"
+                             references="file_upload_status(file_upload_status_id)"
+                             foreignKeyName="file_upload_file_upload_status_fk"/>
+            </column>
+            <column name="status_changed_at" type="datetime(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="datetime(6)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_replaced" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/DDP-3709-file-upload-status.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/DDP-3709-file-upload-status.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210126-file-upload-status-types">
+        <insert tableName="file_upload_status">
+            <column name="file_upload_status_code" value="AUTHORIZED"/>
+        </insert>
+        <insert tableName="file_upload_status">
+            <column name="file_upload_status_code" value="UPLOADED"/>
+        </insert>
+        <insert tableName="file_upload_status">
+            <column name="file_upload_status_code" value="QUARANTINED"/>
+        </insert>
+        <insert tableName="file_upload_status">
+            <column name="file_upload_status_code" value="SCANNED"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/FileUploadDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/FileUploadDaoTest.java
@@ -1,0 +1,50 @@
+package org.broadinstitute.ddp.db.dao;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.broadinstitute.ddp.TxnAwareBaseTest;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.broadinstitute.ddp.model.files.FileUploadStatus;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
+
+public class FileUploadDaoTest extends TxnAwareBaseTest {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+
+    @BeforeClass
+    public static void setup() {
+        testData = TransactionWrapper.withTxn(TestDataSetupUtil::generateBasicUserTestData);
+    }
+
+    @Test
+    public void testCreateAuthorized() {
+        TransactionWrapper.useTxn(handle -> {
+            var dao = handle.attach(FileUploadDao.class);
+
+            long userId = testData.getUserId();
+            FileUpload upload = dao.createAuthorized("guid", "blob", "mime", "file", 123, userId, userId);
+            assertTrue(upload.getId() > 0);
+            assertTrue(StringUtils.isNotBlank(upload.getGuid()));
+
+            FileUpload actual = dao.findById(upload.getId()).orElse(null);
+            assertNotNull(actual);
+            assertEquals(upload.getId(), actual.getId());
+
+            actual = dao.findByGuid(upload.getGuid()).orElse(null);
+            assertNotNull(actual);
+            assertEquals(upload.getGuid(), actual.getGuid());
+            assertEquals(FileUploadStatus.AUTHORIZED, actual.getStatus());
+            assertEquals("first status equals creation time",
+                    actual.getCreatedAt(), actual.getStatusChangedAt());
+
+            handle.rollback();
+        });
+    }
+
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRouteTest.java
@@ -92,7 +92,6 @@ public class CreateUserActivityUploadRouteTest extends IntegrationTestSuite.Test
                 .body(payload, ObjectMapperType.GSON)
                 .when().post(url)
                 .then().assertThat()
-                .log().all()
                 .statusCode(201).contentType(ContentType.JSON)
                 .body("uploadGuid", not(isEmptyOrNullString()))
                 .body("uploadUrl", not(isEmptyOrNullString()))

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRouteTest.java
@@ -1,0 +1,110 @@
+package org.broadinstitute.ddp.route;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.restassured.http.ContentType;
+import io.restassured.mapper.ObjectMapperType;
+import org.broadinstitute.ddp.constants.ErrorCodes;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.json.CreateUserActivityUploadPayload;
+import org.broadinstitute.ddp.model.files.FileUploadStatus;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.broadinstitute.ddp.util.TestFormActivity;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CreateUserActivityUploadRouteTest extends IntegrationTestSuite.TestCase {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+    private static TestFormActivity act;
+    private static ActivityInstanceDto instanceDto;
+    private static String token;
+    private static String url;
+
+    @BeforeClass
+    public static void setup() {
+        TransactionWrapper.useTxn(handle -> {
+            testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            token = testData.getTestingUser().getToken();
+
+            act = TestFormActivity.builder()
+                    .withTextQuestion(true)
+                    .build(handle, testData.getUserId(), testData.getStudyGuid());
+            instanceDto = handle.attach(ActivityInstanceDao.class)
+                    .insertInstance(act.getDef().getActivityId(), testData.getUserGuid());
+
+            String endpoint = RouteConstants.API.USER_ACTIVITY_UPLOADS
+                    .replace(RouteConstants.PathParam.USER_GUID, testData.getUserGuid())
+                    .replace(RouteConstants.PathParam.STUDY_GUID, testData.getStudyGuid())
+                    .replace(RouteConstants.PathParam.INSTANCE_GUID, instanceDto.getGuid());
+            url = RouteTestUtil.getTestingBaseUrl() + endpoint;
+        });
+    }
+
+    @Test
+    public void testInvalidInput() {
+        var payload = new CreateUserActivityUploadPayload(null, "", 123, "mime", false);
+        given().auth().oauth2(token)
+                .body(payload, ObjectMapperType.GSON)
+                .when().post(url)
+                .then().assertThat()
+                .statusCode(400).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.BAD_PAYLOAD));
+    }
+
+    @Test
+    public void testInstanceReadOnly() {
+        TransactionWrapper.useTxn(handle -> assertEquals(1,
+                handle.attach(JdbiActivityInstance.class)
+                        .updateIsReadonlyByGuid(true, instanceDto.getGuid())));
+        try {
+            String stableId = act.getTextQuestion().getStableId();
+            var payload = new CreateUserActivityUploadPayload(stableId, "file.pdf", 123, "application/pdf", false);
+            given().auth().oauth2(token)
+                    .body(payload, ObjectMapperType.GSON)
+                    .when().post(url)
+                    .then().assertThat()
+                    .statusCode(422).contentType(ContentType.JSON)
+                    .body("code", equalTo(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY));
+        } finally {
+            TransactionWrapper.useTxn(handle -> assertEquals(1,
+                    handle.attach(JdbiActivityInstance.class)
+                            .updateIsReadonlyByGuid(null, instanceDto.getGuid())));
+        }
+    }
+
+    @Test
+    public void testUploadAuthorized() {
+        String stableId = act.getTextQuestion().getStableId();
+        var payload = new CreateUserActivityUploadPayload(stableId, "file.pdf", 123, "application/pdf", false);
+
+        String uploadGuid = given().auth().oauth2(token)
+                .body(payload, ObjectMapperType.GSON)
+                .when().post(url)
+                .then().assertThat()
+                .log().all()
+                .statusCode(201).contentType(ContentType.JSON)
+                .body("uploadGuid", not(isEmptyOrNullString()))
+                .body("uploadUrl", not(isEmptyOrNullString()))
+                .extract().path("uploadGuid");
+
+        TransactionWrapper.useTxn(handle -> {
+            var actual = handle.attach(FileUploadDao.class).findByGuid(uploadGuid).orElse(null);
+            assertNotNull(actual);
+            assertEquals("file.pdf", actual.getFileName());
+            assertEquals(123, actual.getFileSize());
+            assertEquals("application/pdf", actual.getMimeType());
+            assertEquals(FileUploadStatus.AUTHORIZED, actual.getStatus());
+        });
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -71,6 +71,7 @@ import org.slf4j.LoggerFactory;
         InvitationCheckStatusRouteTest.class,
         CreateActivityInstanceRouteTest.class,
         CreateTemporaryUserRouteTest.class,
+        CreateUserActivityUploadRouteTest.class,
         DeleteMedicalProviderRouteTest.class,
         DsmTriggerOnDemandActivityRouteTest.class,
         EmbeddedComponentActivityInstanceTest.class,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/FileUploadServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/FileUploadServiceTest.java
@@ -1,0 +1,100 @@
+package org.broadinstitute.ddp.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Instant;
+
+import com.google.cloud.storage.HttpMethod;
+import org.broadinstitute.ddp.TxnAwareBaseTest;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.broadinstitute.ddp.model.files.FileUploadStatus;
+import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.jdbi.v3.core.Handle;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class FileUploadServiceTest extends TxnAwareBaseTest {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+
+    @BeforeClass
+    public static void setup() {
+        testData = TransactionWrapper.withTxn(TestDataSetupUtil::generateBasicUserTestData);
+    }
+
+    @Test
+    @Ignore("un-ignore to try locally")
+    public void testTryAuthorize() {
+        var service = FileUploadService.fromConfig(ConfigManager.getInstance().getConfig());
+        var result = TransactionWrapper.withTxn(handle -> service
+                .authorizeUpload(handle, testData.getUserId(), testData.getUserId(),
+                        "prefix", "application/pdf", "filename.pdf", 50000, false));
+
+        var guid = result.getFileUpload().getGuid();
+        System.out.println("File upload guid: " + guid);
+
+        var url = result.getSignedUrl().toString();
+        System.out.println("File upload url: " + url);
+    }
+
+    @Test
+    public void testAuthorizeUpload() throws MalformedURLException {
+        var now = Instant.now();
+        var dummyUpload = new FileUpload(1, "guid", "blob", "mime", "file", 123, 1, 1,
+                FileUploadStatus.AUTHORIZED, now, now, false);
+        var dummyUrl = new URL("https://datadonationplatform.org");
+        var expectedMime = FileUploadService.DEFAULT_MIME_TYPE;
+        var expectedMethod = HttpMethod.POST;
+
+        var mockHandle = mock(Handle.class);
+        var mockDao = mock(FileUploadDao.class);
+        var serviceSpy = spy(new FileUploadService(null, null, "bucket", 123, 5));
+
+        doReturn(mockDao).when(mockHandle).attach(FileUploadDao.class);
+        doReturn(dummyUpload).when(mockDao)
+                .createAuthorized(any(), any(), any(), any(), anyInt(), anyLong(), anyLong());
+        doReturn(dummyUrl).when(serviceSpy)
+                .generateSignedUrl(startsWith("prefix/"), eq(expectedMime), eq(expectedMethod));
+
+        var result = serviceSpy.authorizeUpload(mockHandle, 1, 1, "prefix", null, "file", 123, true);
+
+        assertNotNull(result);
+        assertFalse(result.isExceededSize());
+        assertNotNull(result.getFileUpload());
+        assertNotNull(result.getSignedUrl());
+
+        var returnedUpload = result.getFileUpload();
+        assertEquals("guid", returnedUpload.getGuid());
+
+        var returnedUrl = result.getSignedUrl();
+        assertEquals(dummyUrl, returnedUrl);
+    }
+
+    @Test
+    public void testAuthorizeUpload_exceededSize() {
+        var service = new FileUploadService(null, null, "bucket", 123, 5);
+        var result = service.authorizeUpload(null, 1, 1, "prefix", "mime", "file", 1024, false);
+        assertNotNull(result);
+        assertTrue("should hit size limit", result.isExceededSize());
+        assertNull(result.getFileUpload());
+        assertNull(result.getSignedUrl());
+    }
+}


### PR DESCRIPTION
## Context

Part 1 of DDP-3709. This PR contains:
* File upload database support,
* New file upload service and config file changes,
* New API endpoint for authorizing file uploads.

Credits to @YuriyPavlovBI for initial implementation in #559, which this PR is based off of. API follows spec as outlined in #565. Note that this merges into my feature branch `ddp-3709`: this is part 1 of a series of "stacked" PRs. More PRs will be created to implement other parts of DDP-3709.

**Pre-Deployment Steps (adapt as appropriate to different environments):**
1. Create new service account named `ddp-file-uploader`.
2. Create new JSON key for service account, and save the JSON file.
3. Create new custom role named `DDP File Uploader` and grant these permissions:
    - `storage.objects.create`
    - `storage.objects.delete`
4. Create new bucket to hold uploads, called `ddp-dev-file-uploads`.
5. Grant `ddp-file-uploader` permission to the bucket with the `DDP File Uploader` role.
6. Save service account and configs into Vault.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

