### PR TITLE
DDP-5575 delete activity instance API endpoint

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/user.studies.activity.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.activity.yml
@@ -86,7 +86,9 @@ delete:
     - Activities
   summary: delete an activity instance
   description: |
-    Deletes the specified activity. Restrictions TBD.
+    Deletes the specified activity. Deletion is only allowed if activity is
+    configured to allow deleting instances. This is specified by the activity's
+    `canDelete` property.
   responses:
     204:
       description: The activity was successfully deleted

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -78,6 +78,7 @@ import org.broadinstitute.ddp.route.CreateActivityInstanceRoute;
 import org.broadinstitute.ddp.route.CreateMailAddressRoute;
 import org.broadinstitute.ddp.route.CreateTemporaryUserRoute;
 import org.broadinstitute.ddp.route.CreateUserActivityUploadRoute;
+import org.broadinstitute.ddp.route.DeleteActivityInstanceRoute;
 import org.broadinstitute.ddp.route.DeleteMailAddressRoute;
 import org.broadinstitute.ddp.route.DeleteMedicalProviderRoute;
 import org.broadinstitute.ddp.route.DeleteTempMailingAddressRoute;
@@ -468,6 +469,7 @@ public class DataDonationPlatform {
                 responseSerializer
         );
         patch(API.USER_ACTIVITIES_INSTANCE, new PatchActivityInstanceRoute(activityInstanceDao), responseSerializer);
+        delete(API.USER_ACTIVITIES_INSTANCE, new DeleteActivityInstanceRoute(actInstService), jsonSerializer);
         get(API.USER_ACTIVITY_SUMMARY, new GetActivityInstanceSummaryRoute(actInstService), responseSerializer);
 
         // User activity answers routes

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
@@ -1,0 +1,76 @@
+package org.broadinstitute.ddp.route;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.broadinstitute.ddp.constants.ErrorCodes;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.ActivityDefStore;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.DataExportDao;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.json.errors.ApiError;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.security.DDPAuth;
+import org.broadinstitute.ddp.service.ActivityInstanceService;
+import org.broadinstitute.ddp.util.ActivityInstanceUtil;
+import org.broadinstitute.ddp.util.ResponseUtil;
+import org.broadinstitute.ddp.util.RouteUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.Request;
+import spark.Response;
+import spark.Route;
+
+public class DeleteActivityInstanceRoute implements Route {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeleteActivityInstanceRoute.class);
+
+    private final ActivityInstanceService service;
+
+    public DeleteActivityInstanceRoute(ActivityInstanceService service) {
+        this.service = service;
+    }
+
+    @Override
+    public ActivityInstanceSummary handle(Request request, Response response) {
+        String studyGuid = request.params(RouteConstants.PathParam.STUDY_GUID);
+        String participantGuid = request.params(RouteConstants.PathParam.USER_GUID);
+        String instanceGuid = request.params(RouteConstants.PathParam.INSTANCE_GUID);
+
+        DDPAuth ddpAuth = RouteUtil.getDDPAuth(request);
+        String operatorGuid = StringUtils.defaultIfBlank(ddpAuth.getOperator(), participantGuid);
+        boolean isStudyAdmin = ddpAuth.hasAdminAccessToStudy(studyGuid);
+
+        LOG.info("Attempting to delete activity instance {} for participant {} in study {} by operator {} (isStudyAdmin={})",
+                instanceGuid, participantGuid, studyGuid, operatorGuid, isStudyAdmin);
+
+        TransactionWrapper.useTxn(handle -> {
+            var found = RouteUtil.findUserAndStudyOrHalt(handle, participantGuid, studyGuid);
+            ActivityInstanceDto instanceDto = RouteUtil.findAccessibleInstanceOrHalt(
+                    response, handle, found.getUser(), found.getStudyDto(), instanceGuid, isStudyAdmin);
+
+            ActivityDefStore activityStore = ActivityDefStore.getInstance();
+            FormActivityDef activityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, instanceDto, studyGuid);
+
+            if (!activityDef.canDeleteInstances()) {
+                String msg = "Activity does not allow deleting instances";
+                LOG.warn(msg);
+                throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
+                        new ApiError(ErrorCodes.OPERATION_NOT_ALLOWED, msg));
+            } else if (instanceDto.getParentActivityCode() == null) {
+                String msg = "Deleting non-nested activity instances is not supported";
+                LOG.warn(msg);
+                throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
+                        new ApiError(ErrorCodes.OPERATION_NOT_ALLOWED, msg));
+            }
+
+            service.deleteInstance(handle, instanceDto);
+            handle.attach(DataExportDao.class).queueDataSync(instanceDto.getParticipantId(), instanceDto.getStudyId());
+        });
+
+        LOG.info("Deleted activity instance {}", instanceGuid);
+        response.status(HttpStatus.SC_NO_CONTENT);
+        return null;
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -23,10 +23,12 @@ import org.broadinstitute.ddp.content.I18nTemplateConstants;
 import org.broadinstitute.ddp.content.RenderValueProvider;
 import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.db.dao.FormActivityDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.StudyLanguageCachedDao;
 import org.broadinstitute.ddp.db.dto.ActivityDto;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceSummaryDto;
 import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -516,5 +518,19 @@ public class ActivityInstanceService {
                 summary.setActivitySummary(summaryText);
             }
         }
+    }
+
+    /**
+     * Delete the provided activity instance and its associated answer data. Caller is responsible for checking if
+     * instance is eligible to be deleted.
+     *
+     * @param handle      the database handle
+     * @param instanceDto the instance
+     */
+    public void deleteInstance(Handle handle, ActivityInstanceDto instanceDto) {
+        // Note: deal with potential child instances here when we support deleting top-level parent instances.
+        var instanceDao = handle.attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class);
+        int numDeleted = instanceDao.deleteAllByIds(Set.of(instanceDto.getId()));
+        DBUtils.checkDelete(1, numDeleted);
     }
 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRouteTest.java
@@ -1,0 +1,228 @@
+package org.broadinstitute.ddp.route;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.restassured.http.ContentType;
+import org.broadinstitute.ddp.constants.ErrorCodes;
+import org.broadinstitute.ddp.constants.RouteConstants;
+import org.broadinstitute.ddp.db.TransactionWrapper;
+import org.broadinstitute.ddp.db.dao.ActivityDao;
+import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.AnswerDao;
+import org.broadinstitute.ddp.db.dao.AuthDao;
+import org.broadinstitute.ddp.db.dao.JdbiActivityInstance;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
+import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.definition.question.QuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.template.Template;
+import org.broadinstitute.ddp.model.activity.instance.answer.TextAnswer;
+import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
+import org.broadinstitute.ddp.model.activity.types.TextInputType;
+import org.broadinstitute.ddp.util.TestDataSetupUtil;
+import org.jdbi.v3.core.Handle;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeleteActivityInstanceRouteTest extends IntegrationTestSuite.TestCase {
+
+    private static TestDataSetupUtil.GeneratedTestData testData;
+    private static Set<Long> instanceIdsToDelete = new HashSet<>();
+    private static FormActivityDef parentActivity;
+    private static FormActivityDef nonDeletableChildAct;
+    private static FormActivityDef deletableChildAct;
+    private static QuestionDef questionDef;
+    private static ActivityInstanceDto parentInstanceDto;
+    private static ActivityInstanceDto nonDeletableInstanceDto;
+    private static String token;
+    private static String url;
+
+    @BeforeClass
+    public static void setup() {
+        TransactionWrapper.useTxn(handle -> {
+            testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            token = testData.getTestingUser().getToken();
+            setupActivityAndInstance(handle);
+        });
+        String endpoint = RouteConstants.API.USER_ACTIVITIES_INSTANCE
+                .replace(RouteConstants.PathParam.USER_GUID, testData.getUserGuid())
+                .replace(RouteConstants.PathParam.STUDY_GUID, testData.getStudyGuid())
+                .replace(RouteConstants.PathParam.INSTANCE_GUID, "{instanceGuid}");
+        url = RouteTestUtil.getTestingBaseUrl() + endpoint;
+    }
+
+    private static void setupActivityAndInstance(Handle handle) {
+        String activityCode = "ACT_DELETE" + Instant.now().toEpochMilli();
+
+        questionDef = TextQuestionDef
+                .builder(TextInputType.TEXT, activityCode + "_Q", Template.text("question"))
+                .build();
+        deletableChildAct = FormActivityDef.generalFormBuilder(activityCode + "_CANDELETE", "v1", testData.getStudyGuid())
+                .addName(new Translation("en", "activity with non-deletable instances"))
+                .setParentActivityCode(activityCode)
+                .setCanDeleteInstances(true)
+                .addSection(new FormSectionDef(null, List.of(new QuestionBlockDef(questionDef))))
+                .build();
+
+        nonDeletableChildAct = FormActivityDef.generalFormBuilder(activityCode + "_NONDELETE", "v1", testData.getStudyGuid())
+                .addName(new Translation("en", "activity with non-deletable instances"))
+                .setParentActivityCode(activityCode)
+                .setCanDeleteInstances(false)
+                .build();
+
+        parentActivity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
+                .addName(new Translation("en", "parent activity"))
+                .build();
+
+        handle.attach(ActivityDao.class).insertActivity(
+                parentActivity, List.of(nonDeletableChildAct, deletableChildAct),
+                RevisionMetadata.now(testData.getUserId(), "test"));
+
+        var instanceDao = handle.attach(ActivityInstanceDao.class);
+        parentInstanceDto = instanceDao.insertInstance(parentActivity.getActivityId(), testData.getUserGuid());
+        nonDeletableInstanceDto = instanceDao.insertInstance(nonDeletableChildAct.getActivityId(),
+                testData.getUserGuid(), testData.getUserGuid(), parentInstanceDto.getId());
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        TransactionWrapper.useTxn(handle -> {
+            var instanceDao = handle.attach(ActivityInstanceDao.class);
+            instanceDao.deleteByInstanceGuid(nonDeletableInstanceDto.getGuid());
+            instanceDao.deleteByInstanceGuid(parentInstanceDto.getGuid());
+        });
+    }
+
+    @After
+    public void deleteLeftoverInstances() {
+        TransactionWrapper.useTxn(handle -> {
+            var instanceDao = handle.attach(ActivityInstanceDao.class);
+            instanceDao.deleteAllByIds(instanceIdsToDelete);
+        });
+        instanceIdsToDelete.clear();
+    }
+
+    @Test
+    public void testDeleteParent_notSupported() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                .when().delete(url).then().assertThat()
+                .statusCode(422).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.OPERATION_NOT_ALLOWED))
+                .body("message", containsString("does not allow deleting"));
+    }
+
+    @Test
+    public void testDeleteNonDeletable_notSupported() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", nonDeletableInstanceDto.getGuid())
+                .when().delete(url).then().assertThat()
+                .statusCode(422).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.OPERATION_NOT_ALLOWED))
+                .body("message", containsString("does not allow deleting"));
+    }
+
+    @Test
+    public void testDelete_instanceNotFound() {
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", "foobar")
+                .when().delete(url).then().assertThat()
+                .statusCode(404).contentType(ContentType.JSON)
+                .body("code", equalTo(ErrorCodes.ACTIVITY_NOT_FOUND))
+                .body("message", containsString("Could not find activity instance"));
+    }
+
+    @Test
+    public void testDelete_instanceIsHidden() {
+        TransactionWrapper.useTxn(handle -> assertEquals(1, handle
+                .attach(ActivityInstanceDao.class)
+                .bulkUpdateIsHiddenByActivityIds(
+                        testData.getUserId(), true, Set.of(parentActivity.getActivityId()))));
+        try {
+            given().auth().oauth2(token)
+                    .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                    .when().delete(url).then().assertThat()
+                    .statusCode(404).contentType(ContentType.JSON)
+                    .body("code", equalTo(ErrorCodes.ACTIVITY_NOT_FOUND))
+                    .body("message", containsString("is hidden"));
+        } finally {
+            TransactionWrapper.useTxn(handle -> assertEquals(1, handle
+                    .attach(ActivityInstanceDao.class)
+                    .bulkUpdateIsHiddenByActivityIds(
+                            testData.getUserId(), false, Set.of(parentActivity.getActivityId()))));
+        }
+    }
+
+    @Test
+    public void testDelete_instanceIsHidden_studyAdmin() {
+        TransactionWrapper.useTxn(handle -> {
+            assertEquals(1, handle.attach(ActivityInstanceDao.class)
+                    .bulkUpdateIsHiddenByActivityIds(
+                            testData.getUserId(), true, Set.of(parentActivity.getActivityId())));
+            handle.attach(AuthDao.class).assignStudyAdmin(testData.getUserId(), testData.getStudyId());
+        });
+        try {
+            // Study admin can access hidden instance, but still should be blocked from deleting parent.
+            given().auth().oauth2(token)
+                    .pathParam("instanceGuid", parentInstanceDto.getGuid())
+                    .when().delete(url).then().assertThat()
+                    .statusCode(422).contentType(ContentType.JSON)
+                    .body("code", equalTo(ErrorCodes.OPERATION_NOT_ALLOWED));
+        } finally {
+            TransactionWrapper.useTxn(handle -> {
+                assertEquals(1, handle.attach(ActivityInstanceDao.class)
+                        .bulkUpdateIsHiddenByActivityIds(
+                                testData.getUserId(), false, Set.of(parentActivity.getActivityId())));
+                handle.attach(AuthDao.class).removeAdminFromAllStudies(testData.getUserId());
+            });
+        }
+    }
+
+    @Test
+    public void testDelete_success() {
+        ActivityInstanceDto instanceDto = TransactionWrapper.withTxn(handle -> {
+            var instance = createInstanceAndDeferCleanup(handle, deletableChildAct.getActivityId());
+            handle.attach(AnswerDao.class).createAnswer(
+                    testData.getUserId(), instance.getId(),
+                    new TextAnswer(null, questionDef.getStableId(), null, "some value"));
+            return instance;
+        });
+
+        given().auth().oauth2(token)
+                .pathParam("instanceGuid", instanceDto.getGuid())
+                .when().delete(url).then().assertThat()
+                .statusCode(204);
+
+        TransactionWrapper.useTxn(handle -> {
+            var jdbiInstance = handle.attach(JdbiActivityInstance.class);
+            assertFalse(jdbiInstance.getByActivityInstanceGuid(instanceDto.getGuid()).isPresent());
+            assertTrue("should not delete other instances", jdbiInstance
+                    .getByActivityInstanceGuid(parentInstanceDto.getGuid()).isPresent());
+            assertTrue("should not delete other instances", jdbiInstance
+                    .getByActivityInstanceGuid(nonDeletableInstanceDto.getGuid()).isPresent());
+        });
+    }
+
+    private ActivityInstanceDto createInstanceAndDeferCleanup(Handle handle, long activityId) {
+        var instanceDao = handle.attach(ActivityInstanceDao.class);
+        var instanceDto = instanceDao.insertInstance(activityId, testData.getUserGuid(),
+                testData.getUserGuid(), parentInstanceDto.getId());
+        instanceIdsToDelete.add(instanceDto.getId());
+        return instanceDto;
+    }
+}


### PR DESCRIPTION
## Context

See DDP-5575. This PR implements new API endpoint for deleting instances. Delete is only allowed if activity definition specifies `canDeleteInstances`. Currently, only child activities can turn on that flag. (See PRs #653).

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

