### PR TITLE
Allow traffic from us-central1 private blocks

### DIFF
--- a/pepper-apis/gae-egress-proxy/squid.conf
+++ b/pepper-apis/gae-egress-proxy/squid.conf
@@ -5,6 +5,7 @@ acl allowed_domains dstdomain .cloud.es.io  # Elasticsearch host
 acl allowed_domains dstdomain api.sendgrid.com  # SendGrid API host
 acl allowed_clients src 69.173.64.0/18      # Broad IP range
 acl allowed_clients src 10.8.0.0/28         # GAE internal IP range
+acl allowed_clients src 10.128.0.0/20       # Google us-central1
 acl CONNECT method CONNECT                  # Use HTTP tunnel
 
 # Limit tunneling to only these ports.


### PR DESCRIPTION
[DDP-5677](https://broadinstitute.atlassian.net/browse/DDP-5677)

## Context
In order to allow the Salt instances to make use of the ElasticSearch proxy, the allowed IP ranges need to be expanded to include the private address block for `us-central1`. Since all environments are in the `us-central1` data center, these changes will support `dev`, `test` and `prod`.

## Checklist
- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] **N/A** If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] **N/A** If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

## FUD Score
- [x] :relaxed: All good, business as usual!

## How do we demo these changes?
- [x] This ticket adds no user-visible features.

## Testing
- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release
- [x] These changes require no special release procedures--just code!

