### PR TITLE
DDP-5582 support nested activity blocks

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -605,7 +605,8 @@ Block.Activity:
             using [getActivitySummary](#operation/getActivitySummary).
             These summary objects contain metadata (`canDelete`, `readOnly`) that indicate what operations are available to operate on the instance.
             The full activity instance can be retrieved using [getActivity](#operation/getActivity) with the provided `instanceGuid` or
-            deleted using [deleteActivity](#operation/deleteActivity).
+            deleted using [deleteActivity](#operation/deleteActivity). Note that these summary objects will not contain an `icon`
+            (so the value will be `null` for the `icon` property).
           type: array
           items:
             $ref: '../pepper.yml#/components/schemas/Activity.Summary'

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityDefStore.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/ActivityDefStore.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.db;
 
 import java.sql.Blob;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -190,6 +191,9 @@ public class ActivityDefStore {
                         children = ((ConditionalBlockDef) block).getNested();
                     } else if (block.getBlockType() == BlockType.GROUP) {
                         children = ((GroupBlockDef) block).getNested();
+                    } else if (block.getBlockType() == BlockType.ACTIVITY) {
+                        // Questions within the nested activity itself are not considered.
+                        children = new ArrayList<>();
                     } else {
                         throw new DDPException("Unhandled container block type " + block.getBlockType());
                     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -362,11 +362,12 @@ public interface ActivityInstanceDao extends SqlObject {
             @Bind("studyGuid") String studyGuid);
 
     @UseStringTemplateSqlLocator
-    @SqlQuery("findNestedSortedInstanceSummariesByUserAndStudyGuids")
+    @SqlQuery("findNestedSortedInstanceSummariesByUserStudyGuidsAndParentInstanceId")
     @RegisterConstructorMapper(ActivityInstanceSummaryDto.class)
     List<ActivityInstanceSummaryDto> findNestedSortedInstanceSummaries(
             @Bind("userGuid") String userGuid,
-            @Bind("studyGuid") String studyGuid);
+            @Bind("studyGuid") String studyGuid,
+            @Bind("parentInstanceId") long parentInstanceId);
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryBaseResponsesByInstanceId")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -362,6 +362,13 @@ public interface ActivityInstanceDao extends SqlObject {
             @Bind("studyGuid") String studyGuid);
 
     @UseStringTemplateSqlLocator
+    @SqlQuery("findNestedSortedInstanceSummariesByUserAndStudyGuids")
+    @RegisterConstructorMapper(ActivityInstanceSummaryDto.class)
+    List<ActivityInstanceSummaryDto> findNestedSortedInstanceSummaries(
+            @Bind("userGuid") String userGuid,
+            @Bind("studyGuid") String studyGuid);
+
+    @UseStringTemplateSqlLocator
     @SqlQuery("queryBaseResponsesByInstanceId")
     @RegisterConstructorMapper(FormResponse.class)
     @UseRowReducer(BaseActivityResponsesReducer.class)

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -29,13 +29,14 @@ public interface JdbiActivity extends SqlObject {
             + "is_write_once, instantiate_upon_registration,edit_timeout_sec,allow_ondemand_trigger,"
             + "exclude_from_display, exclude_status_icon_from_display, allow_unauthenticated, "
             + "is_followup, hide_existing_instances_on_creation, create_on_parent_creation)"
-            + " values(:activityTypeId,:studyId,:activityCode,"
+            + " values((select activity_type_id from activity_type where activity_type_code = :activityType),"
+            + ":studyId,:activityCode,"
             + ":maxInstancesPerUser,:displayOrder,:writeOnce,0,:editTimeoutSec,:allowOndemandTrigger,"
             + ":excludeFromDisplay, :excludeStatusIconFromDisplay, :allowUnauthenticated, :isFollowup, :hideExistingInstancesOnCreation,"
             + ":createOnParentCreation)")
     @GetGeneratedKeys()
     long insertActivity(
-            @Bind("activityTypeId") long activityTypeId,
+            @Bind("activityType") ActivityType activityType,
             @Bind("studyId") long studyId,
             @Bind("activityCode") String activityCode,
             @Bind("maxInstancesPerUser") Integer maxInstancesPerUser,
@@ -122,6 +123,15 @@ public interface JdbiActivity extends SqlObject {
             + "   and act.study_activity_code = :code")
     @RegisterConstructorMapper(ActivityDto.class)
     Optional<ActivityDto> findActivityByStudyGuidAndCode(@Bind("studyGuid") String studyGuid, @Bind("code") String activityCode);
+
+    @SqlQuery("select act.*, (select study_activity_code from study_activity"
+            + "       where study_activity_id = act.parent_activity_id) as parent_activity_code"
+            + "  from study_activity as act"
+            + " where act.parent_activity_id = :parentActId"
+            + "   and act.study_activity_code = :code")
+    @RegisterConstructorMapper(ActivityDto.class)
+    Optional<ActivityDto> findActivityByParentActivityIdAndActivityCode(
+            @Bind("parentActId") long parentActivityId, @Bind("code") String activityCode);
 
     @SqlQuery("select act.*, (select study_activity_code from study_activity"
             + "       where study_activity_id = act.parent_activity_id) as parent_activity_code"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlock.java
@@ -2,10 +2,19 @@ package org.broadinstitute.ddp.db.dao;
 
 import static org.broadinstitute.ddp.constants.SqlConstants.BlockTable;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.db.dto.BlockDto;
+import org.broadinstitute.ddp.db.dto.NestedActivityBlockDto;
+import org.broadinstitute.ddp.model.activity.types.NestedActivityRenderHint;
 import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -27,4 +36,47 @@ public interface JdbiBlock extends SqlObject {
             + " b.block_id = ? and b.block_type_id = bt.block_type_id")
     @RegisterRowMapper(BlockDto.BlockDtoMapper.class)
     BlockDto findById(long blockId);
+
+    @GetGeneratedKeys
+    @SqlUpdate("insert into block_nested_activity (block_id, nested_activity_id, render_hint_id,"
+            + "        allow_multiple, add_button_template_id, revision_id)"
+            + " select :blockId, :nestedActId, nested_activity_render_hint_id,"
+            + "        :allowMultiple, :addButtonTemplateId, :revisionId"
+            + "   from nested_activity_render_hint where nested_activity_render_hint_code = :renderHint")
+    long insertNestedActivityBlock(
+            @Bind("blockId") long blockId,
+            @Bind("nestedActId") long nestedActivityId,
+            @Bind("renderHint") NestedActivityRenderHint renderHint,
+            @Bind("allowMultiple") boolean allowMultiple,
+            @Bind("addButtonTemplateId") Long addButtonTemplateId,
+            @Bind("revisionId") long revisionId);
+
+    @SqlQuery("select bna.*, rh.nested_activity_render_hint_code as render_hint,"
+            + "       (select study_activity_code from study_activity"
+            + "         where study_activity_id = bna.nested_activity_id) as nested_activity_code"
+            + "  from block_nested_activity as bna"
+            + "  join nested_activity_render_hint as rh on rh.nested_activity_render_hint_id = bna.render_hint_id"
+            + "  join revision as rev on rev.revision_id = bna.revision_id"
+            + "  join activity_instance as ai on ai.activity_instance_guid = :instanceGuid"
+            + " where bna.block_id = :blockId"
+            + "   and rev.start_date <= ai.created_at"
+            + "   and (rev.end_date is null or ai.created_at < rev.end_date)")
+    @RegisterConstructorMapper(NestedActivityBlockDto.class)
+    Optional<NestedActivityBlockDto> findNestedActivityBlockDto(
+            @Bind("blockId") long blockId,
+            @Bind("instanceGuid") String instanceGuid);
+
+    @SqlQuery("select bna.*, rh.nested_activity_render_hint_code as render_hint,"
+            + "       (select study_activity_code from study_activity"
+            + "         where study_activity_id = bna.nested_activity_id) as nested_activity_code"
+            + "  from block_nested_activity as bna"
+            + "  join nested_activity_render_hint as rh on rh.nested_activity_render_hint_id = bna.render_hint_id"
+            + "  join revision as rev on rev.revision_id = bna.revision_id"
+            + " where bna.block_id in (<blockIds>)"
+            + "   and rev.start_date <= :timestamp"
+            + "   and (rev.end_date is null or :timestamp < rev.end_date)")
+    @RegisterConstructorMapper(NestedActivityBlockDto.class)
+    Stream<NestedActivityBlockDto> findNestedActivityBlockDtos(
+            @BindList(value = "blockIds", onEmpty = EmptyHandling.NULL) Iterable<Long> blockIds,
+            @Bind("timestamp") long timestamp);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/NestedActivityBlockDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/NestedActivityBlockDto.java
@@ -1,0 +1,69 @@
+package org.broadinstitute.ddp.db.dto;
+
+import org.broadinstitute.ddp.model.activity.types.NestedActivityRenderHint;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+public class NestedActivityBlockDto {
+
+    private long id;
+    private long blockId;
+    private long nestedActivityId;
+    private String nestedActivityCode;
+    private NestedActivityRenderHint renderHint;
+    private boolean allowMultiple;
+    private Long addButtonTemplateId;
+    private long revisionId;
+
+    @JdbiConstructor
+    public NestedActivityBlockDto(
+            @ColumnName("block_nested_activity_id") long id,
+            @ColumnName("block_id") long blockId,
+            @ColumnName("nested_activity_id") long nestedActivityId,
+            @ColumnName("nested_activity_code") String nestedActivityCode,
+            @ColumnName("render_hint") NestedActivityRenderHint renderHint,
+            @ColumnName("allow_multiple") boolean allowMultiple,
+            @ColumnName("add_button_template_id") Long addButtonTemplateId,
+            @ColumnName("revision_id") long revisionId) {
+        this.id = id;
+        this.blockId = blockId;
+        this.nestedActivityId = nestedActivityId;
+        this.nestedActivityCode = nestedActivityCode;
+        this.renderHint = renderHint;
+        this.allowMultiple = allowMultiple;
+        this.addButtonTemplateId = addButtonTemplateId;
+        this.revisionId = revisionId;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getBlockId() {
+        return blockId;
+    }
+
+    public long getNestedActivityId() {
+        return nestedActivityId;
+    }
+
+    public String getNestedActivityCode() {
+        return nestedActivityCode;
+    }
+
+    public NestedActivityRenderHint getRenderHint() {
+        return renderHint;
+    }
+
+    public boolean isAllowMultiple() {
+        return allowMultiple;
+    }
+
+    public Long getAddButtonTemplateId() {
+        return addButtonTemplateId;
+    }
+
+    public long getRevisionId() {
+        return revisionId;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/FormBlockDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/FormBlockDef.java
@@ -74,6 +74,8 @@ public abstract class FormBlockDef {
         public FormBlockDef deserialize(JsonElement elem, Type type, JsonDeserializationContext ctx) throws JsonParseException {
             BlockType blockType = parseBlockType(elem);
             switch (blockType) {
+                case ACTIVITY:
+                    return ctx.deserialize(elem, NestedActivityBlockDef.class);
                 case CONTENT:
                     return ctx.deserialize(elem, ContentBlockDef.class);
                 case QUESTION:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/NestedActivityBlockDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/NestedActivityBlockDef.java
@@ -1,0 +1,61 @@
+package org.broadinstitute.ddp.model.activity.definition;
+
+import java.util.stream.Stream;
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.template.Template;
+import org.broadinstitute.ddp.model.activity.types.BlockType;
+import org.broadinstitute.ddp.model.activity.types.NestedActivityRenderHint;
+
+public final class NestedActivityBlockDef extends FormBlockDef {
+
+    @NotBlank
+    @SerializedName("activityCode")
+    private String activityCode;
+
+    @NotNull
+    @SerializedName("renderHint")
+    private NestedActivityRenderHint renderHint;
+
+    @SerializedName("allowMultiple")
+    private boolean allowMultiple;
+
+    @Valid
+    @SerializedName("addButtonTemplate")
+    private Template addButtonTemplate;
+
+    public NestedActivityBlockDef(String activityCode, NestedActivityRenderHint renderHint,
+                                  boolean allowMultiple, Template addButtonTemplate) {
+        super(BlockType.ACTIVITY);
+        this.activityCode = activityCode;
+        this.renderHint = renderHint;
+        this.allowMultiple = allowMultiple;
+        this.addButtonTemplate = addButtonTemplate;
+    }
+
+    public String getActivityCode() {
+        return activityCode;
+    }
+
+    public NestedActivityRenderHint getRenderHint() {
+        return renderHint;
+    }
+
+    public boolean isAllowMultiple() {
+        return allowMultiple;
+    }
+
+    public Template getAddButtonTemplate() {
+        return addButtonTemplate;
+    }
+
+    @Override
+    public Stream<QuestionDef> getQuestions() {
+        // Questions within the nested activity itself are not considered.
+        return Stream.of();
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -277,6 +277,9 @@ public final class FormInstance extends ActivityInstance {
                         children = ((ConditionalBlock) block).getNested();
                     } else if (block.getBlockType() == BlockType.GROUP) {
                         children = ((GroupBlock) block).getNested();
+                    } else if (block.getBlockType() == BlockType.ACTIVITY) {
+                        // Questions within the nested activity itself are not considered.
+                        children = new ArrayList<>();
                     } else {
                         throw new DDPException("Unhandled container block type " + block.getBlockType());
                     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/NestedActivityBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/NestedActivityBlock.java
@@ -1,0 +1,104 @@
+package org.broadinstitute.ddp.model.activity.instance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import com.google.gson.annotations.SerializedName;
+import org.broadinstitute.ddp.content.ContentStyle;
+import org.broadinstitute.ddp.content.HtmlConverter;
+import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.model.activity.types.BlockType;
+import org.broadinstitute.ddp.model.activity.types.NestedActivityRenderHint;
+import org.broadinstitute.ddp.util.MiscUtil;
+
+public final class NestedActivityBlock extends FormBlock {
+
+    @NotBlank
+    @SerializedName("activityCode")
+    private String activityCode;
+
+    @NotNull
+    @SerializedName("renderHint")
+    private NestedActivityRenderHint renderHint;
+
+    @SerializedName("allowMultiple")
+    private boolean allowMultiple;
+
+    @SerializedName("addButtonText")
+    private String addButtonText;
+
+    @NotNull
+    @SerializedName("instances")
+    private List<ActivityInstanceSummary> instanceSummaries = new ArrayList<>();
+
+    private transient Long addButtonTemplateId;
+
+    public NestedActivityBlock(String activityCode, NestedActivityRenderHint renderHint,
+                               boolean allowMultiple, Long addButtonTemplateId) {
+        super(BlockType.ACTIVITY);
+        this.activityCode = MiscUtil.checkNotBlank(activityCode, "activityCode");
+        this.renderHint = MiscUtil.checkNonNull(renderHint, "renderHint");
+        this.allowMultiple = allowMultiple;
+        this.addButtonTemplateId = addButtonTemplateId;
+    }
+
+    public String getActivityCode() {
+        return activityCode;
+    }
+
+    public NestedActivityRenderHint getRenderHint() {
+        return renderHint;
+    }
+
+    public boolean isAllowMultiple() {
+        return allowMultiple;
+    }
+
+    public Long getAddButtonTemplateId() {
+        return addButtonTemplateId;
+    }
+
+    public String getAddButtonText() {
+        return addButtonText;
+    }
+
+    public List<ActivityInstanceSummary> getInstanceSummaries() {
+        return instanceSummaries;
+    }
+
+    public void addInstanceSummaries(List<ActivityInstanceSummary> instanceSummaries) {
+        if (instanceSummaries != null) {
+            this.instanceSummaries.addAll(instanceSummaries);
+        }
+    }
+
+    @Override
+    public boolean isComplete() {
+        // Nested child activity is checked for completeness separately.
+        return true;
+    }
+
+    @Override
+    public void registerTemplateIds(Consumer<Long> registry) {
+        if (addButtonTemplateId != null) {
+            registry.accept(addButtonTemplateId);
+        }
+    }
+
+    @Override
+    public void applyRenderedTemplates(Provider<String> rendered, ContentStyle style) {
+        if (addButtonTemplateId != null) {
+            addButtonText = rendered.get(addButtonTemplateId);
+            if (addButtonText == null) {
+                throw new NoSuchElementException("No rendered template found for addButtonText with id " + addButtonTemplateId);
+            }
+        }
+        if (style == ContentStyle.BASIC) {
+            addButtonText = HtmlConverter.getPlainText(addButtonText);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/BlockType.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/BlockType.java
@@ -9,11 +9,12 @@ public enum BlockType {
     QUESTION,
 
     // Container blocks.
+    ACTIVITY,
     CONDITIONAL,
     GROUP;
 
     public boolean isContainerBlock() {
-        return Arrays.asList(CONDITIONAL, GROUP).contains(this);
+        return Arrays.asList(ACTIVITY, CONDITIONAL, GROUP).contains(this);
     }
 
     public boolean isQuestionBlock() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/NestedActivityRenderHint.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/types/NestedActivityRenderHint.java
@@ -1,0 +1,6 @@
+package org.broadinstitute.ddp.model.activity.types;
+
+public enum NestedActivityRenderHint {
+    EMBEDDED,
+    MODAL,
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
@@ -26,6 +26,7 @@ import org.broadinstitute.ddp.model.activity.instance.GroupBlock;
 import org.broadinstitute.ddp.model.activity.instance.QuestionBlock;
 import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.instance.validation.ActivityValidationFailure;
+import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.pex.PexInterpreter;
@@ -90,7 +91,7 @@ public class GetActivityInstanceRoute implements Route {
             Optional<ActivityInstance> inst = actInstService.getTranslatedActivity(
                     handle, userGuid, operatorGuid, instanceDto.getActivityType(), instanceGuid, isoLangCode, style
             );
-            if (!inst.isPresent()) {
+            if (inst.isEmpty()) {
                 String errMsg = String.format(
                         "Unable to find activity instance %s of type '%s' in '%s'",
                         instanceGuid,
@@ -103,6 +104,10 @@ public class GetActivityInstanceRoute implements Route {
             LOG.info("Found a translation to the '{}' language code for the activity instance with GUID {}",
                     isoLangCode, instanceGuid);
             ActivityInstance activityInstance = inst.get();
+            if (activityInstance.getActivityType() == ActivityType.FORMS) {
+                actInstService.loadNestedInstanceSummaries(
+                        handle, (FormInstance) activityInstance, studyGuid, userGuid, operatorGuid, isoLangCode);
+            }
             // To-do: change this to just "if (enrollmentStatus.get() == EnrollmentStatusType.EXITED_BEFORE_ENROLLMENT)) {...}"
             // when every user registered in the system will become enrolled automatically
             // When it is implemented, the check for the enrollment status presence is not needed

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -120,7 +120,7 @@ public class ActivityInstanceService {
                 if (summaryDtos == null) {
                     summaryDtos = handle
                             .attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class)
-                            .findNestedSortedInstanceSummaries(userGuid, studyGuid);
+                            .findNestedSortedInstanceSummaries(userGuid, studyGuid, instance.getInstanceId());
                 }
                 if (studyDefaultLangCode == null) {
                     studyDefaultLangCode = new StudyLanguageCachedDao(handle)

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -36,9 +36,13 @@ import org.broadinstitute.ddp.model.activity.definition.i18n.SummaryTranslation;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
 import org.broadinstitute.ddp.model.activity.instance.ActivityInstance;
 import org.broadinstitute.ddp.model.activity.instance.ActivityResponse;
+import org.broadinstitute.ddp.model.activity.instance.FormBlock;
 import org.broadinstitute.ddp.model.activity.instance.FormInstance;
 import org.broadinstitute.ddp.model.activity.instance.FormResponse;
+import org.broadinstitute.ddp.model.activity.instance.FormSection;
+import org.broadinstitute.ddp.model.activity.instance.NestedActivityBlock;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
+import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
 import org.broadinstitute.ddp.model.study.StudyLanguage;
 import org.broadinstitute.ddp.pex.PexInterpreter;
@@ -62,8 +66,9 @@ public class ActivityInstanceService {
     }
 
     /**
-     * Get an activity instance, translated to given language. If activity is a form, visibility of
-     * blocks will be resolved as well.
+     * Get an activity instance, translated to given language. If activity is a form, visibility of blocks will be
+     * resolved as well. Activity instance summaries for nested activity blocks will not be loaded -- this should be
+     * done by caller separately.
      *
      * @param handle          the jdbi handle
      * @param userGuid        the user guid
@@ -89,28 +94,65 @@ public class ActivityInstanceService {
     }
 
     /**
-     * Get a form instance, translated to given language and with visibility of blocks resolved.
+     * Iterate through the instance and load activity instance summaries for each nested activity block.
      *
-     * @param handle           the jdbi handle
-     * @param userGuid         the user guid
-     * @param formInstanceGuid the form instance guid
-     * @param isoLangCode      the iso language code
-     * @return form instance, if found
-     * @throws DDPException if pex evaluation error
+     * @param handle       the database handle
+     * @param instance     the parent instance
+     * @param studyGuid    the study guid
+     * @param userGuid     the participant guid
+     * @param operatorGuid the operator guid
+     * @param isoLangCode  the preferred language iso code
      */
-    public Optional<FormInstance> getTranslatedForm(Handle handle, String userGuid, String operatorGuid, String formInstanceGuid,
-                                                    String isoLangCode, ContentStyle style) {
-        Function<ActivityInstance, FormInstance> typeChecker = (inst) -> {
-            if (ActivityType.FORMS.equals(inst.getActivityType())) {
-                return (FormInstance) inst;
-            } else {
-                LOG.warn("Expected a form instance but got type {} for guid {} lang code {}",
-                        inst.getActivityType(), formInstanceGuid, isoLangCode);
-                return null;
+    public void loadNestedInstanceSummaries(Handle handle, FormInstance instance, String studyGuid,
+                                            String userGuid, String operatorGuid, String isoLangCode) {
+        ActivityDefStore activityStore = ActivityDefStore.getInstance();
+
+        List<ActivityInstanceSummaryDto> summaryDtos = null;
+        String studyDefaultLangCode = null;
+
+        for (FormSection section : instance.getAllSections()) {
+            for (FormBlock block : section.getBlocks()) {
+                if (block.getBlockType() != BlockType.ACTIVITY) {
+                    continue;
+                }
+
+                // There might not be any nested activity blocks, so we do lazy-loading of data here.
+                if (summaryDtos == null) {
+                    summaryDtos = handle
+                            .attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class)
+                            .findNestedSortedInstanceSummaries(userGuid, studyGuid);
+                }
+                if (studyDefaultLangCode == null) {
+                    studyDefaultLangCode = new StudyLanguageCachedDao(handle)
+                            .findLanguages(studyGuid)
+                            .stream()
+                            .filter(StudyLanguage::isDefault)
+                            .map(StudyLanguage::getLanguageCode)
+                            .findFirst()
+                            .orElse(LanguageConstants.EN_LANGUAGE_CODE);
+                }
+
+                NestedActivityBlock nestedActBlock = (NestedActivityBlock) block;
+                List<ActivityInstanceSummaryDto> nestedSummaryDtos = summaryDtos.stream()
+                        .filter(summary -> nestedActBlock.getActivityCode().equals(summary.getActivityCode()))
+                        .collect(Collectors.toList());
+                if (nestedSummaryDtos.isEmpty()) {
+                    continue;
+                }
+
+                List<ActivityInstanceSummary> nestedSummaries = buildTranslatedInstanceSummaries(
+                        handle, activityStore, false, summaryDtos,
+                        studyGuid, isoLangCode, studyDefaultLangCode);
+                performInstanceNumbering(nestedSummaries);
+                nestedSummaries = nestedSummaries.stream()
+                        .filter(summary -> !summary.isHidden())
+                        .collect(Collectors.toList());
+                countQuestionsAndAnswers(handle, userGuid, operatorGuid, studyGuid, nestedSummaries);
+                renderInstanceSummaries(handle, instance.getParticipantUserId(), nestedSummaries);
+
+                nestedActBlock.addInstanceSummaries(nestedSummaries);
             }
-        };
-        return getTranslatedActivity(handle, userGuid, operatorGuid, ActivityType.FORMS,
-                formInstanceGuid, isoLangCode, style).map(typeChecker);
+        }
     }
 
     /**
@@ -149,27 +191,32 @@ public class ActivityInstanceService {
                 .findFirst()
                 .orElse(LanguageConstants.EN_LANGUAGE_CODE);
 
-        return buildTranslatedInstanceSummaries(handle, summaryDtos, studyGuid, preferredLangCode, studyDefaultLangCode);
+        ActivityDefStore activityStore = ActivityDefStore.getInstance();
+        return buildTranslatedInstanceSummaries(
+                handle, activityStore, true, summaryDtos,
+                studyGuid, preferredLangCode, studyDefaultLangCode);
     }
 
     // Does the heavy-lifting of translating activity properties and merging into a full activity instance summary.
     private List<ActivityInstanceSummary> buildTranslatedInstanceSummaries(Handle handle,
+                                                                           ActivityDefStore activityStore,
+                                                                           boolean renderIcon,
                                                                            List<ActivityInstanceSummaryDto> summaryDtos,
                                                                            String studyGuid,
                                                                            String preferredLangCode,
                                                                            String studyDefaultLangCode) {
-        ActivityDefStore activityDefStore = ActivityDefStore.getInstance();
-        Map<String, Blob> formTypeAndStatusTypeToIcon = activityDefStore.findActivityStatusIcons(handle, studyGuid);
         List<ActivityInstanceSummary> summaries = new ArrayList<>();
+        Map<String, Blob> formTypeAndStatusTypeToIcon =
+                renderIcon ? activityStore.findActivityStatusIcons(handle, studyGuid) : null;
 
         for (var summaryDto : summaryDtos) {
-            ActivityDto activityDto = activityDefStore
+            ActivityDto activityDto = activityStore
                     .findActivityDto(handle, summaryDto.getActivityId())
                     .orElseThrow(() -> new DDPException("Could not find activity dto for " + summaryDto.getActivityCode()));
-            ActivityVersionDto versionDto = activityDefStore
+            ActivityVersionDto versionDto = activityStore
                     .findVersionDto(handle, activityDto.getActivityId(), summaryDto.getCreatedAtMillis())
                     .orElseThrow(() -> new DDPException("Could not find activity version for instance" + summaryDto.getGuid()));
-            FormActivityDef def = activityDefStore
+            FormActivityDef def = activityStore
                     .findActivityDef(handle, studyGuid, activityDto, versionDto)
                     .orElseThrow(() -> new DDPException("Could not find activity definition for " + summaryDto.getActivityCode()));
 
@@ -190,14 +237,16 @@ public class ActivityInstanceService {
             String activityTypeCode = def.getActivityType().name();
             String formTypeCode = def.getFormType().name();
             String statusTypeCode = summaryDto.getStatusType().name();
-            String iconBase64;
-            try {
-                Blob iconBlob = def.isExcludeStatusIconFromDisplay() ? null
-                        : formTypeAndStatusTypeToIcon.get(formTypeCode + "-" + statusTypeCode);
-                iconBase64 = iconBlob == null ? null
-                        : Base64.getEncoder().encodeToString(iconBlob.getBytes(1, (int) iconBlob.length()));
-            } catch (SQLException e) {
-                throw new DDPException("Error while generating status icon", e);
+            String iconBase64 = null;
+            if (renderIcon) {
+                try {
+                    Blob iconBlob = def.isExcludeStatusIconFromDisplay() ? null
+                            : formTypeAndStatusTypeToIcon.get(formTypeCode + "-" + statusTypeCode);
+                    iconBase64 = iconBlob == null ? null
+                            : Base64.getEncoder().encodeToString(iconBlob.getBytes(1, (int) iconBlob.length()));
+                } catch (SQLException e) {
+                    throw new DDPException("Error while generating status icon", e);
+                }
             }
 
             boolean isReadonly = ActivityInstanceUtil.isReadonly(

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -252,4 +252,5 @@
     <include file="db-changes/seed/DDP-3709-file-scan-result.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-3709-file-question-and-answer.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5573-activity-nesting.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5582-nested-activity-block.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5582-nested-activity-block.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5582-nested-activity-block.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210219-nested-activity-render-hint-table">
+        <createTable tableName="nested_activity_render_hint">
+            <column name="nested_activity_render_hint_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="nested_activity_render_hint_pk"/>
+            </column>
+            <column name="nested_activity_render_hint_code" type="varchar(20)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="nested_activity_render_hint_uk"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="yufeng" id="20210219-nested-activity-render-hint-types">
+        <insert tableName="nested_activity_render_hint">
+            <column name="nested_activity_render_hint_code" value="EMBEDDED"/>
+        </insert>
+        <insert tableName="nested_activity_render_hint">
+            <column name="nested_activity_render_hint_code" value="MODAL"/>
+        </insert>
+    </changeSet>
+
+    <changeSet author="yufeng" id="20210219-activity-block-type">
+        <insert tableName="block_type">
+            <column name="block_type_code" value="ACTIVITY"/>
+        </insert>
+    </changeSet>
+
+    <changeSet author="yufeng" id="20210219-block-nested-activity-table">
+        <createTable tableName="block_nested_activity">
+            <column name="block_nested_activity_id" type="bigint" autoIncrement="true" startWith="1">
+                <constraints primaryKey="true" primaryKeyName="block_nested_activity_pk"/>
+            </column>
+            <column name="block_id" type="bigint">
+                <constraints nullable="false"
+                             references="block(block_id)"
+                             foreignKeyName="block_nested_activity_block_fk"/>
+            </column>
+            <column name="nested_activity_id" type="bigint">
+                <constraints nullable="false"
+                             references="study_activity(study_activity_id)"
+                             foreignKeyName="block_nested_activity_activity_fk"/>
+            </column>
+            <column name="render_hint_id" type="bigint">
+                <constraints nullable="false"
+                             references="nested_activity_render_hint(nested_activity_render_hint_id)"
+                             foreignKeyName="block_nested_activity_render_hint_fk"/>
+            </column>
+            <column name="allow_multiple" type="boolean">
+                <constraints nullable="false"/>
+            </column>
+            <column name="add_button_template_id" type="bigint">
+                <constraints nullable="true"
+                             references="template(template_id)"
+                             foreignKeyName="block_nested_activity_add_button_template_fk"/>
+            </column>
+            <column name="revision_id" type="bigint">
+                <constraints nullable="false"
+                             references="revision(revision_id)"
+                             foreignKeyName="block_nested_activity_revision_fk"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
@@ -113,10 +113,10 @@ findNonNestedSortedInstanceSummariesByUserAndStudyGuids() ::= <<
  order by act.display_order asc, ai.created_at desc
 >>
 
-findNestedSortedInstanceSummariesByUserAndStudyGuids() ::= <<
+findNestedSortedInstanceSummariesByUserStudyGuidsAndParentInstanceId() ::= <<
 <select_all_latest_instance_summaries()>
  where u.guid = :userGuid
    and s.guid = :studyGuid
-   and ai.parent_instance_id is not null
+   and ai.parent_instance_id = :parentInstanceId
  order by act.display_order asc, ai.created_at asc
 >>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
@@ -112,3 +112,11 @@ findNonNestedSortedInstanceSummariesByUserAndStudyGuids() ::= <<
    and actp.study_activity_id is null
  order by act.display_order asc, ai.created_at desc
 >>
+
+findNestedSortedInstanceSummariesByUserAndStudyGuids() ::= <<
+<select_all_latest_instance_summaries()>
+ where u.guid = :userGuid
+   and s.guid = :studyGuid
+   and ai.parent_instance_id is not null
+ order by act.display_order asc, ai.created_at asc
+>>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
@@ -99,9 +99,9 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             String instanceGuid = setupActivityAndInstance(handle);
 
-            Optional<FormInstance> inst = service.getTranslatedForm(handle, testData.getUserGuid(),
-                    testData.getUserGuid(), instanceGuid, "en",
-                    ContentStyle.STANDARD);
+            Optional<FormInstance> inst = service.getTranslatedActivity(handle, testData.getUserGuid(),
+                    testData.getUserGuid(), ActivityType.FORMS, instanceGuid, "en",
+                    ContentStyle.STANDARD).map(i -> (FormInstance) i);
             assertTrue(inst.isPresent());
             assertEquals(inst.get().getActivityType(), ActivityType.FORMS);
             assertEquals(inst.get().getGuid(), instanceGuid);
@@ -124,9 +124,9 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
     @Test
     public void getTranslatedForm_notFound() {
         TransactionWrapper.useTxn(handle -> {
-            Optional<FormInstance> inst = service.getTranslatedForm(handle, testData.getUserGuid(), testData.getUserGuid(),
-                    "random guid", "en",
-                    ContentStyle.STANDARD);
+            Optional<FormInstance> inst = service.getTranslatedActivity(handle, testData.getUserGuid(), testData.getUserGuid(),
+                    ActivityType.FORMS, "random guid", "en",
+                    ContentStyle.STANDARD).map(i -> (FormInstance) i);
             assertNotNull(inst);
             assertFalse(inst.isPresent());
         });


### PR DESCRIPTION
## Context

See DDP-5582. This PR implements the new `ACTIVITY` block type.

* Can now define "nested activity" block type in activity definition. Referenced activity must be a child activity.
* GetActivityInstance will now return these activity blocks along with the "child instance summaries" for each activity block.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
