### PR TITLE
DDP-5235 first version of DSS tasks pubsub implementation  (#621)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
             develop)
               DEPLOY_ENV=dev
             ;;
-            ddp-5484-fix-caching)
+            DDP-5235-housekeeping-dsm-pubsub-connection-draft)
               DEPLOY_ENV=dev
             ;;
             test)
@@ -900,7 +900,7 @@ workflows:
                 - develop
                 - &rc /^rc.*/
                 - &hotfix /^hotfix.*/
-                - ddp-5484-fix-caching
+                - DDP-5235-housekeeping-dsm-pubsub-connection-draft
       - parallel-compile-and-test-job:
           parallelism: *test_parallelism
           <<: *compile_and_test_filters
@@ -911,7 +911,7 @@ workflows:
             branches:
               only:
                 - develop
-                - ddp-5484-fix-caching
+                - DDP-5235-housekeeping-dsm-pubsub-connection-draft
           requires:
             - parallel-compile-and-test-job
             - compile-and-run-test-suite-job

--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -52,6 +52,9 @@
     "pubsub": {
         "enableHousekeepingTasks": {{$conf.Data.pubsub.enableHousekeepingTasks}},
         "housekeepingTasksSubscription": "{{$conf.Data.pubsub.housekeepingTasksSubscription}}",
+        "pubSubTasksSubscription": "{{$conf.Data.pubsub.pubSubTasksSubscription}}",
+        "pubSubTasksResultTopic": "{{$conf.Data.pubsub.pubSubTasksResultTopic}}",
+        "pubSubTaskSubscriberAwaitRunningTimeout": "{{$conf.Data.pubsub.pubSubTaskSubscriberAwaitRunningTimeout}}"
     },
     "studyExportBucket": "{{$conf.Data.studyExportBucket}}",
     "schedules": {

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -92,6 +92,9 @@
     "pubsub": {
         "enableHousekeepingTasks": false,
         "housekeepingTasksSubscription": "local-housekeeping-tasks-sub",
+        "pubSubTasksSubscription": "local-dsm-to-dss-tasks-sub",
+        "pubSubTasksResultTopic": "local-dss-to-dsm-results",
+        "pubSubTaskSubscriberAwaitRunningTimeout": 30
     },
     "studyExportBucket": "ddp-dev-study-exports-testing",
     "schedules": {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.ddp;
 
+import static org.broadinstitute.ddp.constants.ConfigFile.PUBSUB_TASKS_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskConnectionService.DEFAULT_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT_SEC;
+
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -14,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
@@ -52,6 +56,9 @@ import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.db.housekeeping.dao.JdbiEvent;
 import org.broadinstitute.ddp.db.housekeeping.dao.JdbiMessage;
 import org.broadinstitute.ddp.event.HousekeepingTaskReceiver;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskConnectionService;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException;
+import org.broadinstitute.ddp.event.pubsubtask.impl.PubSubTaskProcessorFactoryImpl;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.exception.MessageBuilderException;
 import org.broadinstitute.ddp.exception.NoSendableEmailAddressException;
@@ -170,6 +177,8 @@ public class Housekeeping {
     private static Scheduler scheduler;
     private static Subscriber taskSubscriber;
 
+    private static PubSubTaskConnectionService pubSubTaskConnectionService;
+
     public static void setAfterHandler(AfterHandlerCallback afterHandler) {
         synchronized (afterHandlerGuard) {
             afterHandling = afterHandler;
@@ -220,6 +229,21 @@ public class Housekeeping {
         setupTaskReceiver(cfg, pubSubProject);
 
         final PubSubConnectionManager pubsubConnectionManager = new PubSubConnectionManager(usePubSubEmulator);
+
+        pubSubTaskConnectionService = new PubSubTaskConnectionService(
+                pubsubConnectionManager,
+                pubSubProject,
+                cfg.getString(ConfigFile.PUBSUB_TASKS_SUB),
+                cfg.getString(ConfigFile.PUBSUB_TASKS_RESULT_TOPIC),
+                ConfigUtil.getIntOrElse(cfg, PUBSUB_TASKS_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT,
+                        DEFAULT_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT_SEC),
+                new PubSubTaskProcessorFactoryImpl());
+        try {
+            pubSubTaskConnectionService.create();
+        } catch (PubSubTaskException e) {
+            LOG.error("Failed to init PubSubTask API", e);
+        }
+
         TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, handle -> {
             JdbiMessageDestination messageDestinationDao = handle.attach(JdbiMessageDestination.class);
             for (String topicName : messageDestinationDao.getAllTopics()) {
@@ -447,6 +471,15 @@ public class Housekeeping {
         if (scheduler != null) {
             JobScheduler.shutdownScheduler(scheduler, true);
         }
+
+        if (pubSubTaskConnectionService != null) {
+            try {
+                pubSubTaskConnectionService.destroy();
+            } catch (PubSubTaskException e) {
+                LOG.error("Failed to shutdown PubSubTask API", e);
+            }
+        }
+
         LOG.info("Housekeeping is shutting down");
     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/ConfigFile.java
@@ -100,6 +100,9 @@ public class ConfigFile {
     public static final String BACKEND_AUTH0_TEST_CLIENT_NAME2 = "backendTestClientName2";
     public static final String PUBSUB_ENABLE_HKEEP_TASKS = "pubsub.enableHousekeepingTasks";
     public static final String PUBSUB_HKEEP_TASKS_SUB = "pubsub.housekeepingTasksSubscription";
+    public static final String PUBSUB_TASKS_SUB = "pubsub.pubSubTasksSubscription";
+    public static final String PUBSUB_TASKS_RESULT_TOPIC = "pubsub.pubSubTasksResultTopic";
+    public static final String PUBSUB_TASKS_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT = "pubsub.pubSubTaskSubscriberAwaitRunningTimeout";
     public static final String SLACK_HOOK = "slack.hook";
     public static final String SLACK_CHANNEL = "slack.channel";
     public static final String SLACK_QUEUE_SIZE = "slack.queueSize";

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/UserProfileSql.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/UserProfileSql.java
@@ -73,6 +73,13 @@ public interface UserProfileSql extends SqlObject {
     @SqlUpdate("update user_profile set last_name = :lastName where user_id = :userId")
     int updateLastName(@Bind("userId") long userId, @Bind("lastName") String lastName);
 
+    @SqlUpdate("update user_profile up join user u on u.user_id=up.user_id"
+               + " set up.first_name=:firstName, up.last_name=:lastName"
+               + " where u.guid=:userGuid")
+    int updateFirstAndLastNameByUserGuid(@Bind("userGuid") String userGuid,
+                                         @Bind("firstName") String firstName,
+                                         @Bind("lastName") String lastName);
+
     @SqlUpdate("update user_profile set do_not_contact = :doNotContact where user_id = :userId")
     int updateDoNotContact(@Bind("userId") long userId, @Bind("doNotContact") Boolean doNotContact);
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTask.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTask.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import java.util.Map;
+
+/**
+ * Data extracted from PubSubTask message
+ * (published to pubsub topic which DSS subscribed to - subscription is specified by
+ * config parameter "pubsub.pubSubTasksSubscription").
+ *
+ * <p>Data is fetched from pubsub message attributes and from message payload (JSON doc).
+ */
+public class PubSubTask {
+
+    public static final String ATTR_TASK_TYPE = "taskType";
+
+    private final String messageId;
+    private final String taskType;
+    private final Map<String, String> attributes;
+    private final String payloadJson;
+
+
+    /**
+     * Put the data extracted from PubSubTask message
+     * @param messageId - ID of a message
+     * @param taskType - type of a task: one of known types is 'UPDATE_PROFILE' and it can be added new types/processors which
+     *                 should be registered via {@link PubSubTaskProcessorFactory} and the factory implementation
+     *                 to be passed as a parameter to {@link PubSubTaskConnectionService} constructor.
+     * @param attributes  - pub sub message attributes
+     * @param payloadJson - raw string with payload JSON doc.
+     */
+    public PubSubTask(String messageId, String taskType, Map<String, String> attributes, String payloadJson) {
+        this.messageId = messageId;
+        this.taskType = taskType;
+        this.attributes = attributes;
+        this.payloadJson = payloadJson;
+    }
+
+    public String getMessageId() {
+        return messageId;
+    }
+
+    public String getTaskType() {
+        return taskType;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public String getPayloadJson() {
+        return payloadJson;
+    }
+
+    @Override
+    public String toString() {
+        return "taskType=" + taskType + ", messageId=" + messageId + ", attr=" + attributes + ", payload={" + payloadJson + "}";
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskConnectionService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskConnectionService.java
@@ -1,0 +1,138 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.errorMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.ProjectTopicName;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.housekeeping.PubSubConnectionManager;
+import org.slf4j.Logger;
+
+/**
+ * Creates PubSubTask Subscriber
+ * (reading messages from PubSubTask subscription defined by config param "pubsub.pubSubTasksSubscription")
+ * and PubSubTask result Publisher
+ * (publishing results to topic defined by config param "pubsub.pubSubTasksResultTopic").
+ *
+ * <p>Creates {@link PubSubTaskReceiver} which process PubSubTask-messages (coming from PubSubTask subscription):
+ * parses it and runs corresponding {@link PubSubTaskProcessor} which executes needed actions according to
+ * PubSubTask 'taskType' (each processor implemented for a specific 'taskType').
+ * After doing an action it is called the {@link PubSubTaskResultSender}
+ * which sends result to a topic "pubsub.pubSubTasksResultTopic".
+ */
+public class PubSubTaskConnectionService {
+
+    private static final Logger LOG = getLogger(PubSubTaskConnectionService.class);
+
+    public static final int DEFAULT_SUBSCRIBER_AWAIT_RUNNING_TIMEOUT_SEC = 30;
+    public static final int SUBSCRIBER_FAILURE_LISTENER_THREAD_COUNT = 4;
+    public static final int PUBLISHER_AWAIT_TERMINATION_TIMEOUT_MIN = 1;
+
+    private final PubSubConnectionManager pubSubConnectionManager;
+    private final ProjectSubscriptionName projectSubscriptionName;
+    private final ProjectTopicName pubSubTaskResultProjectTopicName;
+    private final PubSubTaskProcessorFactory pubSubTaskProcessorFactory;
+    private final int subscriberAwaitRunningTimeout;
+
+    private PubSubTaskReceiver pubSubTaskReceiver;
+    private PubSubTaskResultSender pubSubTaskResultSender;
+
+    private Subscriber pubSubTaskSubscriber;
+    private Publisher pubSubTaskResultPublisher;
+
+
+    public PubSubTaskConnectionService(
+            PubSubConnectionManager pubSubConnectionManager,
+            String projectId,
+            String subscription,
+            String pubSubTaskResultPubSubTopic,
+            int subscriberAwaitRunningTimeout,
+            PubSubTaskProcessorFactory pubSubTaskProcessorFactory) {
+        this.pubSubConnectionManager = pubSubConnectionManager;
+        projectSubscriptionName = ProjectSubscriptionName.of(projectId, subscription);
+        pubSubTaskResultProjectTopicName = ProjectTopicName.of(projectId, pubSubTaskResultPubSubTopic);
+        this.subscriberAwaitRunningTimeout = subscriberAwaitRunningTimeout;
+        this.pubSubTaskProcessorFactory = pubSubTaskProcessorFactory;
+    }
+
+    public void create() {
+        try {
+            createPubSubTaskResultPublisher();
+            pubSubTaskResultSender = new PubSubTaskResultSender(pubSubTaskResultPublisher);
+            pubSubTaskReceiver = new PubSubTaskReceiver(projectSubscriptionName, pubSubTaskProcessorFactory, pubSubTaskResultSender);
+
+            var executorProvider =
+                    InstantiatingExecutorProvider.newBuilder().setExecutorThreadCount(SUBSCRIBER_FAILURE_LISTENER_THREAD_COUNT).build();
+            var callbackExecutor = Executors.newSingleThreadExecutor();
+
+            createPubSubTaskSubscriber(executorProvider, callbackExecutor);
+
+        } catch (Exception e) {
+            throw new PubSubTaskException(errorMsg("Failed to create PubSubTask connection"), e);
+        }
+    }
+
+    public void destroy() {
+        if (pubSubTaskSubscriber != null && pubSubTaskSubscriber.isRunning()) {
+            pubSubTaskSubscriber.stopAsync();
+        }
+        if (pubSubTaskResultPublisher != null) {
+            try {
+                pubSubTaskResultPublisher.shutdown();
+                pubSubTaskResultPublisher.awaitTermination(PUBLISHER_AWAIT_TERMINATION_TIMEOUT_MIN, TimeUnit.MINUTES);
+            } catch (Exception e) {
+                throw new PubSubTaskException(errorMsg("Failed to shutdown PubSubTask connection"), e);
+            }
+        }
+    }
+
+    private void createPubSubTaskSubscriber(ExecutorProvider executorProvider, ExecutorService callbackExecutor) {
+        try {
+            pubSubTaskSubscriber = pubSubConnectionManager.subscribeBuilder(projectSubscriptionName, pubSubTaskReceiver)
+                    .setExecutorProvider(executorProvider)
+                    .setSystemExecutorProvider(executorProvider)
+                    .build();
+
+            pubSubTaskSubscriber.addListener(
+                    new Subscriber.Listener() {
+                        public void failed(Subscriber.State from, Throwable failure) {
+                            LOG.error(errorMsg("Unrecoverable failure happened during subscribing to subscription "
+                                    + projectSubscriptionName), failure);
+                            if (!executorProvider.getExecutor().isShutdown()) {
+                                createPubSubTaskSubscriber(executorProvider, callbackExecutor);
+                            }
+                        }
+                    },
+                    callbackExecutor);
+
+            pubSubTaskSubscriber.startAsync().awaitRunning(subscriberAwaitRunningTimeout, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            pubSubTaskSubscriber.stopAsync();
+            throw new DDPException("Could not start subscriber for subscription"
+                    + projectSubscriptionName.getSubscription(), e);
+        }
+        LOG.info(infoMsg("Subscriber to subscription {} is STARTED"), projectSubscriptionName);
+    }
+
+    public void createPubSubTaskResultPublisher() {
+        try {
+            pubSubTaskResultPublisher = pubSubConnectionManager.getOrCreatePublisher(pubSubTaskResultProjectTopicName);
+        } catch (IOException e) {
+            throw new DDPException("Could not create publisher for topic "
+                    + pubSubTaskResultProjectTopicName.getTopic(), e);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskException.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskException.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import org.broadinstitute.ddp.exception.DDPException;
+
+/**
+ * Exception that come out of PubSubTask processing API.
+ */
+public class PubSubTaskException extends DDPException {
+
+    private final boolean shouldRetry;
+    private final PubSubTask pubSubTask;
+
+    public PubSubTaskException(String message) {
+        this(message, null, null, false);
+    }
+
+    public PubSubTaskException(String message, Throwable e) {
+        this(message, e, null, false);
+    }
+
+    public PubSubTaskException(String message, boolean shouldRetry) {
+        this(message, null, null, shouldRetry);
+    }
+
+    public PubSubTaskException(String message, PubSubTask pubSubTask) {
+        this(message, null, pubSubTask, false);
+    }
+
+    public PubSubTaskException(String message, Throwable e, PubSubTask pubSubTask, boolean shouldRetry) {
+        super(message, e);
+        this.pubSubTask = pubSubTask;
+        this.shouldRetry = shouldRetry;
+    }
+
+    public boolean isShouldRetry() {
+        return shouldRetry;
+    }
+
+    public PubSubTask getPubSubTask() {
+        return pubSubTask;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskLogUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskLogUtil.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+/**
+ * Adds a prefix to log messages in PubSubTask API.
+ */
+public class PubSubTaskLogUtil {
+
+    /**
+     * This prefix added to every log message of PubSubTask API.
+     * And it allows to easily find in logs the log messages related to this API only.
+     * Fpr example on Google Cloud logs:
+     * <pre>
+     *     textPayload: "PUBSUB_TASK"
+     * </pre>
+     */
+    private static final String LOG_PREFIX_PUBSUB_TASK = "PUBSUB_TASK";
+
+    public static String infoMsg(String msg) {
+        return LOG_PREFIX_PUBSUB_TASK + ": " + msg;
+    }
+
+    public static String errorMsg(String msg) {
+        return LOG_PREFIX_PUBSUB_TASK + " error: " + msg;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessor.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessor.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+/**
+ * Interface defining a processor which should do actions
+ * in response to PubSubTask published to special pubsub topic
+ * (DSS subscribed to this topic and subscription configured by config param "pubsub.pubSubTasksSubscription").
+ */
+@FunctionalInterface
+public interface PubSubTaskProcessor {
+
+    PubSubTaskResult processPubSubTask(PubSubTask pubSubTask);
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorAbstract.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorAbstract.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import static java.lang.String.format;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.errorMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.SUCCESS;
+import static org.slf4j.LoggerFactory.getLogger;
+
+
+import com.google.gson.Gson;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.slf4j.Logger;
+
+
+/**
+ * Abstract implementation of processor which processes PubSubTask.
+ * {@link PubSubTaskProcessor} implementations should extend this abstract class.
+ */
+public abstract class PubSubTaskProcessorAbstract implements PubSubTaskProcessor {
+
+    protected static final Logger LOG = getLogger(PubSubTaskProcessorAbstract.class);
+
+    protected final Gson gson = GsonUtil.standardGson();
+
+    @Override
+    public PubSubTaskResult processPubSubTask(PubSubTask pubSubTask) {
+        PubSubTaskResult.PubSubTaskResultType pubSubTaskResultType = SUCCESS;
+        String errorMessage = null;
+        try {
+            LOG.info(infoMsg("PubSubTask processing STARTED: {}"), pubSubTask);
+
+            handleTask(pubSubTask);
+
+        } catch (PubSubTaskException e) {
+            if (!e.isShouldRetry()) {
+                throw e;
+            } else {
+                LOG.warn(errorMsg(format("PubSubTask processing FAILED, will retry: taskType=%s", pubSubTask.getTaskType())));
+            }
+            errorMessage = e.getMessage();
+        }
+
+        var pubSubTaskResult = new PubSubTaskResult(pubSubTaskResultType, errorMessage, pubSubTask);
+
+        LOG.info(infoMsg("PubSubTask processing COMPLETED: taskType={}, pubSubTaskResult={}"),
+                pubSubTask.getTaskType(), pubSubTaskResult);
+
+        return pubSubTaskResult;
+    }
+
+    protected abstract void handleTask(PubSubTask pubSubTask);
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorFactory.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorFactory.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+/**
+ * Factory for registering {@link PubSubTaskProcessor}'s
+ * for each of known PubSubTask taskType's.
+ */
+public interface PubSubTaskProcessorFactory {
+
+    PubSubTaskDescriptor getPubSubTaskDescriptor(String pubSubTaskType);
+
+    /**
+     * Holds data which necessary for {@link PubSubTask} processing
+     */
+    class PubSubTaskDescriptor {
+        private final PubSubTaskProcessor pubSubTaskProcessor;
+
+        public PubSubTaskDescriptor(PubSubTaskProcessor pubSubTaskProcessor) {
+            this.pubSubTaskProcessor = pubSubTaskProcessor;
+        }
+
+        public PubSubTaskProcessor getPubSubTaskProcessor() {
+            return pubSubTaskProcessor;
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorFactoryAbstract.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorFactoryAbstract.java
@@ -1,0 +1,33 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Abstract implementation of processors factory. It provides protected method
+ * which should be used for {@link PubSubTaskProcessor}-s registration:
+ * <pre>
+ * {@link #registerPubSubTaskProcessors()} - this should be overridden;
+ * {@link #registerPubSubTaskProcessor(String, PubSubTaskProcessor)} - this should be called
+ *   within {@link #registerPubSubTaskProcessors()} for registering a certain processor.
+ * </pre>
+ */
+public abstract class PubSubTaskProcessorFactoryAbstract implements PubSubTaskProcessorFactory {
+
+    protected final Map<String, PubSubTaskDescriptor> pubSubTaskDescriptors = new HashMap<>();
+
+    public PubSubTaskProcessorFactoryAbstract() {
+        registerPubSubTaskProcessors();
+    }
+
+    protected  void registerPubSubTaskProcessor(String pubSubTaskType, PubSubTaskProcessor pubSubTaskProcessor) {
+        pubSubTaskDescriptors.put(pubSubTaskType, new PubSubTaskDescriptor(pubSubTaskProcessor));
+    }
+
+    protected abstract void registerPubSubTaskProcessors();
+
+    @Override
+    public PubSubTaskDescriptor getPubSubTaskDescriptor(String pubSubTaskType) {
+        return pubSubTaskDescriptors.get(pubSubTaskType);
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskReceiver.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskReceiver.java
@@ -1,0 +1,96 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import static java.lang.String.format;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask.ATTR_TASK_TYPE;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.errorMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.ERROR;
+import static org.slf4j.LoggerFactory.getLogger;
+
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import org.slf4j.Logger;
+
+/**
+ * Receive and process PubSubTask-messages fetched from a subscription
+ * defined by config param "pubsub.pubSubTasksSubscription" and fetched by subscriber registered by
+ * {@link PubSubTaskConnectionService}.
+ *
+ * <p>When PubSubTask-message is received it is processed by a {@link PubSubTaskProcessor}
+ * which selected by a message attribute 'taskType' (from
+ * factory {@link PubSubTaskProcessorFactory}.
+ *
+ * <p>After a task is processed the result of processing is published to the results topic
+ * defined by config param "pubsub.pubSubTasksResultTopic".
+ * The result message published to the topic by {@link PubSubTaskResultSender}
+ */
+public class PubSubTaskReceiver implements MessageReceiver {
+
+    private static final Logger LOG = getLogger(PubSubTaskReceiver.class);
+
+    private final ProjectSubscriptionName projectSubscriptionName;
+    private final PubSubTaskProcessorFactory pubSubTaskProcessorFactory;
+    private final ResultSender pubSubTaskResultSender;
+
+    public PubSubTaskReceiver(ProjectSubscriptionName projectSubscriptionName,
+                              PubSubTaskProcessorFactory pubSubTaskProcessorFactory,
+                              ResultSender pubSubTaskResultSender) {
+        this.projectSubscriptionName = projectSubscriptionName;
+        this.pubSubTaskProcessorFactory = pubSubTaskProcessorFactory;
+        this.pubSubTaskResultSender = pubSubTaskResultSender;
+    }
+
+    @Override
+    public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+        PubSubTask pubSubTask = null;
+        try {
+            pubSubTask = parseMessage(message);
+            var pubSubTaskResult = processPubSubTask(pubSubTask);
+            if (pubSubTaskResult.getPubSubTaskResultPayload().getResultType() == ERROR) {
+                consumer.nack();
+            } else {
+                consumer.ack();
+                sendResponse(pubSubTaskResult);
+            }
+        } catch (Exception e) {
+            consumer.ack();
+            LOG.error(errorMsg(e.getMessage()), e);
+            if (pubSubTask != null) {
+                sendResponse(new PubSubTaskResult(ERROR, e.getMessage(), pubSubTask));
+            }
+        }
+    }
+
+    private PubSubTaskResult processPubSubTask(PubSubTask pubSubTask) {
+        return pubSubTaskProcessorFactory.getPubSubTaskDescriptor(pubSubTask.getTaskType())
+                .getPubSubTaskProcessor().processPubSubTask(pubSubTask);
+    }
+
+    private PubSubTask parseMessage(PubsubMessage message) {
+        String messageId = message.getMessageId();
+        String taskType = message.getAttributesOrDefault(ATTR_TASK_TYPE, null);
+        String payloadJson = message.getData() != null ? message.getData().toStringUtf8() : null;
+
+        PubSubTask pubSubTask = new PubSubTask(messageId, taskType, message.getAttributesMap(), payloadJson);
+
+        LOG.info(infoMsg("PubSubTask message received[subscription={}, id={}]: {}}"),
+                projectSubscriptionName, messageId, pubSubTask);
+
+        var pubSubTaskDescriptor = pubSubTaskProcessorFactory.getPubSubTaskDescriptor(taskType);
+        if (pubSubTaskDescriptor == null) {
+            throw new PubSubTaskException(format("PubSubTask message [id=%s] has unknown taskType=%s", messageId, taskType),
+                    pubSubTask);
+        }
+
+        return pubSubTask;
+    }
+
+    private void sendResponse(PubSubTaskResult pubSubTaskResult) {
+        if (pubSubTaskResultSender != null) {
+            pubSubTaskResultSender.sendPubSubTaskResult(pubSubTaskResult);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResult.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResult.java
@@ -1,0 +1,69 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+/**
+ * Data to be published to PubSubTaskResult topic.
+ */
+public class PubSubTaskResult {
+
+    /**
+     * Name of an attribute to be added to result message.
+     * It contains ID of a PubSubTask-message (incoming message)
+     */
+    public static final String ATTR_TASK_MESSAGE_ID = "taskMessageId";
+
+    public enum PubSubTaskResultType {
+        SUCCESS,
+        ERROR
+    }
+
+    private final PubSubTaskResultPayload pubSubTaskResultPayload;
+
+    private final PubSubTask pubSubTask;
+
+    public PubSubTaskResult(PubSubTaskResultType resultType, String errorMessage, PubSubTask pubSubTask) {
+        this.pubSubTaskResultPayload = new PubSubTaskResultPayload(resultType, errorMessage);
+        this.pubSubTask = pubSubTask;
+    }
+
+    public PubSubTaskResultPayload getPubSubTaskResultPayload() {
+        return pubSubTaskResultPayload;
+    }
+
+    public PubSubTask getPubSubTask() {
+        return pubSubTask;
+    }
+
+    @Override
+    public String toString() {
+        return pubSubTaskResultPayload.resultType + (pubSubTaskResultPayload.errorMessage != null
+                ? ": " + pubSubTaskResultPayload.errorMessage : "");
+    }
+
+
+    /**
+     * Data to be set to PubSubTaskResult payload (JSON document).
+     * It contains the following fields:
+     * <ul>
+     *     <li>resultType - type of result (SUCCESS or ERROR);</li>
+     *     <li>errorMessage - message (if resultType==ERROR).</li>
+     * </ul>
+     */
+    public static class PubSubTaskResultPayload {
+
+        private final PubSubTaskResultType resultType;
+        private final String errorMessage;
+
+        public PubSubTaskResultPayload(PubSubTaskResultType resultType, String errorMessage) {
+            this.resultType = resultType;
+            this.errorMessage = errorMessage;
+        }
+
+        public PubSubTaskResultType getResultType() {
+            return resultType;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResultMessageCreator.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResultMessageCreator.java
@@ -1,0 +1,32 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask.ATTR_TASK_TYPE;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.ATTR_TASK_MESSAGE_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_PARTICIPANT_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_STUDY_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_USER_ID;
+
+
+import com.google.gson.Gson;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.broadinstitute.ddp.util.GsonUtil;
+
+
+public class PubSubTaskResultMessageCreator {
+
+    private final Gson gson = GsonUtil.standardGson();
+
+    public PubsubMessage createPubSubMessage(PubSubTaskResult pubSubTaskResult) {
+        var messageJson = gson.toJson(pubSubTaskResult.getPubSubTaskResultPayload());
+        var messageBuilder = PubsubMessage.newBuilder()
+                .setData(ByteString.copyFromUtf8(messageJson))
+                .putAttributes(ATTR_TASK_MESSAGE_ID, pubSubTaskResult.getPubSubTask().getMessageId())
+                .putAttributes(ATTR_TASK_TYPE, pubSubTaskResult.getPubSubTask().getTaskType())
+                .putAttributes(ATTR_PARTICIPANT_GUID, pubSubTaskResult.getPubSubTask().getAttributes().get(ATTR_PARTICIPANT_GUID))
+                .putAttributes(ATTR_USER_ID, pubSubTaskResult.getPubSubTask().getAttributes().get(ATTR_USER_ID))
+                .putAttributes(ATTR_STUDY_GUID, pubSubTaskResult.getPubSubTask().getAttributes().get(ATTR_STUDY_GUID));
+        return messageBuilder.build();
+    }
+
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResultSender.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskResultSender.java
@@ -1,0 +1,71 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+import static java.lang.String.format;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.errorMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
+import static org.slf4j.LoggerFactory.getLogger;
+
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.ApiException;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.pubsub.v1.PubsubMessage;
+import org.slf4j.Logger;
+
+/**
+ * Builds {@link PubSubTaskResult}-message and publishes it
+ * to outgoing topic (name specified in Config parameter
+ * "pubsub.pubSubTasksResultTopic").
+ */
+public class PubSubTaskResultSender implements ResultSender {
+
+    private static final Logger LOG = getLogger(PubSubTaskResultSender.class);
+
+    private final Publisher publisher;
+    private final PubSubTaskResultMessageCreator messageCreator = new PubSubTaskResultMessageCreator();
+
+    public PubSubTaskResultSender(Publisher publisher) {
+        this.publisher = publisher;
+    }
+
+    @Override
+    public void sendPubSubTaskResult(PubSubTaskResult pubSubTaskResult) {
+
+        PubsubMessage pubSubMessage = messageCreator.createPubSubMessage(pubSubTaskResult);
+
+        LOG.info(format(infoMsg("Publish PubSubTaskResult message to topic=%s: result={%s}, pubSubTask={%s}"),
+                publisher.getTopicName(), pubSubTaskResult, pubSubTaskResult.getPubSubTask()));
+
+        ApiFuture<String> publishResult = publisher.publish(pubSubMessage);
+
+        ApiFutures.addCallback(
+                publishResult,
+                new ApiFutureCallback<>() {
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        String statusCode = null;
+                        if (e instanceof ApiException) {
+                            ApiException apiException = ((ApiException) e);
+                            statusCode = apiException.getStatusCode().getCode().toString();
+                        }
+                        String msg = errorMsg("Failed to send PubSubTask response \"" + pubSubTaskResult + "\"");
+                        if (statusCode != null) {
+                            msg += ", statusCode=" + statusCode;
+                        }
+                        LOG.error(msg, e);
+                    }
+
+                    @Override
+                    public void onSuccess(String messageId) {
+                        LOG.info(infoMsg("Result \"{}\" successfully published to pubsub topic={}. MessageId={}"),
+                                pubSubTaskResult, publisher.getTopicName(), messageId);
+                    }
+                },
+                MoreExecutors.directExecutor()
+        );
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/ResultSender.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/ResultSender.java
@@ -1,0 +1,12 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+/**
+ * Interface providing possibility to define custom
+ * sender for {@link PubSubTaskResult}.
+ *
+ */
+public interface ResultSender {
+
+    void sendPubSubTaskResult(PubSubTaskResult pubSubTaskResult);
+}
+

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/PubSubTaskProcessorFactoryImpl.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/PubSubTaskProcessorFactoryImpl.java
@@ -1,0 +1,22 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl;
+
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.TASK_TYPE__UPDATE_PROFILE;
+
+
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskProcessorFactory;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskProcessorFactoryAbstract;
+import org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileProcessor;
+
+/**
+ * Default implementation of {@link PubSubTaskProcessorFactory}.
+ */
+public class PubSubTaskProcessorFactoryImpl extends PubSubTaskProcessorFactoryAbstract {
+
+    @Override
+    protected void registerPubSubTaskProcessors() {
+        registerPubSubTaskProcessor(
+                TASK_TYPE__UPDATE_PROFILE,
+                new UpdateProfileProcessor()
+        );
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateEmailHandler.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateEmailHandler.java
@@ -1,0 +1,90 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
+
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.FIELD_EMAIL;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Properties;
+
+
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.TransactionWrapper.DB;
+import org.broadinstitute.ddp.db.dao.DataExportDao;
+import org.broadinstitute.ddp.db.dao.JdbiUser;
+import org.broadinstitute.ddp.db.dto.UserDto;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException;
+import org.broadinstitute.ddp.util.Auth0Util;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+
+public class UpdateEmailHandler {
+
+    private static final Logger LOG = getLogger(UpdateEmailHandler.class);
+
+    public void updateEmail(String userGuid, Properties payload) {
+        TransactionWrapper.useTxn(DB.APIS, handle -> updateEmail(handle, userGuid, payload));
+    }
+
+    private void updateEmail(Handle handle, String userGuid, Properties payload) {
+        if (payload.containsKey(FIELD_EMAIL)) {
+            String email = payload.getProperty(FIELD_EMAIL);
+            var userDto = handle.attach(JdbiUser.class).findByUserGuid(userGuid);
+            if (userDto == null) {
+                throw new PubSubTaskException("User profile is not found for guid=" + userGuid);
+            }
+            validateUserForLoginDataUpdateEligibility(userDto);
+
+            LOG.info(infoMsg("Attempting to change the email of the user {}"), userGuid);
+
+            updateEmailInAuth0(handle, userDto, email, userGuid);
+        }
+    }
+
+    private void validateUserForLoginDataUpdateEligibility(UserDto userDto) {
+        String errMsg = null;
+        if (userDto == null) {
+            errMsg = "User " + userDto.getUserGuid() + " does not exist in Pepper";
+        }
+        if (userDto.getAuth0UserId() == null) {
+            errMsg = "User " + userDto.getUserGuid() + " is not associated with the Auth0 user " + userDto.getAuth0UserId();
+        }
+        if (errMsg != null) {
+            throw new PubSubTaskException(errMsg);
+        }
+    }
+
+    /**
+     * NOTE: Similar logic is implemented in class UpdateUserEmailRoute.java
+     */
+    private void updateEmailInAuth0(Handle handle, UserDto userDto, String email, String userGuid) {
+        var mgmtAPI = Auth0Util.getManagementApiInstanceForUser(userDto.getUserGuid(), handle);
+        var status = Auth0Util.updateUserEmail(mgmtAPI, userDto, email);
+        String errMsg = null;
+        switch (status.getAuth0Status()) {
+            case SUCCESS:
+                handle.attach(DataExportDao.class).queueDataSync(userDto.getUserId(), true);
+                LOG.info(infoMsg("The email of the user {} was successfully changed"), userGuid);
+                break;
+            case INVALID_TOKEN:
+                errMsg = "The provided Auth0 token is invalid";
+                break;
+            case MALFORMED_EMAIL:
+                errMsg = "The new email " + email + " is malformed and was rejected by Auth0";
+                break;
+            case EMAIL_ALREADY_EXISTS:
+                errMsg = "The new email " + email + " already exists in Auth0, please choose another";
+                break;
+            case UNKNOWN_PROBLEM:
+                errMsg = "An unknown problem happened in Pepper or Auth0";
+                if (status.getErrorMessage() != null) {
+                    errMsg = errMsg + " Auth0 message: " + status.getErrorMessage();
+                }
+                throw new PubSubTaskException(errMsg, true);
+            default:
+                errMsg = "The returned Auth0 call status is unknown - something completely unexpected happened";
+        }
+        if (errMsg != null) {
+            throw new PubSubTaskException(errMsg);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateFirstLastNameHandler.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateFirstLastNameHandler.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
+
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.FIELD_FIRST_NAME;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.FIELD_LAST_NAME;
+
+import java.util.Properties;
+
+
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.TransactionWrapper.DB;
+import org.broadinstitute.ddp.db.dao.DataExportDao;
+import org.broadinstitute.ddp.db.dao.UserProfileDao;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException;
+import org.jdbi.v3.core.Handle;
+
+public class UpdateFirstLastNameHandler {
+
+    public void updateFirstLastName(String userGuid, Properties payload) {
+        TransactionWrapper.useTxn(DB.APIS, handle -> updateFirstLastName(handle, userGuid, payload));
+    }
+
+    private void updateFirstLastName(Handle handle, String userGuid, Properties payload) {
+        var profileDao = handle.attach(UserProfileDao.class);
+        var profile = profileDao.findProfileByUserGuid(userGuid).orElse(null);
+        if (profile == null) {
+            throw new PubSubTaskException("User profile is not found for guid=" + userGuid);
+        }
+        String firstName = detectFieldValueForUpdate(payload, FIELD_FIRST_NAME, profile.getFirstName());
+        String lastName = detectFieldValueForUpdate(payload, FIELD_LAST_NAME, profile.getLastName());
+        int count = profileDao.getUserProfileSql().updateFirstAndLastNameByUserGuid(userGuid, firstName, lastName);
+        if (count > 0) {
+            handle.attach(DataExportDao.class).queueDataSync(userGuid);
+        } else {
+            throw new PubSubTaskException("User profile is not found for guid=" + userGuid);
+        }
+    }
+
+    private String detectFieldValueForUpdate(Properties payload, String fieldName, String currentValue) {
+        return payload.containsKey(fieldName) ? payload.getProperty(fieldName) : currentValue;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileConstants.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
+
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask;
+
+/**
+ * Constants specific for taskType='UPDATE_PROFILE'
+ */
+public class UpdateProfileConstants {
+
+    /**
+     * {@link PubSubTask} taskType for updating some user profile data
+     */
+    public static final String TASK_TYPE__UPDATE_PROFILE = "UPDATE_PROFILE";
+
+    // attribute names
+    public static final String ATTR_PARTICIPANT_GUID = "participantGuid";
+    public static final String ATTR_USER_ID = "userId";
+    public static final String ATTR_STUDY_GUID = "studyGuid";
+
+    // possible payload fields
+    static final String FIELD_EMAIL = "email";
+    static final String FIELD_FIRST_NAME = "firstName";
+    static final String FIELD_LAST_NAME = "lastName";
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileProcessor.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileProcessor.java
@@ -1,0 +1,56 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
+
+import static java.lang.String.format;
+import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_PARTICIPANT_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_USER_ID;
+
+import java.util.Properties;
+
+
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskProcessorAbstract;
+
+
+/**
+ * Processes PubSubTask of taskType='UPDATE_PROFILE'.
+ * It updates person's email, first, and last name.
+ *
+ * <p>Does the following steps:
+ * <ul>
+ *     <li>updates user's email (checking if this email not used by another user);</li>
+ *     <li>updates user's first and last name.</li>
+ * </ul>
+ * NOTE: if any data field is null then it is not updated.
+ */
+public class UpdateProfileProcessor extends PubSubTaskProcessorAbstract {
+
+    @Override
+    public void handleTask(PubSubTask pubSubTask) {
+        validateTaskData(pubSubTask);
+        updateData(pubSubTask);
+    }
+
+    protected void validateTaskData(PubSubTask pubSubTask) {
+        String participantGuid = pubSubTask.getAttributes().get(ATTR_PARTICIPANT_GUID);
+        String userId = pubSubTask.getAttributes().get(ATTR_USER_ID);
+        if (isBlank(participantGuid) || isBlank(userId)) {
+            throw new PubSubTaskException(format("Error processing taskType=%s - some attributes are not specified: "
+                            + "participantGuid=%s, userId=%s", pubSubTask.getTaskType(), participantGuid, userId), pubSubTask);
+        }
+        if (isBlank(pubSubTask.getPayloadJson())) {
+            throw new PubSubTaskException("Error processing taskType=%s: empty payload", pubSubTask);
+        }
+    }
+
+    protected void updateData(PubSubTask pubSubTask) {
+        Properties properties = gson.fromJson(pubSubTask.getPayloadJson(), Properties.class);
+
+        var participantGuid = pubSubTask.getAttributes().get(ATTR_PARTICIPANT_GUID);
+
+        new UpdateEmailHandler().updateEmail(participantGuid, properties);
+
+        new UpdateFirstLastNameHandler().updateFirstLastName(participantGuid, properties);
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
@@ -39,6 +39,14 @@ public class ConfigUtil {
     }
 
     /**
+     * Get value as integer if the key is present and value is not null.
+     * If key not present then return a default value.
+     */
+    public static int getIntOrElse(Config cfg, String key, int defaultValue) {
+        return cfg.hasPath(key) ? cfg.getInt(key) : defaultValue;
+    }
+
+    /**
      * Get value as long if the key is present and value is not null.
      */
     public static Long getLongIfPresent(Config cfg, String key) {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/PubSubTaskTestUtil.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/PubSubTaskTestUtil.java
@@ -1,0 +1,85 @@
+package org.broadinstitute.ddp.event.pubsubtask;
+
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask.ATTR_TASK_TYPE;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_PARTICIPANT_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_STUDY_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_USER_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.TASK_TYPE__UPDATE_PROFILE;
+
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskProcessorFactoryAbstract;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult;
+import org.broadinstitute.ddp.event.pubsubtask.api.ResultSender;
+import org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileProcessor;
+
+public class PubSubTaskTestUtil {
+
+    public static final String PROJECT_ID = "projectId";
+    public static final String PUBSUB_SUBSCRIPTION = "pubSubSubscription";
+
+    public static final String TEST_MESSAGE_ID = "msg_id";
+    public static final String TEST_PARTICIPANT_GUID = "participant_guid";
+    public static final String TEST_USER_ID = "user_id";
+    public static final String TEST_STUDY_GUID = "study_guid";
+
+    public static final String EMAIL = "email";
+    public static final String EDUCATION = "education";
+    public static final String MARITAL_STATUS = "maritalStatus";
+    public static final String FIRST_NAME = "firstName";
+    public static final String LAST_NAME = "lastName";
+
+    public static final String TEST_EMAIL = "test@datadonationplatform.org";
+    public static final String TEST_EDUCATION = "University";
+    public static final String TEST_MARITAL_STATUS = "Married";
+    public static final String TEST_FIRST_NAME = "Lorenzo";
+    public static final String TEST_LAST_NAME = "Montana";
+
+
+
+    public static PubsubMessage buildMessage(String taskType, String payloadJson, boolean buildValidMessage) {
+        var messageBuilder = PubsubMessage.newBuilder()
+                .setMessageId(TEST_MESSAGE_ID)
+                .setData(ByteString.copyFromUtf8(payloadJson))
+                .putAttributes(ATTR_TASK_TYPE, taskType);
+        if (buildValidMessage) {
+            messageBuilder.putAttributes(ATTR_PARTICIPANT_GUID, TEST_PARTICIPANT_GUID)
+                    .putAttributes(ATTR_USER_ID, TEST_USER_ID)
+                    .putAttributes(ATTR_STUDY_GUID, TEST_STUDY_GUID);
+        }
+        return messageBuilder.build();
+    }
+
+    public static class TestResultSender implements ResultSender {
+        private PubSubTaskResult pubSubTaskResult;
+
+        @Override
+        public void sendPubSubTaskResult(PubSubTaskResult pubSubTaskResult) {
+            this.pubSubTaskResult = pubSubTaskResult;
+        }
+
+        public PubSubTaskResult getPubSubTaskResult() {
+            return pubSubTaskResult;
+        }
+    }
+
+    public static class TestTaskProcessorFactory extends PubSubTaskProcessorFactoryAbstract {
+
+        @Override
+        protected void registerPubSubTaskProcessors() {
+            registerPubSubTaskProcessor(
+                    TASK_TYPE__UPDATE_PROFILE,
+                    new TestUpdateProfileProcessor()
+            );
+        }
+
+        class TestUpdateProfileProcessor extends UpdateProfileProcessor {
+
+            @Override
+            protected void updateData(PubSubTask pubSubTask) {
+            }
+        }
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskCustomMessageTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskCustomMessageTest.java
@@ -1,0 +1,171 @@
+package org.broadinstitute.ddp.event.pubsubtask.api;
+
+
+import static java.lang.String.format;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.EDUCATION;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.EMAIL;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.MARITAL_STATUS;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.PROJECT_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.PUBSUB_SUBSCRIPTION;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_EDUCATION;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_EMAIL;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_MARITAL_STATUS;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_MESSAGE_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_PARTICIPANT_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_STUDY_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_USER_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.buildMessage;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.ATTR_TASK_MESSAGE_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.ERROR;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.SUCCESS;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_PARTICIPANT_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_STUDY_GUID;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_USER_ID;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.Properties;
+
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.gson.Gson;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.junit.Test;
+
+public class PubSubTaskCustomMessageTest {
+
+    private final ProjectSubscriptionName projectSubscriptionName =
+            ProjectSubscriptionName.of(PROJECT_ID, PUBSUB_SUBSCRIPTION);
+    private PubSubTaskProcessorFactory testFactory;
+    private PubSubTaskReceiver pubSubTaskReceiver;
+    private PubSubTaskResultMessageCreator resultMessageCreator;
+    private PubSubTaskTestUtil.TestResultSender testResultSender;
+
+    private final Gson gson = GsonUtil.standardGson();
+
+    /**
+     * Verify that if processor registered with payloadClass=null, parse message,
+     * check that payload can be converted to a map and properties fetched from it.
+     * Create result pubsub message (successful one) out of the parsed {@link PubSubTask}
+     */
+    @Test
+    public void testCustomMessageProcessing1() {
+        init();
+        var message = buildMessage(TestProcessor1.TEST_TASK_1,
+                format("{'%s':'%s', '%s':'%s', '%s':'%s'}",
+                        EMAIL, TEST_EMAIL, EDUCATION, TEST_EDUCATION, MARITAL_STATUS, TEST_MARITAL_STATUS), true);
+        pubSubTaskReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+
+        PubSubTask pubSubTask = testResultSender.getPubSubTaskResult().getPubSubTask();
+
+        assertEquals("{'email':'test@datadonationplatform.org', 'education':'University', 'maritalStatus':'Married'}",
+                pubSubTask.getPayloadJson());
+
+        assertEquals(TEST_PARTICIPANT_GUID, pubSubTask.getAttributes().get(ATTR_PARTICIPANT_GUID));
+        assertEquals(TEST_USER_ID, pubSubTask.getAttributes().get(ATTR_USER_ID));
+        assertEquals(TEST_STUDY_GUID, pubSubTask.getAttributes().get(ATTR_STUDY_GUID));
+
+        Properties payload = gson.fromJson(pubSubTask.getPayloadJson(), Properties.class);
+        assertEquals(TEST_EMAIL, payload.get(EMAIL));
+        assertEquals(TEST_EDUCATION, payload.get(EDUCATION));
+        assertEquals(TEST_MARITAL_STATUS, payload.get(MARITAL_STATUS));
+
+        PubSubTaskResult result = new PubSubTaskResult(SUCCESS, null, pubSubTask);
+        PubsubMessage resultMessage = resultMessageCreator.createPubSubMessage(result);
+
+        assertEquals(TEST_MESSAGE_ID, resultMessage.getAttributesOrDefault(ATTR_TASK_MESSAGE_ID, null));
+        assertEquals(TEST_PARTICIPANT_GUID, resultMessage.getAttributesOrDefault(ATTR_PARTICIPANT_GUID, null));
+        assertEquals(TEST_USER_ID, resultMessage.getAttributesOrDefault(ATTR_USER_ID, null));
+        assertEquals(TEST_STUDY_GUID, resultMessage.getAttributesOrDefault(ATTR_STUDY_GUID, null));
+        assertEquals("{\"resultType\":\"SUCCESS\",\"errorMessage\":null}", resultMessage.getData().toStringUtf8());
+    }
+
+    /**
+     * Verify that in case if created a processor with specified payload class
+     * then payload data will be copied to instance of this class.
+     */
+    @Test
+    public void testCustomMessageProcessing2() {
+        init();
+        var message = buildMessage(TestProcessor2.TEST_TASK_2,
+                format("{'%s':'%s', '%s':'%s'}", EMAIL, TEST_EMAIL, EDUCATION, TEST_EDUCATION), true);
+        pubSubTaskReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+
+        PubSubTask pubSubTask = testResultSender.getPubSubTaskResult().getPubSubTask();
+
+        assertEquals(TEST_PARTICIPANT_GUID, pubSubTask.getAttributes().get(ATTR_PARTICIPANT_GUID));
+        assertEquals(TEST_USER_ID, pubSubTask.getAttributes().get(ATTR_USER_ID));
+        assertEquals(TEST_STUDY_GUID, pubSubTask.getAttributes().get(ATTR_STUDY_GUID));
+
+        PubSubTaskResult result = new PubSubTaskResult(ERROR, "Custom error occured", pubSubTask);
+        PubsubMessage resultMessage = resultMessageCreator.createPubSubMessage(result);
+        assertEquals("{\"resultType\":\"ERROR\",\"errorMessage\":\"Custom error occured\"}",
+                resultMessage.getData().toStringUtf8());
+    }
+
+    private void init() {
+        testFactory = new TestFactory();
+        testResultSender = new PubSubTaskTestUtil.TestResultSender();
+        pubSubTaskReceiver = new PubSubTaskReceiver(projectSubscriptionName, testFactory, testResultSender);
+        resultMessageCreator = new PubSubTaskResultMessageCreator();
+    }
+
+    class TestProcessor1 extends PubSubTaskProcessorAbstract {
+
+        static final String TEST_TASK_1 = "TEST_TASK_1";
+
+        @Override
+        protected void handleTask(PubSubTask pubSubTask) {
+        }
+    }
+
+    class TestProcessor2 extends PubSubTaskProcessorAbstract {
+
+        static final String TEST_TASK_2 = "TEST_TASK_2";
+
+        @Override
+        protected void handleTask(PubSubTask pubSubTask) {
+        }
+    }
+
+    class TestPayload2 {
+        String email;
+        String education;
+        String maritalStatus;
+
+        public TestPayload2(String email, String education, String maritalStatus) {
+            this.email = email;
+            this.education = education;
+            this.maritalStatus = maritalStatus;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+
+        public String getEducation() {
+            return education;
+        }
+
+        public String getMaritalStatus() {
+            return maritalStatus;
+        }
+    }
+
+    class TestFactory extends PubSubTaskProcessorFactoryAbstract {
+        @Override
+        protected void registerPubSubTaskProcessors() {
+            registerPubSubTaskProcessor(
+                    TestProcessor1.TEST_TASK_1,
+                    new TestProcessor1()
+            );
+            registerPubSubTaskProcessor(
+                    TestProcessor2.TEST_TASK_2,
+                    new TestProcessor2()
+            );
+        }
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/PubSubTaskUpdateProfileMessageTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/PubSubTaskUpdateProfileMessageTest.java
@@ -1,0 +1,92 @@
+package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
+
+
+import static java.lang.String.format;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.EMAIL;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.FIRST_NAME;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.LAST_NAME;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.PROJECT_ID;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.PUBSUB_SUBSCRIPTION;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_EMAIL;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_FIRST_NAME;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TEST_LAST_NAME;
+import static org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.buildMessage;
+import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.ERROR;
+import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.TASK_TYPE__UPDATE_PROFILE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+
+
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.gson.Gson;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil;
+import org.broadinstitute.ddp.event.pubsubtask.PubSubTaskTestUtil.TestResultSender;
+import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskReceiver;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.junit.Test;
+
+public class PubSubTaskUpdateProfileMessageTest {
+
+    private final ProjectSubscriptionName projectSubscriptionName =
+            ProjectSubscriptionName.of(PROJECT_ID, PUBSUB_SUBSCRIPTION);
+    private PubSubTaskReceiver pubSubTaskReceiver;
+    private TestResultSender testResultSender;
+
+    private final Gson gson = GsonUtil.standardGson();
+
+
+    @Test
+    public void testUpdateProfileValidMessageParser() {
+        buildMessageAndAssert(true);
+
+        assertEquals("{'email':'test@datadonationplatform.org', 'firstName':'Lorenzo', 'lastName':'Montana'}",
+                testResultSender.getPubSubTaskResult().getPubSubTask().getPayloadJson());
+        Map<String, String> payload = gson.fromJson(testResultSender.getPubSubTaskResult().getPubSubTask().getPayloadJson(), Map.class);
+        assertEquals(TEST_EMAIL, payload.get(EMAIL));
+        assertEquals(TEST_FIRST_NAME, payload.get(FIRST_NAME));
+        assertEquals(TEST_LAST_NAME, payload.get(LAST_NAME));
+    }
+
+    @Test
+    public void testUpdateProfileInvalidMessageParser() {
+        buildMessageAndAssert(false);
+
+        assertEquals("{'email':'test@datadonationplatform.org', 'firstName':'Lorenzo', 'lastName':'Montana'}",
+                testResultSender.getPubSubTaskResult().getPubSubTask().getPayloadJson());
+        assertEquals(ERROR, testResultSender.getPubSubTaskResult().getPubSubTaskResultPayload().getResultType());
+        assertEquals("Error processing taskType=UPDATE_PROFILE - some attributes are not specified: "
+                        + "participantGuid=null, userId=null",
+                testResultSender.getPubSubTaskResult().getPubSubTaskResultPayload().getErrorMessage());
+    }
+
+    @Test
+    public void testUpdateProfileEmptyBodyMessageParser() {
+        init();
+        var message = buildMessage(TASK_TYPE__UPDATE_PROFILE, "", true);
+
+        pubSubTaskReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+
+        assertEquals(4, testResultSender.getPubSubTaskResult().getPubSubTask().getAttributes().size());
+        assertEquals("", testResultSender.getPubSubTaskResult().getPubSubTask().getPayloadJson());
+        assertEquals(ERROR, testResultSender.getPubSubTaskResult().getPubSubTaskResultPayload().getResultType());
+        assertEquals("Error processing taskType=%s: empty payload",
+                testResultSender.getPubSubTaskResult().getPubSubTaskResultPayload().getErrorMessage());
+    }
+
+    private void buildMessageAndAssert(boolean buildValidMessage) {
+        init();
+        var message = buildMessage(TASK_TYPE__UPDATE_PROFILE,
+                format("{'%s':'%s', '%s':'%s', '%s':'%s'}",
+                        EMAIL, TEST_EMAIL, FIRST_NAME, TEST_FIRST_NAME, LAST_NAME, TEST_LAST_NAME), buildValidMessage);
+        pubSubTaskReceiver.receiveMessage(message, mock(AckReplyConsumer.class));
+    }
+
+    private void init() {
+        testResultSender = new TestResultSender();
+        pubSubTaskReceiver = new PubSubTaskReceiver(projectSubscriptionName,
+                new PubSubTaskTestUtil.TestTaskProcessorFactory(), testResultSender);
+    }
+}


### PR DESCRIPTION
Custom release to rollout the "DSS tasks" feature to production. See DDP-5235.

Release steps:

1. Create the appropriate pubsub topics/subscriptions.
2. Update Vault with new configurations.
3. Share pubsub coordinates with DSM.
4. Deploy release.