### PR TITLE
[DDP-3709] part 6: background job to cleanup file uploads

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -59,6 +59,9 @@
         "quarantineBucket": "{{$conf.Data.fileUploads.quarantineBucket}}",
         "maxFileSizeBytes": {{$conf.Data.fileUploads.maxFileSizeBytes}},
         "maxSignedUrlMins": {{$conf.Data.fileUploads.maxSignedUrlMins}},
+        "removalExpireTime": {{$conf.Data.fileUploads.removalExpireTime}},
+        "removalExpireUnit": "{{$conf.Data.fileUploads.removalExpireUnit}}", // Java TimeUnit, up to MILLISECONDS granularity.
+        "removalBatchSize": {{$conf.Data.fileUploads.removalBatchSize}},
         "enableScanResultHandler": {{$conf.Data.fileUploads.enableScanResultHandler}},
         "scanResultSubscription": "{{$conf.Data.fileUploads.scanResultSubscription}}",
         "signerServiceAccount": {{$conf.Data.fileUploads.signerServiceAccount | toJSONPretty}}
@@ -77,6 +80,7 @@
         "drugLoader": "{{$conf.Data.schedules.drugLoader}}",
         "cancerLoader": "{{$conf.Data.schedules.cancerLoader}}",
         "studyExport": "{{$conf.Data.schedules.studyExport}}",
+        "fileUploadCleanup": "{{$conf.Data.schedules.fileUploadCleanup}}",
         "tempUserCleanup": "{{$conf.Data.schedules.tempUserCleanup}}"
     },
     "preferredSourceIPHeader":"X-AppEngine-User-IP",

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -98,6 +98,9 @@
         "quarantineBucket": "ddp-local-file-quarantine",
         "maxFileSizeBytes": 2000000,
         "maxSignedUrlMins": 5,
+        "removalExpireTime": 1,
+        "removalExpireUnit": "DAYS",
+        "removalBatchSize": 100,
         "enableScanResultHandler": false,
         "scanResultSubscription": "cf-file-scan-result-local-hkeep-sub",
         "signerServiceAccount": {{$fileUploads.signerServiceAccount | toJSONPretty}}
@@ -116,6 +119,7 @@
         "drugLoader": "0 0 8,20 ? * * *",
         "cancerLoader": "0 0 8,20 ? * * *",
         "studyExport": "0 0 9 ? * * *",
+        "fileUploadCleanup": "0 0 5 ? * * *",
         "tempUserCleanup": "0 30 5 ? * * *"
     },
     "housekeepingMaxConnections": 50,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -77,6 +77,7 @@ import org.broadinstitute.ddp.housekeeping.schedule.CheckKitsJob;
 import org.broadinstitute.ddp.housekeeping.schedule.DataSyncJob;
 import org.broadinstitute.ddp.housekeeping.schedule.DatabaseBackupCheckJob;
 import org.broadinstitute.ddp.housekeeping.schedule.DatabaseBackupJob;
+import org.broadinstitute.ddp.housekeeping.schedule.FileUploadCleanupJob;
 import org.broadinstitute.ddp.housekeeping.schedule.OnDemandExportJob;
 import org.broadinstitute.ddp.housekeeping.schedule.StudyDataExportJob;
 import org.broadinstitute.ddp.housekeeping.schedule.TemporaryUserCleanupJob;
@@ -478,6 +479,7 @@ public class Housekeeping {
                     DataSyncJob.register(scheduler, cfg);
                     DatabaseBackupJob.register(scheduler, cfg);
                     DatabaseBackupCheckJob.register(scheduler, cfg);
+                    FileUploadCleanupJob.register(scheduler, cfg);
                     TemporaryUserCleanupJob.register(scheduler, cfg);
                     StudyDataExportJob.register(scheduler, cfg);
                 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/client/GoogleBucketClient.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/client/GoogleBucketClient.java
@@ -1,8 +1,16 @@
 package org.broadinstitute.ddp.client;
 
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
 import com.google.auth.Credentials;
+import com.google.auth.ServiceAccountSigner;
 import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.HttpMethod;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -23,6 +31,18 @@ public class GoogleBucketClient {
 
     public GoogleBucketClient(Storage storage) {
         this.storage = storage;
+    }
+
+    public URL generateSignedUrl(ServiceAccountSigner signer,
+                                 String bucketName, String blobName,
+                                 long expirationTime, TimeUnit timeUnit,
+                                 HttpMethod method, Map<String, String> headers) {
+        BlobInfo blobInfo = BlobInfo.newBuilder(BlobId.of(bucketName, blobName)).build();
+        return storage.signUrl(blobInfo, expirationTime, timeUnit,
+                Storage.SignUrlOption.signWith(signer),
+                Storage.SignUrlOption.withV4Signature(),
+                Storage.SignUrlOption.httpMethod(method),
+                Storage.SignUrlOption.withExtHeaders(headers));
     }
 
     public Bucket getBucket(String bucketName) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -62,6 +62,7 @@ public class ConfigFile {
     public static final String DB_BACKUP_SCHEDULE = "schedules.dbBackup";
     public static final String DB_BACKUP_CHECK_SCHEDULE = "schedules.dbBackupCheck";
     public static final String STUDY_EXPORT_SCHEDULE = "schedules.studyExport";
+    public static final String FILE_UPLOAD_CLEANUP_SCHEDULE = "schedules.fileUploadCleanup";
     public static final String TEMP_USER_CLEANUP_SCHEDULE = "schedules.tempUserCleanup";
 
     // database instance names
@@ -201,6 +202,9 @@ public class ConfigFile {
         public static final String QUARANTINE_BUCKET = prefix + "quarantineBucket";
         public static final String MAX_FILE_SIZE_BYTES = prefix + "maxFileSizeBytes";
         public static final String MAX_SIGNED_URL_MINS = prefix + "maxSignedUrlMins";
+        public static final String REMOVAL_EXPIRE_TIME = prefix + "removalExpireTime";
+        public static final String REMOVAL_EXPIRE_UNIT = prefix + "removalExpireUnit";
+        public static final String REMOVAL_BATCH_SIZE = prefix + "removalBatchSize";
         public static final String ENABLE_SCAN_RESULT_HANDLER = prefix + "enableScanResultHandler";
         public static final String SCAN_RESULT_SUBSCRIPTION = prefix + "scanResultSubscription";
         public static final String SIGNER_SERVICE_ACCOUNT = prefix + "signerServiceAccount";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadSql.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
@@ -40,6 +42,6 @@ public interface FileUploadSql extends SqlObject {
             @Bind("scannedAt") Instant scannedAt,
             @Bind("scanResult") FileScanResult scanResult);
 
-    @SqlUpdate("delete from file_upload where file_upload_id = :id")
-    int delete(@Bind("id") long fileUploadId);
+    @SqlUpdate("delete from file_upload where file_upload_id in (<ids>)")
+    int bulkDelete(@BindList(value = "ids", onEmpty = EmptyHandling.NULL) Iterable<Long> fileUploadIds);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/schedule/FileUploadCleanupJob.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/schedule/FileUploadCleanupJob.java
@@ -1,0 +1,83 @@
+package org.broadinstitute.ddp.housekeeping.schedule;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.constants.ConfigFile;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.service.FileUploadService;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.quartz.CronScheduleBuilder;
+import org.quartz.DisallowConcurrentExecution;
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@DisallowConcurrentExecution
+public class FileUploadCleanupJob implements Job {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FileUploadCleanupJob.class);
+
+    private static FileUploadService service;
+
+    public static JobKey getKey() {
+        return Keys.Cleanup.FileUploadJob;
+    }
+
+    public static void register(Scheduler scheduler, Config cfg) throws SchedulerException {
+        service = FileUploadService.fromConfig(cfg);
+        JobDetail job = JobBuilder.newJob(FileUploadCleanupJob.class)
+                .withIdentity(getKey())
+                .requestRecovery(false)
+                .storeDurably(true)
+                .build();
+        scheduler.addJob(job, true);
+        LOG.info("Added job {} to scheduler", getKey());
+
+        String schedule = ConfigUtil.getStrIfPresent(cfg, ConfigFile.FILE_UPLOAD_CLEANUP_SCHEDULE);
+        if (schedule == null || schedule.equalsIgnoreCase("off")) {
+            LOG.warn("Job {} is set to be turned off, no trigger added", getKey());
+            return;
+        }
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+                .withIdentity(Keys.Cleanup.FileUploadTrigger)
+                .forJob(getKey())
+                .withSchedule(CronScheduleBuilder
+                        .cronSchedule(schedule)
+                        .inTimeZone(TimeZone.getTimeZone(ZoneId.of("UTC")))
+                        .withMisfireHandlingInstructionFireAndProceed())
+                .startNow()
+                .build();
+        scheduler.scheduleJob(trigger);
+        LOG.info("Added trigger {} for job {} with schedule '{}'", trigger.getKey(), getKey(), schedule);
+    }
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        try {
+            LOG.info("Running job {}", getKey());
+            long start = Instant.now().toEpochMilli();
+
+            TransactionWrapper.useTxn(TransactionWrapper.DB.APIS,
+                    handle -> service.removeUnusedUploads(handle));
+
+            long elapsed = Instant.now().toEpochMilli() - start;
+            LOG.info("Job {} completed in {}ms", getKey(), elapsed);
+        } catch (Exception e) {
+            LOG.error("Error while executing job {}", getKey(), e);
+            throw new JobExecutionException(e, false);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/schedule/Keys.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/housekeeping/schedule/Keys.java
@@ -14,7 +14,9 @@ public class Keys {
 
     public static class Cleanup {
         public static final JobKey TempUserJob = JobKey.jobKey("temp-user", "cleanup");
+        public static final JobKey FileUploadJob = JobKey.jobKey("file-upload", "cleanup");
         public static final TriggerKey TempUserTrigger = TriggerKey.triggerKey("temp-user", "cleanup");
+        public static final TriggerKey FileUploadTrigger = TriggerKey.triggerKey("file-upload", "cleanup");
     }
 
     public static class DbBackups {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
@@ -185,8 +185,7 @@ public class PatchFormAnswersRouteStandaloneTest {
     public static void doSuiteTearDown() {
         TransactionWrapper.useTxn(handle -> {
             var fileDao = handle.attach(FileUploadDao.class);
-            fileDao.deleteById(upload1.getId());
-            fileDao.deleteById(upload2.getId());
+            fileDao.deleteByIds(Set.of(upload1.getId(), upload2.getId()));
         });
         IntegrationTestSuite.tearDown();
     }


### PR DESCRIPTION
## Context

Part of DDP-3709. This PR adds a background Quartz job to cleanup "unused" file uploads.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

Need to add new config properties to Vault. I recommend the following (remove anything older than 1 day and run job every day at 5am UTC):
```
    "fileUploads": {
        "removalExpireTime": 1,
        "removalExpireUnit": "DAYS",
        "removalBatchSize": 100,
    },
    "schedules": {
        "fileUploadCleanup": "0 0 5 ? * * *",
    },
```