### PR TITLE
DDP-5571 activity instance summary API

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -87,6 +87,7 @@ import org.broadinstitute.ddp.route.DsmTriggerOnDemandActivityRoute;
 import org.broadinstitute.ddp.route.ErrorRoute;
 import org.broadinstitute.ddp.route.GetActivityInstanceRoute;
 import org.broadinstitute.ddp.route.GetActivityInstanceStatusTypeListRoute;
+import org.broadinstitute.ddp.route.GetActivityInstanceSummaryRoute;
 import org.broadinstitute.ddp.route.GetCancerSuggestionsRoute;
 import org.broadinstitute.ddp.route.GetConsentSummariesRoute;
 import org.broadinstitute.ddp.route.GetConsentSummaryRoute;
@@ -467,6 +468,7 @@ public class DataDonationPlatform {
                 responseSerializer
         );
         patch(API.USER_ACTIVITIES_INSTANCE, new PatchActivityInstanceRoute(activityInstanceDao), responseSerializer);
+        get(API.USER_ACTIVITY_SUMMARY, new GetActivityInstanceSummaryRoute(actInstService), responseSerializer);
 
         // User activity answers routes
         FormActivityService formService = new FormActivityService(interpreter);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/RouteConstants.java
@@ -90,6 +90,8 @@ public class RouteConstants {
                 PathParam.USER_GUID, PathParam.STUDY_GUID);
         public static final String USER_ACTIVITIES_INSTANCE = fmt(BASE + "/user/%s/studies/%s/activities/%s",
                 PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
+        public static final String USER_ACTIVITY_SUMMARY = fmt(BASE + "/user/%s/studies/%s/activities/%s/summary",
+                PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
         public static final String USER_ACTIVITY_ANSWERS = fmt(BASE + "/user/%s/studies/%s/activities/%s/answers",
                 PathParam.USER_GUID, PathParam.STUDY_GUID, PathParam.INSTANCE_GUID);
         public static final String USER_ACTIVITY_UPLOADS = fmt(BASE + "/user/%s/studies/%s/activities/%s/uploads",

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.java
@@ -370,6 +370,14 @@ public interface ActivityInstanceDao extends SqlObject {
             @Bind("parentInstanceId") long parentInstanceId);
 
     @UseStringTemplateSqlLocator
+    @SqlQuery("findSortedInstanceSummariesByUserStudyActivityGuids")
+    @RegisterConstructorMapper(ActivityInstanceSummaryDto.class)
+    List<ActivityInstanceSummaryDto> findSortedInstanceSummaries(
+            @Bind("userGuid") String userGuid,
+            @Bind("studyGuid") String studyGuid,
+            @Bind("activityCode") String activityCode);
+
+    @UseStringTemplateSqlLocator
     @SqlQuery("queryBaseResponsesByInstanceId")
     @RegisterConstructorMapper(FormResponse.class)
     @UseRowReducer(BaseActivityResponsesReducer.class)

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceSummaryDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceSummaryDto.java
@@ -21,6 +21,9 @@ public class ActivityInstanceSummaryDto {
     private boolean isHidden;
     private InstanceStatusType statusType;
 
+    private int instanceNumber;
+    private String previousInstanceGuid;
+
     @JdbiConstructor
     public ActivityInstanceSummaryDto(
             @ColumnName("activity_instance_id") long id,
@@ -107,5 +110,21 @@ public class ActivityInstanceSummaryDto {
 
     public InstanceStatusType getStatusType() {
         return statusType;
+    }
+
+    public int getInstanceNumber() {
+        return instanceNumber;
+    }
+
+    public void setInstanceNumber(int instanceNumber) {
+        this.instanceNumber = instanceNumber;
+    }
+
+    public String getPreviousInstanceGuid() {
+        return previousInstanceGuid;
+    }
+
+    public void setPreviousInstanceGuid(String previousInstanceGuid) {
+        this.previousInstanceGuid = previousInstanceGuid;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRoute.java
@@ -1,0 +1,64 @@
+package org.broadinstitute.ddp.route;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.db.dto.LanguageDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.security.DDPAuth;
+import org.broadinstitute.ddp.service.ActivityInstanceService;
+import org.broadinstitute.ddp.util.RouteUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class GetActivityInstanceSummaryRoute implements Route {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GetActivityInstanceSummaryRoute.class);
+
+    private final ActivityInstanceService service;
+
+    public GetActivityInstanceSummaryRoute(ActivityInstanceService service) {
+        this.service = service;
+    }
+
+    @Override
+    public ActivityInstanceSummary handle(Request request, Response response) {
+        String studyGuid = request.params(RouteConstants.PathParam.STUDY_GUID);
+        String participantGuid = request.params(RouteConstants.PathParam.USER_GUID);
+        String instanceGuid = request.params(RouteConstants.PathParam.INSTANCE_GUID);
+
+        DDPAuth ddpAuth = RouteUtil.getDDPAuth(request);
+        String operatorGuid = StringUtils.defaultIfBlank(ddpAuth.getOperator(), participantGuid);
+        boolean isStudyAdmin = ddpAuth.hasAdminAccessToStudy(studyGuid);
+        LanguageDto preferredLangDto = RouteUtil.getUserLanguage(request);
+
+        LOG.info("Fetching summary for activity instance {} and participant {} in study {} by operator {} (isStudyAdmin={})",
+                instanceGuid, participantGuid, studyGuid, operatorGuid, isStudyAdmin);
+
+        return TransactionWrapper.withTxn(handle -> {
+            var found = RouteUtil.findUserAndStudyOrHalt(handle, participantGuid, studyGuid);
+            User participantUser = found.getUser();
+            ActivityInstanceDto instanceDto = RouteUtil.findAccessibleInstanceOrHalt(
+                    response, handle, participantUser, found.getStudyDto(), instanceGuid, isStudyAdmin);
+
+            ActivityInstanceSummary summary = service
+                    .findTranslatedInstanceSummary(handle, participantGuid, studyGuid,
+                            instanceDto.getActivityCode(), instanceGuid, preferredLangDto.getIsoCode())
+                    .orElseThrow(() -> new DDPException("Could not find translated summary for activity instance " + instanceGuid));
+
+            List<ActivityInstanceSummary> summaries = List.of(summary);
+            service.countQuestionsAndAnswers(handle, participantGuid, operatorGuid, studyGuid, summaries);
+            service.renderInstanceSummaries(handle, participantUser.getId(), summaries);
+
+            return summaries.get(0);
+        });
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserActivityInstanceListRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserActivityInstanceListRoute.java
@@ -58,8 +58,6 @@ public class UserActivityInstanceListRoute implements Route {
             List<ActivityInstanceSummary> summaries = service.listTranslatedInstanceSummaries(
                     handle, userGuid, studyGuid, preferredUserLanguage.getIsoCode()
             );
-            // IMPORTANT: do numbering before filtering so each instance is assigned their correct number.
-            service.performInstanceNumbering(summaries);
             if (!isStudyAdmin) {
                 // Study admins are allowed to view all the data, so if they're NOT admin then do filtering.
                 summaries = filterActivityInstancesFromDisplay(summaries);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/RouteUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/RouteUtil.java
@@ -190,6 +190,21 @@ public class RouteUtil {
         return instanceDto;
     }
 
+    public static ActivityInstanceDto findAccessibleInstanceOrHalt(Response response, Handle handle,
+                                                                   User participantUser, StudyDto studyDto,
+                                                                   String instanceGuid, boolean isOperatorStudyAdmin) {
+        ActivityInstanceDto instanceDto = handle.attach(JdbiActivityInstance.class)
+                .getByActivityInstanceGuid(instanceGuid)
+                .orElseThrow(() -> {
+                    String msg = "Could not find activity instance with guid " + instanceGuid;
+                    return ResponseUtil.haltError(response, 404, new ApiError(ErrorCodes.ACTIVITY_NOT_FOUND, msg));
+                });
+        haltIfError(participantUser, participantUser.getGuid(),
+                studyDto.getGuid(), instanceGuid, studyDto,
+                instanceDto, response, isOperatorStudyAdmin);
+        return instanceDto;
+    }
+
     public static void haltIfError(User user, String participantGuid, String studyGuid, String instanceGuid, StudyDto studyDto,
                                    ActivityInstanceDto instanceDto, Response response, boolean isOperatorStudyAdmin) {
         if (instanceDto.getStudyId() != studyDto.getId() || instanceDto.getParticipantId() != user.getId()) {

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
@@ -120,3 +120,11 @@ findNestedSortedInstanceSummariesByUserStudyGuidsAndParentInstanceId() ::= <<
    and ai.parent_instance_id = :parentInstanceId
  order by act.display_order asc, ai.created_at asc
 >>
+
+findSortedInstanceSummariesByUserStudyActivityGuids() ::= <<
+<select_all_latest_instance_summaries()>
+ where u.guid = :userGuid
+   and s.guid = :studyGuid
+   and act.study_activity_code = :activityCode
+ order by ai.created_at asc
+>>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
@@ -1,0 +1,177 @@
+package org.broadinstitute.ddp.route;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import io.restassured.http.ContentType;
+import org.broadinstitute.ddp.constants.ErrorCodes;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.ActivityDao;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.AuthDao;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.jdbi.v3.core.Handle;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.TestCase {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+    private static FormActivityDef parentActivity;
+    private static FormActivityDef nestedActivity;
+    private static ActivityInstanceDto parentInstanceDto;
+    private static ActivityInstanceDto nestedInstanceDto;
+    private static String token;
+    private static String url;
+
+    @BeforeClass
+    public static void setup() {
+        TransactionWrapper.useTxn(handle -> {
+            testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            token = testData.getTestingUser().getToken();
+            setupActivityAndInstance(handle);
+        });
+        String endpoint = RouteConstants.API.USER_ACTIVITY_SUMMARY
+                .replace(RouteConstants.PathParam.USER_GUID, testData.getUserGuid())
+                .replace(RouteConstants.PathParam.STUDY_GUID, testData.getStudyGuid())
+                .replace(RouteConstants.PathParam.INSTANCE_GUID, "{instanceGuid}");
+        url = RouteTestUtil.getTestingBaseUrl() + endpoint;
+    }
+
+    private static void setupActivityAndInstance(Handle handle) {
+        String activityCode = "ACT_SUMMARY" + Instant.now().toEpochMilli();
+        nestedActivity = FormActivityDef.generalFormBuilder(activityCode + "_NESTED", "v1", testData.getStudyGuid())
+                .addName(new Translation("en", "nested activity"))
+                .setParentActivityCode(activityCode)
+                .build();
+        parentActivity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
+                .addName(new Translation("en", "parent activity"))
+                .build();
+        handle.attach(ActivityDao.class).insertActivity(
+                parentActivity, List.of(nestedActivity),
+                RevisionMetadata.now(testData.getUserId(), "test"));
+
+        var instanceDao = handle.attach(ActivityInstanceDao.class);
+        parentInstanceDto = instanceDao.insertInstance(parentActivity.getActivityId(), testData.getUserGuid());
+        nestedInstanceDto = instanceDao.insertInstance(nestedActivity.getActivityId(), testData.getUserGuid(),
+                testData.getUserGuid(), parentInstanceDto.getId());
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        TransactionWrapper.useTxn(handle -> {
+            var instanceDao = handle.attach(ActivityInstanceDao.class);
+            instanceDao.deleteByInstanceGuid(nestedInstanceDto.getGuid());
+            instanceDao.deleteByInstanceGuid(parentInstanceDto.getGuid());
+        });
+    }
+
+    @Test
+    public void testSuccessful() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                .when().get(url).then().assertThat()
+                .statusCode(200).contentType(ContentType.JSON)
+                .body("activityCode", equalTo(parentActivity.getActivityCode()))
+                .body("instanceGuid", equalTo(parentInstanceDto.getGuid()));
+    }
+
+    @Test
+    public void testSuccessful_childInstanceSummary() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", nestedInstanceDto.getGuid())
+                .when().get(url).then().assertThat()
+                .statusCode(200).contentType(ContentType.JSON)
+                .body("activityCode", equalTo(nestedActivity.getActivityCode()))
+                .body("instanceGuid", equalTo(nestedInstanceDto.getGuid()));
+    }
+
+    @Test
+    public void testInstanceNotFound() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", "foobar")
+                .when().get(url).then().assertThat()
+                .statusCode(404).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.ACTIVITY_NOT_FOUND))
+                .body("message", containsString("Could not find"));
+    }
+
+    @Test
+    public void testInstanceIsHidden() {
+        TransactionWrapper.useTxn(handle -> assertEquals(1, handle
+                .attach(ActivityInstanceDao.class)
+                .bulkUpdateIsHiddenByActivityIds(
+                        testData.getUserId(), true, Set.of(parentActivity.getActivityId()))));
+        try {
+            given().auth().oauth2(token)
+                    .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                    .when().get(url).then().assertThat()
+                    .statusCode(404).contentType(ContentType.JSON)
+                    .body("code", equalTo(ErrorCodes.ACTIVITY_NOT_FOUND))
+                    .body("message", containsString("is hidden"));
+        } finally {
+            TransactionWrapper.useTxn(handle -> assertEquals(1, handle
+                    .attach(ActivityInstanceDao.class)
+                    .bulkUpdateIsHiddenByActivityIds(
+                            testData.getUserId(), false, Set.of(parentActivity.getActivityId()))));
+        }
+    }
+
+    @Test
+    public void testMultipleInstancesOfActivity() {
+        ActivityInstanceDto anotherInstanceDto = TransactionWrapper.withTxn(handle -> handle
+                .attach(ActivityInstanceDao.class)
+                .insertInstance(nestedActivity.getActivityId(), testData.getUserGuid(),
+                        testData.getUserGuid(), parentInstanceDto.getId()));
+        try {
+            given().auth().oauth2(token)
+                    .pathParam("instanceGuid", anotherInstanceDto.getGuid())
+                    .when().get(url).then().assertThat()
+                    .statusCode(200).contentType(ContentType.JSON)
+                    .body("activityCode", equalTo(nestedActivity.getActivityCode()))
+                    .body("instanceGuid", equalTo(anotherInstanceDto.getGuid()))
+                    .body("activityName", containsString("#2"));
+        } finally {
+            TransactionWrapper.useTxn(handle -> handle
+                    .attach(ActivityInstanceDao.class)
+                    .deleteByInstanceGuid(anotherInstanceDto.getGuid()));
+        }
+    }
+
+    @Test
+    public void testStudyAdmin_instanceIsHidden_stillReturned() {
+        TransactionWrapper.useTxn(handle -> {
+            assertEquals(1, handle.attach(ActivityInstanceDao.class)
+                    .bulkUpdateIsHiddenByActivityIds(
+                            testData.getUserId(), true, Set.of(parentActivity.getActivityId())));
+            handle.attach(AuthDao.class).assignStudyAdmin(testData.getUserId(), testData.getStudyId());
+        });
+        try {
+            given().auth().oauth2(token)
+                    .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                    .when().get(url).then().assertThat()
+                    .statusCode(200).contentType(ContentType.JSON)
+                    .body("instanceGuid", equalTo(parentInstanceDto.getGuid()))
+                    .body("isHidden", equalTo(true));
+        } finally {
+            TransactionWrapper.useTxn(handle -> {
+                assertEquals(1, handle.attach(ActivityInstanceDao.class)
+                        .bulkUpdateIsHiddenByActivityIds(
+                                testData.getUserId(), false, Set.of(parentActivity.getActivityId())));
+                handle.attach(AuthDao.class).removeAdminFromAllStudies(testData.getUserId());
+            });
+        }
+    }
+}

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/IntegrationTestSuite.java
@@ -76,6 +76,7 @@ import org.slf4j.LoggerFactory;
         DsmTriggerOnDemandActivityRouteTest.class,
         EmbeddedComponentActivityInstanceTest.class,
         ErrorHandlingRouteTest.class,
+        GetActivityInstanceSummaryRouteTest.class,
         GetConsentSummariesRouteTest.class,
         GetConsentSummaryRouteTest.class,
         GetDsmKitRequestsRouteTest.class,


### PR DESCRIPTION
## Context

See DDP-5571. This PR implements the new API endpoint for fetching single activity instance summary ([see docs here](https://pepper-dev.datadonationplatform.org/docs#operation/getActivitySummary)).

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
