### PR TITLE
DDP-5573 3/3: handle parent/child instance status updates

### DIFF
--- a/pepper-apis/docs/specification/src/components/responses.yml
+++ b/pepper-apis/docs/specification/src/components/responses.yml
@@ -58,7 +58,10 @@ ActivityAnswersPatchBadPayloadResponse:
       schema:
         $ref: '../pepper.yml#/components/schemas/Error.ActivityAnswersPatchBadPayload'
 ActivityAnswersPatchInvalidResponse:
-  description: activity instance or question is read-only or answer submission failed validation
+  description: |
+    Activity instance or question is read-only or answer submission failed validation.
+    If this is a child nested instance and parent instance is read-only, then
+    answer submission is not allowed and `ACTIVITY_INSTANCE_IS_READONLY` is returned.
   content:
     application/json:
       schema:
@@ -81,7 +84,11 @@ ActivityAnswersPutResponse:
           workflow:
             $ref: '../pepper.yml#/components/schemas/WorkflowNextSuggestion'
 ActivityAnswersPutInvalidResponse:
-  description: activity instance is read-only, required questions not answered yet, or there are validation errors
+  description: |
+    Activity instance is read-only, required questions not answered yet, or there are validation errors.
+    If this is a child nested instance and parent instance is read-only, then `ACTIVITY_INSTANCE_IS_READONLY`
+    will be returned. If this is a parent instance and child instances does not yet meet required questions
+    requirements, then `QUESTION_REQUIREMENTS_NOT_MET` will be returned.
   content:
     application/json:
       schema:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.answers.yml
@@ -83,6 +83,9 @@ put:
     Indicates to server that user is done with an activity. This API ensures
     any required questions in an activity is answered, and then transitions
     the user's activity instance to an appropriate status (i.e. `COMPLETE`).
+    If activity is a parent instance with nested child instances, then those
+    child instances must have their required questions answered before the
+    parent instance is allowed to be completed.
 
     Completing an activity may also trigger some server-side post-submission
     processes, if any are configured for the activity/study. Activities are

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/UserActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/UserActivityInstanceSummary.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.db.dto;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.broadinstitute.ddp.model.user.User;
 
@@ -17,6 +18,10 @@ public class UserActivityInstanceSummary {
 
     public User getParticipantUser() {
         return participantUser;
+    }
+
+    public Stream<ActivityInstanceDto> getInstancesStream() {
+        return activityInstanceDtos.stream();
     }
 
     public Optional<ActivityInstanceDto> getActivityInstanceByGuid(String guid) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -11,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
@@ -21,6 +21,7 @@ import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.content.RenderValueProvider;
 import org.broadinstitute.ddp.content.Renderable;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
@@ -258,16 +259,18 @@ public final class FormInstance extends ActivityInstance {
      * Evaluate and update the form's block visibilities, assuming that those are all loaded. If the block does not have
      * a conditional expression (and thus toggle-able), no change will be made to the block.
      *
-     * @param handle       the jdbi handle
-     * @param interpreter  the pex interpreter to evaluate expressions
-     * @param userGuid     the user guid
-     * @param instanceGuid the activity instance guid
+     * @param handle          the jdbi handle
+     * @param interpreter     the pex interpreter to evaluate expressions
+     * @param userGuid        the user guid
+     * @param instanceGuid    the activity instance guid
+     * @param instanceSummary container that holds data about user's instances
      * @throws DDPException if pex evaluation error
      */
-    public void updateBlockStatuses(Handle handle, PexInterpreter interpreter, String userGuid, String operatorGuid, String instanceGuid) {
+    public void updateBlockStatuses(Handle handle, PexInterpreter interpreter, String userGuid, String operatorGuid,
+                                    String instanceGuid, UserActivityInstanceSummary instanceSummary) {
         for (FormSection section : getAllSections()) {
             for (FormBlock block : section.getBlocks()) {
-                updateBlockStatus(handle, interpreter, block, userGuid, operatorGuid, instanceGuid);
+                updateBlockStatus(handle, interpreter, block, userGuid, operatorGuid, instanceGuid, instanceSummary);
                 if (block.getBlockType().isContainerBlock()) {
                     List<FormBlock> children;
                     if (block.getBlockType() == BlockType.CONDITIONAL) {
@@ -278,7 +281,7 @@ public final class FormInstance extends ActivityInstance {
                         throw new DDPException("Unhandled container block type " + block.getBlockType());
                     }
                     for (FormBlock child : children) {
-                        updateBlockStatus(handle, interpreter, child, userGuid, operatorGuid, instanceGuid);
+                        updateBlockStatus(handle, interpreter, child, userGuid, operatorGuid, instanceGuid, instanceSummary);
                     }
                 }
             }
@@ -286,10 +289,10 @@ public final class FormInstance extends ActivityInstance {
     }
 
     private void updateBlockStatus(Handle handle, PexInterpreter interpreter, FormBlock block, String userGuid,
-                                   String operatorGuid, String instanceGuid) {
+                                   String operatorGuid, String instanceGuid, UserActivityInstanceSummary instanceSummary) {
         if (block.getShownExpr() != null) {
             try {
-                boolean shown = interpreter.eval(block.getShownExpr(), handle, userGuid, operatorGuid, instanceGuid);
+                boolean shown = interpreter.eval(block.getShownExpr(), handle, userGuid, operatorGuid, instanceGuid, instanceSummary);
                 block.setShown(shown);
             } catch (PexException e) {
                 String msg = String.format("Error evaluating pex expression for form activity instance %s and block %s: `%s`",

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -38,9 +38,7 @@ import org.broadinstitute.ddp.db.dao.FileUploadDao;
 import org.broadinstitute.ddp.db.dao.JdbiQuestionCached;
 import org.broadinstitute.ddp.db.dao.QuestionCachedDao;
 import org.broadinstitute.ddp.db.dao.UserDao;
-import org.broadinstitute.ddp.db.dto.ActivityDto;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
-import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
 import org.broadinstitute.ddp.db.dto.AnswerDto;
 import org.broadinstitute.ddp.db.dto.CompositeQuestionDto;
 import org.broadinstitute.ddp.db.dto.LanguageDto;
@@ -143,7 +141,6 @@ public class PatchFormAnswersRoute implements Route {
         PatchAnswerResponse result = TransactionWrapper.withTxn(handle -> {
             UserActivityInstanceSummary instanceSummary = RouteUtil.findUserActivityInstanceSummaryOrHalt(
                     response, handle, participantGuid, studyGuid, instanceGuid, isStudyAdmin);
-
             ActivityInstanceDto instanceDto = instanceSummary.getActivityInstanceByGuid(instanceGuid).get();
 
             if (!ActivityType.FORMS.equals(instanceDto.getActivityType())) {
@@ -152,23 +149,11 @@ public class PatchFormAnswersRoute implements Route {
                 throw ResponseUtil.haltError(response, 400, new ApiError(ErrorCodes.INVALID_REQUEST, msg));
             }
 
-            User operatorUser = handle.attach(UserDao.class).findUserByGuid(operatorGuid)
-                    .orElseThrow(() -> new DDPException("Could not find operator with guid " + operatorGuid));
-
             PatchAnswerPayload payload = parseBodyPayload(request);
             if (payload == null) {
                 String msg = "Unable to process request body";
                 throw ResponseUtil.haltError(response, 400, new ApiError(ErrorCodes.BAD_PAYLOAD, msg));
             }
-
-            ActivityDefStore activityStore = ActivityDefStore.getInstance();
-            ActivityDto activityDto = activityStore.findActivityDto(handle, instanceDto.getActivityId())
-                    .orElseThrow(() -> new DDPException("Could not find activity dto for instance " + instanceGuid));
-            ActivityVersionDto versionDto = activityStore
-                    .findVersionDto(handle, instanceDto.getActivityId(), instanceDto.getCreatedAtMillis())
-                    .orElseThrow(() -> new DDPException("Could not find activity version for instance " + instanceGuid));
-            FormActivityDef formActivityDef = activityStore.findActivityDef(handle, studyGuid, activityDto, versionDto)
-                    .orElseThrow(() -> new DDPException("Could not find activity definition for instance " + instanceGuid));
 
             PatchAnswerResponse res = new PatchAnswerResponse();
             List<AnswerSubmission> submissions = payload.getSubmissions();
@@ -177,26 +162,50 @@ public class PatchFormAnswersRoute implements Route {
                 return res;
             }
 
-            if (!isStudyAdmin && ActivityInstanceUtil.isReadonly(formActivityDef.getEditTimeoutSec(), instanceDto.getCreatedAtMillis(),
-                    instanceDto.getStatusType().name(), formActivityDef.isWriteOnce(), instanceDto.getReadonly())) {
-                String msg = "Activity instance with GUID " + instanceGuid + " is read-only, cannot submit answer(s) for it";
-                LOG.info(msg);
-                throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+            ActivityDefStore activityStore = ActivityDefStore.getInstance();
+            FormActivityDef activityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, instanceDto, studyGuid);
+
+            ActivityInstanceDto parentInstanceDto = null;
+            FormActivityDef parentActivityDef = null;
+            String parentInstanceGuid = instanceDto.getParentInstanceGuid();
+            if (parentInstanceGuid != null) {
+                parentInstanceDto = instanceSummary
+                        .getActivityInstanceByGuid(parentInstanceGuid)
+                        .orElseThrow(() -> new DDPException("Could not find parent instance " + parentInstanceGuid));
+                parentActivityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, parentInstanceDto, studyGuid);
+            }
+
+            if (!isStudyAdmin) {
+                if (parentInstanceDto != null && ActivityInstanceUtil.isInstanceReadOnly(parentActivityDef, parentInstanceDto)) {
+                    String msg = "Parent activity instance with GUID " + parentInstanceDto.getGuid()
+                            + " is read-only, cannot submit answer(s) for child instance " + instanceGuid;
+                    LOG.info(msg);
+                    throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                }
+                if (ActivityInstanceUtil.isInstanceReadOnly(activityDef, instanceDto)) {
+                    String msg = "Activity instance with GUID " + instanceGuid + " is read-only, cannot submit answer(s) for it";
+                    LOG.info(msg);
+                    throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                }
             }
 
             var answerDao = new AnswerCachedDao(handle);
             var questionDao = new QuestionCachedDao(handle);
             var jdbiQuestion = questionDao.getJdbiQuestion();
 
-            LanguageDto preferredUserLanguage = RouteUtil.getUserLanguage(request);
-            String isoLanguageCode = preferredUserLanguage.getIsoCode();
-            Long languageCodeId = preferredUserLanguage.getId();
+            LanguageDto preferredUserLangDto = RouteUtil.getUserLanguage(request);
+
+            User operatorUser = instanceSummary.getParticipantUser();
+            if (!participantGuid.equals(operatorGuid)) {
+                operatorUser = handle.attach(UserDao.class).findUserByGuid(operatorGuid)
+                        .orElseThrow(() -> new DDPException("Could not find operator with guid " + operatorGuid));
+            }
 
             try {
                 Map<String, List<Rule>> failedRulesByQuestion = new HashMap<>();
                 for (AnswerSubmission submission : submissions) {
                     String questionStableId = extractQuestionStableId(submission, response);
-                    QuestionDef questionDef = formActivityDef.getQuestionByStableId(questionStableId);
+                    QuestionDef questionDef = activityDef.getQuestionByStableId(questionStableId);
 
                     if (questionDef == null) {
                         LOG.warn("Could not find questiondef with id: " + questionStableId);
@@ -207,7 +216,7 @@ public class PatchFormAnswersRoute implements Route {
                     // @TODO might be able to get rid of this query and a bunch of *CachedDao classes
                     // if can figure out how to create Rule objects from RuleDef
                     Question question = questionDao.getQuestionByActivityInstanceAndDto(questionDto,
-                            instanceGuid, false, languageCodeId);
+                            instanceGuid, false, preferredUserLangDto.getId());
 
                     if (!isStudyAdmin && question.isReadonly()) {
                         String msg = "Question with stable id " + questionStableId + " is read-only, cannot update question";
@@ -321,25 +330,29 @@ public class PatchFormAnswersRoute implements Route {
                 throw ResponseUtil.haltError(response, 400, new ApiError(ErrorCodes.REQUIRED_PARAMETER_MISSING, e.getMessage()));
             }
 
-
-            res.setBlockVisibilities(formService.getBlockVisibilities(handle, instanceSummary, formActivityDef, participantGuid,
+            res.setBlockVisibilities(formService.getBlockVisibilities(handle, instanceSummary, activityDef, participantGuid,
                     operatorGuid, instanceGuid));
 
             List<ActivityValidationFailure> failures = getActivityValidationFailures(
-                    handle, participantGuid, operatorGuid, instanceDto, languageCodeId
+                    handle, participantGuid, operatorGuid, instanceDto, preferredUserLangDto.getId()
             );
             if (!failures.isEmpty()) {
                 LOG.info("Activity validation failed, reasons: {}", createValidationFailureSummaries(failures));
                 return enrichPayloadWithValidationFailures(res, failures);
             }
-            handle.attach(ActivityInstanceStatusDao.class).updateOrInsertStatus(instanceDto, InstanceStatusType.IN_PROGRESS,
-                    Instant.now().toEpochMilli(), operatorUser, instanceSummary.getParticipantUser());
 
+            var instanceStatusDao = handle.attach(ActivityInstanceStatusDao.class);
+            instanceStatusDao.updateOrInsertStatus(instanceDto, InstanceStatusType.IN_PROGRESS,
+                    Instant.now().toEpochMilli(), operatorUser, instanceSummary.getParticipantUser());
+            if (parentInstanceDto != null) {
+                instanceStatusDao.updateOrInsertStatus(parentInstanceDto, InstanceStatusType.IN_PROGRESS,
+                        Instant.now().toEpochMilli(), operatorUser, instanceSummary.getParticipantUser());
+            }
             handle.attach(DataExportDao.class).queueDataSync(participantGuid, studyGuid);
 
             GoogleAnalyticsMetricsTracker.getInstance().sendAnalyticsMetrics(studyGuid, GoogleAnalyticsMetrics.EVENT_CATEGORY_PATCH_ANSWERS,
                     GoogleAnalyticsMetrics.EVENT_ACTION_PATCH_ANSWERS, GoogleAnalyticsMetrics.EVENT_LABEL_PATCH_ANSWERS,
-                    activityDto.getActivityCode(), 1);
+                    instanceDto.getActivityCode(), 1);
 
             return res;
         });

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.route;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -12,19 +13,26 @@ import org.broadinstitute.ddp.analytics.GoogleAnalyticsMetricsTracker;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
+import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.FormInstanceDao;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceStatusDao;
 import org.broadinstitute.ddp.db.dao.AnswerDao;
 import org.broadinstitute.ddp.db.dao.DataExportDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.JdbiFormActivitySetting;
 import org.broadinstitute.ddp.db.dao.JdbiMailAddress;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.FormActivitySettingDto;
 import org.broadinstitute.ddp.db.dto.LanguageDto;
+import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
+import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.json.PutAnswersResponse;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.json.workflow.WorkflowResponse;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.instance.ComponentBlock;
 import org.broadinstitute.ddp.model.activity.instance.FormComponent;
 import org.broadinstitute.ddp.model.activity.instance.FormInstance;
@@ -35,6 +43,7 @@ import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.ComponentType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
 import org.broadinstitute.ddp.model.address.MailAddress;
+import org.broadinstitute.ddp.model.user.User;
 import org.broadinstitute.ddp.model.workflow.ActivityState;
 import org.broadinstitute.ddp.model.workflow.WorkflowState;
 import org.broadinstitute.ddp.pex.PexInterpreter;
@@ -42,7 +51,7 @@ import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.service.ActivityValidationService;
 import org.broadinstitute.ddp.service.DsmAddressValidationStatus;
 import org.broadinstitute.ddp.service.WorkflowService;
-import org.broadinstitute.ddp.util.FormActivityStatusUtil;
+import org.broadinstitute.ddp.util.ActivityInstanceUtil;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
 import org.jdbi.v3.core.Handle;
@@ -88,42 +97,59 @@ public class PutFormAnswersRoute implements Route {
 
         PutAnswersResponse resp = TransactionWrapper.withTxn(
                 handle -> {
-                    var instanceDto = RouteUtil.findAccessibleInstanceOrHalt(
+                    UserActivityInstanceSummary instanceSummary = RouteUtil.findUserActivityInstanceSummaryOrHalt(
                             response, handle, userGuid, studyGuid, instanceGuid, isStudyAdmin);
+                    ActivityInstanceDto instanceDto = instanceSummary.getActivityInstanceByGuid(instanceGuid).get();
 
-                    LanguageDto preferredUserLanguage = RouteUtil.getUserLanguage(request);
-                    String isoLangCode = preferredUserLanguage.getIsoCode();
-                    long langCodeId = preferredUserLanguage.getId();
+                    LanguageDto preferredUserLangDto = RouteUtil.getUserLanguage(request);
+                    ActivityDefStore activityStore = ActivityDefStore.getInstance();
+                    FormActivityDef activityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, instanceDto, studyGuid);
 
-                    FormInstance form = formInstanceDao.getBaseFormByGuid(handle, instanceGuid, isoLangCode);
-                    if (form == null) {
-                        String msg = String.format("Could not find activity instance %s for user %s using language %s",
-                                instanceGuid, userGuid, isoLangCode);
-                        LOG.warn(msg);
-                        throw ResponseUtil.haltError(response, 404, new ApiError(ErrorCodes.ACTIVITY_NOT_FOUND, msg));
+                    ActivityInstanceDto parentInstanceDto = null;
+                    FormActivityDef parentActivityDef = null;
+                    String parentInstanceGuid = instanceDto.getParentInstanceGuid();
+                    if (parentInstanceGuid != null) {
+                        parentInstanceDto = instanceSummary
+                                .getActivityInstanceByGuid(parentInstanceGuid)
+                                .orElseThrow(() -> new DDPException("Could not find parent instance " + parentInstanceGuid));
+                        parentActivityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, parentInstanceDto, studyGuid);
                     }
 
-                    if (!isStudyAdmin && form.isReadonly()) {
-                        String msg = "Activity instance " + instanceGuid + " is read-only, cannot update activity";
-                        LOG.info(msg);
-                        throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                    if (!isStudyAdmin) {
+                        if (parentInstanceDto != null && ActivityInstanceUtil.isInstanceReadOnly(parentActivityDef, parentInstanceDto)) {
+                            String msg = "Parent activity instance " + parentInstanceDto.getGuid()
+                                    + " is read-only, cannot update child instance " + instanceGuid;
+                            LOG.info(msg);
+                            throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                        }
+                        if (ActivityInstanceUtil.isInstanceReadOnly(activityDef, instanceDto)) {
+                            String msg = "Activity instance " + instanceGuid + " is read-only, cannot update activity";
+                            LOG.info(msg);
+                            throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                        }
                     }
 
-                    formInstanceDao.loadAllSectionsForForm(handle, form, langCodeId);
-                    form.updateBlockStatuses(handle, interpreter, userGuid, operatorGuid, instanceGuid);
-
+                    FormInstance form = loadFormInstance(
+                            response, handle, userGuid, operatorGuid,
+                            instanceGuid, preferredUserLangDto, instanceSummary);
                     if (!form.isComplete()) {
                         String msg = "The status cannot be set to COMPLETE because the question requirements are not met";
                         LOG.info(msg);
                         throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.QUESTION_REQUIREMENTS_NOT_MET, msg));
                     }
 
+                    if (parentInstanceDto == null) {
+                        checkChildInstancesCompleteness(
+                                response, handle, userGuid, operatorGuid,
+                                instanceGuid, preferredUserLangDto, instanceSummary);
+                    }
+
                     // FIXME: address doesn't get saved until this PUT call finishes, so we couldn't check address here.
                     // checkAddressRequirements(handle, userGuid, form);
 
                     List<ActivityValidationFailure> validationFailures = actValidationService.validate(
-                            handle, interpreter, userGuid, operatorGuid, instanceGuid, form.getActivityId(), langCodeId
-                    );
+                            handle, interpreter, userGuid, operatorGuid, instanceGuid, form.getActivityId(),
+                            preferredUserLangDto.getId());
                     if (!validationFailures.isEmpty()) {
                         String msg = "Activity validation failed";
                         List<String> validationErrorSummaries = validationFailures
@@ -143,9 +169,20 @@ public class PutFormAnswersRoute implements Route {
                                 I18nContentRenderer.newValueProvider(handle, form.getParticipantUserId()).getSnapshot());
                     }
 
-                    FormActivityStatusUtil.updateFormActivityStatus(
-                            handle, InstanceStatusType.COMPLETE, instanceGuid, operatorGuid
-                    );
+                    User participantUser = instanceSummary.getParticipantUser();
+                    User operatorUser = participantUser;
+                    if (!userGuid.equals(operatorGuid)) {
+                        operatorUser = handle.attach(UserDao.class).findUserByGuid(operatorGuid)
+                                .orElseThrow(() -> new DDPException("Could not find operator with guid " + operatorGuid));
+                    }
+
+                    var instanceStatusDao = handle.attach(ActivityInstanceStatusDao.class);
+                    instanceStatusDao.updateOrInsertStatus(instanceDto, InstanceStatusType.COMPLETE,
+                            Instant.now().toEpochMilli(), operatorUser, participantUser);
+                    if (parentInstanceDto != null) {
+                        instanceStatusDao.updateOrInsertStatus(parentInstanceDto, InstanceStatusType.IN_PROGRESS,
+                                Instant.now().toEpochMilli(), operatorUser, participantUser);
+                    }
 
                     // Cleanup hidden answers.
                     Set<Long> answerIdsToDelete = form.collectHiddenAnswers()
@@ -182,6 +219,55 @@ public class PutFormAnswersRoute implements Route {
 
         response.status(200);
         return resp;
+    }
+
+    private FormInstance loadFormInstance(Response response,
+                                          Handle handle,
+                                          String userGuid,
+                                          String operatorGuid,
+                                          String instanceGuid,
+                                          LanguageDto preferredLangDto,
+                                          UserActivityInstanceSummary instanceSummary) {
+        long langCodeId = preferredLangDto.getId();
+        String isoLangCode = preferredLangDto.getIsoCode();
+        FormInstance form = formInstanceDao.getBaseFormByGuid(handle, instanceGuid, isoLangCode);
+        if (form == null) {
+            String msg = String.format("Could not find activity instance %s for user %s using language %s",
+                    instanceGuid, userGuid, isoLangCode);
+            LOG.warn(msg);
+            throw ResponseUtil.haltError(response, 404, new ApiError(ErrorCodes.ACTIVITY_NOT_FOUND, msg));
+        }
+        formInstanceDao.loadAllSectionsForForm(handle, form, langCodeId);
+        form.updateBlockStatuses(handle, interpreter, userGuid, operatorGuid, instanceGuid, instanceSummary);
+        return form;
+    }
+
+    private void checkChildInstancesCompleteness(Response response,
+                                                 Handle handle,
+                                                 String userGuid,
+                                                 String operatorGuid,
+                                                 String instanceGuid,
+                                                 LanguageDto preferredLangDto,
+                                                 UserActivityInstanceSummary instanceSummary) {
+        // For a parent instance, check if there are any child instances and if those are complete.
+        List<ActivityInstanceDto> childInstances = instanceSummary.getInstancesStream()
+                .filter(instance -> instanceGuid.equals(instance.getParentInstanceGuid()))
+                .collect(Collectors.toList());
+        for (var childInstanceDto : childInstances) {
+            if (childInstanceDto.getStatusType() != InstanceStatusType.COMPLETE) {
+                // Child instance is not finished but it might not have required questions, so check it.
+                FormInstance childForm = loadFormInstance(
+                        response, handle, userGuid, operatorGuid,
+                        childInstanceDto.getGuid(), preferredLangDto, instanceSummary);
+                if (!childForm.isComplete()) {
+                    String msg = "Status for instance " + instanceGuid + " cannot be set to COMPLETE because the"
+                            + " question requirements are not met for child instance " + childInstanceDto.getGuid();
+                    LOG.info(msg);
+                    throw ResponseUtil.haltError(response, 422,
+                            new ApiError(ErrorCodes.QUESTION_REQUIREMENTS_NOT_MET, msg));
+                }
+            }
+        }
     }
 
     void checkAddressRequirements(Handle handle, String participantGuid, FormInstance form) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -82,7 +82,7 @@ public class ActivityInstanceService {
         }
 
         if (ActivityType.FORMS.equals(inst.getActivityType())) {
-            ((FormInstance) inst).updateBlockStatuses(handle, interpreter, userGuid, operatorGuid, actInstanceGuid);
+            ((FormInstance) inst).updateBlockStatuses(handle, interpreter, userGuid, operatorGuid, actInstanceGuid, null);
         }
 
         return Optional.of(inst);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -398,7 +398,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
 
             block.getNested().get(0).setShown(false);
             block.getNested().get(0).setShownExpr("true");
-            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid(), null);
             assertTrue(block.getNested().get(0).isShown());
         });
     }
@@ -412,11 +412,11 @@ public class FormInstanceTest extends TxnAwareBaseTest {
             form.addBodySections(Collections.singletonList(s1));
 
             content.setShown(false);
-            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid(), null);
             assertFalse(content.isShown());
 
             content.setShownExpr("true");
-            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid(), null);
             assertTrue(content.isShown());
         });
     }
@@ -425,7 +425,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     public void testUpdateBlockStatuses_withoutExpr_defaultShown() {
         TransactionWrapper.useTxn(handle -> {
             FormInstance form = buildTestInstance();
-            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, interpreter, userGuid, userGuid, form.getGuid(), null);
 
             for (FormSection sect : form.getBodySections()) {
                 for (FormBlock block : sect.getBlocks()) {
@@ -444,10 +444,10 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             FormInstance form = buildTestInstance();
 
-            when(mockInterpreter.eval(anyString(), any(Handle.class), eq(userGuid), eq(userGuid), eq(form.getGuid())))
+            when(mockInterpreter.eval(anyString(), any(Handle.class), eq(userGuid), eq(userGuid), eq(form.getGuid()), any()))
                     .thenReturn(true);
 
-            form.updateBlockStatuses(handle, mockInterpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, mockInterpreter, userGuid, userGuid, form.getGuid(), null);
 
             for (FormSection sect : form.getBodySections()) {
                 for (FormBlock block : sect.getBlocks()) {
@@ -469,10 +469,10 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             FormInstance form = buildTestInstance();
 
-            when(mockInterpreter.eval(anyString(), any(Handle.class), eq(userGuid), eq(userGuid), eq(form.getGuid())))
+            when(mockInterpreter.eval(anyString(), any(Handle.class), eq(userGuid), eq(userGuid), eq(form.getGuid()), any()))
                     .thenThrow(new PexException("testing"));
 
-            form.updateBlockStatuses(handle, mockInterpreter, userGuid, userGuid, form.getGuid());
+            form.updateBlockStatuses(handle, mockInterpreter, userGuid, userGuid, form.getGuid(), null);
             fail("expected exception was not thrown");
         });
     }


### PR DESCRIPTION
## Context

This PR implements the last requirement for DDP-5573. I think these are significant changes so putting these changes in its own PR for more focused review. Highlights of changes:

* Updated patch/put routes to handle updating parent instance's status.
* Updated patch/put routes to check parent instance read-only status before proceeding.
* Made some small optimizations and refactors.

Part 1: #644 
Part 2: #641 

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [ ] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
