### PR TITLE
DDP-5576 include canDelete in instance/summary API responses

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -115,6 +115,7 @@ Activity:
     - sections
     - lastUpdatedText
     - lastUpdated
+    - canDelete
     - isFollowup
     - isHidden
     - sectionIndex
@@ -177,6 +178,9 @@ Activity:
       format: date-time
       nullable: true
       description: The date time the activity definition (NOT the instance) was last updated
+    canDelete:
+      type: boolean
+      description: whether the activity instance can be deleted
     isFollowup:
       type: boolean
       description: whether this activity is considered a "follow-up"
@@ -207,9 +211,9 @@ Activity.Summary:
     - readonly
     - numQuestions
     - numQuestionsAnswered
+    - canDelete
     - isFollowup
     - isHidden
-    - canDelete
   properties:
     activityCode:
       description: the source activity for this instance
@@ -263,13 +267,12 @@ Activity.Summary:
       description: false if the activity can be modified
       example: false
       type: boolean
-    canDelete:
-      type: boolean
-      description: |
-        whether the activity instance can be deleted.
     statusCode:
       $ref: "../pepper.yml#/components/schemas/ActivityInstanceStatusType"
       example: IN_PROGRESS
+    canDelete:
+      type: boolean
+      description: whether the activity instance can be deleted
     isFollowup:
       description: true if the activity is generally considered to be an activity that comes after the "main" activities
       type: boolean

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/constants/SqlConstants.java
@@ -79,6 +79,7 @@ public class SqlConstants {
         public static final String EXCLUDE_STATUS_ICON_FROM_DISPLAY = "exclude_status_icon_from_display";
         public static final String ALLOW_UNAUTHENTICATED = "allow_unauthenticated";
         public static final String IS_FOLLOWUP = "is_followup";
+        public static final String CAN_DELETE_INSTANCES = "can_delete_instances";
     }
 
     public static final class ActivityVersionTable {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
@@ -116,6 +116,7 @@ public class FormInstanceDao {
                 boolean isFollowup = rs.getBoolean(StudyActivityTable.IS_FOLLOWUP);
                 boolean isInstanceHidden = rs.getBoolean(ActivityInstanceTable.IS_HIDDEN);
                 boolean excludeFromDisplay = rs.getBoolean(StudyActivityTable.EXCLUDE_FROM_DISPLAY);
+                boolean canDelete = rs.getBoolean(StudyActivityTable.CAN_DELETE_INSTANCES);
                 int sectionIndex = rs.getInt(ActivityInstanceTable.SECTION_INDEX);
 
                 form = new FormInstance(
@@ -137,6 +138,7 @@ public class FormInstanceDao {
                         firstCompletedAt,
                         lastUpdatedTemplateId,
                         lastUpdated,
+                        canDelete,
                         isFollowup,
                         isInstanceHidden,
                         excludeFromDisplay,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
@@ -55,6 +55,9 @@ public class ActivityInstanceSummary implements TranslatedSummary {
     @SerializedName("numQuestionsAnswered")
     private int numQuestionsAnswered;
 
+    @SerializedName("canDelete")
+    private boolean canDelete;
+
     @SerializedName("isFollowup")
     private boolean isFollowup;
 
@@ -96,6 +99,7 @@ public class ActivityInstanceSummary implements TranslatedSummary {
             boolean excludeFromDisplay,
             boolean isInstanceHidden,
             long createdAt,
+            boolean canDelete,
             boolean isFollowup,
             String versionTag,
             long versionId,
@@ -122,6 +126,7 @@ public class ActivityInstanceSummary implements TranslatedSummary {
         this.isInstanceHidden = isInstanceHidden;
         this.isHidden = isInstanceHidden || excludeFromDisplay;
         this.createdAt = createdAt;
+        this.canDelete = canDelete;
         this.isFollowup = isFollowup;
         this.versionTag = versionTag;
         this.versionId = versionId;
@@ -204,6 +209,10 @@ public class ActivityInstanceSummary implements TranslatedSummary {
 
     public long getCreatedAt() {
         return createdAt;
+    }
+
+    public boolean canDelete() {
+        return canDelete;
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ActivityInstance.java
@@ -35,6 +35,9 @@ public class ActivityInstance {
     @SerializedName("subtitle")
     protected String subtitle;
 
+    @SerializedName("canDelete")
+    protected boolean canDelete;
+
     @SerializedName("isFollowup")
     private boolean isFollowup;
 
@@ -53,7 +56,7 @@ public class ActivityInstance {
             long participantUserId,
             long instanceId, long activityId, ActivityType activityType, String guid, String title, String subtitle,
             String statusTypeCode, Boolean readonly, String activityCode, long createdAtMillis, Long firstCompletedAt,
-            boolean isFollowup, boolean excludeFromDisplay, boolean isInstanceHidden
+            boolean canDelete, boolean isFollowup, boolean excludeFromDisplay, boolean isInstanceHidden
     ) {
         this.participantUserId = participantUserId;
         this.instanceId = instanceId;
@@ -67,6 +70,7 @@ public class ActivityInstance {
         this.activityCode = activityCode;
         this.createdAtMillis = createdAtMillis;
         this.firstCompletedAt = firstCompletedAt;
+        this.canDelete = canDelete;
         this.isFollowup = isFollowup;
         this.excludeFromDisplay = excludeFromDisplay;
         this.isInstanceHidden = isInstanceHidden;
@@ -127,6 +131,10 @@ public class ActivityInstance {
 
     public Long getFirstCompletedAt() {
         return firstCompletedAt;
+    }
+
+    public boolean canDelete() {
+        return canDelete;
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -89,13 +89,14 @@ public final class FormInstance extends ActivityInstance {
             Long firstCompletedAt,
             Long lastUpdatedTextTemplateId,
             LocalDateTime activityDefinitionLastUpdated,
+            boolean canDelete,
             boolean isFollowup,
             boolean isInstanceHidden,
             boolean excludeFromDisplay,
             int sectionIndex
     ) {
         super(participantUserId, instanceId, activityId, ActivityType.FORMS, guid, title, subtitle, statusTypeCode, readonly, activityCode,
-                createdAtMillis, firstCompletedAt, isFollowup, isInstanceHidden, excludeFromDisplay);
+                createdAtMillis, firstCompletedAt, canDelete, isFollowup, isInstanceHidden, excludeFromDisplay);
         this.formType = MiscUtil.checkNonNull(formType, "formType");
         if (listStyleHint != null) {
             this.listStyleHint = listStyleHint;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -357,6 +357,7 @@ public class ActivityInstanceService {
                     def.isExcludeFromDisplay(),
                     summaryDto.isHidden(),
                     summaryDto.getCreatedAtMillis(),
+                    def.canDeleteInstances(),
                     def.isFollowup(),
                     versionDto.getVersionTag(),
                     versionDto.getId(),

--- a/pepper-apis/src/main/resources/sql.conf
+++ b/pepper-apis/src/main/resources/sql.conf
@@ -245,6 +245,7 @@
                    sa.is_write_once,
                    sa.is_followup,
                    sa.exclude_from_display,
+                   sa.can_delete_instances,
                    ai.is_readonly,
                    ai.is_hidden,
                    ai.created_at,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -512,16 +512,16 @@ public class FormInstanceTest extends TxnAwareBaseTest {
     private FormInstance buildEmptyTestInstance(long participantUserId) {
         return new FormInstance(
                 participantUserId, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "name", "subtitle", "CREATED", false,
-                ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null, false,
-                false, false, 0
+                ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null,
+                false, false, false, false, 0
         );
     }
 
     private FormInstance buildEmptyTestInstanceWithHtmlInTitleAndSubtitle() {
         return new FormInstance(
                 1L, 1L, 1L, "SOME_CODE", FormType.GENERAL, "SOME_GUID", "<div>title</div>", "<em>subtitle</em>", "CREATED", false,
-                ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null, false,
-                false, false, 0
+                ListStyleHint.NUMBER, null, null, null, Instant.now().toEpochMilli(), null, null, null,
+                false, false, false, false, 0
         );
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.time.Instant;
@@ -258,6 +259,7 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
         activity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
                 .addName(new Translation("en", "activity " + activityCode))
                 .setParentActivityCode(parentActCode)
+                .setCanDeleteInstances(true)
                 .addSections(Arrays.asList(dateSection, textSection, plistSection, textSection2, agreementSection, contentSection))
                 .addSection(iconSection)
                 .addSection(compSection)
@@ -343,6 +345,7 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
         assertEquals(activityCode, inst.getActivityCode());
         assertEquals(InstanceStatusType.CREATED, inst.getStatusType());
         assertEquals(parentInstanceDto.getGuid(), inst.getParentInstanceGuid());
+        assertTrue("child instance should have canDelete true", inst.canDelete());
     }
 
     @Test
@@ -406,6 +409,7 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
                 .body("activityCode", equalTo(parentActivity.getActivityCode()))
                 .body("guid", equalTo(parentInstanceDto.getGuid()))
                 .body("parentInstanceGuid", nullValue())
+                .body("canDelete", equalTo(false))
                 .root("sections[0].blocks[0]")
                 .body("blockType", equalTo(BlockType.ACTIVITY.name()))
                 .body("activityCode", equalTo(activityCode))
@@ -414,7 +418,8 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
                 .body("addButtonText", equalTo("add button"))
                 .body("instances.size()", equalTo(1))
                 .body("instances[0].activityCode", equalTo(activityCode))
-                .body("instances[0].instanceGuid", equalTo(instanceDto.getGuid()));
+                .body("instances[0].instanceGuid", equalTo(instanceDto.getGuid()))
+                .body("instances[0].canDelete", equalTo(true));
     }
 
     @Test

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
@@ -56,6 +56,7 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
         nestedActivity = FormActivityDef.generalFormBuilder(activityCode + "_NESTED", "v1", testData.getStudyGuid())
                 .addName(new Translation("en", "nested activity"))
                 .setParentActivityCode(activityCode)
+                .setCanDeleteInstances(true)
                 .build();
         parentActivity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
                 .addName(new Translation("en", "parent activity"))
@@ -87,7 +88,8 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .statusCode(200).contentType(ContentType.JSON)
                 .body("activityCode", equalTo(parentActivity.getActivityCode()))
                 .body("instanceGuid", equalTo(parentInstanceDto.getGuid()))
-                .body("parentInstanceGuid", nullValue());
+                .body("parentInstanceGuid", nullValue())
+                .body("canDelete", equalTo(false));
     }
 
     @Test
@@ -98,7 +100,8 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .statusCode(200).contentType(ContentType.JSON)
                 .body("activityCode", equalTo(nestedActivity.getActivityCode()))
                 .body("instanceGuid", equalTo(nestedInstanceDto.getGuid()))
-                .body("parentInstanceGuid", equalTo(parentInstanceDto.getGuid()));
+                .body("parentInstanceGuid", equalTo(parentInstanceDto.getGuid()))
+                .body("canDelete", equalTo(true));
     }
 
     @Test

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PutFormAnswersRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PutFormAnswersRouteStandaloneTest.java
@@ -815,7 +815,7 @@ public class PutFormAnswersRouteStandaloneTest extends IntegrationTestSuite.Test
     public void testCheckAddressRequirements_noRequirements() {
         var mockHandle = mock(Handle.class);
         var form = new FormInstance(1L, 1L, 1L, "", FormType.GENERAL, "", "", "", "CREATED",
-                null, null, null, null, null, 1L, null, null, null, false, false, false, 0);
+                null, null, null, null, null, 1L, null, null, null, false, false, false, false, 0);
         form.addBodySections(List.of(new FormSection(List.of(
                 new ComponentBlock(new MailingAddressComponent(1L, 1L, false, false, false))))));
         new PutFormAnswersRoute(null, null, null, null)
@@ -830,7 +830,7 @@ public class PutFormAnswersRouteStandaloneTest extends IntegrationTestSuite.Test
         doReturn(mockAddrDao).when(mockHandle).attach(JdbiMailAddress.class);
 
         var form = new FormInstance(1L, 1L, 1L, "", FormType.GENERAL, "", "", "", "CREATED",
-                null, null, null, null, null, 1L, null, null, null, false, false, false, 0);
+                null, null, null, null, null, 1L, null, null, null, false, false, false, false, 0);
         form.addBodySections(List.of(new FormSection(List.of(
                 new ComponentBlock(new MailingAddressComponent(1L, 1L, false, true, false))))));
         var route = new PutFormAnswersRoute(null, null, null, null);
@@ -862,7 +862,7 @@ public class PutFormAnswersRouteStandaloneTest extends IntegrationTestSuite.Test
         doReturn(mockAddrDao).when(mockHandle).attach(JdbiMailAddress.class);
 
         var form = new FormInstance(1L, 1L, 1L, "", FormType.GENERAL, "", "", "", "CREATED",
-                null, null, null, null, null, 1L, null, null, null, false, false, false, 0);
+                null, null, null, null, null, 1L, null, null, null, false, false, false, false, 0);
         form.addBodySections(List.of(new FormSection(List.of(
                 new ComponentBlock(new MailingAddressComponent(1L, 1L, false, true, true))))));
         var route = new PutFormAnswersRoute(null, null, null, null);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserActivityInstanceListRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserActivityInstanceListRouteStandaloneTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.route;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -116,6 +117,7 @@ public class UserActivityInstanceListRouteStandaloneTest extends IntegrationTest
         nestedAct = FormActivityDef.generalFormBuilder(code + "_NESTED", "v1", testData.getStudyGuid())
                 .addName(new Translation("en", "nested activity"))
                 .setParentActivityCode(code)
+                .setCanDeleteInstances(true)
                 .build();
 
         prequal = FormActivityDef.formBuilder(FormType.PREQUALIFIER, code, "v1", testData.getStudyGuid())
@@ -196,6 +198,7 @@ public class UserActivityInstanceListRouteStandaloneTest extends IntegrationTest
 
         Assert.assertTrue("Could not find prequal in list of activity instances for test user", hasPrequal);
         Assert.assertFalse(hasReadonlyActivities);
+        assertFalse(userActivity.canDelete());
     }
 
     @Test

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
@@ -344,7 +344,7 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
     public void testRenderInstanceSummaries_rendersNameEvenWhenThereIsNoSummaryText() {
         var summaries = List.of(new ActivityInstanceSummary(
                 "activity", 1L, "guid", "name", null, null, null, null, null, "type", "form", "status",
-                null, false, "en", false, false, 1L, false, "version", 1L, 1L));
+                null, false, "en", false, false, 1L, false, false, "version", 1L, 1L));
         summaries.get(0).setInstanceNumber(2);
 
         TransactionWrapper.useTxn(handle ->


### PR DESCRIPTION
## Context

See DDP-5576. This PR adds the new `canDelete` property to the "instance summary" and "full instance" JSON response objects returned by the activity API endpoints.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

