### PR TITLE
DDP-5659 fix model notification in JdbiUmbrellaStudyCached

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
@@ -139,7 +139,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
         if (val > 0) {
             StudyDto dto = findByStudyGuid(guid);
             if (dto != null) {
-                notifyModelUpdated(ModelChangeType.UMBRELLA, dto.getId());
+                notifyModelUpdated(ModelChangeType.STUDY, dto.getId());
                 removeFromCache(dto);
             }
         }
@@ -164,7 +164,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
         if (val > 0) {
             StudyDto dto = findByStudyGuid(guid);
             if (dto != null) {
-                notifyModelUpdated(ModelChangeType.UMBRELLA, dto.getUmbrellaId());
+                notifyModelUpdated(ModelChangeType.STUDY, dto.getId());
                 removeFromCache(dto);
             }
         }
@@ -190,7 +190,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                        Long precisionId, boolean shareLocation, String studyEmail, String recaptchaSiteKey) {
         long studyId = delegate.insert(studyName, studyGuid, umbrellaId, webBaseUrl, auth0TenantId, irbPassword, precisionId, shareLocation,
                 studyEmail, recaptchaSiteKey);
-        notifyModelUpdated(ModelChangeType.UMBRELLA, umbrellaId);
+        notifyModelUpdated(ModelChangeType.STUDY, studyId);
         return studyId;
     }
 
@@ -199,7 +199,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
                        boolean shareLocation, String studyEmail, String recaptchaSiteKey) {
         long studyId = delegate.insert(studyName, studyGuid, umbrellaId, webBaseUrl, auth0TenantId, precision, shareLocation,
                 studyEmail, recaptchaSiteKey);
-        notifyModelUpdated(ModelChangeType.UMBRELLA, umbrellaId);
+        notifyModelUpdated(ModelChangeType.STUDY, studyId);
         return studyId;
     }
 
@@ -207,7 +207,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
     public int updateIrbPasswordByGuid(String irbPassword, String studyGuid) {
         int modified = delegate.updateIrbPasswordByGuid(irbPassword, studyGuid);
         if (modified > 0) {
-            notifyModelUpdated(ModelChangeType.UMBRELLA, findByStudyGuid(studyGuid).getUmbrellaId());
+            notifyModelUpdated(ModelChangeType.STUDY, findByStudyGuid(studyGuid).getId());
         }
         return modified;
     }
@@ -216,7 +216,7 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
     public boolean updateWebBaseUrl(String studyGuid, String webBaseUrl) {
         boolean modified = delegate.updateWebBaseUrl(studyGuid, webBaseUrl);
         if (modified) {
-            notifyModelUpdated(ModelChangeType.UMBRELLA, findByStudyGuid(studyGuid).getUmbrellaId());
+            notifyModelUpdated(ModelChangeType.STUDY, findByStudyGuid(studyGuid).getId());
         }
         return modified;
     }


### PR DESCRIPTION
## Context

See DDP-5659. Disclaimer: I don't actually know what I'm doing in this PR. I'm not too familiar with how the "model notification" works for the cache, but the code looks wrong so I'm trying to fix it. I discovered this while working on DDP-5583, where I had to add new sql statements to `JdbiUmbrellaStudy` and thus `JdbiUmbrellaStudyCached`. Please advice.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :scream: I'm sweaty and nervous

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

I did NOT test this.

## Release

- [x] These changes require no special release procedures--just code!

