### PR TITLE
Modify study builder to load labeled Event Configurations

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
@@ -12,6 +12,7 @@ import org.broadinstitute.ddp.db.dto.NotificationTemplateSubstitutionDto;
 import org.broadinstitute.ddp.db.dto.QueuedEventDto;
 import org.broadinstitute.ddp.db.dto.QueuedNotificationDto;
 import org.broadinstitute.ddp.db.dto.QueuedPdfGenerationDto;
+import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.types.EventActionType;
 import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
 import org.broadinstitute.ddp.model.event.EventConfiguration;
@@ -37,6 +38,16 @@ public interface EventDao extends SqlObject {
         return getEventConfigurationDtosByStudyId(studyId).stream()
                 .map(dto -> new EventConfiguration(dto))
                 .collect(Collectors.toList());
+    }
+
+    default Optional<EventConfiguration> getAllEventConfigurationsByStudyIdAndLabel(long studyId, String label) {
+        if (label == null) {
+            throw new DDPException("label argument cannot be null");
+        }
+        return getEventConfigurationDtosByStudyId(studyId).stream()
+                .map(dto -> new EventConfiguration(dto))
+                .filter(cfg -> label.equals(cfg.getLabel()))
+                .findFirst();
     }
 
     default List<EventConfiguration> getAllEventConfigurationsByStudyIdAndTriggerType(long studyId,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
@@ -40,7 +40,7 @@ public interface EventDao extends SqlObject {
                 .collect(Collectors.toList());
     }
 
-    default Optional<EventConfiguration> getAllEventConfigurationsByStudyIdAndLabel(long studyId, String label) {
+    default Optional<EventConfiguration> getEventConfigurationByStudyIdAndLabel(long studyId, String label) {
         if (label == null) {
             throw new DDPException("label argument cannot be null");
         }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
@@ -45,8 +45,8 @@ public interface EventDao extends SqlObject {
             throw new DDPException("label argument cannot be null");
         }
         return getEventConfigurationDtosByStudyId(studyId).stream()
-                .map(dto -> new EventConfiguration(dto))
                 .filter(cfg -> label.equals(cfg.getLabel()))
+                .map(dto -> new EventConfiguration(dto))
                 .findFirst();
     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiEventConfiguration.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiEventConfiguration.java
@@ -9,12 +9,13 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface JdbiEventConfiguration extends SqlObject {
 
     @SqlUpdate("insert into event_configuration"
-            + "(event_trigger_id,event_action_id,umbrella_study_id,created_at,is_active,max_occurrences_per_user,"
+            + "(label,event_trigger_id,event_action_id,umbrella_study_id,created_at,is_active,max_occurrences_per_user,"
             + "post_delay_seconds,precondition_expression_id,cancel_expression_id, dispatch_to_housekeeping, execution_order) "
-            + " values(:triggerId,:actionId,:studyId,:createdAt,true,:maxOccurrencesPerUser,:postDelay,:preconditionId,"
+            + " values(:label,:triggerId,:actionId,:studyId,:createdAt,true,:maxOccurrencesPerUser,:postDelay,:preconditionId,"
             + ":cancelId, :dispatchToHousekeeping, :executionOrder)")
     @GetGeneratedKeys
     long insert(
+            @Bind("label")String label,
             @Bind("triggerId") long eventTriggerId,
             @Bind("actionId") long eventActionId,
             @Bind("studyId") long studyId,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
@@ -26,6 +26,7 @@ public class EventConfigurationDto {
     private String cancelExpression;
     private Integer maxOccurrencesPerUser;
     private int executionOrder;
+    private String label;
     private String gcpTopic; // FIXME should not be a base field of EventAction
 
     /**
@@ -101,6 +102,7 @@ public class EventConfigurationDto {
     // No sub-table
 
     public EventConfigurationDto(long eventConfigurationId,
+                                 String label,
                                  EventTriggerType eventTriggerType,
                                  EventActionType eventActionType,
                                  int postDelaySeconds,
@@ -128,6 +130,7 @@ public class EventConfigurationDto {
                                  String contactEmailQuestionStableId,
                                  Boolean markExistingInvitationsAsVoided) {
         this.eventConfigurationId = eventConfigurationId;
+        this.label = label;
         this.eventTriggerType = eventTriggerType;
         this.eventActionType = eventActionType;
         this.postDelaySeconds = postDelaySeconds;
@@ -158,6 +161,10 @@ public class EventConfigurationDto {
 
     public long getEventConfigurationId() {
         return eventConfigurationId;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     public EventTriggerType getEventTriggerType() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
@@ -19,9 +19,11 @@ public class EventConfiguration {
     private boolean dispatchToHousekeeping;
     private Integer postDelaySeconds;
     private int executionOrder;
+    private String label;
 
     public EventConfiguration(EventConfigurationDto dto) {
         this.eventConfigurationId = dto.getEventConfigurationId();
+        this.label = dto.getLabel();
         this.eventActionType = dto.getEventActionType();
         this.eventTriggerType = dto.getEventTriggerType();
         this.preconditionExpression = dto.getPreconditionExpression();
@@ -129,6 +131,10 @@ public class EventConfiguration {
 
     public long getEventConfigurationId() {
         return eventConfigurationId;
+    }
+
+    public String getLabel() {
+        return label;
     }
 
     public EventActionType getEventActionType() {

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -255,4 +255,5 @@
     <include file="db-changes/schema/DDP-5582-nested-activity-block.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5402-create-indices-for-revision-and-user-study-enrollment.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5604-activity-can-delete-instances.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5679-add-event-configuration-label.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5679-add-event-configuration-label.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5679-add-event-configuration-label.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="mocana" id="20210309-add-event-configuration-label">
+        <addColumn tableName="event_configuration">
+            <column name="label" type="varchar(36)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+        <createIndex tableName="event_configuration" indexName="event_configuration_label_idx">
+            <column name="label"/>
+        </createIndex>
+        <addUniqueConstraint tableName="event_configuration" columnNames="umbrella_study_id,label"
+                             constraintName="event_configuration_label_uk"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/EventDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/EventDao.sql.stg
@@ -6,6 +6,7 @@ group EventDao;
 eventConfigurationLookup() ::= <<
 SELECT
      ec.event_configuration_id,
+     ec.label,
      ett.event_trigger_type_code event_trigger_type,
      eat.event_action_type_code event_action_type,
      ec.post_delay_seconds,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/housekeeping/HousekeepingSendgridEmailNotificationTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/housekeeping/HousekeepingSendgridEmailNotificationTest.java
@@ -109,7 +109,7 @@ public class HousekeepingSendgridEmailNotificationTest extends HousekeepingTest 
             long eventTriggerId = eventTriggerDao.insertBaseTrigger(EventTriggerType.ACTIVITY_STATUS);
             activityStatusTriggerDao.insert(eventTriggerId, testActivity.getActivityId(), COMPLETE);
 
-            insertedEventConfigId = eventConfigDao.insert(eventTriggerId, testEmailActionId, generatedTestData
+            insertedEventConfigId = eventConfigDao.insert(null, eventTriggerId, testEmailActionId, generatedTestData
                             .getStudyId(), Instant.now().toEpochMilli(), 1, null, trueExpressionId,
                     falseExpressionId, true, 1);
             assertThat(testEmailActionId, notNullValue());

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/CreateInvitationEventActionTest.java
@@ -191,7 +191,7 @@ public class CreateInvitationEventActionTest extends TxnAwareBaseTest {
             // setup downstream event
             long triggerId = handle.attach(EventTriggerDao.class).insertStaticTrigger(EventTriggerType.INVITATION_CREATED);
             long actionId = handle.attach(EventActionDao.class).insertMarkActivitiesReadOnlyAction(Set.of(activity.getActivityId()));
-            handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+            handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                     Instant.now().toEpochMilli(), null, null, null, null, false, 1);
 
             var signal = new EventSignal(testData.getUserId(), testData.getUserId(), testData.getUserGuid(),

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
@@ -175,7 +175,7 @@ public class NotificationEventActionTest extends TxnAwareBaseTest {
                                                               NotificationType notificationType, NotificationServiceType serviceType,
                                                               Long linkedActivityId) {
         long eventConfigurationId = insertInvitationEmailEventConfiguration(handle, triggerType);
-        return new EventConfigurationDto(eventConfigurationId, triggerType, EventActionType.NOTIFICATION, 0, true,
+        return new EventConfigurationDto(eventConfigurationId, "EMAIL_EVENT", triggerType, EventActionType.NOTIFICATION, 0, true,
                 null, null, null, 1, MessageDestination.PARTICIPANT_NOTIFICATION.name(),
                 null, null, null, null, null, null, null, null,
                 notificationType, serviceType, linkedActivityId,
@@ -186,7 +186,7 @@ public class NotificationEventActionTest extends TxnAwareBaseTest {
         long triggerId = handle.attach(EventTriggerDao.class).insertStaticTrigger(staticTriggerType);
         long actionId = handle.attach(EventActionDao.class).insertInvitationEmailNotificationAction(
                 new SendgridEmailEventActionDto("dummy-template-key", "en", false));
-        return handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+        return handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                 Instant.now().toEpochMilli(), null, 0, null, null, true, 1);
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/EventServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/EventServiceTest.java
@@ -162,7 +162,7 @@ public class EventServiceTest extends IntegrationTestSuite.TestCase {
                     precondExprId = handle.attach(JdbiExpression.class).getByGuid(TestData.expressionGuid).get().getId();
                     creationExprId = handle.attach(JdbiExpression.class).insertExpression("true").getId();
                     autoInstantiationConfigurationId = jdbiEventConfig.insert(
-                            eventTriggerId,
+                            null, eventTriggerId,
                             activityInstanceCreationEventActionId,
                             umbrellaStudyId,
                             timestamp,
@@ -175,7 +175,7 @@ public class EventServiceTest extends IntegrationTestSuite.TestCase {
                     );
 
                     updateDSMInclusionConfigurationId = jdbiEventConfig.insert(
-                            eventTriggerId,
+                            null, eventTriggerId,
                             dsmInclusionEventActionId,
                             umbrellaStudyId,
                             timestamp,
@@ -188,7 +188,7 @@ public class EventServiceTest extends IntegrationTestSuite.TestCase {
                     );
 
                     announcementConfigId = jdbiEventConfig.insert(
-                            eventTriggerId,
+                            null, eventTriggerId,
                             announcementActionId,
                             umbrellaStudyId,
                             timestamp,

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/JoinMailingListRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/JoinMailingListRouteTest.java
@@ -104,7 +104,7 @@ public class JoinMailingListRouteTest extends IntegrationTestSuite.TestCase {
         long emailActionId = eventActionDao.insertNotificationAction(eventAction);
 
         long eventTriggerId = eventTriggerDao.insertMailingListTrigger();
-        insertedEventConfigId = jdbiEventConfig.insert(eventTriggerId, emailActionId, testData.getStudyId(),
+        insertedEventConfigId = jdbiEventConfig.insert(null, eventTriggerId, emailActionId, testData.getStudyId(),
                 Instant.now().toEpochMilli(), null, null, null,
                 null, true, 1);
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
@@ -96,7 +96,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
         long actionId = handle.attach(EventActionDao.class).insertNotificationAction(
                 new SendgridEmailEventActionDto(sendgridTemplateGuid, "en", false));
         return handle.attach(JdbiEventConfiguration.class).insert(
-                triggerId, actionId, generatedTestData.getStudyId(),
+                null, triggerId, actionId, generatedTestData.getStudyId(),
                 Instant.now().toEpochMilli(), 1, null, null, null, true, 1);
     }
 
@@ -265,7 +265,7 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
             Expression cancelExpr = handle.attach(JdbiExpression.class).insertExpression(
                     "!user.event.kit.isReason(\"REPLACEMENT\")");
             handle.attach(JdbiEventConfiguration.class).insert(
-                    triggerId, actionId, testData.getStudyId(),
+                    null, triggerId, actionId, testData.getStudyId(),
                     Instant.now().toEpochMilli(), 1, null, null, cancelExpr.getId(), false, 1);
         });
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/SendEmailRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/SendEmailRouteTest.java
@@ -228,7 +228,7 @@ public class SendEmailRouteTest extends IntegrationTestSuite.TestCase {
             throw new Exception("Unsupported key type");
         }
 
-        return handle.attach(JdbiEventConfiguration.class).insert(eventTriggerId, emailActionId, testData.getStudyId(),
+        return handle.attach(JdbiEventConfiguration.class).insert(null, eventTriggerId, emailActionId, testData.getStudyId(),
                 Instant.now().toEpochMilli(), null, null, trueExpressionId,
                 falseExpressionId, true, 1);
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/SendExitNotificationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/SendExitNotificationRouteTest.java
@@ -192,7 +192,7 @@ public class SendExitNotificationRouteTest extends IntegrationTestSuite.TestCase
         long actionId = handle.attach(EventActionDao.class).insertStudyNotificationAction(
                 new SendgridEmailEventActionDto("template", "en", false));
 
-        return handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+        return handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                 Instant.now().toEpochMilli(), null, null, null, null, true, 1);
 
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserRegistrationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/UserRegistrationRouteTest.java
@@ -701,7 +701,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
             long actionId = handle.attach(EventActionDao.class)
                     .insertNotificationAction(new SendgridEmailEventActionDto("abc", "en", false));
             return handle.attach(JdbiEventConfiguration.class)
-                    .insert(triggerId, actionId, testStudy.getId(), Instant.now().toEpochMilli(), null, null, null, null, true, 1);
+                    .insert(null, triggerId, actionId, testStudy.getId(), Instant.now().toEpochMilli(), null, null, null, null, true, 1);
         });
 
         User tempUser = TransactionWrapper.withTxn(handle ->
@@ -899,7 +899,7 @@ public class UserRegistrationRouteTest extends IntegrationTestSuite.TestCase {
                         .insertStaticTrigger(EventTriggerType.GOVERNED_USER_REGISTERED);
                 long actionId = handle.attach(EventActionDao.class)
                         .insertStaticAction(EventActionType.USER_ENROLLED);
-                handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testStudy.get().getId(),
+                handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testStudy.get().getId(),
                         Instant.now().toEpochMilli(), null, 0, null, null, false, 1);
             });
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AgeUpServiceTest.java
@@ -126,7 +126,7 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
                     .insertStaticTrigger(EventTriggerType.REACHED_AOM);
             long actionId = handle.attach(EventActionDao.class)
                     .insertMarkActivitiesReadOnlyAction(Set.of(instanceDto.getActivityId()));
-            handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+            handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                     Instant.now().toEpochMilli(), null, 0, null, null, false, 1);
 
             GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));
@@ -166,7 +166,7 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
                     .insertStaticTrigger(EventTriggerType.REACHED_AOM_PREP);
             long actionId = handle.attach(EventActionDao.class)
                     .insertMarkActivitiesReadOnlyAction(Set.of(instanceDto.getActivityId()));
-            handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+            handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                     Instant.now().toEpochMilli(), null, 0, null, null, false, 1);
 
             GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));
@@ -200,7 +200,7 @@ public class AgeUpServiceTest extends TxnAwareBaseTest {
                     .insertStaticTrigger(EventTriggerType.REACHED_AOM_PREP);
             long actionId = handle.attach(EventActionDao.class)
                     .insertInvitationEmailNotificationAction(new SendgridEmailEventActionDto("template", "en", false));
-            handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, testData.getStudyId(),
+            handle.attach(JdbiEventConfiguration.class).insert(null, triggerId, actionId, testData.getStudyId(),
                     Instant.now().toEpochMilli(), null, 0, null, null, true, 1);
 
             GovernancePolicy policy = new GovernancePolicy(1L, testData.getStudyId(), testData.getStudyGuid(), new Expression("true"));

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/WorkflowServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/WorkflowServiceTest.java
@@ -432,7 +432,7 @@ public class WorkflowServiceTest extends TxnAwareBaseTest {
             long actionId = eventActionDao.insertInstanceCreationAction(triggeredFormActivity.getActivityId());
             JdbiEventConfiguration jdbiEventConfig = handle.attach(JdbiEventConfiguration.class);
             long eventConfigurationId = jdbiEventConfig.insert(
-                    triggerId, actionId, testData.getStudyId(), Instant.now().toEpochMilli(), 1, 0, null, null, false, 1
+                    null, triggerId, actionId, testData.getStudyId(), Instant.now().toEpochMilli(), 1, 0, null, null, false, 1
             );
 
             service.suggestNextState(

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/TestDataSetupUtil.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/TestDataSetupUtil.java
@@ -682,7 +682,7 @@ public class TestDataSetupUtil {
                 InstanceStatusType.COMPLETE);
 
         generatedTestData.setEnrollmentConfigurationId(handle.attach(JdbiEventConfiguration.class).insert(
-                generatedTestData.getEnrollmentEventTriggerId(),
+                null, generatedTestData.getEnrollmentEventTriggerId(),
                 generatedTestData.getEnrollmentActionId(),
                 generatedTestData.getStudyId(),
                 Instant.now().toEpochMilli(),

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -111,7 +111,7 @@ public class EventBuilder {
 
        List<String> existingCfgLabelsInDb = eventCfgsToLoad.stream()
                 .map(eventCfg -> handle.attach(EventDao.class)
-                        .getAllEventConfigurationsByStudyIdAndLabel(studyDto.getId(), eventCfg.getString("label")))
+                        .getEventConfigurationByStudyIdAndLabel(studyDto.getId(), eventCfg.getString("label")))
                 .filter(existingCfg -> existingCfg.isPresent())
                 .map(presentCfg -> presentCfg.get().getLabel())
                 .collect(toList());

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -97,16 +97,16 @@ public class EventBuilder {
         List<Config> allLabeledCfgs = cfg.getConfigList("events").stream()
                 .filter(eventCfg -> eventCfg.hasPath("label") && eventCfg.getString("label") != null)
                 .collect(toList());
-       List<String> allCfgLabels = allLabeledCfgs.stream().map(cfg -> cfg.getString("label")).collect(toList());
+       Set<String> allCfgLabels = allLabeledCfgs.stream().map(cfg -> cfg.getString("label")).collect(toSet());
        Set<String> notFoundEventLabels = eventLabelsToLoad.stream().filter(eventName -> !allCfgLabels.contains(eventName)).collect(toSet());
        if (!notFoundEventLabels.isEmpty()) {
            throw new DDPException("Could not find events " + String.join(", ", notFoundEventLabels));
        }
-       if (allCfgLabels.size() > eventLabelsToLoad.size()) {
+       if (allLabeledCfgs.size() > allCfgLabels.size()) {
            throw new DDPException("Found duplicate names in event configuration entries");
        }
        List<Config> eventCfgsToLoad = allLabeledCfgs.stream()
-                   .filter(cfg -> allCfgLabels.contains(cfg.getString("label")))
+                   .filter(cfg -> eventLabelsToLoad.contains(cfg.getString("label")))
                    .collect(toList());
 
        List<String> existingCfgLabelsInDb = eventCfgsToLoad.stream()

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -1,14 +1,20 @@
 package org.broadinstitute.ddp.studybuilder;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.typesafe.config.Config;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.db.dao.EventActionDao;
+import org.broadinstitute.ddp.db.dao.EventDao;
 import org.broadinstitute.ddp.db.dao.EventTriggerDao;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
@@ -70,6 +76,10 @@ public class EventBuilder {
         insertEvents(handle);
     }
 
+    void run(Handle handle, String[] labels) {
+        insertLabeledEvents(handle, labels);
+    }
+
     private void insertEvents(Handle handle) {
         if (!cfg.hasPath("events")) {
             return;
@@ -79,9 +89,45 @@ public class EventBuilder {
         }
     }
 
+    private void insertLabeledEvents(Handle handle, String[] eventLabelArray) {
+        if (!cfg.hasPath("events")) {
+            return;
+        }
+        Set<String> eventLabelsToLoad = new HashSet<>(Arrays.asList(eventLabelArray));
+        List<Config> allLabeledCfgs = cfg.getConfigList("events").stream()
+                .filter(eventCfg -> eventCfg.hasPath("label") && eventCfg.getString("label") != null)
+                .collect(toList());
+       List<String> allCfgLabels = allLabeledCfgs.stream().map(cfg -> cfg.getString("label")).collect(toList());
+       Set<String> notFoundEventLabels = eventLabelsToLoad.stream().filter(eventName -> !allCfgLabels.contains(eventName)).collect(toSet());
+       if (!notFoundEventLabels.isEmpty()) {
+           throw new DDPException("Could not find events " + String.join(", ", notFoundEventLabels));
+       }
+       if (allCfgLabels.size() > eventLabelsToLoad.size()) {
+           throw new DDPException("Found duplicate names in event configuration entries");
+       }
+       List<Config> eventCfgsToLoad = allLabeledCfgs.stream()
+                   .filter(cfg -> allCfgLabels.contains(cfg.getString("label")))
+                   .collect(toList());
+
+       List<String> existingCfgLabelsInDb = eventCfgsToLoad.stream()
+                .map(eventCfg -> handle.attach(EventDao.class)
+                        .getAllEventConfigurationsByStudyIdAndLabel(studyDto.getId(), eventCfg.getString("label")))
+                .filter(existingCfg -> existingCfg.isPresent())
+                .map(presentCfg -> presentCfg.get().getLabel())
+                .collect(toList());
+
+       if (!existingCfgLabelsInDb.isEmpty()) {
+           LOG.warn("Events with following labels already exist" + StringUtils.join(", ", existingCfgLabelsInDb));
+           return;
+       }
+
+        eventCfgsToLoad.forEach(eventCfg -> insertEvent(handle, eventCfg));
+    }
+
     public void insertEvent(Handle handle, Config eventCfg) {
         Config triggerCfg = eventCfg.getConfig("trigger");
         Config actionCfg = eventCfg.getConfig("action");
+        String label = eventCfg.hasPath("label") ? eventCfg.getString("label") : null;
 
         long triggerId = insertEventTrigger(handle, triggerCfg);
         long actionId = insertEventAction(handle, actionCfg, triggerCfg);
@@ -92,7 +138,7 @@ public class EventBuilder {
         Integer maxOccurrencesPerUser = ConfigUtil.getIntIfPresent(eventCfg, "maxOccurrencesPerUser");
         Integer delaySeconds = ConfigUtil.getIntIfPresent(eventCfg, "delaySeconds");
 
-        long eventId = handle.attach(JdbiEventConfiguration.class).insert(triggerId, actionId, studyDto.getId(),
+        long eventId = handle.attach(JdbiEventConfiguration.class).insert(label, triggerId, actionId, studyDto.getId(),
                 Instant.now().toEpochMilli(), maxOccurrencesPerUser, delaySeconds, preconditionExprId, cancelExprId,
                 eventCfg.getBoolean("dispatchToHousekeeping"), eventCfg.getInt("order"));
         LOG.info("Created event with id={}, trigger={}, action={}", eventId, triggerAsStr(triggerCfg), actionAsStr(actionCfg));
@@ -256,13 +302,13 @@ public class EventBuilder {
             Set<Long> activityIds = actionCfg.getStringList("activityCodes")
                     .stream()
                     .map(activtyCode -> ActivityBuilder.findActivityId(handle, studyDto.getId(), activtyCode))
-                    .collect(Collectors.toSet());
+                    .collect(toSet());
             return actionDao.insertHideActivitiesAction(activityIds);
         } else if (EventActionType.MARK_ACTIVITIES_READ_ONLY.name().equals(type)) {
             Set<Long> activityIds = actionCfg.getStringList("activityCodes")
                     .stream()
                     .map(activtyCode -> ActivityBuilder.findActivityId(handle, studyDto.getId(), activtyCode))
-                    .collect(Collectors.toSet());
+                    .collect(toSet());
             return actionDao.insertMarkActivitiesReadOnlyAction(activityIds);
         } else {
             return actionDao.insertStaticAction(EventActionType.valueOf(type));

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -138,6 +138,13 @@ public class StudyBuilder {
         new EventBuilder(cfg, studyDto, adminDto.getUserId()).run(handle);
     }
 
+    public void runLabeledEvents(Handle handle, String[] labels) {
+        StudyDto studyDto = getStudy(handle);
+        UserDto adminDto = getAdminUser(handle);
+        new EventBuilder(cfg, studyDto, adminDto.getUserId()).run(handle, labels);
+    }
+
+
     public void runUpdatePdfTemplates(Handle handle) {
         StudyDto studyDto = getStudy(handle);
         Path dirPath = cfgPath.getParent();

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -17,7 +17,6 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.exception.DDPException;

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -17,6 +17,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -59,6 +60,7 @@ public class StudyBuilderCli {
         options.addOption(null, "only-activity", true, "only run activity setup for given activity code");
         options.addOption(null, "only-workflow", false, "only run workflow setup");
         options.addOption(null, "only-events", false, "only run events setup");
+        options.addOption(null, "only-labeled-events", true, "only run events in given list");
         options.addOption(null, "only-update-pdfs", false, "only run pdf template updates (deprecated)");
         options.addOption(null, "no-workflow", false, "do not run workflow setup");
         options.addOption(null, "no-events", false, "do not run events setup");
@@ -148,6 +150,13 @@ public class StudyBuilderCli {
         } else if (cmd.hasOption("only-events")) {
             log("executing events setup...");
             execute(builder::runEvents, isDryRun);
+            log("done");
+            return;
+        } else if (cmd.hasOption("only-labeled-events")) {
+            log("executing events setup...");
+            String eventLabelsArg = cmd.getOptionValue("only-labeled-events");
+            String[] eventLabels = eventLabelsArg == null ? new String[0] : eventLabelsArg.split("\\s*,\\s*");
+            execute(handle -> builder.runLabeledEvents(handle, eventLabels), isDryRun);
             log("done");
             return;
         } else if (cmd.hasOption("only-update-pdfs")) {

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -153,7 +153,7 @@ public class StudyBuilderCli {
             log("done");
             return;
         } else if (cmd.hasOption("only-labeled-events")) {
-            log("executing events setup...");
+            log("executing labeled events setup...");
             String eventLabelsArg = cmd.getOptionValue("only-labeled-events");
             String[] eventLabels = eventLabelsArg == null ? new String[0] : eventLabelsArg.split("\\s*,\\s*");
             execute(handle -> builder.runLabeledEvents(handle, eventLabels), isDryRun);

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -60,7 +60,7 @@ public class StudyBuilderCli {
         options.addOption(null, "only-activity", true, "only run activity setup for given activity code");
         options.addOption(null, "only-workflow", false, "only run workflow setup");
         options.addOption(null, "only-events", false, "only run events setup");
-        options.addOption(null, "only-labeled-events", true, "only run events in given list");
+        options.addOption(null, "only-labeled-events", true, "only run events in comma-separated list of labels");
         options.addOption(null, "only-update-pdfs", false, "only run pdf template updates (deprecated)");
         options.addOption(null, "no-workflow", false, "do not run workflow setup");
         options.addOption(null, "no-events", false, "do not run events setup");


### PR DESCRIPTION
## Context

In the interest of avoiding creating java patch code to update configuration, we are adding a command line options to study builder to load specific event configuration entries.
Part of implementation involves adding a "label" property to Event Configurations.

## FUD Score

_Overall, how are you feeling about these changes?_

- [X ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?
Can try to add one or more event configuration entries into a study.conf file and specify them in the command line.

## Release

- [ X] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

