### PR TITLE
DDP-5585 include parent instance guid in API responses

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
@@ -13,6 +13,9 @@ public class ActivityInstanceSummary implements TranslatedSummary {
     @SerializedName("instanceGuid")
     private String activityInstanceGuid;
 
+    @SerializedName("parentInstanceGuid")
+    private String parentInstanceGuid;
+
     @SerializedName("activityName")
     private String activityName;
 
@@ -266,5 +269,13 @@ public class ActivityInstanceSummary implements TranslatedSummary {
 
     public void setPreviousInstanceGuid(String previousInstanceGuid) {
         this.previousInstanceGuid = previousInstanceGuid;
+    }
+
+    public String getParentInstanceGuid() {
+        return parentInstanceGuid;
+    }
+
+    public void setParentInstanceGuid(String parentInstanceGuid) {
+        this.parentInstanceGuid = parentInstanceGuid;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
@@ -17,6 +17,9 @@ public class ActivityInstance {
     @SerializedName("guid")
     private String guid;
 
+    @SerializedName("parentInstanceGuid")
+    private String parentInstanceGuid;
+
     @SerializedName("activityCode")
     private String activityCode;
 
@@ -145,5 +148,13 @@ public class ActivityInstance {
      */
     public boolean isHidden() {
         return isHidden;
+    }
+
+    public String getParentInstanceGuid() {
+        return parentInstanceGuid;
+    }
+
+    public void setParentInstanceGuid(String parentInstanceGuid) {
+        this.parentInstanceGuid = parentInstanceGuid;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
@@ -104,6 +104,7 @@ public class GetActivityInstanceRoute implements Route {
             LOG.info("Found a translation to the '{}' language code for the activity instance with GUID {}",
                     isoLangCode, instanceGuid);
             ActivityInstance activityInstance = inst.get();
+            activityInstance.setParentInstanceGuid(instanceDto.getParentInstanceGuid());
             if (activityInstance.getActivityType() == ActivityType.FORMS) {
                 actInstService.loadNestedInstanceSummaries(
                         handle, (FormInstance) activityInstance, studyGuid, userGuid, operatorGuid, isoLangCode);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -363,6 +363,7 @@ public class ActivityInstanceService {
                     versionDto.getRevStart());
             summary.setInstanceNumber(summaryDto.getInstanceNumber());
             summary.setPreviousInstanceGuid(summaryDto.getPreviousInstanceGuid());
+            summary.setParentInstanceGuid(summaryDto.getParentInstanceGuid());
             summaries.add(summary);
         }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
@@ -342,6 +342,7 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
         assertEquals(instanceDto.getGuid(), inst.getGuid());
         assertEquals(activityCode, inst.getActivityCode());
         assertEquals(InstanceStatusType.CREATED, inst.getStatusType());
+        assertEquals(parentInstanceDto.getGuid(), inst.getParentInstanceGuid());
     }
 
     @Test
@@ -402,8 +403,9 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
                 .pathParam("instanceGuid", parentInstanceDto.getGuid())
                 .when().get(url).then().assertThat()
                 .statusCode(200).contentType(ContentType.JSON)
-                .log().all()
                 .body("activityCode", equalTo(parentActivity.getActivityCode()))
+                .body("guid", equalTo(parentInstanceDto.getGuid()))
+                .body("parentInstanceGuid", nullValue())
                 .root("sections[0].blocks[0]")
                 .body("blockType", equalTo(BlockType.ACTIVITY.name()))
                 .body("activityCode", equalTo(activityCode))

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.route;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Instant;
@@ -85,7 +86,8 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .when().get(url).then().assertThat()
                 .statusCode(200).contentType(ContentType.JSON)
                 .body("activityCode", equalTo(parentActivity.getActivityCode()))
-                .body("instanceGuid", equalTo(parentInstanceDto.getGuid()));
+                .body("instanceGuid", equalTo(parentInstanceDto.getGuid()))
+                .body("parentInstanceGuid", nullValue());
     }
 
     @Test
@@ -95,7 +97,8 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .when().get(url).then().assertThat()
                 .statusCode(200).contentType(ContentType.JSON)
                 .body("activityCode", equalTo(nestedActivity.getActivityCode()))
-                .body("instanceGuid", equalTo(nestedInstanceDto.getGuid()));
+                .body("instanceGuid", equalTo(nestedInstanceDto.getGuid()))
+                .body("parentInstanceGuid", equalTo(parentInstanceDto.getGuid()));
     }
 
     @Test
@@ -142,6 +145,7 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                     .statusCode(200).contentType(ContentType.JSON)
                     .body("activityCode", equalTo(nestedActivity.getActivityCode()))
                     .body("instanceGuid", equalTo(anotherInstanceDto.getGuid()))
+                    .body("parentInstanceGuid", equalTo(parentInstanceDto.getGuid()))
                     .body("activityName", containsString("#2"));
         } finally {
             TransactionWrapper.useTxn(handle -> handle

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserActivityInstanceListRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserActivityInstanceListRouteStandaloneTest.java
@@ -4,6 +4,7 @@ import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
@@ -174,6 +175,7 @@ public class UserActivityInstanceListRouteStandaloneTest extends IntegrationTest
         boolean hasReadonlyActivities = false;
         assertEquals(userActivities.size(), 1);
         ActivityInstanceSummary userActivity = userActivities.get(0);
+        assertNull(userActivity.getParentInstanceGuid());
         assertEquals(userActivity.getNumQuestionsAnswered(), 1);
         assertEquals(userActivity.getNumQuestions(), 2);
         if (ActivityType.FORMS.name().equals(userActivity.getActivityType())) {


### PR DESCRIPTION
## Context

See DDP-5585. This PR exposes new `parentInstanceGuid` property in both the "instance summary" and "full instance" objects. Note that no sql queries were changed in this PR because we are already querying for the necessary data.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
