### PR TITLE
DDP-5604 support canDeleteInstances activity definition flag

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -84,10 +84,13 @@ public interface FormActivityDao extends SqlObject {
             throw new IllegalStateException("Requires non-null activity code that follows accepted naming pattern");
         }
         if (activity.getParentActivityCode() != null) {
-            throw new IllegalArgumentException("Nested activity must be created alongside their parent activity");
+            throw new UnsupportedOperationException("Nested activity must be created alongside their parent activity");
         }
         if (activity.isCreateOnParentCreation()) {
-            throw new IllegalArgumentException("createOnParentCreation can only be set on nested child activities");
+            throw new UnsupportedOperationException("createOnParentCreation can only be set on nested child activities");
+        }
+        if (activity.canDeleteInstances()) {
+            throw new UnsupportedOperationException("canDeleteInstances can only be set on nested child activities");
         }
 
         nestedActivities = ListUtils.defaultIfNull(nestedActivities, List.of());
@@ -132,7 +135,7 @@ public interface FormActivityDao extends SqlObject {
                 activity.getMaxInstancesPerUser(), activity.getDisplayOrder(), activity.isWriteOnce(), activity.getEditTimeoutSec(),
                 activity.isOndemandTriggerAllowed(), activity.isExcludeFromDisplay(), activity.isExcludeStatusIconFromDisplay(),
                 activity.isAllowUnauthenticated(), activity.isFollowup(), activity.isHideInstances(),
-                activity.isCreateOnParentCreation());
+                activity.isCreateOnParentCreation(), activity.canDeleteInstances());
         activity.setActivityId(activityId);
         return activityId;
     }
@@ -244,6 +247,7 @@ public interface FormActivityDao extends SqlObject {
                 .setExcludeStatusIconFromDisplay(activityDto.shouldExcludeStatusIconFromDisplay())
                 .setHideInstances(activityDto.isHideExistingInstancesOnCreation())
                 .setCreateOnParentCreation(activityDto.isCreateOnParentCreation())
+                .setCanDeleteInstances(activityDto.canDeleteInstances())
                 .setIsFollowup(activityDto.isFollowup());
 
         List<Translation> names = new ArrayList<>();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -28,12 +28,12 @@ public interface JdbiActivity extends SqlObject {
             + " (activity_type_id,study_id,study_activity_code,max_instances_per_user,display_order,"
             + "is_write_once, instantiate_upon_registration,edit_timeout_sec,allow_ondemand_trigger,"
             + "exclude_from_display, exclude_status_icon_from_display, allow_unauthenticated, "
-            + "is_followup, hide_existing_instances_on_creation, create_on_parent_creation)"
+            + "is_followup, hide_existing_instances_on_creation, create_on_parent_creation, can_delete_instances)"
             + " values((select activity_type_id from activity_type where activity_type_code = :activityType),"
             + ":studyId,:activityCode,"
             + ":maxInstancesPerUser,:displayOrder,:writeOnce,0,:editTimeoutSec,:allowOndemandTrigger,"
             + ":excludeFromDisplay, :excludeStatusIconFromDisplay, :allowUnauthenticated, :isFollowup, :hideExistingInstancesOnCreation,"
-            + ":createOnParentCreation)")
+            + ":createOnParentCreation, :canDeleteInstances)")
     @GetGeneratedKeys()
     long insertActivity(
             @Bind("activityType") ActivityType activityType,
@@ -49,7 +49,8 @@ public interface JdbiActivity extends SqlObject {
             @Bind("allowUnauthenticated") boolean allowUnauthenticated,
             @Bind("isFollowup") boolean isFollowup,
             @Bind("hideExistingInstancesOnCreation") boolean hideExistingInstancesOnCreation,
-            @Bind("createOnParentCreation") boolean createOnParentCreation
+            @Bind("createOnParentCreation") boolean createOnParentCreation,
+            @Bind("canDeleteInstances") boolean canDeleteInstances
     );
 
     @SqlUpdate("update study_activity"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
@@ -24,6 +24,7 @@ public class ActivityDto {
     private final boolean excludeStatusIconFromDisplay;
     private final boolean hideExistingInstancesOnCreation;
     private final boolean createOnParentCreation;
+    private final boolean canDeleteInstances;
     private String activityCode;
 
     @JdbiConstructor
@@ -45,7 +46,8 @@ public class ActivityDto {
             @ColumnName("is_followup") boolean isFollowup,
             @ColumnName("exclude_status_icon_from_display") boolean excludeStatusIconFromDisplay,
             @ColumnName("hide_existing_instances_on_creation") boolean hideExistingInstancesOnCreation,
-            @ColumnName("create_on_parent_creation") boolean createOnParentCreation
+            @ColumnName("create_on_parent_creation") boolean createOnParentCreation,
+            @ColumnName("can_delete_instances") boolean canDeleteInstances
     ) {
         this.activityId = activityId;
         this.activityTypeId = activityTypeId;
@@ -65,6 +67,7 @@ public class ActivityDto {
         this.excludeStatusIconFromDisplay = excludeStatusIconFromDisplay;
         this.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
         this.createOnParentCreation = createOnParentCreation;
+        this.canDeleteInstances = canDeleteInstances;
     }
 
     public long getActivityId() {
@@ -143,6 +146,10 @@ public class ActivityDto {
         return createOnParentCreation;
     }
 
+    public boolean canDeleteInstances() {
+        return canDeleteInstances;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -169,7 +176,8 @@ public class ActivityDto {
                 && isFollowup == that.isFollowup
                 && excludeStatusIconFromDisplay == that.excludeStatusIconFromDisplay
                 && hideExistingInstancesOnCreation == that.hideExistingInstancesOnCreation
-                && createOnParentCreation == that.createOnParentCreation;
+                && createOnParentCreation == that.createOnParentCreation
+                && canDeleteInstances == that.canDeleteInstances;
     }
 
     @Override
@@ -192,6 +200,7 @@ public class ActivityDto {
                 isFollowup,
                 excludeStatusIconFromDisplay,
                 hideExistingInstancesOnCreation,
-                createOnParentCreation);
+                createOnParentCreation,
+                canDeleteInstances);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
@@ -72,6 +72,9 @@ public abstract class ActivityDef {
     @SerializedName("createOnParentCreation")
     protected boolean createOnParentCreation;
 
+    @SerializedName("canDeleteInstances")
+    protected boolean canDeleteInstances;
+
     @NotEmpty
     @SerializedName("translatedNames")
     protected List<@Valid @NotNull Translation> translatedNames;
@@ -273,6 +276,10 @@ public abstract class ActivityDef {
         return createOnParentCreation;
     }
 
+    public boolean canDeleteInstances() {
+        return canDeleteInstances;
+    }
+
     /**
      * Builder that helps construct common elements of an activity definition.
      *
@@ -304,6 +311,7 @@ public abstract class ActivityDef {
         protected boolean isFollowup;
         protected boolean hideExistingInstancesOnCreation;
         protected boolean createOnParentCreation;
+        protected boolean canDeleteInstances;
 
         /**
          * Returns the subclass builder instance to enable method chaining.
@@ -328,6 +336,7 @@ public abstract class ActivityDef {
             activity.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
             activity.translatedSecondNames.addAll(secondNames);
             activity.createOnParentCreation = createOnParentCreation;
+            activity.canDeleteInstances = canDeleteInstances;
         }
 
         public T setParentActivityCode(String parentActivityCode) {
@@ -507,6 +516,11 @@ public abstract class ActivityDef {
 
         public T setCreateOnParentCreation(boolean createOnParentCreation) {
             this.createOnParentCreation = createOnParentCreation;
+            return self();
+        }
+
+        public T setCanDeleteInstances(boolean canDeleteInstances) {
+            this.canDeleteInstances = canDeleteInstances;
             return self();
         }
     }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -254,4 +254,5 @@
     <include file="db-changes/schema/DDP-5573-activity-nesting.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5582-nested-activity-block.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5402-create-indices-for-revision-and-user-study-enrollment.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5604-activity-can-delete-instances.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5604-activity-can-delete-instances.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5604-activity-can-delete-instances.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210222-activity-can-delete-instances-column">
+        <addColumn tableName="study_activity">
+            <column name="can_delete_instances" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
@@ -91,8 +91,13 @@ public class UpdateActivityBaseSettings implements CustomTask {
                 definition.getBoolean("isFollowup"),
                 definition.getBoolean("excludeStatusIconFromDisplay"),
                 definition.getBoolean("hideExistingInstancesOnCreation"),
-                ConfigUtil.getBoolOrElse(definition, "createOnParentCreation", false));
+                ConfigUtil.getBoolOrElse(definition, "createOnParentCreation", false),
+                ConfigUtil.getBoolOrElse(definition, "canDeleteInstances", false));
         if (!currentDto.equals(latestDto)) {
+            if (currentDto.canDeleteInstances() != latestDto.canDeleteInstances()) {
+                throw new UnsupportedOperationException("Updating `canDeleteInstances` setting is currently not supported"
+                        + " to prevent accidental updates of this property and allowing undesired deletion of data");
+            }
             jdbiActivity.updateActivity(
                     latestDto.getActivityId(),
                     latestDto.getDisplayOrder(),


### PR DESCRIPTION
## Context

See DDP-5604. This PR _only_ adds support for a new `canDeleteInstances` flag. Actual deletion will be handled in different ticket/PR.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

