### PR TITLE
DDP-5045 fix sendgrid events verification

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/SendGridEventVerificationFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/SendGridEventVerificationFilter.java
@@ -10,12 +10,13 @@ import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
+import java.security.Security;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 
-
 import com.sendgrid.helpers.eventwebhook.EventWebhook;
 import com.sendgrid.helpers.eventwebhook.EventWebhookHeader;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.slf4j.Logger;
@@ -43,6 +44,20 @@ public class SendGridEventVerificationFilter implements Filter {
 
     public SendGridEventVerificationFilter(String cfgParamSendGridEventsVerificationKey) {
         this.cfgParamSendGridEventsVerificationKey = cfgParamSendGridEventsVerificationKey;
+        registerSecurityProvider();
+    }
+
+    private void registerSecurityProvider() {
+        boolean alreadyRegistered = false;
+        for (var provider : Security.getProviders()) {
+            if (BouncyCastleProvider.PROVIDER_NAME.equals(provider.getName())) {
+                alreadyRegistered = true;
+                break;
+            }
+        }
+        if (!alreadyRegistered) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/SendGridEventRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/SendGridEventRoute.java
@@ -7,7 +7,6 @@ import static org.broadinstitute.ddp.constants.ErrorCodes.DATA_PERSIST_ERROR;
 import static org.broadinstitute.ddp.constants.ErrorCodes.MISSING_BODY;
 import static org.slf4j.LoggerFactory.getLogger;
 
-
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.json.errors.ApiError;
@@ -45,7 +44,7 @@ public class SendGridEventRoute implements Route {
         try {
             TransactionWrapper.useTxn(handle -> sendGridEventService.persistLogEvents(handle, sendGridEvents));
         } catch (Exception e) {
-            haltError(SC_INTERNAL_SERVER_ERROR, DATA_PERSIST_ERROR, "Error saving auth0 event", e);
+            haltError(SC_INTERNAL_SERVER_ERROR, DATA_PERSIST_ERROR, "Error saving sendgrid event", e);
         }
     }
 

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -255,4 +255,5 @@
     <include file="db-changes/schema/DDP-5582-nested-activity-block.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5402-create-indices-for-revision-and-user-study-enrollment.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5604-activity-can-delete-instances.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5045-sendgrid-event-message-id-nullable.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5045-sendgrid-event-message-id-nullable.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5045-sendgrid-event-message-id-nullable.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210309-sendgrid-event-sg-message-id-column-nullable">
+        <dropNotNullConstraint tableName="sendgrid_event" columnName="sg_message_id" columnDataType="varchar(100)"/>
+    </changeSet>
+
+</databaseChangeLog>
+


### PR DESCRIPTION
## Context

While testing the sendgrid webhook feature in `dev` environment, I noticed we didn't turn on "Signed Event Webhooks". After turning it on and setting the appropriate `sendgrid.eventsVerificationKey` in the config file, I noticed there was an issue in the logs:

```
2021-03-09 17:49:38.092 EST POST 401 1.72 KiB 15 ms SendGrid Event API /pepper/v1/sendgrid-event
2021-03-09 17:49:38.105 EST 22:49:38.105 c7c0dcd6-5168-451b-a7f8-d1e4eb9ed7e1 167.89.117.70, 169.254.1.1 C: S: [qtp2061423649-157] WARN o.b.d.f.SendGridEventVerificationFilter Error during SendGrid event signature verification: java.security.NoSuchProviderException: no such provider: BC
```

After doing some digging, I found this [GitHub issue][issue] and [this code example][example], which shows how to add the security provider. I manually deployed this fix to `dev` and verified that it fixes the problem. While I'm in here, I also fixed a few things.

[issue]: https://github.com/sendgrid/sendgrid-java/issues/624
[example]: https://github.com/sendgrid/sendgrid-java/blob/main/examples/helpers/eventwebhook/Example.java

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] Go through some study workflows that sends emails or trigger example email events from SendGrid.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

