### PR TITLE
DDP-5574 update create instance endpoint to require parent instance

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1135,7 +1135,7 @@ Error.StudyExit:
           enum:
             - OPERATION_NOT_ALLOWED
             - NOT_SUPPORTED
-Error.TooManyInstances:
+Error.CreateActivityInstance:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Error'
     - type: object
@@ -1143,6 +1143,7 @@ Error.TooManyInstances:
         code:
           type: string
           enum:
+            - ACTIVITY_INSTANCE_IS_READONLY
             - TOO_MANY_INSTANCES
 Error.UserStudyActivityNotFound:
   allOf:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activities.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activities.yml
@@ -31,7 +31,16 @@ post:
   tags:
     - Activities
   summary: create a new instance of an activity
-  description: Given an `activityCode`, the server will create a new instance of the activity for the specified user if the configured conditions for the activity is met.
+  description: |
+    Given an `activityCode`, the server will create a new instance of the activity
+    for the specified user if the configured conditions for the activity is met.
+    When creating instances of child nested activities, request must provide the
+    corresponding parent activity instance.
+
+    **Study Admins**
+
+    Creating child instance is not supported if parent instance is hidden or
+    read-only, unless operator is a study admin.
   requestBody:
     required: true
     content:
@@ -47,7 +56,7 @@ post:
               example: ABCDEFGH12
             parentInstanceGuid:
               description: |
-                in the case the activity instance being created is a child activity, need to specify the parent instance with their guid.
+                In the case the activity instance being created is a child activity, need to specify the parent instance guid.
               type: string
               example: ABCDEFGH12
   responses:
@@ -76,10 +85,10 @@ post:
             schema:
               $ref: '../pepper.yml#/components/schemas/Error.UserStudyActivityNotFound'
       422:
-        description: activity instance failed to be created
+        description: activity instance failed to be created, e.g. too many instances or parent is read-only
         content:
           application/json:
             schema:
-              $ref: '../pepper.yml#/components/schemas/Error.TooManyInstances'
+              $ref: '../pepper.yml#/components/schemas/Error.CreateActivityInstance'
       default:
         $ref: '../pepper.yml#/components/responses/ErrorResponse'

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceCreationValidation.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityInstanceCreationValidation.java
@@ -6,6 +6,8 @@ import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 public class ActivityInstanceCreationValidation {
 
     private final long activityId;
+    private final Long parentActivityId;
+    private final String parentActivityCode;
     private final boolean hideExistingInstancesOnCreation;
     private final Integer maxInstancesPerUser;
     private final int numInstancesForUser;
@@ -14,10 +16,14 @@ public class ActivityInstanceCreationValidation {
     @JdbiConstructor
     public ActivityInstanceCreationValidation(
             @ColumnName("study_activity_id") long activityId,
+            @ColumnName("parent_activity_id") Long parentActivityId,
+            @ColumnName("parent_activity_code") String parentActivityCode,
             @ColumnName("hide_existing_instances_on_creation") boolean hideExistingInstancesOnCreation,
             @ColumnName("max_instances_per_user") Integer maxInstancesPerUser,
             @ColumnName("num_instances_for_user") int numInstancesForUser) {
         this.activityId = activityId;
+        this.parentActivityId = parentActivityId;
+        this.parentActivityCode = parentActivityCode;
         this.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
         this.maxInstancesPerUser = maxInstancesPerUser;
         this.numInstancesForUser = numInstancesForUser;
@@ -30,6 +36,14 @@ public class ActivityInstanceCreationValidation {
 
     public long getActivityId() {
         return activityId;
+    }
+
+    public Long getParentActivityId() {
+        return parentActivityId;
+    }
+
+    public String getParentActivityCode() {
+        return parentActivityCode;
     }
 
     public boolean isHideExistingInstancesOnCreation() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/ActivityInstanceCreationPayload.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/ActivityInstanceCreationPayload.java
@@ -10,12 +10,23 @@ public class ActivityInstanceCreationPayload {
     @SerializedName("activityCode")
     private String activityCode;
 
+    @SerializedName("parentInstanceGuid")
+    private String parentInstanceGuid;
+
     public ActivityInstanceCreationPayload(String activityCode) {
         this.activityCode = activityCode;
+    }
+
+    public ActivityInstanceCreationPayload(String activityCode, String parentInstanceGuid) {
+        this.activityCode = activityCode;
+        this.parentInstanceGuid = parentInstanceGuid;
     }
 
     public String getActivityCode() {
         return activityCode;
     }
 
+    public String getParentInstanceGuid() {
+        return parentInstanceGuid;
+    }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateActivityInstanceRoute.java
@@ -2,16 +2,22 @@ package org.broadinstitute.ddp.route;
 
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.DataExportDao;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceCreationValidation;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.json.ActivityInstanceCreationPayload;
 import org.broadinstitute.ddp.json.ActivityInstanceCreationResponse;
 import org.broadinstitute.ddp.json.errors.ApiError;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.security.DDPAuth;
+import org.broadinstitute.ddp.util.ActivityInstanceUtil;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
 import org.broadinstitute.ddp.util.ValidatedJsonInputRoute;
@@ -31,13 +37,19 @@ public class CreateActivityInstanceRoute extends ValidatedJsonInputRoute<Activit
 
     @Override
     public Object handle(Request request, Response response, ActivityInstanceCreationPayload payload) throws Exception {
-        String activityCode = payload.getActivityCode();
         String participantGuid = request.params(RouteConstants.PathParam.USER_GUID);
         String studyGuid = request.params(RouteConstants.PathParam.STUDY_GUID);
-        String operatorGuid = RouteUtil.getDDPAuth(request).getOperator();
 
-        LOG.info("Request to create instance of activity {} in study {} for user {} by operator {}",
-                activityCode, studyGuid, participantGuid, operatorGuid);
+        DDPAuth ddpAuth = RouteUtil.getDDPAuth(request);
+        String operatorGuid = StringUtils.defaultIfBlank(ddpAuth.getOperator(), participantGuid);
+        boolean isStudyAdmin = ddpAuth.hasAdminAccessToStudy(studyGuid);
+
+        String activityCode = payload.getActivityCode();
+        String parentInstanceGuid = payload.getParentInstanceGuid();
+
+        LOG.info("Request to create instance of activity {} in study {} for user {}"
+                        + " and parent instance {} by operator {} (isStudyAdmin={})",
+                activityCode, studyGuid, participantGuid, parentInstanceGuid, operatorGuid, isStudyAdmin);
 
         return TransactionWrapper.withTxn(handle -> {
             var found = RouteUtil.findUserAndStudyOrHalt(handle, participantGuid, studyGuid);
@@ -52,14 +64,47 @@ public class CreateActivityInstanceRoute extends ValidatedJsonInputRoute<Activit
                 var err = new ApiError(ErrorCodes.ACTIVITY_NOT_FOUND,
                         "Could not find creation validation information for activity " + activityCode);
                 LOG.warn(err.getMessage());
-                throw ResponseUtil.haltError(response, 404, err);
+                throw ResponseUtil.haltError(response, HttpStatus.SC_NOT_FOUND, err);
+            }
+
+            Long parentInstanceId = null;
+            if (validation.getParentActivityCode() != null) {
+                if (StringUtils.isBlank(parentInstanceGuid)) {
+                    String msg = "Creating child nested activity instance requires parent instance guid";
+                    LOG.warn(msg);
+                    throw ResponseUtil.haltError(response, HttpStatus.SC_BAD_REQUEST,
+                            new ApiError(ErrorCodes.BAD_PAYLOAD, msg));
+                }
+
+                ActivityInstanceDto parentInstanceDto = RouteUtil.findAccessibleInstanceOrHalt(
+                        response, handle, found.getUser(), found.getStudyDto(),
+                        parentInstanceGuid, isStudyAdmin);
+
+                if (!validation.getParentActivityCode().equals(parentInstanceDto.getActivityCode())) {
+                    String msg = "Child activity's parent activity does not match provided parent instance's activity";
+                    LOG.warn(msg);
+                    throw ResponseUtil.haltError(response, HttpStatus.SC_BAD_REQUEST,
+                            new ApiError(ErrorCodes.BAD_PAYLOAD, msg));
+                }
+
+                ActivityDefStore activityStore = ActivityDefStore.getInstance();
+                FormActivityDef parentActivity = ActivityInstanceUtil.getActivityDef(handle, activityStore, parentInstanceDto, studyGuid);
+                if (!isStudyAdmin && ActivityInstanceUtil.isInstanceReadOnly(parentActivity, parentInstanceDto)) {
+                    String msg = "Could not create child activity instance, parent instance is read-only";
+                    LOG.warn(msg);
+                    throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
+                            new ApiError(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY, msg));
+                }
+
+                parentInstanceId = parentInstanceDto.getId();
             }
 
             // check for max instances
             if (validation.hasTooManyInstances()) {
                 LOG.warn("Participant has {} instances which exceeds max allowed of {}",
                         validation.getNumInstancesForUser(), validation.getMaxInstancesPerUser());
-                throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.TOO_MANY_INSTANCES, null));
+                throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
+                        new ApiError(ErrorCodes.TOO_MANY_INSTANCES, null));
             }
 
             long studyActivityId = validation.getActivityId();
@@ -67,7 +112,6 @@ public class CreateActivityInstanceRoute extends ValidatedJsonInputRoute<Activit
                 activityInstanceDao.bulkUpdateIsHiddenByActivityIds(participantId, true, Set.of(studyActivityId));
             }
 
-            Long parentInstanceId = null;
             String instanceGuid = activityInstanceDao
                     .insertInstance(studyActivityId, operatorGuid, participantGuid, parentInstanceId)
                     .getGuid();

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/ActivityInstanceDao.sql.stg
@@ -2,6 +2,11 @@ group ActivityInstanceDao;
 
 queryActivityInstanceCreationValidation() ::= <<
 select act.study_activity_id,
+       act.parent_activity_id,
+       (select study_activity_code
+          from study_activity
+         where study_activity_id = act.parent_activity_id
+       ) as parent_activity_code,
        act.hide_existing_instances_on_creation,
        act.max_instances_per_user,
        (select count(1)

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateActivityInstanceRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/CreateActivityInstanceRouteTest.java
@@ -1,13 +1,18 @@
 package org.broadinstitute.ddp.route;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
@@ -16,11 +21,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.AuthDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.json.ActivityInstanceCreationPayload;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.broadinstitute.ddp.util.TestFormActivity;
 import org.junit.After;
@@ -30,8 +40,11 @@ import org.junit.Test;
 public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCase {
 
     private static final Collection<String> activityInstancesToDelete = new HashSet<>();
+    private static final Collection<String> parentInstancesToDelete = new HashSet<>();
     private static TestDataSetupUtil.GeneratedTestData testData;
-    private static TestFormActivity act;
+    private static TestFormActivity anotherActivity;
+    private static FormActivityDef parentActivity;
+    private static FormActivityDef nestedActivity;
     private static String token;
     private static String url;
 
@@ -43,29 +56,52 @@ public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCa
                     .replace(RouteConstants.PathParam.USER_GUID, testData.getUserGuid())
                     .replace(RouteConstants.PathParam.STUDY_GUID, testData.getStudyGuid());
             url = RouteTestUtil.getTestingBaseUrl() + endpoint;
+            token = testData.getTestingUser().getToken();
 
-            act = TestFormActivity.builder()
-                    .setMaxInstancesPerUser(1)
-                    .setHideExistingInstances(true)
+            anotherActivity = TestFormActivity.builder()
                     .build(handle, testData.getUserId(), testData.getStudyGuid());
 
-            token = testData.getTestingUser().getToken();
+            String activityCode = "ACT" + Instant.now().toEpochMilli();
+            nestedActivity = FormActivityDef.generalFormBuilder(activityCode + "_NESTED", "v1", testData.getStudyGuid())
+                    .addName(new Translation("en", "nested activity"))
+                    .setParentActivityCode(activityCode)
+                    .build();
+            parentActivity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
+                    .addName(new Translation("en", "parent activity"))
+                    .setMaxInstancesPerUser(1)
+                    .setHideInstances(true)
+                    .build();
+            handle.attach(ActivityDao.class).insertActivity(
+                    parentActivity, List.of(nestedActivity),
+                    RevisionMetadata.now(testData.getUserId(), "test"));
         });
     }
 
     @After
     public void deleteCreatedInstances() {
         TransactionWrapper.useTxn(handle -> {
+            // Delete child instances before parent instances.
             var instanceDao = handle.attach(ActivityInstanceDao.class);
-            for (var instanceGuid : activityInstancesToDelete) {
+            var instanceGuids = new ArrayList<>(activityInstancesToDelete);
+            instanceGuids.addAll(parentInstancesToDelete);
+            for (var instanceGuid : instanceGuids) {
                 instanceDao.deleteByInstanceGuid(instanceGuid);
             }
         });
         activityInstancesToDelete.clear();
+        parentInstancesToDelete.clear();
     }
 
     private ValidatableResponse makeCreationRequest(String activityCode) {
-        ActivityInstanceCreationPayload payload = new ActivityInstanceCreationPayload(activityCode);
+        var payload = new ActivityInstanceCreationPayload(activityCode);
+        return given().auth().oauth2(token)
+                .body(payload, ObjectMapperType.GSON)
+                .when().post(url)
+                .then().assertThat();
+    }
+
+    private ValidatableResponse makeChildCreationRequest(String activityCode, String parentInstanceGuid) {
+        var payload = new ActivityInstanceCreationPayload(activityCode, parentInstanceGuid);
         return given().auth().oauth2(token)
                 .body(payload, ObjectMapperType.GSON)
                 .when().post(url)
@@ -95,7 +131,7 @@ public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCa
 
     @Test
     public void testCreateActivityNoExistingInstancesShouldSucceed() {
-        String instanceGuid = makeCreationRequest(act.getDef().getActivityCode())
+        String instanceGuid = makeCreationRequest(parentActivity.getActivityCode())
                 .statusCode(200).and().extract().path("instanceGuid");
 
         assertTrue(StringUtils.isNotBlank(instanceGuid));
@@ -106,17 +142,18 @@ public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCa
                 .getByActivityInstanceGuid(instanceGuid)
                 .orElse(null));
         assertNotNull(instance);
+        assertNull("should not have a parent", instance.getParentInstanceGuid());
     }
 
     @Test
     public void testCreateActivityShouldFailBecauseTooManyInstances() {
-        String instanceGuid = makeCreationRequest(act.getDef().getActivityCode())
+        String instanceGuid = makeCreationRequest(parentActivity.getActivityCode())
                 .statusCode(200).and().extract().path("instanceGuid");
 
         assertTrue(StringUtils.isNoneBlank(instanceGuid));
         activityInstancesToDelete.add(instanceGuid);
 
-        makeCreationRequest(act.getDef().getActivityCode())
+        makeCreationRequest(parentActivity.getActivityCode())
                 .statusCode(422)
                 .contentType(ContentType.JSON)
                 .body("code", equalTo(ErrorCodes.TOO_MANY_INSTANCES));
@@ -126,15 +163,15 @@ public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCa
     public void testCreateActivityShouldHideExistingInstances() {
         TransactionWrapper.useTxn(handle -> assertEquals(1, handle
                 .attach(JdbiActivity.class)
-                .updateMaxInstancesPerUserById(act.getDef().getActivityId(), null)));
+                .updateMaxInstancesPerUserById(parentActivity.getActivityId(), null)));
 
-        String firstInstanceGuid = makeCreationRequest(act.getDef().getActivityCode())
+        String firstInstanceGuid = makeCreationRequest(parentActivity.getActivityCode())
                 .statusCode(200).and().extract().path("instanceGuid");
 
         assertTrue(StringUtils.isNoneBlank(firstInstanceGuid));
         activityInstancesToDelete.add(firstInstanceGuid);
 
-        String secondInstanceGuid = makeCreationRequest(act.getDef().getActivityCode())
+        String secondInstanceGuid = makeCreationRequest(parentActivity.getActivityCode())
                 .statusCode(200).and().extract().path("instanceGuid");
 
         assertTrue(StringUtils.isNoneBlank(secondInstanceGuid));
@@ -150,7 +187,96 @@ public class CreateActivityInstanceRouteTest extends IntegrationTestSuite.TestCa
         } finally {
             TransactionWrapper.useTxn(handle -> assertEquals(1, handle
                     .attach(JdbiActivity.class)
-                    .updateMaxInstancesPerUserById(act.getDef().getActivityId(), 1)));
+                    .updateMaxInstancesPerUserById(parentActivity.getActivityId(), 1)));
+        }
+    }
+
+    @Test
+    public void testCreateChildActivity_missingParentInstanceGuid() {
+        makeChildCreationRequest(nestedActivity.getActivityCode(), "")
+                .statusCode(400).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.BAD_PAYLOAD))
+                .body("message", containsString("requires parent instance guid"));
+    }
+
+    @Test
+    public void testCreateChildActivity_parentInstanceNotFound() {
+        makeChildCreationRequest(nestedActivity.getActivityCode(), "foobar")
+                .statusCode(404).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.ACTIVITY_NOT_FOUND))
+                .body("message", containsString("Could not find activity instance"));
+    }
+
+    @Test
+    public void testCreateChildActivity_incorrectParentActivity() {
+        String someInstanceGuid = makeCreationRequest(anotherActivity.getDef().getActivityCode())
+                .statusCode(200).and().extract().path("instanceGuid");
+        activityInstancesToDelete.add(someInstanceGuid);
+
+        makeChildCreationRequest(nestedActivity.getActivityCode(), someInstanceGuid)
+                .statusCode(400).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.BAD_PAYLOAD))
+                .body("message", containsString("does not match"));
+    }
+
+    @Test
+    public void testCreateChildActivity_parentInstanceReadOnly() {
+        String parentInstanceGuid = makeCreationRequest(parentActivity.getActivityCode())
+                .statusCode(200).and().extract().path("instanceGuid");
+        parentInstancesToDelete.add(parentInstanceGuid);
+
+        TransactionWrapper.useTxn(handle -> assertEquals(1, handle
+                .attach(JdbiActivityInstance.class)
+                .updateIsReadonlyByGuid(true, parentInstanceGuid)));
+
+        makeChildCreationRequest(nestedActivity.getActivityCode(), parentInstanceGuid)
+                .statusCode(422).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.ACTIVITY_INSTANCE_IS_READONLY))
+                .body("message", containsString("read-only"));
+    }
+
+    @Test
+    public void testCreateChildActivity_success() {
+        String parentInstanceGuid = makeCreationRequest(parentActivity.getActivityCode())
+                .statusCode(200).and().extract().path("instanceGuid");
+        parentInstancesToDelete.add(parentInstanceGuid);
+
+        String instanceGuid = makeChildCreationRequest(nestedActivity.getActivityCode(), parentInstanceGuid)
+                .statusCode(200).contentType(ContentType.JSON)
+                .and().extract().path("instanceGuid");
+
+        assertTrue(StringUtils.isNotBlank(instanceGuid));
+        activityInstancesToDelete.add(instanceGuid);
+
+        ActivityInstanceDto instance = TransactionWrapper.withTxn(handle -> handle
+                .attach(JdbiActivityInstance.class)
+                .getByActivityInstanceGuid(instanceGuid)
+                .orElse(null));
+        assertNotNull(instance);
+        assertEquals(parentInstanceGuid, instance.getParentInstanceGuid());
+    }
+
+    @Test
+    public void testStudyAdmin_createChildActivity_parentInstanceReadOnly() {
+        String parentInstanceGuid = makeCreationRequest(parentActivity.getActivityCode())
+                .statusCode(200).and().extract().path("instanceGuid");
+        parentInstancesToDelete.add(parentInstanceGuid);
+
+        TransactionWrapper.useTxn(handle -> {
+            assertEquals(1, handle.attach(JdbiActivityInstance.class)
+                    .updateIsReadonlyByGuid(true, parentInstanceGuid));
+            handle.attach(AuthDao.class).assignStudyAdmin(testData.getUserId(), testData.getStudyId());
+        });
+
+        try {
+            String instanceGuid = makeChildCreationRequest(nestedActivity.getActivityCode(), parentInstanceGuid)
+                    .statusCode(200).contentType(ContentType.JSON)
+                    .and().extract().path("instanceGuid");
+            assertTrue(StringUtils.isNotBlank(instanceGuid));
+            activityInstancesToDelete.add(instanceGuid);
+        } finally {
+            TransactionWrapper.useTxn(handle -> handle.attach(AuthDao.class)
+                    .removeAdminFromAllStudies(testData.getUserId()));
         }
     }
 }


### PR DESCRIPTION
## Context

See DDP-5574. This PR updates the [CreateActivityInstance](https://pepper-dev.datadonationplatform.org/docs#operation/createActivity) API endpoint to check for parent instance when creating child instance.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
