### PR TITLE
[DDP-3709] part 5: file scan result handler

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -56,8 +56,11 @@
     "fileUploads": {
         "uploadsBucket": "{{$conf.Data.fileUploads.uploadsBucket}}",
         "scannedBucket": "{{$conf.Data.fileUploads.scannedBucket}}",
+        "quarantineBucket": "{{$conf.Data.fileUploads.quarantineBucket}}",
         "maxFileSizeBytes": {{$conf.Data.fileUploads.maxFileSizeBytes}},
         "maxSignedUrlMins": {{$conf.Data.fileUploads.maxSignedUrlMins}},
+        "enableScanResultHandler": {{$conf.Data.fileUploads.enableScanResultHandler}},
+        "scanResultSubscription": "{{$conf.Data.fileUploads.scanResultSubscription}}",
         "signerServiceAccount": {{$conf.Data.fileUploads.signerServiceAccount | toJSONPretty}}
     },
     "pdfArchiveBucket": "{{$conf.Data.pdfArchiveBucket}}",

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -95,8 +95,11 @@
     "fileUploads": {
         "uploadsBucket": "ddp-local-file-uploads",
         "scannedBucket": "ddp-local-file-scanned",
+        "quarantineBucket": "ddp-local-file-quarantine",
         "maxFileSizeBytes": 2000000,
         "maxSignedUrlMins": 5,
+        "enableScanResultHandler": false,
+        "scanResultSubscription": "cf-file-scan-result-local-hkeep-sub",
         "signerServiceAccount": {{$fileUploads.signerServiceAccount | toJSONPretty}}
     },
     "pdfArchiveBucket": "pepper-pdf-dev",

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -9,17 +9,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.ApiService;
+import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
 import com.google.api.gax.rpc.ApiException;
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.pubsub.v1.AckReplyConsumer;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.Publisher;
@@ -33,6 +39,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
+import org.broadinstitute.ddp.client.GoogleBucketClient;
 import org.broadinstitute.ddp.client.SendGridClient;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.constants.RouteConstants;
@@ -51,6 +58,7 @@ import org.broadinstitute.ddp.db.dto.QueuedEventDto;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.db.housekeeping.dao.JdbiEvent;
 import org.broadinstitute.ddp.db.housekeeping.dao.JdbiMessage;
+import org.broadinstitute.ddp.event.FileScanResultReceiver;
 import org.broadinstitute.ddp.event.HousekeepingTaskReceiver;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.exception.MessageBuilderException;
@@ -90,6 +98,7 @@ import org.broadinstitute.ddp.service.PdfGenerationService;
 import org.broadinstitute.ddp.service.PdfService;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.ConfigUtil;
+import org.broadinstitute.ddp.util.GoogleCredentialUtil;
 import org.broadinstitute.ddp.util.LiquibaseUtil;
 import org.broadinstitute.ddp.util.LogbackConfigurationPrinter;
 import org.jdbi.v3.core.Handle;
@@ -169,6 +178,7 @@ public class Housekeeping {
 
     private static Scheduler scheduler;
     private static Subscriber taskSubscriber;
+    private static Subscriber fileScanResultSubscriber;
 
     public static void setAfterHandler(AfterHandlerCallback afterHandler) {
         synchronized (afterHandlerGuard) {
@@ -218,6 +228,7 @@ public class Housekeeping {
 
         setupScheduler(cfg);
         setupTaskReceiver(cfg, pubSubProject);
+        setupFileScanResultReceiver(cfg, pubSubProject);
 
         final PubSubConnectionManager pubsubConnectionManager = new PubSubConnectionManager(usePubSubEmulator);
         TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, handle -> {
@@ -441,6 +452,9 @@ public class Housekeeping {
             }
         }
         pubsubConnectionManager.close();
+        if (fileScanResultSubscriber != null) {
+            fileScanResultSubscriber.stopAsync();
+        }
         if (taskSubscriber != null) {
             taskSubscriber.stopAsync();
         }
@@ -503,6 +517,83 @@ public class Housekeeping {
         } else {
             LOG.warn("Housekeeping tasks is not enabled");
         }
+    }
+
+    private static void setupFileScanResultReceiver(Config cfg, String projectId) {
+        boolean enabled = cfg.getBoolean(ConfigFile.FileUploads.ENABLE_SCAN_RESULT_HANDLER);
+        if (!enabled) {
+            LOG.warn("File scan result handler is not enabled");
+            return;
+        }
+
+        var subName = ProjectSubscriptionName.of(projectId,
+                cfg.getString(ConfigFile.FileUploads.SCAN_RESULT_SUBSCRIPTION));
+
+        boolean ensureDefault = cfg.getBoolean(ConfigFile.REQUIRE_DEFAULT_GCP_CREDENTIALS);
+        GoogleCredentials credentials = GoogleCredentialUtil.initCredentials(ensureDefault);
+        if (credentials == null) {
+            throw new DDPException("Could not get bucket credentials");
+        }
+
+        var storageClient = new GoogleBucketClient(projectId, credentials);
+        var receiver = new FileScanResultReceiver(storageClient,
+                cfg.getString(ConfigFile.FileUploads.UPLOADS_BUCKET),
+                cfg.getString(ConfigFile.FileUploads.SCANNED_BUCKET),
+                cfg.getString(ConfigFile.FileUploads.QUARANTINE_BUCKET));
+
+        // This is the default thread factory, just setting a custom name here.
+        ThreadFactory threadFactory = runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setName("file-scan-result-subscriber-1");
+            thread.setDaemon(true);
+            return thread;
+        };
+
+        // For now, handle messages one at a time so we don't overwhelm resources.
+        ExecutorProvider executorProvider = InstantiatingExecutorProvider.newBuilder()
+                .setThreadFactory(threadFactory)
+                .setExecutorThreadCount(1)
+                .build();
+
+        ExecutorService callbackExecutor = Executors.newSingleThreadExecutor();
+        Subscriber.Builder builder = Subscriber.newBuilder(subName, receiver)
+                .setSystemExecutorProvider(executorProvider)
+                .setExecutorProvider(executorProvider)
+                .setParallelPullCount(1);
+
+        startNewSubscriberWithRecovery(subName, builder, executorProvider, callbackExecutor, subscriber -> {
+            LOG.info("Started file scan result subscriber to subscription {}", subName);
+            fileScanResultSubscriber = subscriber;
+        });
+    }
+
+    private static void startNewSubscriberWithRecovery(ProjectSubscriptionName subscription,
+                                                       Subscriber.Builder builder,
+                                                       ExecutorProvider executorProvider,
+                                                       ExecutorService callbackExecutor,
+                                                       Consumer<Subscriber> consumer) {
+        Subscriber newSubscriber = builder.build();
+
+        // Add handler that recursively calls back in here to renew subscriber.
+        newSubscriber.addListener(new ApiService.Listener() {
+            @Override
+            public void failed(ApiService.State from, Throwable failure) {
+                LOG.error("Subscriber to subscription {} encountered unrecoverable failure from {}"
+                        + ", rebuilding subscriber", subscription, from, failure);
+                if (!executorProvider.getExecutor().isShutdown()) {
+                    startNewSubscriberWithRecovery(subscription, builder, executorProvider, callbackExecutor, consumer);
+                }
+            }
+        }, callbackExecutor);
+
+        try {
+            newSubscriber.startAsync().awaitRunning(30L, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            throw new DDPException("Could not start subscriber to subscription " + subscription, e);
+        }
+
+        // All set, pass new subscriber downstream.
+        consumer.accept(newSubscriber);
     }
 
     private static void respondToGAEStartHook(String envPort) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/client/GoogleBucketClient.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/client/GoogleBucketClient.java
@@ -1,28 +1,59 @@
 package org.broadinstitute.ddp.client;
 
 import com.google.auth.Credentials;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
+import org.broadinstitute.ddp.exception.DDPException;
 
 /**
  * A client wrapper around Google Bucket services.
  */
 public class GoogleBucketClient {
 
-    private final StorageOptions storage;
+    private final Storage storage;
 
     public GoogleBucketClient(String gcpProjectId, Credentials credentials) {
         this(StorageOptions.newBuilder()
                 .setCredentials(credentials)
                 .setProjectId(gcpProjectId)
-                .build());
+                .build().getService());
     }
 
-    public GoogleBucketClient(StorageOptions storage) {
+    public GoogleBucketClient(Storage storage) {
         this.storage = storage;
     }
 
     public Bucket getBucket(String bucketName) {
-        return storage.getService().get(bucketName);
+        return storage.get(bucketName);
+    }
+
+    public Blob getBlob(String bucketName, String fileName) {
+        return storage.get(bucketName, fileName);
+    }
+
+    public Blob copyBlob(Blob sourceBlob, String destBucketName, String destFileName) {
+        try {
+            return sourceBlob.copyTo(destBucketName, destFileName).getResult();
+        } catch (Exception e) {
+            throw new DDPException("Failed to copy source blob " + sourceBlob.getBlobId()
+                    + " to destination bucket " + destBucketName);
+        }
+    }
+
+    public Blob moveBlob(Blob sourceBlob, String destBucketName, String destFileName) {
+        // No native support for moving blobs, so have to emulate with a two-step operation.
+        Blob destBlob = copyBlob(sourceBlob, destBucketName, destFileName);
+        deleteBlob(sourceBlob);
+        return destBlob;
+    }
+
+    public void deleteBlob(Blob blob) {
+        try {
+            blob.delete();
+        } catch (Exception e) {
+            throw new DDPException("Failed to delete blob " + blob.getBlobId());
+        }
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -195,10 +195,14 @@ public class ConfigFile {
     }
 
     public static class FileUploads {
-        public static final String UPLOADS_BUCKET = "fileUploads.uploadsBucket";
-        public static final String SCANNED_BUCKET = "fileUploads.scannedBucket";
-        public static final String MAX_FILE_SIZE_BYTES = "fileUploads.maxFileSizeBytes";
-        public static final String MAX_SIGNED_URL_MINS = "fileUploads.maxSignedUrlMins";
-        public static final String SIGNER_SERVICE_ACCOUNT = "fileUploads.signerServiceAccount";
+        private static final String prefix = "fileUploads.";
+        public static final String UPLOADS_BUCKET = prefix + "uploadsBucket";
+        public static final String SCANNED_BUCKET = prefix + "scannedBucket";
+        public static final String QUARANTINE_BUCKET = prefix + "quarantineBucket";
+        public static final String MAX_FILE_SIZE_BYTES = prefix + "maxFileSizeBytes";
+        public static final String MAX_SIGNED_URL_MINS = prefix + "maxSignedUrlMins";
+        public static final String ENABLE_SCAN_RESULT_HANDLER = prefix + "enableScanResultHandler";
+        public static final String SCAN_RESULT_SUBSCRIPTION = prefix + "scanResultSubscription";
+        public static final String SIGNER_SERVICE_ACCOUNT = prefix + "signerServiceAccount";
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.model.activity.instance.answer.FileInfo;
+import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.broadinstitute.ddp.model.files.FileUpload;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
 import org.jdbi.v3.sqlobject.SqlObject;
@@ -32,8 +33,8 @@ public interface FileUploadDao extends SqlObject {
         DBUtils.checkUpdate(1, getFileUploadSql().updateIsVerified(fileUploadId, true));
     }
 
-    default void markUploaded(long fileUploadId, Instant uploadTime) {
-        DBUtils.checkUpdate(1, getFileUploadSql().updateUploadedAt(fileUploadId, uploadTime));
+    default void updateStatus(long fileUploadId, Instant uploadedAt, Instant scannedAt, FileScanResult scanResult) {
+        DBUtils.checkUpdate(1, getFileUploadSql().updateStatus(fileUploadId, uploadedAt, scannedAt, scanResult));
     }
 
     default void deleteById(long fileUploadId) {
@@ -60,6 +61,13 @@ public interface FileUploadDao extends SqlObject {
             + " where f.file_upload_id = :id for update")
     @RegisterConstructorMapper(FileUpload.class)
     Optional<FileUpload> findAndLockById(@Bind("id") long fileUploadId);
+
+    @SqlQuery("select f.*, (select file_scan_result_code from file_scan_result"
+            + "       where file_scan_result_id = f.scan_result_id) as scan_result"
+            + "  from file_upload as f"
+            + " where f.file_upload_guid = :guid for update")
+    @RegisterConstructorMapper(FileUpload.class)
+    Optional<FileUpload> findAndLockByGuid(@Bind("guid") String fileUploadGuid);
 
     @SqlQuery("select file_upload_id, file_name, file_size"
             + "  from file_upload where file_upload_guid = :guid")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.db.dao;
 
 import java.time.Instant;
 
+import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
@@ -30,10 +31,14 @@ public interface FileUploadSql extends SqlObject {
             @Bind("id") long fileUploadId,
             @Bind("verified") boolean isVerified);
 
-    @SqlUpdate("update file_upload set uploaded_at = :uploadTime where file_upload_id = :id")
-    int updateUploadedAt(
+    @SqlUpdate("update file_upload set uploaded_at = :uploadedAt, scanned_at = :scannedAt, scan_result_id = ("
+            + " select file_scan_result_id from file_scan_result where file_scan_result_code = :scanResult)"
+            + "  where file_upload_id = :id")
+    int updateStatus(
             @Bind("id") long fileUploadId,
-            @Bind("uploadTime") Instant uploadTime);
+            @Bind("uploadedAt") Instant uploadedAt,
+            @Bind("scannedAt") Instant scannedAt,
+            @Bind("scanResult") FileScanResult scanResult);
 
     @SqlUpdate("delete from file_upload where file_upload_id = :id")
     int delete(@Bind("id") long fileUploadId);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -1,0 +1,157 @@
+package org.broadinstitute.ddp.event;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.storage.Blob;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.pubsub.v1.PubsubMessage;
+import org.broadinstitute.ddp.client.GoogleBucketClient;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.model.files.FileScanResult;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FileScanResultReceiver implements MessageReceiver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileScanResultReceiver.class);
+
+    public static final String ATTR_BUCKET_ID = "bucketId";
+    public static final String ATTR_OBJECT_ID = "objectId";
+    public static final String ATTR_SCAN_RESULT = "scanResult";
+
+    private final GoogleBucketClient storageClient;
+    private final String uploadsBucket;
+    private final String scannedBucket;
+    private final String quarantineBucket;
+
+    public FileScanResultReceiver(GoogleBucketClient storageClient,
+                                  String uploadsBucket,
+                                  String scannedBucket,
+                                  String quarantineBucket) {
+        this.storageClient = storageClient;
+        this.uploadsBucket = uploadsBucket;
+        this.scannedBucket = scannedBucket;
+        this.quarantineBucket = quarantineBucket;
+    }
+
+    @Override
+    public void receiveMessage(PubsubMessage message, AckReplyConsumer reply) {
+        String msgId = message.getMessageId();
+        Instant published = Instant.ofEpochSecond(
+                message.getPublishTime().getSeconds(),
+                message.getPublishTime().getNanos());
+        LOG.info("Received file scan result message with id={} timestamp={}", msgId, published);
+
+        String bucketName = message.getAttributesOrDefault(ATTR_BUCKET_ID, null);
+        String fileName = message.getAttributesOrDefault(ATTR_OBJECT_ID, null);
+        String result = message.getAttributesOrDefault(ATTR_SCAN_RESULT, null);
+        LOG.info("File scan result: bucket={} file={} result={}", bucketName, fileName, result);
+
+        if (bucketName == null || bucketName.isBlank()) {
+            LOG.warn("File scan result message is missing bucket name, ack-ing");
+            reply.ack();
+            return;
+        } else if (!bucketName.equals(uploadsBucket)) {
+            LOG.warn("Expected source bucket '{}' but got message for bucket '{}', ack-ing", uploadsBucket, bucketName);
+            reply.ack();
+            return;
+        }
+
+        if (fileName == null || fileName.isBlank()) {
+            LOG.warn("File scan result message is missing file name, ack-ing");
+            reply.ack();
+            return;
+        }
+
+        if (result == null || result.isBlank()) {
+            LOG.warn("File scan result message is missing scan result, ack-ing");
+            reply.ack();
+            return;
+        }
+
+        FileScanResult scanResult;
+        try {
+            scanResult = FileScanResult.valueOf(result);
+        } catch (Exception e) {
+            LOG.error("Received unrecognized file scan result '{}', ack-ing", result);
+            reply.ack();
+            return;
+        }
+
+        Blob blob = storageClient.getBlob(uploadsBucket, fileName);
+        if (blob == null || !blob.exists()) {
+            // This might be duplicate due to pubsub at-least-once delivery. Let's report it for now.
+            LOG.error("Could not find file '{}' in bucket '{}', might be missing or had been"
+                    + " moved already, ack-ing", fileName, bucketName);
+            reply.ack();
+            return;
+        }
+
+        boolean shouldAck;
+        try {
+            shouldAck = withAPIsTxn(handle -> handleFileScanResult(handle, blob, scanResult, published));
+        } catch (Exception e) {
+            LOG.error("Error while processing file scan result, nack-ing and retrying", e);
+            shouldAck = false;
+        }
+        if (shouldAck) {
+            reply.ack();
+        } else {
+            reply.nack();
+        }
+    }
+
+    private String parseFileUploadGuid(String fileName) {
+        // For authorized uploads, the base file name should be the upload guid.
+        return Path.of(fileName).getFileName().toString();
+    }
+
+    private boolean handleFileScanResult(Handle handle, Blob blob, FileScanResult scanResult, Instant scannedAt) {
+        // Find and lock file upload so we can safely update and move file.
+        var uploadDao = handle.attach(FileUploadDao.class);
+        String uploadGuid = parseFileUploadGuid(blob.getName());
+        FileUpload upload = uploadDao.findAndLockByGuid(uploadGuid).orElse(null);
+
+        if (upload == null) {
+            // If we didn't find it, then likely not a file we authorized. Let's report it.
+            LOG.error("Could not find file upload with guid '{}', ack-ing", uploadGuid);
+            return true;
+        }
+
+        if (upload.getScannedAt() != null) {
+            // File was already scanned (so should have been moved to a different bucket), but somehow
+            // we still found it in the uploads bucket. Let's report it for now.
+            LOG.error("File was already scanned at {} with result {}, ack-ing", upload.getScannedAt(), upload.getScanResult());
+            return true;
+        }
+
+        String destBucket = scanResult == FileScanResult.CLEAN ? scannedBucket : quarantineBucket;
+        try {
+            storageClient.moveBlob(blob, destBucket, blob.getName());
+            LOG.info("Moved blob {} to destination bucket {} for file upload {}",
+                    blob.getBlobId(), destBucket, uploadGuid);
+        } catch (Exception e) {
+            LOG.error("Error while moving blob {} to destination bucket {} for file upload {},"
+                    + "nack-ing and retrying", blob.getBlobId(), destBucket, uploadGuid, e);
+            return false;
+        }
+
+        Instant uploadedAt = Instant.ofEpochMilli(blob.getCreateTime());
+        uploadDao.updateStatus(upload.getId(), uploadedAt, scannedAt, scanResult);
+        LOG.info("Finished processing file scan result for file upload {}", uploadGuid);
+
+        return true;
+    }
+
+    @VisibleForTesting
+    <T, X extends Exception> T withAPIsTxn(HandleCallback<T, X> callback) throws X {
+        return TransactionWrapper.withTxn(TransactionWrapper.DB.APIS, callback);
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/event/FileScanResultReceiverTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/event/FileScanResultReceiverTest.java
@@ -1,0 +1,98 @@
+package org.broadinstitute.ddp.event;
+
+import static org.broadinstitute.ddp.event.FileScanResultReceiver.ATTR_BUCKET_ID;
+import static org.broadinstitute.ddp.event.FileScanResultReceiver.ATTR_OBJECT_ID;
+import static org.broadinstitute.ddp.event.FileScanResultReceiver.ATTR_SCAN_RESULT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.storage.Blob;
+import com.google.pubsub.v1.PubsubMessage;
+import org.broadinstitute.ddp.client.GoogleBucketClient;
+import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.model.files.FileScanResult;
+import org.broadinstitute.ddp.model.files.FileUpload;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.HandleCallback;
+import org.junit.Test;
+
+public class FileScanResultReceiverTest {
+
+    @Test
+    public void testReceiveMessage() {
+        // Create mocks.
+        var mockReply = mock(AckReplyConsumer.class);
+        var mockStorage = mock(GoogleBucketClient.class);
+        var mockHandle = mock(Handle.class);
+        var mockDao = mock(FileUploadDao.class);
+        var mockBlob = mock(Blob.class);
+        var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+        var upload = new FileUpload(1L, "guid", "blob", "mime", "name",
+                123L, 1L, 1L, true, now, null, null, null);
+        var msg = PubsubMessage.newBuilder()
+                .setMessageId("foo")
+                .putAttributes(ATTR_BUCKET_ID, "uploads")
+                .putAttributes(ATTR_OBJECT_ID, "foo/bar/guid")
+                .putAttributes(ATTR_SCAN_RESULT, FileScanResult.CLEAN.name())
+                .build();
+
+        // Setup behavior.
+        doReturn(true).when(mockBlob).exists();
+        doReturn("foo/bar/guid").when(mockBlob).getName();
+        doReturn(now.toEpochMilli()).when(mockBlob).getCreateTime();
+        doReturn(mockBlob).when(mockStorage).getBlob(any(), any());
+        doReturn(mockDao).when(mockHandle).attach(FileUploadDao.class);
+        doReturn(Optional.of(upload)).when(mockDao).findAndLockByGuid(any());
+
+        var receiverSpy = spy(new FileScanResultReceiver(mockStorage, "uploads", "scanned", "quarantine"));
+        doAnswer(invocation -> ((HandleCallback) invocation.getArgument(0)).withHandle(mockHandle))
+                .when(receiverSpy).withAPIsTxn(any());
+
+        // Test it!
+        receiverSpy.receiveMessage(msg, mockReply);
+
+        // Do asserts.
+        verify(mockStorage).getBlob("uploads", "foo/bar/guid");
+        verify(mockStorage).moveBlob(any(), eq("scanned"), eq("foo/bar/guid"));
+        verify(mockDao).findAndLockByGuid("guid");
+        verify(mockReply, times(1)).ack();
+        verify(mockReply, never()).nack();
+    }
+
+    @Test
+    public void testReceiveMessage_checksPayload_andGracefullyAcks() {
+        var builder = PubsubMessage.newBuilder().setMessageId("foo");
+        var replyMock = mock(AckReplyConsumer.class);
+        var receiver = new FileScanResultReceiver(null, "uploads", "scanned", "quarantine");
+
+        builder.clearAttributes();
+        receiver.receiveMessage(builder.build(), replyMock);
+        verify(replyMock, times(1)).ack();
+        reset(replyMock);
+
+        builder.putAttributes(ATTR_BUCKET_ID, "not-uploads");
+        receiver.receiveMessage(builder.build(), replyMock);
+        verify(replyMock, times(1)).ack();
+        reset(replyMock);
+
+        builder.putAttributes(ATTR_BUCKET_ID, "uploads");
+        builder.putAttributes(ATTR_OBJECT_ID, "foo.pdf");
+        builder.putAttributes(ATTR_SCAN_RESULT, "unknown-scan-result");
+        receiver.receiveMessage(builder.build(), replyMock);
+        verify(replyMock, times(1)).ack();
+        reset(replyMock);
+    }
+}


### PR DESCRIPTION
## Context

Part of DDP-3709. This PR implements a pubsub subscriber that listens for file scan results from the file scanner service. It'll manage moving the file upload's underlying bucket file to the appropriate destination bucket and updating status of file upload.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

* Need to create a pubsub subscription to the `cf-file-scan-result` topic.
  * Add filter `attributes.bucketId="ddp-dev-file-uploads"`, use retry backoff, and set a long ack timeout.
* Create the scanned/quarantine buckets.
* Add new configs into Vault.