### PR TITLE
DDP-5658 support revisioned templates

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/FormInstanceDao.java
@@ -183,8 +183,8 @@ public class FormInstanceDao {
 
         Map<Long, FormSection> sections = handle.attach(org.broadinstitute.ddp.db.dao.SectionBlockDao.class)
                 .findAllInstanceSectionsById(sectionIds);
-        Map<Long, List<FormBlock>> blockMap = sectionBlockDao.getBlocksForSections(handle, sectionIds, form.getGuid(), langCodeId,
-                includeDeprecated);
+        Map<Long, List<FormBlock>> blockMap = sectionBlockDao.getBlocksForSections(handle, sectionIds, form.getGuid(),
+                form.getCreatedAtMillis(), langCodeId, includeDeprecated);
 
         List<FormSection> bodySections = new ArrayList<>();
         for (long id : bodyIds) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
@@ -181,7 +181,7 @@ public interface ComponentDao extends SqlObject {
         for (var componentDto : componentDtos.values()) {
             templateIds.addAll(componentDto.getTemplateIds());
         }
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
 
         Map<Long, ComponentBlockDef> blockDefs = new HashMap<>();
         for (var blockDto : blockDtos) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -292,7 +292,7 @@ public interface FormActivityDao extends SqlObject {
             builder.setLastUpdated(settingDto.getLastUpdated());
             builder.setSnapshotSubstitutionsOnSubmit(settingDto.shouldSnapshotSubstitutionsOnSubmit());
 
-            Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(settingDto.getTemplateIds());
+            Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(settingDto.getTemplateIds(), revisionStart);
             builder.setLastUpdatedTextTemplate(templates.getOrDefault(settingDto.getLastUpdatedTextTemplateId(), null));
             builder.setReadonlyHintTemplate(templates.getOrDefault(settingDto.getReadonlyHintTemplateId(), null));
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -181,10 +181,6 @@ public interface JdbiActivity extends SqlObject {
             @Bind("maxInstances") Integer maxInstances
     );
 
-    default List<ActivityValidationDto> findValidationsById(long activityId, long languageCodeId) {
-        return getJdbiActivityValidation()._findByActivityIdTranslated(activityId, languageCodeId);
-    }
-
     default int deleteValidationsByCode(long activityId) {
         return getJdbiActivityValidation()._deleteByActivityId(activityId);
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
@@ -137,16 +137,11 @@ public interface JdbiActivityInstance extends SqlObject {
     @RegisterConstructorMapper(ActivityInstanceDto.class)
     List<ActivityInstanceDto> findAllByUserIdAndStudyId(@Bind("userId") long participantUserId, @Bind("studyId") long studyId);
 
-    @SqlQuery("select ai.activity_instance_guid "
-            + " from activity_instance as ai "
-            + " join user as u on ai.participant_id = u.user_id"
-            + " join study_activity as act on act.study_activity_id = ai.study_activity_id"
-            + " join question as q on q.study_activity_id = act.study_activity_id"
-            + " where q.question_id = :questionId"
-            + " and u.guid = :userGuid"
-            + " order by ai.created_at desc limit 1")
-    Optional<String> findLatestInstanceGuidFromUserGuidAndQuestionId(@Bind("userGuid") String userGuid,
-                                                                     @Bind("questionId") long questionId);
+    @UseStringTemplateSqlLocator
+    @SqlQuery("findLatestInstanceFromUserGuidAndQuestionId")
+    @RegisterConstructorMapper(ActivityInstanceDto.class)
+    Optional<ActivityInstanceDto> findLatestInstanceFromUserGuidAndQuestionId(@Bind("userGuid") String userGuid,
+                                                                              @Bind("questionId") long questionId);
 
     @SqlQuery(
             "select ai.activity_instance_id from user u join activity_instance ai on ai.participant_id = u.user_id"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityValidation.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityValidation.java
@@ -4,9 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.dto.ActivityValidationDto;
-
 import org.jdbi.v3.core.result.LinkedHashMapRowReducer;
 import org.jdbi.v3.core.result.RowView;
 import org.jdbi.v3.sqlobject.CreateSqlObject;
@@ -57,17 +55,6 @@ public interface JdbiActivityValidation extends SqlObject {
             @Bind("expressionText") String expressionText,
             @Bind("errorMessageTemplateId") long errorMessageTemplateId
     );
-
-    default List<ActivityValidationDto> _findByActivityIdTranslated(long activityId, long isoLanguageCode) {
-        List<ActivityValidationDto> validations = _findByActivityId(activityId);
-        I18nContentRenderer i18nContentRenderer = new I18nContentRenderer();
-        validations.forEach(
-                validation -> validation.setErrorMessage(
-                        i18nContentRenderer.renderContent(getHandle(), validation.getErrorMessageTemplateId(), isoLanguageCode)
-                )
-        );
-        return validations;
-    }
 
     @SqlQuery(
             "SELECT sa.study_activity_id AS av_study_activity_id, av.activity_validation_id AS av_activity_validation_id,"

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiRevision.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiRevision.java
@@ -38,6 +38,16 @@ public interface JdbiRevision extends SqlObject {
     }
 
     /**
+     * Create a copy of the revision with only the start date and no end date.
+     */
+    @GetGeneratedKeys
+    @SqlUpdate("insert into revision ("
+            + "        start_date, changed_by_user_id, change_reason, end_date, terminated_by_user_id, terminated_reason)"
+            + " select start_date, changed_by_user_id, change_reason, null, null, null"
+            + "   from revision where revision_id = :revisionId")
+    long copyStart(@Bind("revisionId") long revisionIdToCopy);
+
+    /**
      * Create a copy of given revision and terminate it by setting the end date.
      */
     @UseStringTemplateSqlLocator

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
@@ -165,27 +165,31 @@ public interface QuestionDao extends SqlObject {
     /**
      * Get the non-deprecated question for a given block.
      *
-     * @param blockId              the block id
-     * @param activityInstanceGuid the form instance guid
+     * @param blockId                 the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return single question, if it's not deprecated
      */
     default Optional<Question> getQuestionByBlockId(long blockId,
                                                     String activityInstanceGuid,
+                                                    long instanceCreatedAtMillis,
                                                     long langCodeId) {
-        return getQuestionByBlockId(blockId, activityInstanceGuid, false, langCodeId);
+        return getQuestionByBlockId(blockId, activityInstanceGuid, instanceCreatedAtMillis, false, langCodeId);
     }
 
 
     /**
      * Get the question for a given block. Toggle if okay with deprecated questions.
      *
-     * @param blockId              the block id
-     * @param activityInstanceGuid the form instance guid
-     * @param includeDeprecated    flag indicating whether or nto to include deprecated questions
+     * @param blockId                 the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
+     * @param includeDeprecated       flag indicating whether or nto to include deprecated questions
      * @return single question, if it's not deprecated
      */
     default Optional<Question> getQuestionByBlockId(long blockId,
                                                     String activityInstanceGuid,
+                                                    long instanceCreatedAtMillis,
                                                     boolean includeDeprecated,
                                                     long langCodeId) {
         QuestionDto dto = getJdbiBlockQuestion()
@@ -199,33 +203,37 @@ public interface QuestionDao extends SqlObject {
             return Optional.empty();
         } else {
             // Use of() instead of ofNullable() since it should be non-null.
-            return Optional.of(getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid, langCodeId));
+            return Optional.of(getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid, instanceCreatedAtMillis, langCodeId));
         }
     }
 
     /**
      * Get the non-deprecated control question for a conditional block.
      *
-     * @param blockId              the block id
-     * @param activityInstanceGuid the form instance guid
+     * @param blockId                 the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return control question, if it's not deprecated
      */
     default Optional<Question> getControlQuestionByBlockId(long blockId,
                                                            String activityInstanceGuid,
+                                                           long instanceCreatedAtMillis,
                                                            long langCodeId) {
-        return getControlQuestionByBlockId(blockId, activityInstanceGuid, false, langCodeId);
+        return getControlQuestionByBlockId(blockId, activityInstanceGuid, instanceCreatedAtMillis, false, langCodeId);
     }
 
     /**
      * Get the control question for a conditional block. This allows fetching deprecated control questions. Prefer the
      * other method that excludes them.
      *
-     * @param blockId              the block id
-     * @param activityInstanceGuid the form instance guid
+     * @param blockId                 the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return control question
      */
     default Optional<Question> getControlQuestionByBlockId(long blockId,
                                                            String activityInstanceGuid,
+                                                           long instanceCreatedAtMillis,
                                                            boolean includeDeprecated,
                                                            long langCodeId) {
         QuestionDto questionDto = getHandle().attach(JdbiBlockConditionalControl.class)
@@ -238,37 +246,43 @@ public interface QuestionDao extends SqlObject {
                     questionDto.getId(), blockId, activityInstanceGuid);
             return Optional.empty();
         } else {
-            return Optional.of(getQuestionByActivityInstanceAndDto(questionDto, activityInstanceGuid, true, langCodeId));
+            return Optional.of(getQuestionByActivityInstanceAndDto(questionDto, activityInstanceGuid,
+                    instanceCreatedAtMillis, true, langCodeId));
         }
     }
 
     /**
      * Get a question for a given id. Gets answers as well if it has any.
      *
-     * @param questionId           the block id
-     * @param activityInstanceGuid the form instance guid
+     * @param questionId              the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return single question
      */
-    default Question getQuestionByIdAndActivityInstanceGuid(long questionId, String activityInstanceGuid, long langCodeId) {
-        return getQuestionByIdAndActivityInstanceGuid(questionId, activityInstanceGuid, true, langCodeId);
+    default Question getQuestionByIdAndActivityInstanceGuid(long questionId, String activityInstanceGuid,
+                                                            long instanceCreatedAtMillis, long langCodeId) {
+        return getQuestionByIdAndActivityInstanceGuid(questionId, activityInstanceGuid, instanceCreatedAtMillis, true, langCodeId);
     }
 
     /**
      * Get a question for a given id. Toggle get answers as well if it has any.
      *
-     * @param questionId           the block id
-     * @param activityInstanceGuid the form instance guid
+     * @param questionId              the block id
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return single question
      */
     default Question getQuestionByIdAndActivityInstanceGuid(
             long questionId,
             String activityInstanceGuid,
+            long instanceCreatedAtMillis,
             boolean retrieveAnswers,
             long langCodeId
     ) {
         return getJdbiQuestion().findQuestionDtoById(questionId)
                 .filter(dto -> dto.getRevisionEnd() == null)
-                .map(dto -> getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid, retrieveAnswers, langCodeId))
+                .map(dto -> getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid,
+                        instanceCreatedAtMillis, retrieveAnswers, langCodeId))
                 .orElseThrow(() -> new DaoException(String.format("No question found with id %d", questionId)));
     }
 
@@ -285,32 +299,37 @@ public interface QuestionDao extends SqlObject {
                                                          boolean retrieveAnswers,
                                                          long langCodeId) {
         return getHandle().attach(JdbiActivityInstance.class)
-                .findLatestInstanceGuidFromUserGuidAndQuestionId(userGuid, dto.getId())
-                .map(instanceGuid -> getQuestionByActivityInstanceAndDto(dto, instanceGuid, retrieveAnswers, langCodeId))
+                .findLatestInstanceFromUserGuidAndQuestionId(userGuid, dto.getId())
+                .map(instanceDto -> getQuestionByActivityInstanceAndDto(dto, instanceDto.getGuid(),
+                        instanceDto.getCreatedAtMillis(), retrieveAnswers, langCodeId))
                 .orElseThrow(null);
     }
 
     /**
      * Get question by activity instance and dto. Gets answers as well if it has any.
      *
-     * @param dto                  question dto
-     * @param activityInstanceGuid the form instance guid
+     * @param dto                     question dto
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @return single question
      */
-    default Question getQuestionByActivityInstanceAndDto(QuestionDto dto, String activityInstanceGuid, long langCodeId) {
-        return getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid, true, langCodeId);
+    default Question getQuestionByActivityInstanceAndDto(QuestionDto dto, String activityInstanceGuid,
+                                                         long instanceCreatedAtMillis, long langCodeId) {
+        return getQuestionByActivityInstanceAndDto(dto, activityInstanceGuid, instanceCreatedAtMillis, true, langCodeId);
     }
 
     /**
      * Get question by activity instance and dto. Toggles getting answers as well if it has any.
      *
-     * @param dto                  question dto
-     * @param activityInstanceGuid the form instance guid
-     * @param retrieveAnswers      flag indicating whether to get answers for question
+     * @param dto                     question dto
+     * @param activityInstanceGuid    the form instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
+     * @param retrieveAnswers         flag indicating whether to get answers for question
      * @return single question
      */
     default Question getQuestionByActivityInstanceAndDto(QuestionDto dto,
                                                          String activityInstanceGuid,
+                                                         long instanceCreatedAtMillis,
                                                          boolean retrieveAnswers,
                                                          long langCodeId) {
         if (dto == null) {
@@ -323,7 +342,7 @@ public interface QuestionDao extends SqlObject {
                     .findAnswerIdsByInstanceGuidAndQuestionId(activityInstanceGuid, dto.getId()));
         }
 
-        List<Rule> untypedRules = getValidationDao().getValidationRules(dto, langCodeId);
+        List<Rule> untypedRules = getValidationDao().getValidationRules(dto, langCodeId, instanceCreatedAtMillis);
 
         Question question;
 
@@ -351,7 +370,7 @@ public interface QuestionDao extends SqlObject {
                 break;
             case COMPOSITE:
                 question = getCompositeQuestion((CompositeQuestionDto) dto,
-                        activityInstanceGuid, answerIds, untypedRules, langCodeId);
+                        activityInstanceGuid, instanceCreatedAtMillis, answerIds, untypedRules, langCodeId);
                 break;
             default:
                 throw new DaoException("Unknown question type: " + dto.getType());
@@ -696,14 +715,16 @@ public interface QuestionDao extends SqlObject {
     /**
      * Build a composite question.
      *
-     * @param dto                  the question dto
-     * @param activityInstanceGuid the activity instance guid
-     * @param answerIds            list of base answer ids to question (may be empty)
-     * @param untypedRules         list of untyped validations for question (may be empty)
+     * @param dto                     the question dto
+     * @param activityInstanceGuid    the activity instance guid
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
+     * @param answerIds               list of base answer ids to question (may be empty)
+     * @param untypedRules            list of untyped validations for question (may be empty)
      * @return composite question object
      */
     default CompositeQuestion getCompositeQuestion(CompositeQuestionDto dto,
                                                    String activityInstanceGuid,
+                                                   long instanceCreatedAtMillis,
                                                    List<Long> answerIds,
                                                    List<Rule> untypedRules,
                                                    long langCodeId) {
@@ -713,7 +734,8 @@ public interface QuestionDao extends SqlObject {
         try (var stream = jdbiQuestion.findQuestionDtosByIds(childIds)) {
             childQuestions = stream
                     .map(childQuestionDto ->
-                            getQuestionByActivityInstanceAndDto(childQuestionDto, activityInstanceGuid, false, langCodeId))
+                            getQuestionByActivityInstanceAndDto(childQuestionDto, activityInstanceGuid,
+                                    instanceCreatedAtMillis, false, langCodeId))
                     .collect(toList());
         }
 
@@ -1379,7 +1401,7 @@ public interface QuestionDao extends SqlObject {
         for (var questionDto : questionDtos) {
             templateIds.addAll(questionDto.getTemplateIds());
         }
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
 
         Map<Long, QuestionDef> questionDefs = new HashMap<>();
         List<PicklistQuestionDto> picklistDtos = new ArrayList<>();
@@ -1450,7 +1472,7 @@ public interface QuestionDao extends SqlObject {
         for (var container : questionIdToContainer.values()) {
             templateIds.addAll(container.getTemplateIds());
         }
-        Map<Long, Template> picklistTemplates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> picklistTemplates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
         templates.putAll(picklistTemplates);
 
         Map<Long, PicklistQuestionDef> picklistDefs = new HashMap<>();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/SectionBlockDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/SectionBlockDao.java
@@ -569,7 +569,7 @@ public interface SectionBlockDao extends SqlObject {
                 templateIds.add(nameTemplateId);
             }
         }
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
 
         Map<Long, FormSectionDef> sectionDefs = new HashMap<>();
         for (var sectionDto : sectionDtos) {
@@ -655,7 +655,7 @@ public interface SectionBlockDao extends SqlObject {
                 templateIds.add(nestedActBlockDto.getAddButtonTemplateId());
             }
         }
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
 
         Map<Long, NestedActivityBlockDef> blockDefs = new HashMap<>();
         for (var blockDto : blockDtos) {
@@ -734,7 +734,7 @@ public interface SectionBlockDao extends SqlObject {
                 templateIds.add(titleTemplateId);
             }
         }
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
 
         Map<Long, GroupBlockDef> blockDefs = new HashMap<>();
         for (var blockDto : blockDtos) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/TemplateDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/TemplateDao.java
@@ -179,23 +179,24 @@ public interface TemplateDao extends SqlObject {
     @RegisterRowMapper(TextAndVarCountMapper.class)
     Map<Long, TextAndVarCount> findAllTextAndVarCountsByIds(@BindList("templateIds") Set<Long> templateIds);
 
-    default Template loadTemplateById(long templateId) {
-        try (var stream = loadTemplatesByIds(Set.of(templateId))) {
+    default Template loadTemplateByIdAndTimestamp(long templateId, long timestamp) {
+        try (var stream = loadTemplatesByIdsAndTimestamp(Set.of(templateId), timestamp)) {
             return stream.findFirst().orElse(null);
         }
     }
 
     @UseStringTemplateSqlLocator
-    @SqlQuery("queryTemplatesByIds")
+    @SqlQuery("queryTemplatesByIdsAndTimestamp")
     @RegisterConstructorMapper(Template.class)
     @RegisterConstructorMapper(TemplateVariable.class)
     @RegisterConstructorMapper(Translation.class)
     @UseRowReducer(TemplateReducer.class)
-    Stream<Template> loadTemplatesByIds(
-            @BindList(value = "templateIds", onEmpty = EmptyHandling.NULL) Iterable<Long> templateIds);
+    Stream<Template> loadTemplatesByIdsAndTimestamp(
+            @BindList(value = "templateIds", onEmpty = EmptyHandling.NULL) Iterable<Long> templateIds,
+            @Bind("timestamp") long timestamp);
 
-    default Map<Long, Template> collectTemplatesByIds(Iterable<Long> templateIds) {
-        try (var stream = loadTemplatesByIds(templateIds)) {
+    default Map<Long, Template> collectTemplatesByIdsAndTimestamp(Iterable<Long> templateIds, long timestamp) {
+        try (var stream = loadTemplatesByIdsAndTimestamp(templateIds, timestamp)) {
             return stream.collect(Collectors.toMap(Template::getTemplateId, Function.identity()));
         }
     }
@@ -247,7 +248,8 @@ public interface TemplateDao extends SqlObject {
         }
     }
 
-    default Map<Long, Map<String, String>> findAllTranslatedVariablesByIds(Set<Long> templateIds, long langCodeId, Long defaultLangCodeId) {
+    default Map<Long, Map<String, String>> findAllTranslatedVariablesByIds(Set<Long> templateIds, long langCodeId,
+                                                                           Long defaultLangCodeId, long timestamp) {
         String query = StringTemplateSqlLocator
                 .findStringTemplate(TemplateDao.class, "queryAllTranslatedVariablesByTemplateIdsAndLangId")
                 .render();
@@ -255,6 +257,7 @@ public interface TemplateDao extends SqlObject {
                 .bindList("templateIds", new ArrayList<>(templateIds))
                 .bind("langCodeId", langCodeId)
                 .bind("defaultLangCodeId", defaultLangCodeId)
+                .bind("timestamp", timestamp)
                 .reduceRows(new HashMap<>(), (accumulator, row) -> {
                     long key = row.getColumn(TemplateTable.ID, Long.class);
                     Map<String, String> vars = accumulator.computeIfAbsent(key, k -> new HashMap<>());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ValidationDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/ValidationDao.java
@@ -129,10 +129,11 @@ public interface ValidationDao extends SqlObject {
      * Get all validations for a given question by id and language code.
      *
      * @param questionDto the question dto object
-     * @param langCodeId the language code id
+     * @param langCodeId  the language code id
+     * @param timestamp   the timestamp to pinpoint template variable substitution text revisions
      * @return list of validations corresponding to the question
      */
-    default List<Rule> getValidationRules(QuestionDto questionDto, long langCodeId) {
+    default List<Rule> getValidationRules(QuestionDto questionDto, long langCodeId, long timestamp) {
         List<Rule> rules = new ArrayList<>();
 
         List<RuleDto> ruleDtos = getJdbiQuestionValidation().getAllActiveValidations(questionDto);
@@ -142,7 +143,7 @@ public interface ValidationDao extends SqlObject {
         for (RuleDto ruleDto : ruleDtos) {
             String correctionHint = null;
             if (ruleDto.getHintTemplateId() != null) {
-                correctionHint = i18nContentRenderer.renderContent(getHandle(), ruleDto.getHintTemplateId(), langCodeId);
+                correctionHint = i18nContentRenderer.renderContent(getHandle(), ruleDto.getHintTemplateId(), langCodeId, timestamp);
             }
             String message = getJdbiI18nValidationMsgTrans().getValidationMessage(
                     getJdbiValidationType().getTypeId(ruleDto.getRuleType()),
@@ -412,7 +413,7 @@ public interface ValidationDao extends SqlObject {
             });
         }
 
-        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIds(templateIds);
+        Map<Long, Template> templates = getTemplateDao().collectTemplatesByIdsAndTimestamp(templateIds, timestamp);
         Map<Long, List<RuleDef>> questionIdToRuleDefs = new HashMap<>();
 
         for (var dto : ruleDtos) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -207,7 +207,7 @@ public final class FormInstance extends ActivityInstance {
 
         Map<String, Object> context = new HashMap<>();
         context.put(I18nTemplateConstants.DDP, valueProvider);
-        Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId, context);
+        Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId, context, getCreatedAtMillis());
         Renderable.Provider<String> provider = rendered::get;
 
         for (FormSection section : allSections) {
@@ -215,7 +215,7 @@ public final class FormInstance extends ActivityInstance {
         }
 
         if (readonlyHintTemplateId != null) {
-            readonlyHint = renderer.renderContent(handle, readonlyHintTemplateId, langCodeId);
+            readonlyHint = renderer.renderContent(handle, readonlyHintTemplateId, langCodeId, getCreatedAtMillis());
             // Strip down HTML tags if the plain text is requested
             if (style == ContentStyle.BASIC) {
                 readonlyHint = HtmlConverter.getPlainText(readonlyHint);
@@ -232,7 +232,8 @@ public final class FormInstance extends ActivityInstance {
             // Intentionally converting to a date here for display purposes
             LocalDate lastUpdatedDate = activityDefinitionLastUpdated == null ? null : activityDefinitionLastUpdated.toLocalDate();
             varNameToValueMap.put(I18nTemplateConstants.LAST_UPDATED, lastUpdatedDate);
-            activityDefinitionLastUpdatedText = renderer.renderContent(handle, lastUpdatedTextTemplateId, langCodeId, varNameToValueMap);
+            activityDefinitionLastUpdatedText = renderer.renderContent(handle,
+                    lastUpdatedTextTemplateId, langCodeId, varNameToValueMap, getCreatedAtMillis());
 
             if (style == ContentStyle.BASIC) {
                 activityDefinitionLastUpdatedText = HtmlConverter.getPlainText(activityDefinitionLastUpdatedText);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceRoute.java
@@ -131,7 +131,8 @@ public class GetActivityInstanceRoute implements Route {
             Handle handle, ActivityInstance activityInstance, String userGuid, String operatorGuid, long languageCodeId
     ) {
         List<ActivityValidationFailure> validationFailures = actValidationService.validate(
-                handle, interpreter, userGuid, operatorGuid, activityInstance.getGuid(), activityInstance.getActivityId(), languageCodeId
+                handle, interpreter, userGuid, operatorGuid, activityInstance.getGuid(), activityInstance.getCreatedAtMillis(),
+                activityInstance.getActivityId(), languageCodeId
         );
         if (validationFailures.isEmpty()) {
             return activityInstance;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetUserAnnouncementsRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetUserAnnouncementsRoute.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.route;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -7,7 +8,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.http.HttpStatus;
-
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;
 import org.broadinstitute.ddp.content.ContentStyle;
@@ -24,10 +24,8 @@ import org.broadinstitute.ddp.model.user.UserAnnouncement;
 import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -83,8 +81,10 @@ public class GetUserAnnouncementsRoute implements Route {
 
             if (!announcements.isEmpty()) {
                 try {
+                    // Render messages using current time to get latest templates.
+                    long timestamp = Instant.now().toEpochMilli();
                     long langCodeId = preferredUserLanguage.getId();
-                    renderer.bulkRenderAndApply(handle, announcements, style, langCodeId);
+                    renderer.bulkRenderAndApply(handle, announcements, style, langCodeId, timestamp);
                 } catch (NoSuchElementException e) {
                     ApiError err = new ApiError(ErrorCodes.SERVER_ERROR, String.format(
                             "Error while rendering announcement messages for user %s and study %s",

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/InvitationCheckStatusRoute.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.route;
 
 import static org.broadinstitute.ddp.json.invitation.InvitationCheckStatusPayload.QUALIFICATION_ZIP_CODE;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -151,7 +152,10 @@ public class InvitationCheckStatusRoute extends ValidatedJsonInputRoute<Invitati
                             .findFirst()
                             .orElse(null);
                     if (errorTmplId != null) {
-                        msg = handle.attach(TemplateDao.class).loadTemplateById(errorTmplId).render(langCode);
+                        // Query using the current time to get the latest template.
+                        msg = handle.attach(TemplateDao.class)
+                                .loadTemplateByIdAndTimestamp(errorTmplId, Instant.now().toEpochMilli())
+                                .render(langCode);
                     }
                     return new ApiError(ErrorCodes.INVALID_INVITATION_QUALIFICATIONS, msg);
                 }
@@ -181,8 +185,9 @@ public class InvitationCheckStatusRoute extends ValidatedJsonInputRoute<Invitati
                 .map(StudySettings::getInviteErrorTemplateId)
                 .orElse(null);
         if (inviteErrorTmplId != null) {
+            // Query using the current time to get the latest template.
             return handle.attach(TemplateDao.class)
-                    .loadTemplateById(inviteErrorTmplId)
+                    .loadTemplateByIdAndTimestamp(inviteErrorTmplId, Instant.now().toEpochMilli())
                     .render(langCode);
         } else {
             return DEFAULT_INVITE_ERROR_MSG;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PatchFormAnswersRoute.java
@@ -216,7 +216,7 @@ public class PatchFormAnswersRoute implements Route {
                     // @TODO might be able to get rid of this query and a bunch of *CachedDao classes
                     // if can figure out how to create Rule objects from RuleDef
                     Question question = questionDao.getQuestionByActivityInstanceAndDto(questionDto,
-                            instanceGuid, false, preferredUserLangDto.getId());
+                            instanceGuid, instanceDto.getCreatedAtMillis(), false, preferredUserLangDto.getId());
 
                     if (!isStudyAdmin && question.isReadonly()) {
                         String msg = "Question with stable id " + questionStableId + " is read-only, cannot update question";
@@ -754,7 +754,8 @@ public class PatchFormAnswersRoute implements Route {
             Handle handle, String participantGuid, String operatorGuid, ActivityInstanceDto instanceDto, long languageCodeId
     ) {
         return actValidationService.validate(
-                handle, interpreter, participantGuid, operatorGuid, instanceDto.getGuid(), instanceDto.getActivityId(), languageCodeId
+                handle, interpreter, participantGuid, operatorGuid, instanceDto.getGuid(), instanceDto.getCreatedAtMillis(),
+                instanceDto.getActivityId(), languageCodeId
         );
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -148,8 +148,8 @@ public class PutFormAnswersRoute implements Route {
                     // checkAddressRequirements(handle, userGuid, form);
 
                     List<ActivityValidationFailure> validationFailures = actValidationService.validate(
-                            handle, interpreter, userGuid, operatorGuid, instanceGuid, form.getActivityId(),
-                            preferredUserLangDto.getId());
+                            handle, interpreter, userGuid, operatorGuid, instanceGuid, form.getCreatedAtMillis(),
+                            form.getActivityId(), preferredUserLangDto.getId());
                     if (!validationFailures.isEmpty()) {
                         String msg = "Activity validation failed";
                         List<String> validationErrorSummaries = validationFailures

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityValidationService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityValidationService.java
@@ -28,6 +28,7 @@ public class ActivityValidationService {
      * @param interpreter the pex interpreter to evaluate expressions
      * @param userGuid the guid of the user (required by the interpreter)
      * @param activityInstanceGuid the guid of the activity instance to validate
+     * @param instanceCreatedAtMillis the timestamp of when instance was created
      * @param activityId the id of the study activity that should be validated
      * @param languageCodeId the id of the language the error message will be translated to
      */
@@ -37,6 +38,7 @@ public class ActivityValidationService {
             String userGuid,
             String operatorGuid,
             String activityInstanceGuid,
+            long instanceCreatedAtMillis,
             long activityId,
             long languageCodeId
     ) {
@@ -71,7 +73,7 @@ public class ActivityValidationService {
         List<ActivityValidationFailure> validationFailures = new ArrayList<>();
         var renderer = new I18nContentRenderer();
         for (var failed : failedDtos) {
-            String msg = renderer.renderContent(handle, failed.getErrorMessageTemplateId(), languageCodeId);
+            String msg = renderer.renderContent(handle, failed.getErrorMessageTemplateId(), languageCodeId, instanceCreatedAtMillis);
             validationFailures.add(new ActivityValidationFailure(msg, failed.getAffectedQuestionStableIds()));
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AddressService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/AddressService.java
@@ -5,6 +5,7 @@ import static org.broadinstitute.ddp.service.DsmAddressValidationStatus.DSM_INVA
 import static org.broadinstitute.ddp.service.DsmAddressValidationStatus.DSM_VALID_ADDRESS_STATUS;
 import static org.broadinstitute.ddp.service.OLCService.DEFAULT_OLC_PRECISION;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -370,7 +371,10 @@ public class AddressService {
                             .findFirst()
                             .orElse(null);
                     if (warningTmplId != null) {
-                        msg = handle.attach(TemplateDao.class).loadTemplateById(warningTmplId).render(langCode);
+                        // Query using the current time to get the latest template.
+                        msg = handle.attach(TemplateDao.class)
+                                .loadTemplateByIdAndTimestamp(warningTmplId, Instant.now().toEpochMilli())
+                                .render(langCode);
                     }
                     warns.add(new AddressWarning(AddressWarning.Warn.ZIP_UNSUPPORTED.getCode(), msg));
                     break;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StatisticsUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StatisticsUtil.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.util;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +85,10 @@ public class StatisticsUtil {
                 options.add(option);
                 optionByStableId.put(option.getStableId(), option);
             }
-            renderer.bulkRenderAndApply(handle, options, style, langId);
+
+            // As we see above, we're querying the latest question and picklist options,
+            // so we use the current time here to render the latest templates.
+            renderer.bulkRenderAndApply(handle, options, style, langId, Instant.now().toEpochMilli());
             statisticsItems.forEach((item) -> item.getData().put("optionDetails", optionByStableId.get(item.getName())));
         }
 

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.sql.stg
@@ -82,3 +82,12 @@ queryAllByUserIdAndStudyId() ::= <<
  where ai.participant_id = :userId
    and act.study_id = :studyId
 >>
+
+findLatestInstanceFromUserGuidAndQuestionId() ::= <<
+<select_all_instances()>
+  join question as q on q.study_activity_id = act.study_activity_id
+  join user as u on u.user_id = ai.participant_id
+ where u.guid = :userGuid
+   and q.question_id = :questionId
+ order by ai.created_at desc limit 1
+>>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/TemplateDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/TemplateDao.sql.stg
@@ -8,11 +8,19 @@ from
   left join i18n_template_substitution as i18n_ts on
     i18n_ts.template_variable_id = tv.template_variable_id and
     i18n_ts.language_code_id = :langCodeId
+  left join revision as i18n_ts_rev on
+    i18n_ts_rev.revision_id = i18n_ts.revision_id
   left join i18n_template_substitution as i18n_ts_def on
     i18n_ts_def.template_variable_id = tv.template_variable_id and
     i18n_ts_def.language_code_id = :defaultLangCodeId
+  left join revision as i18n_ts_def_rev on
+    i18n_ts_def_rev.revision_id = i18n_ts_def.revision_id
 where
   tv.template_id in (\<templateIds\>) and
+  ( (i18n_ts_rev.start_date \<= :timestamp and (i18n_ts_rev.end_date is null or :timestamp \< i18n_ts_rev.end_date))
+    or
+    (i18n_ts_def_rev.start_date \<= :timestamp and (i18n_ts_def_rev.end_date is null or :timestamp \< i18n_ts_def_rev.end_date))
+  ) and
   (i18n_ts.substitution_value is not null or i18n_ts_def.substitution_value is not null)
 >>
 
@@ -33,8 +41,12 @@ select t.template_id,
   left join template_variable as tv on tv.template_id = t.template_id
   left join i18n_template_substitution as ts on ts.template_variable_id = tv.template_variable_id
   left join language_code as lc on lc.language_code_id = ts.language_code_id
+  left join revision as ts_rev on ts_rev.revision_id = ts.revision_id
 >>
 
-queryTemplatesByIds(templateIds) ::= <<
-<select_all_templates()> where t.template_id in (<templateIds>)
+queryTemplatesByIdsAndTimestamp(templateIds) ::= <<
+<select_all_templates()>
+ where t.template_id in (<templateIds>)
+   and (ts.i18n_template_substitution_id is null
+       or (ts_rev.start_date \<= :timestamp and (ts_rev.end_date is null or :timestamp \< ts_rev.end_date)))
 >>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/SectionBlockDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/SectionBlockDaoTest.java
@@ -18,6 +18,7 @@ import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.JdbiQuestion;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.model.activity.definition.ConditionalBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.ContentBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
@@ -79,10 +80,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             FormSectionDef body3 = new FormSectionDef("s3", Collections.emptyList());
 
             FormActivityDef form = insertDummyActivity(handle, intro, closing, userGuid, studyGuid, body1, body2, body3);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(intro, closing, body1, body2, body3);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(intro.getSectionId());
@@ -128,10 +131,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
 
             FormSectionDef s1 = new FormSectionDef("s1", Collections.singletonList(block));
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, s1);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(s1);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(s1.getSectionId());
@@ -164,10 +169,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
 
             FormSectionDef s1 = new FormSectionDef("s1", Collections.singletonList(block));
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, s1);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(s1);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(s1.getSectionId());
@@ -193,10 +200,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             FormSectionDef body = new FormSectionDef("s1", Collections.singletonList(new QuestionBlockDef(question)));
 
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, body);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(body);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(body.getSectionId());
@@ -205,7 +214,7 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             assertEquals(BlockType.QUESTION, blocks.get(0).getBlockType());
 
             assertEquals(1, handle.attach(JdbiQuestion.class).updateIsDeprecatedById(question.getQuestionId(), true));
-            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             blocks = mapping.get(body.getSectionId());
@@ -225,10 +234,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             FormSectionDef body = new FormSectionDef("s1", Collections.singletonList(block));
 
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, body);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(body);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(body.getSectionId());
@@ -237,7 +248,7 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             assertEquals(BlockType.CONDITIONAL, blocks.get(0).getBlockType());
 
             assertEquals(1, handle.attach(JdbiQuestion.class).updateIsDeprecatedById(control.getQuestionId(), true));
-            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             blocks = mapping.get(body.getSectionId());
@@ -258,10 +269,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             FormSectionDef body = new FormSectionDef("s1", Collections.singletonList(block));
 
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, body);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(body);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(body.getSectionId());
@@ -274,7 +287,7 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             assertEquals(BlockType.QUESTION, cond.getNested().get(0).getBlockType());
 
             assertEquals(1, handle.attach(JdbiQuestion.class).updateIsDeprecatedById(nested.getQuestionId(), true));
-            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             blocks = mapping.get(body.getSectionId());
@@ -299,10 +312,12 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             FormSectionDef body = new FormSectionDef("s1", Collections.singletonList(block));
 
             FormActivityDef form = insertDummyActivity(handle, null, null, userGuid, studyGuid, body);
-            String instanceGuid = insertNewInstance(handle, form.getActivityId(), userGuid);
+            var instanceDto = insertNewInstance(handle, form.getActivityId(), userGuid);
+            String instanceGuid = instanceDto.getGuid();
 
             List<Long> sectionIds = extractSectionIds(body);
-            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            Map<Long, List<FormBlock>> mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid,
+                    instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             List<FormBlock> blocks = mapping.get(body.getSectionId());
@@ -315,7 +330,7 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
             assertEquals(BlockType.QUESTION, group.getNested().get(0).getBlockType());
 
             assertEquals(1, handle.attach(JdbiQuestion.class).updateIsDeprecatedById(nested.getQuestionId(), true));
-            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, langCodeId);
+            mapping = dao.getBlocksForSections(handle, sectionIds, instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId);
             assertEquals(sectionIds.size(), mapping.size());
 
             blocks = mapping.get(body.getSectionId());
@@ -330,10 +345,9 @@ public class SectionBlockDaoTest extends TxnAwareBaseTest {
         });
     }
 
-    private String insertNewInstance(Handle handle, long activityId, String userGuid) {
+    private ActivityInstanceDto insertNewInstance(Handle handle, long activityId, String userGuid) {
         return handle.attach(ActivityInstanceDao.class)
-                .insertInstance(activityId, userGuid, userGuid, InstanceStatusType.CREATED, false)
-                .getGuid();
+                .insertInstance(activityId, userGuid, userGuid, InstanceStatusType.CREATED, false);
     }
 
     private FormActivityDef insertDummyActivity(Handle handle, FormSectionDef intro, FormSectionDef closing,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/QuestionDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/QuestionDaoTest.java
@@ -719,7 +719,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
         List<Long> answers = new ArrayList<>(Arrays.asList(answer.getAnswerId()));
 
         return new GetGenericQuestionData(form, version1.getActivityId(),
-                activityInstanceDto.getGuid(), question, answers);
+                activityInstanceDto.getGuid(), activityInstanceDto.getCreatedAtMillis(), question, answers);
     }
 
     @Test
@@ -730,7 +730,8 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             long blockId = genericQuestionData.getForm().getSections().get(0).getBlocks().get(0).getBlockId();
 
             Optional<Question> questionOptional = handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(blockId, genericQuestionData.getActivityInstanceGuid(), langCodeId);
+                    .getQuestionByBlockId(blockId, genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(), langCodeId);
 
             assertNotNull(questionOptional.orElse(null));
             assertEquals(questionOptional.get().getQuestionType(), QuestionType.TEXT);
@@ -753,7 +754,8 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             thrown.expectMessage("No question found for block " + blockId
                     + " and activity instance " + genericQuestionData.getActivityInstanceGuid());
             handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(blockId, genericQuestionData.getActivityInstanceGuid(), false, langCodeId);
+                    .getQuestionByBlockId(blockId, genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(), false, langCodeId);
 
             handle.rollback();
         });
@@ -775,12 +777,13 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             long blockId = form.getSections().get(0).getBlocks().get(0).getBlockId();
 
             Optional<Question> questionOptional = handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(blockId, activityInstanceDto.getGuid(), langCodeId);
+                    .getQuestionByBlockId(blockId, activityInstanceDto.getGuid(), activityInstanceDto.getCreatedAtMillis(), langCodeId);
 
             assertFalse(questionOptional.isPresent());
 
             questionOptional = handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(blockId, activityInstanceDto.getGuid(), true, langCodeId);
+                    .getQuestionByBlockId(blockId, activityInstanceDto.getGuid(),
+                            activityInstanceDto.getCreatedAtMillis(), true, langCodeId);
 
             assertTrue(questionOptional.isPresent());
 
@@ -796,6 +799,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             Question question1 = handle.attach(QuestionDao.class)
                     .getQuestionByIdAndActivityInstanceGuid(genericQuestionData.getQuestion().getQuestionId(),
                             genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(),
                             langCodeId);
 
             assertEquals(question1.getQuestionType(), QuestionType.TEXT);
@@ -815,6 +819,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             Question question1 = handle.attach(QuestionDao.class)
                     .getQuestionByIdAndActivityInstanceGuid(genericQuestionData.getQuestion().getQuestionId(),
                             genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(),
                             false,
                             langCodeId);
 
@@ -838,6 +843,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             Question question1 = handle.attach(QuestionDao.class)
                     .getQuestionByActivityInstanceAndDto(questionDto,
                             genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(),
                             langCodeId);
 
             assertEquals(question1.getQuestionType(), QuestionType.TEXT);
@@ -860,6 +866,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             Question question1 = handle.attach(QuestionDao.class)
                     .getQuestionByActivityInstanceAndDto(questionDto,
                             genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(),
                             false,
                             langCodeId);
 
@@ -882,6 +889,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             handle.attach(QuestionDao.class)
                     .getQuestionByActivityInstanceAndDto(null,
                             genericQuestionData.getActivityInstanceGuid(),
+                            genericQuestionData.getInstanceCreatedAtMillis(),
                             false,
                             langCodeId);
 
@@ -931,14 +939,16 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     .generateTestFormActivityInstanceForUser(handle, version1.getActivityId(), testData.getUserGuid());
 
             Optional<Question> res = handle.attach(QuestionDao.class)
-                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(), langCodeId);
+                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(),
+                            activityInstanceDto.getCreatedAtMillis(), langCodeId);
 
             assertTrue(res.isPresent());
             assertEquals(control.getQuestionId(), (Long) res.get().getQuestionId());
 
             assertEquals(1, handle.attach(JdbiQuestion.class).updateIsDeprecatedById(control.getQuestionId(), true));
             res = handle.attach(QuestionDao.class)
-                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(), langCodeId);
+                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(),
+                            activityInstanceDto.getCreatedAtMillis(), langCodeId);
             assertFalse(res.isPresent());
 
             handle.rollback();
@@ -968,7 +978,8 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             thrown.expectMessage("No control question found for block " + block.getBlockId()
                     + " and activity instance " + activityInstanceDto.getGuid());
             handle.attach(QuestionDao.class)
-                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(), langCodeId);
+                    .getControlQuestionByBlockId(block.getBlockId(), activityInstanceDto.getGuid(),
+                            activityInstanceDto.getCreatedAtMillis(), langCodeId);
 
             handle.rollback();
         });
@@ -983,7 +994,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     .findQuestionDtoById(genericQuestionData.getQuestion().getQuestionId()).get();
 
             Question question1 = handle.attach(QuestionDao.class).getQuestionByActivityInstanceAndDto(questionDto,
-                    genericQuestionData.getActivityInstanceGuid(), true, langCodeId);
+                    genericQuestionData.getActivityInstanceGuid(), genericQuestionData.getInstanceCreatedAtMillis(), true, langCodeId);
 
             assertEquals(question1.getQuestionType(), QuestionType.TEXT);
 
@@ -1134,15 +1145,15 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     .addSection(new FormSectionDef(null, Collections.singletonList(block)))
                     .build();
             handle.attach(ActivityDao.class).insertActivity(form, RevisionMetadata.now(testData.getUserId(), "test"));
-            String instanceGuid = TestDataSetupUtil
-                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid())
-                    .getGuid();
+            var instanceDto = TestDataSetupUtil
+                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid());
+            String instanceGuid = instanceDto.getGuid();
             QuestionDao[] daos = {new QuestionCachedDao(handle), handle.attach(QuestionDao.class)};
             Question question = null;
 
             for (QuestionDao dao : daos) {
                 CacheService.getInstance().resetAllCaches();
-                question = dao.getQuestionByBlockId(block.getBlockId(), instanceGuid, langCodeId).get();
+                question = dao.getQuestionByBlockId(block.getBlockId(), instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId).get();
                 assertEquals(QuestionType.PICKLIST, question.getQuestionType());
                 assertEquals(prompt.getTemplateId(), (Long) question.getPromptTemplateId());
                 assertEquals(sid, question.getStableId());
@@ -1219,12 +1230,12 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     .addSection(new FormSectionDef(null, Collections.singletonList(block)))
                     .build();
             handle.attach(ActivityDao.class).insertActivity(form, RevisionMetadata.now(testData.getUserId(), "test"));
-            String instanceGuid = TestDataSetupUtil
-                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid())
-                    .getGuid();
+            var instanceDto = TestDataSetupUtil
+                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid());
+            String instanceGuid = instanceDto.getGuid();
 
             Question question = handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(block.getBlockId(), instanceGuid, langCodeId).get();
+                    .getQuestionByBlockId(block.getBlockId(), instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId).get();
             assertEquals(QuestionType.TEXT, question.getQuestionType());
             assertEquals(prompt.getTemplateId(), (Long) question.getPromptTemplateId());
             assertEquals(sid, question.getStableId());
@@ -1254,12 +1265,12 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
                     .addSection(new FormSectionDef(null, Collections.singletonList(block)))
                     .build();
             handle.attach(ActivityDao.class).insertActivity(form, RevisionMetadata.now(testData.getUserId(), "test"));
-            String instanceGuid = TestDataSetupUtil
-                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid())
-                    .getGuid();
+            var instanceDto = TestDataSetupUtil
+                    .generateTestFormActivityInstanceForUser(handle, form.getActivityId(), testData.getUserGuid());
+            String instanceGuid = instanceDto.getGuid();
 
             Question question = handle.attach(QuestionDao.class)
-                    .getQuestionByBlockId(block.getBlockId(), instanceGuid, langCodeId).get();
+                    .getQuestionByBlockId(block.getBlockId(), instanceGuid, instanceDto.getCreatedAtMillis(), langCodeId).get();
             assertEquals(QuestionType.TEXT, question.getQuestionType());
             assertEquals(prompt.getTemplateId(), (Long) question.getPromptTemplateId());
             assertEquals(sid, question.getStableId());
@@ -1452,6 +1463,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
 
             Question actual = handle.attach(QuestionDao.class)
                     .getQuestionByActivityInstanceAndDto(questionDto, instanceDto.getGuid(),
+                            instanceDto.getCreatedAtMillis(),
                             LanguageStore.getDefault().getId());
             assertEquals(QuestionType.FILE, actual.getQuestionType());
             assertEquals(sid, actual.getStableId());
@@ -1485,6 +1497,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
 
             Question actual = handle.attach(QuestionDao.class)
                     .getQuestionByActivityInstanceAndDto(questionDto, instanceDto.getGuid(),
+                            instanceDto.getCreatedAtMillis(),
                             LanguageStore.getDefault().getId());
             assertEquals(QuestionType.NUMERIC, actual.getQuestionType());
             assertEquals(sid, actual.getStableId());
@@ -1616,6 +1629,7 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
             Question question = handle.attach(QuestionDao.class).getCompositeQuestion(
                     (CompositeQuestionDto) questionDto,
                     activityInstanceDto.getGuid(),
+                    activityInstanceDto.getCreatedAtMillis(),
                     List.of(ans.getAnswerId()),
                     Collections.emptyList(),
                     langCodeId);
@@ -1687,14 +1701,16 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
         private FormActivityDef form;
         private long activityId;
         private String activityInstanceGuid;
+        private long instanceCreatedAtMillis;
         private TextQuestionDef question;
         private List<Long> answerIds;
 
         public GetGenericQuestionData(FormActivityDef form, long activityId, String activityInstanceGuid,
-                                      TextQuestionDef question, List<Long> answerIds) {
+                                      long instanceCreatedAtMillis, TextQuestionDef question, List<Long> answerIds) {
             this.form = form;
             this.activityId = activityId;
             this.activityInstanceGuid = activityInstanceGuid;
+            this.instanceCreatedAtMillis = instanceCreatedAtMillis;
             this.question = question;
             this.answerIds = answerIds;
         }
@@ -1709,6 +1725,10 @@ public class QuestionDaoTest extends TxnAwareBaseTest {
 
         public String getActivityInstanceGuid() {
             return activityInstanceGuid;
+        }
+
+        public long getInstanceCreatedAtMillis() {
+            return instanceCreatedAtMillis;
         }
 
         public TextQuestionDef getQuestion() {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/TemplateDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/TemplateDaoTest.java
@@ -56,9 +56,8 @@ public class TemplateDaoTest extends TxnAwareBaseTest {
             assertEquals((Long) revId, jdbiTmpl.getRevisionIdIfActive(tmpl.getTemplateId()).get());
             assertEquals(2, jdbiSub.getActiveRevisionIdsByTemplateId(tmpl.getTemplateId()).size());
 
-
             //load template
-            Template loadedTmpl = dao.loadTemplateById(tmpl.getTemplateId());
+            Template loadedTmpl = dao.loadTemplateByIdAndTimestamp(tmpl.getTemplateId(), millis);
             assertNotNull(loadedTmpl.getTemplateId());
             assertNotNull(loadedTmpl.getTemplateCode());
             assertEquals(tmpl.getTemplateCode(), loadedTmpl.getTemplateCode());

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ValidationDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/ValidationDaoTest.java
@@ -80,7 +80,8 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
                     -1L, -1L,
                     -1, false, false, false, false, -1, -1, null
             );
-            List<Rule> validations = handle.attach(ValidationDao.class).getValidationRules(nonExistingQuestionDto, enLangId);
+            List<Rule> validations = handle.attach(ValidationDao.class)
+                    .getValidationRules(nonExistingQuestionDto, enLangId, Instant.now().toEpochMilli());
             assertEquals(0, validations.size());
         });
     }
@@ -92,7 +93,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), -1);
+                    .getValidationRules(buildQuestionDto(form, question), -1, Instant.now().toEpochMilli());
             assertEquals(0, validations.size());
 
             handle.rollback();
@@ -106,7 +107,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), enLangId);
+                    .getValidationRules(buildQuestionDto(form, question), enLangId, Instant.now().toEpochMilli());
             assertEquals(1, validations.size());
             Rule rule = validations.get(0);
             assertEquals(RuleType.REQUIRED, rule.getRuleType());
@@ -132,7 +133,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), enLangId);
+                    .getValidationRules(buildQuestionDto(form, question), enLangId, Instant.now().toEpochMilli());
             assertEquals(1, validations.size());
             Rule rule = validations.get(0);
             assertEquals(RuleType.AGE_RANGE, rule.getRuleType());
@@ -155,7 +156,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), enLangId);
+                    .getValidationRules(buildQuestionDto(form, question), enLangId, Instant.now().toEpochMilli());
             assertEquals(3, validations.size());
 
             assertEquals(RuleType.REQUIRED, validations.get(0).getRuleType());
@@ -181,7 +182,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), enLangId);
+                    .getValidationRules(buildQuestionDto(form, question), enLangId, Instant.now().toEpochMilli());
             assertEquals(ruleDefs.size(), validations.size());
             assertEquals(ruleDefs.size(), validations.stream().filter(Rule::getAllowSave).count());
             assertEquals(0, validations.stream().filter(validation -> !validation.getAllowSave()).count());
@@ -206,7 +207,7 @@ public class ValidationDaoTest extends TxnAwareBaseTest {
             var form = insertDummyActivity(handle, userGuid, studyGuid, question);
 
             List<Rule> validations = handle.attach(ValidationDao.class)
-                    .getValidationRules(buildQuestionDto(form, question), enLangId);
+                    .getValidationRules(buildQuestionDto(form, question), enLangId, Instant.now().toEpochMilli());
             assertEquals(ruleDefs.size(), validations.size());
             assertEquals(ruleDefs.size(), validations.stream().filter(Rule::getAllowSave).count());
             assertEquals(0, validations.stream().filter(validation -> !validation.getAllowSave()).count());

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -102,7 +102,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "<p>this is body</p>");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
@@ -121,7 +121,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "<p>this is body</p>");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
@@ -142,7 +142,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(2L, "this is bold prompt");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -162,7 +162,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <b>bold</b> prompt");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -183,7 +183,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
@@ -199,7 +199,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
         I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any())).thenReturn(fixture);
+        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
@@ -217,7 +217,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
             handle.attach(UserProfileSql.class).upsertLastName(testData.getUserId(), "bar");
 
             I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-            doReturn(Collections.emptyMap()).when(mockRenderer).bulkRender(any(), any(), anyLong(), any());
+            doReturn(Collections.emptyMap()).when(mockRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
             doReturn(handle.attach(UserProfileDao.class)).when(mockHandle).attach(UserProfileDao.class);
 
             FormInstance form = buildEmptyTestInstance(testData.getUserId());
@@ -232,7 +232,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
                 assertEquals("foo", snaphost.get(I18nTemplateConstants.Snapshot.PARTICIPANT_FIRST_NAME));
                 assertEquals("bar", snaphost.get(I18nTemplateConstants.Snapshot.PARTICIPANT_LAST_NAME));
                 return true;
-            }));
+            }), anyLong());
 
             handle.rollback();
         });

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
@@ -868,6 +868,7 @@ public class PatchFormAnswersRouteStandaloneTest {
             assertTrue(optCompQuestion.isPresent());
             Question compositeQuestionWithAnswers = handle.attach(QuestionDao.class)
                     .getQuestionByIdAndActivityInstanceGuid(optCompQuestion.get().getId(), instanceGuid,
+                            instanceDto.getCreatedAtMillis(),
                             LanguageStore.getDefault().getId());
             assertTrue(compositeQuestionWithAnswers instanceof CompositeQuestion);
             List<CompositeAnswer> savedCompositeAnswers = ((CompositeQuestion) compositeQuestionWithAnswers).getAnswers();

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityValidationServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityValidationServiceTest.java
@@ -37,6 +37,7 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
     private static TestDataSetupUtil.GeneratedTestData testData;
     private static String userGuid;
     private static String activityInstanceGuid;
+    private static long instanceCreatedAtMillis;
     private static long activityId;
     private static long langCodeId;
     private static FormActivityDef activity;
@@ -77,6 +78,7 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         // Inserting activity instance
         ActivityInstanceDto instanceDto = handle.attach(ActivityInstanceDao.class).insertInstance(activity.getActivityId(), userGuid);
         activityInstanceGuid = instanceDto.getGuid();
+        instanceCreatedAtMillis = instanceDto.getCreatedAtMillis();
         // Inserting answers
         var answerDao = handle.attach(AnswerDao.class);
         answerDao.createAnswer(testData.getUserId(), instanceDto.getId(),
@@ -95,7 +97,7 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             insertValidation(handle, "false", "Should never fail");
             List<ActivityValidationFailure> validationFailures = actValidationService.validate(
-                    handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId
+                    handle, interpreter, userGuid, userGuid, activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId
             );
             Assert.assertTrue(validationFailures.isEmpty());
             handle.rollback();
@@ -107,7 +109,7 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             insertValidation(handle, "true", "Should always fail");
             List<ActivityValidationFailure> validationFailures = actValidationService.validate(
-                    handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId
+                    handle, interpreter, userGuid, userGuid, activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId
             );
             Assert.assertEquals(1, validationFailures.size());
             Assert.assertNotNull(validationFailures.get(0));
@@ -124,7 +126,7 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
             Assert.assertEquals(
                     2,
                     actValidationService.validate(
-                            handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId
+                            handle, interpreter, userGuid, userGuid, activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId
                     ).get(0).getAffectedQuestionStableIds().size()
             );
             handle.rollback();
@@ -138,7 +140,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
             insertValidation(handle, "true", "Should always fail");
             Assert.assertEquals(
                     2,
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .size()
             );
             handle.rollback();
@@ -152,7 +155,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
             insertValidation(handle, "true", "Should always fail");
             Assert.assertEquals(
                     1,
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .size()
             );
             handle.rollback();
@@ -164,7 +168,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             insertValidation(handle, "true & true", "Should fail - syntax");
             Assert.assertTrue(
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .isEmpty()
             );
             handle.rollback();
@@ -177,7 +182,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
             insertValidation(handle, "true", "true", "Precondition is TRUE - expression should fail");
             Assert.assertEquals(
                     1,
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .size()
             );
             handle.rollback();
@@ -189,7 +195,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             insertValidation(handle, "false", "true", "Precondition is FALSE - expression should NOT fail");
             Assert.assertTrue(
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .isEmpty()
             );
             handle.rollback();
@@ -202,7 +209,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
             insertValidation(handle, null, "true", "Precondition is NULL - expression should NOT fail");
             Assert.assertEquals(
                     1,
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .size()
             );
             handle.rollback();
@@ -214,7 +222,8 @@ public class ActivityValidationServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> {
             insertValidation(handle, "true & true", "true", "Precondition is malformed - expression should NOT fail");
             Assert.assertTrue(
-                    actValidationService.validate(handle, interpreter, userGuid, userGuid, activityInstanceGuid, activityId, langCodeId)
+                    actValidationService.validate(handle, interpreter, userGuid, userGuid,
+                            activityInstanceGuid, instanceCreatedAtMillis, activityId, langCodeId)
                             .isEmpty()
             );
             handle.rollback();

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
@@ -720,7 +720,8 @@ public class AngioConsentVersion2 implements CustomTask {
 
         @SqlQuery("select ai.*, stat_type.activity_instance_status_type_code as activity_instance_status_type,"
                 + "       act_type.activity_type_code as activity_type, act.allow_unauthenticated, act.study_id,"
-                + "       act.study_activity_code"
+                + "       act.study_activity_code,"
+                + "       null as parent_instance_guid, null as parent_activity_id, null as parent_activity_code"
                 + "  from activity_instance as ai"
                 + "  join activity_instance_status as stat on stat.activity_instance_id = ai.activity_instance_id"
                 + "  join activity_instance_status_type as stat_type"

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainConsentVersion2.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainConsentVersion2.java
@@ -137,7 +137,7 @@ public class BrainConsentVersion2 implements CustomTask {
                 dobDto.getId(), ageRangeValidation.getId(), ageRangeValidation.getRevisionId(), ageRangeValidation.getRuleType());
 
         UpdateTemplatesInPlace updateTemplatesTask = new UpdateTemplatesInPlace();
-        updateTemplatesTask.traverseActivity(handle, activityCode, definition, activity);
+        updateTemplatesTask.traverseActivity(handle, activityCode, definition, activity, versionDto.getRevStart());
         LOG.info("updated variables for styling changes");
 
         //update brain_consent_s3_election_agree listHintStyle to NONE

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainFixPrequalValidations.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainFixPrequalValidations.java
@@ -1,0 +1,104 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.JdbiActivityValidation;
+import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
+import org.broadinstitute.ddp.db.dao.JdbiRevision;
+import org.broadinstitute.ddp.db.dao.JdbiTemplate;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.JdbiVariableSubstitution;
+import org.broadinstitute.ddp.db.dao.TemplateDao;
+import org.broadinstitute.ddp.db.dto.ActivityValidationDto;
+import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A one-time task to fix revision data for Brain study's Prequal activity validations.
+ *
+ * <p>In the Brain study's `patch-log.conf` file, we see that we ran `BrainPrequalV2` before `BrainPreqalValidations`.
+ * This means when we go insert activity validations, the first version of Prequal has been marked terminated, and a new
+ * v2 has been created. Given how `InsertActivityValidations` was previously written, it will insert templates for an
+ * activity validation using the same revision_id as the oldest activity version. This means for Brain's Prequal
+ * activity, we inserted templates that are effectively terminated. This is an issue when we query activity validation
+ * templates using proper time ranges.
+ *
+ * <p>This task fixes this issue by creating the appropriate revisioning data and updating the templates
+ * with new revision_ids.
+ */
+public class BrainFixPrequalValidations implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrainFixPrequalValidations.class);
+    private static final String STUDY_GUID = "cmi-brain";
+    private static final String PREQUAL_ACT_CODE = "PREQUAL";
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        if (!studyCfg.getString("study.guid").equals(STUDY_GUID)) {
+            throw new DDPException("This task is only for the " + STUDY_GUID + " study!");
+        }
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(STUDY_GUID);
+
+        var jdbiRevision = handle.attach(JdbiRevision.class);
+        var jdbiActVersion = handle.attach(JdbiActivityVersion.class);
+        var jdbiActValidation = handle.attach(JdbiActivityValidation.class);
+        var jdbiSubstitution = handle.attach(JdbiVariableSubstitution.class);
+        var jdbiTemplate = handle.attach(JdbiTemplate.class);
+        var templateDao = handle.attach(TemplateDao.class);
+
+        long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), PREQUAL_ACT_CODE);
+        List<ActivityVersionDto> versions = jdbiActVersion.findAllVersionsInAscendingOrder(activityId);
+        if (versions.isEmpty()) {
+            throw new DDPException("Could not find versions for activity " + PREQUAL_ACT_CODE);
+        }
+
+        ActivityVersionDto oldestVersion = versions.get(0);
+        long newRevId = jdbiRevision.copyStart(oldestVersion.getRevId());
+
+        // Find the templates associated with the activity validations.
+        List<Long> validationMessageIds = jdbiActValidation._findByActivityId(activityId)
+                .stream()
+                .map(ActivityValidationDto::getErrorMessageTemplateId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        LOG.info("Found {} activity validation message templates to update", validationMessageIds.size());
+
+        // Find the translation text objects for each template.
+        // Each variable should only have one translation for the Brain study.
+        // We use the oldest version's start time for the query to ensure we find them.
+        List<Long> translationIds = templateDao
+                .loadTemplatesByIdsAndTimestamp(validationMessageIds, oldestVersion.getRevStart())
+                .flatMap(template -> template.getVariables().stream())
+                .flatMap(variable -> variable.getTranslations().stream())
+                .map(translation -> translation.getId().get())
+                .collect(Collectors.toList());
+        LOG.info("Found {} template variable translations to update", translationIds.size());
+
+        // Manually update the templates and translations to use the new revision_id.
+        // The new revision_id doesn't have an end date, so it ensures templates are visible for all activity versions.
+        long[] newTranslationRevIds = new long[translationIds.size()];
+        Arrays.fill(newTranslationRevIds, newRevId);
+        int[] updated = jdbiSubstitution.bulkUpdateRevisionIdsBySubIds(translationIds, newTranslationRevIds);
+        DBUtils.checkUpdate(translationIds.size(), Arrays.stream(updated).sum());
+        for (var templateId : validationMessageIds) {
+            DBUtils.checkUpdate(1, jdbiTemplate.updateRevisionIdById(templateId, newRevId));
+        }
+
+        LOG.info("Finished fixing activity validations for " + PREQUAL_ACT_CODE);
+    }
+}

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainPediatricsUpdates.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainPediatricsUpdates.java
@@ -97,7 +97,7 @@ public class BrainPediatricsUpdates implements CustomTask {
                 releaseActivityCode, "v1").get();
         FormActivityDef activity = (FormActivityDef) activityDao.findDefByDtoAndVersion(activityDto, versionDto);
         UpdateTemplatesInPlace updateTemplatesTask = new UpdateTemplatesInPlace();
-        updateTemplatesTask.traverseActivity(handle, releaseActivityCode, definition, activity);
+        updateTemplatesTask.traverseActivity(handle, releaseActivityCode, definition, activity, versionDto.getRevStart());
         //update release subtitle
         String newSubtitle = "<p class=\"no-margin sticky__text\"><span>"
                 + " If you have questions about the study or the consent form at any time, please contact us at </span> "

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/InsertActivityValidations.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/InsertActivityValidations.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
+import org.broadinstitute.ddp.db.dao.JdbiRevision;
 import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
 import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
@@ -66,7 +67,9 @@ abstract class InsertActivityValidations implements CustomTask {
             }
 
             // Since activity validations wasn't designed with revisions in mind, we use the oldest version here to be safe.
-            long revId = versions.get(0).getRevId();
+            // We make a copy of it here so to ensure we use a revision that has a start date but no end date.
+            ActivityVersionDto oldestVersion = versions.get(0);
+            long revId = handle.attach(JdbiRevision.class).copyStart(oldestVersion.getRevId());
 
             builder.insertValidations(handle, activityId, activityCode, revId, List.copyOf(item.getConfigList("validations")));
         }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityTemplatesInPlace.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityTemplatesInPlace.java
@@ -83,7 +83,7 @@ public class UpdateActivityTemplatesInPlace implements CustomTask {
                 FormActivityDef activity = (FormActivityDef) activityDao.findDefByDtoAndVersion(activityDto, versionDto);
 
                 var updateTask = new UpdateTemplatesInPlace();
-                updateTask.traverseActivity(handle, activityCode, definition, activity);
+                updateTask.traverseActivity(handle, activityCode, definition, activity, versionDto.getRevStart());
                 found = true;
                 break;
             }


### PR DESCRIPTION
## Context

See DDP-5658. Database supports storing revisioned templates, but our queries are not accounting for revisioned "template variable substitutions". This PR refactors the code to support such revisioned templates. This will make it easier for studies to create new revisions of activities that requires only simple word change to templates, as in DDP-5583.

Key concepts:
* Templates contain a list of variables, and each variable have a list of translation substitution texts.
* These variable substitutions can be revisioned using time-based approach (e.g. start date, end date).
* So when querying for revisioned templates, we'll need a timestamp to pinpoint the revision.
* When querying for activity definitions, we use the activity's version start time as timestamp.
* When querying for activity instances, we use the instance's created_at time as timestamp.

I have ran several studies locally, and tested fetching of activity data for various revisions. It looks fine for me locally as far as I can tell. When this is merged, I'll ask for Kiara's help to thoroughly regression test this.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :sweat_smile: There might be some issues here

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

