### PR TITLE
DDP-5605 fix export of empty row

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/collectors/ActivityMetadataCollector.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/collectors/ActivityMetadataCollector.java
@@ -20,7 +20,7 @@ public class ActivityMetadataCollector {
     private static final Logger LOG = LoggerFactory.getLogger(ActivityMetadataCollector.class);
 
     public List<String> emptyRow(boolean hasParent) {
-        List<String> row = Arrays.asList("", "", "", "", "");
+        List<String> row = new ArrayList<>(Arrays.asList("", "", "", "", ""));
         if (hasParent) {
             row.add("");
         }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/export/collectors/ActivityMetadataCollectorTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/export/collectors/ActivityMetadataCollectorTest.java
@@ -1,0 +1,42 @@
+package org.broadinstitute.ddp.export.collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class ActivityMetadataCollectorTest {
+
+    @Test
+    public void testEmptyRow() {
+        var collector = new ActivityMetadataCollector();
+
+        List<String> actual = collector.emptyRow(false);
+        assertEquals(5, actual.size());
+
+        actual = collector.emptyRow(true);
+        assertEquals(6, actual.size());
+        assertEquals("", actual.get(0));
+    }
+
+    @Test
+    public void testMappings() {
+        var collector = new ActivityMetadataCollector();
+        Map<String, Object> actual = collector.mappings("foo_v1", true);
+        assertTrue(actual.containsKey("foo_v1_parent"));
+    }
+
+    @Test
+    public void testHeaders() {
+        var collector = new ActivityMetadataCollector();
+
+        List<String> actual = collector.headers("foo_v1", true);
+        assertTrue(actual.contains("foo_v1_parent"));
+
+        actual = collector.headers("foo_v1", true, 5);
+        assertTrue(actual.contains("foo_v1_5_parent"));
+    }
+}


### PR DESCRIPTION
## Context

Related to change for DDP-5605. Saw this issue in our dev alerts Slack channel:

```
[housekeeping] Error while formatting data into csv for participant DEP5ZBGT6IUBTPROVV5Y and study CMI-OSTEO, skipping null
at java.base/java.util.AbstractList.add(AbstractList.java:153)
at java.base/java.util.AbstractList.add(AbstractList.java:111)
at org.broadinstitute.ddp.export.collectors.ActivityMetadataCollector.emptyRow(ActivityMetadataCollector.java:25)
at org.broadinstitute.ddp.export.DataExporter.exportDataSetAsCsv(DataExporter.java:1210)
at org.broadinstitute.ddp.export.DataExportCoordinator.lambda$buildExportToCsvRunnable$4(DataExportCoordinator.java:213)
at java.base/java.lang.Thread.run(Thread.java:834)
```

Issue is that the list object returned by `Arrays.asList()` is not mutable, so we need to wrap it in a mutable list.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests

## Release

- [x] These changes require no special release procedures--just code!


