### PR TITLE
DDP-5587 support rendering answers into title/subtitle

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -213,7 +213,7 @@ public class RenderValueProvider {
 
     private String renderAnswerUsingFormResponse(String questionStableId, String fallbackValue) {
         Answer answer = formResponse.getAnswer(questionStableId);
-        if (answer == null) {
+        if (answer == null || answer.isEmpty()) {
             // No answer response for this question yet, so use fallback.
             return fallbackValue;
         }
@@ -242,7 +242,7 @@ public class RenderValueProvider {
         Question question = formInstance.getQuestionByStableId(questionStableId);
         Answer answer = question != null && question.isAnswered()
                 ? (Answer) question.getAnswers().get(0) : null;
-        if (answer == null) {
+        if (answer == null || answer.isEmpty()) {
             return fallbackValue;
         }
         switch (answer.getQuestionType()) {
@@ -359,6 +359,9 @@ public class RenderValueProvider {
             return this;
         }
 
+        /**
+         * If caller has a FormResponse object available, then use this.
+         */
         public Builder withFormResponse(FormResponse formResponse, FormActivityDef formActivity, String isoLangCode) {
             provider.formResponse = formResponse;
             provider.formActivity = formActivity;
@@ -366,6 +369,9 @@ public class RenderValueProvider {
             return this;
         }
 
+        /**
+         * If caller has a FormInstance object available, then use this.
+         */
         public Builder withFormInstance(FormInstance formInstance) {
             provider.formInstance = formInstance;
             return this;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
@@ -162,8 +162,16 @@ public class ActivityInstanceSummary implements TranslatedSummary {
         return activityTitle;
     }
 
+    public void setActivityTitle(String activityTitle) {
+        this.activityTitle = activityTitle;
+    }
+
     public String getActivitySubtitle() {
         return activitySubtitle;
+    }
+
+    public void setActivitySubtitle(String activitySubtitle) {
+        this.activitySubtitle = activitySubtitle;
     }
 
     public String getActivityDescription() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ComponentBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ComponentBlock.java
@@ -1,10 +1,12 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.content.ContentStyle;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.util.MiscUtil;
 
@@ -27,6 +29,11 @@ public class ComponentBlock extends FormBlock implements Numberable  {
         MiscUtil.checkNonNull(formComponent, "formComponent");
         this.formComponent = formComponent;
         this.hideDisplayNumber = formComponent.hideDisplayNumber;
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        return Stream.empty();
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ConditionalBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ConditionalBlock.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.model.activity.instance;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -37,6 +38,11 @@ public final class ConditionalBlock extends FormBlock implements Numberable {
 
     public List<FormBlock> getNested() {
         return nested;
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        return Stream.concat(Stream.of(control), nested.stream().flatMap(FormBlock::streamQuestions));
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ContentBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/ContentBlock.java
@@ -2,11 +2,13 @@ package org.broadinstitute.ddp.model.activity.instance;
 
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 
 public final class ContentBlock extends FormBlock {
@@ -47,6 +49,11 @@ public final class ContentBlock extends FormBlock {
 
     public long getBodyTemplateId() {
         return bodyTemplateId;
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        return Stream.empty();
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormBlock.java
@@ -1,9 +1,11 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.content.Renderable;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.util.MiscUtil;
 
@@ -25,6 +27,11 @@ public abstract class FormBlock implements Renderable {
     FormBlock(BlockType type) {
         this.blockType = MiscUtil.checkNonNull(type, "type");
     }
+
+    /**
+     * Return a stream of all questions contained in this block.
+     */
+    public abstract Stream<Question> streamQuestions();
 
     /**
      * Has the user completed what's required for this block?

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/FormInstance.java
@@ -10,10 +10,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
@@ -24,6 +27,7 @@ import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.FormType;
@@ -64,11 +68,14 @@ public final class FormInstance extends ActivityInstance {
     @SerializedName("lastUpdatedText")
     private String activityDefinitionLastUpdatedText;
 
+    @SerializedName("sectionIndex")
+    private int sectionIndex;
+
     private transient Long introductionSectionId;
     private transient Long closingSectionId;
     private transient Long readonlyHintTemplateId;
     private transient Long lastUpdatedTextTemplateId;
-    private int sectionIndex;
+    private transient Map<String, Question> stableIdToQuestion;
 
     public FormInstance(
             long participantUserId,
@@ -183,6 +190,16 @@ public final class FormInstance extends ActivityInstance {
         this.sectionIndex = sectionIndex;
     }
 
+    public Question getQuestionByStableId(String stableId) {
+        if (stableIdToQuestion == null) {
+            stableIdToQuestion = getAllSections().stream()
+                    .flatMap(section -> section.getBlocks().stream())
+                    .flatMap(FormBlock::streamQuestions)
+                    .collect(Collectors.toMap(Question::getStableId, Function.identity()));
+        }
+        return stableIdToQuestion.get(stableId);
+    }
+
     /**
      * Render all the content templates in the form by rendering them, translating them to given language,
      * and converting them to the given content style.
@@ -202,16 +219,33 @@ public final class FormInstance extends ActivityInstance {
             section.registerTemplateIds(consumer);
         }
 
+        Map<String, String> commonSnapshot = I18nContentRenderer
+                .newValueProviderBuilder(handle, getParticipantUserId())
+                .build().getSnapshot();
         Map<String, String> snapshot = handle.attach(ActivityInstanceDao.class).findSubstitutions(getInstanceId());
-        RenderValueProvider valueProvider = I18nContentRenderer.newValueProvider(handle, getParticipantUserId(), snapshot);
-
         Map<String, Object> context = new HashMap<>();
-        context.put(I18nTemplateConstants.DDP, valueProvider);
+        context.put(I18nTemplateConstants.DDP, new RenderValueProvider.Builder()
+                .withSnapshot(commonSnapshot)
+                .withSnapshot(snapshot)
+                .build());
+
         Map<Long, String> rendered = renderer.bulkRender(handle, templateIds, langCodeId, context, getCreatedAtMillis());
         Renderable.Provider<String> provider = rendered::get;
-
         for (FormSection section : allSections) {
             section.applyRenderedTemplates(provider, style);
+        }
+
+        // Render other properties like title and subtitle.
+        context.put(I18nTemplateConstants.DDP, new RenderValueProvider.Builder()
+                .withFormInstance(this)
+                .withSnapshot(commonSnapshot)
+                .withSnapshot(snapshot)
+                .build());
+        if (StringUtils.isNotBlank(title)) {
+            title = renderer.renderToString(title, context);
+        }
+        if (StringUtils.isNotBlank(subtitle)) {
+            subtitle = renderer.renderToString(subtitle, context);
         }
 
         if (readonlyHintTemplateId != null) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/GroupBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/GroupBlock.java
@@ -4,11 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.ListStyleHint;
 import org.broadinstitute.ddp.model.activity.types.PresentationHint;
@@ -63,6 +65,11 @@ public final class GroupBlock extends FormBlock {
 
     public List<FormBlock> getNested() {
         return nested;
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        return nested.stream().flatMap(FormBlock::streamQuestions);
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/NestedActivityBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/NestedActivityBlock.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -11,6 +12,7 @@ import com.google.gson.annotations.SerializedName;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.HtmlConverter;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.model.activity.instance.question.Question;
 import org.broadinstitute.ddp.model.activity.types.BlockType;
 import org.broadinstitute.ddp.model.activity.types.NestedActivityRenderHint;
 import org.broadinstitute.ddp.util.MiscUtil;
@@ -74,6 +76,12 @@ public final class NestedActivityBlock extends FormBlock {
         if (instanceSummaries != null) {
             this.instanceSummaries.addAll(instanceSummaries);
         }
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        // Questions within the nested activity itself are not considered.
+        return Stream.empty();
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/QuestionBlock.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/QuestionBlock.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.model.activity.instance;
 
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -28,6 +29,11 @@ public class QuestionBlock extends FormBlock implements Numberable {
 
     public Question getQuestion() {
         return question;
+    }
+
+    @Override
+    public Stream<Question> streamQuestions() {
+        return Stream.of(question);
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/PicklistQuestion.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/PicklistQuestion.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotEmpty;
@@ -139,6 +140,12 @@ public final class PicklistQuestion extends Question<PicklistAnswer> {
 
     public Long getPicklistLabelTemplateId() {
         return picklistLabelTemplateId;
+    }
+
+    public Stream<PicklistOption> streamAllPicklistOptions() {
+        return Stream.concat(
+                picklistOptions.stream(),
+                picklistOptions.stream().flatMap(opt -> opt.getNestedOptions().stream()));
     }
 
     @Override

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRoute.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.route;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.constants.RouteConstants;
@@ -9,6 +10,7 @@ import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.db.dto.LanguageDto;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.model.activity.instance.FormResponse;
 import org.broadinstitute.ddp.model.user.User;
 import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.service.ActivityInstanceService;
@@ -55,8 +57,9 @@ public class GetActivityInstanceSummaryRoute implements Route {
                     .orElseThrow(() -> new DDPException("Could not find translated summary for activity instance " + instanceGuid));
 
             List<ActivityInstanceSummary> summaries = List.of(summary);
-            service.countQuestionsAndAnswers(handle, participantGuid, operatorGuid, studyGuid, summaries);
-            service.renderInstanceSummaries(handle, participantUser.getId(), summaries);
+            Map<String, FormResponse> responses = service.countQuestionsAndAnswers(
+                    handle, participantGuid, operatorGuid, studyGuid, summaries);
+            service.renderInstanceSummaries(handle, participantUser.getId(), studyGuid, summaries, responses);
 
             return summaries.get(0);
         });

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserActivityInstanceListRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UserActivityInstanceListRoute.java
@@ -3,6 +3,7 @@ package org.broadinstitute.ddp.route;
 import static org.broadinstitute.ddp.util.ResponseUtil.halt400ErrorResponse;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -11,6 +12,7 @@ import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dto.LanguageDto;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
+import org.broadinstitute.ddp.model.activity.instance.FormResponse;
 import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.service.ActivityInstanceService;
 import org.broadinstitute.ddp.util.RouteUtil;
@@ -62,8 +64,9 @@ public class UserActivityInstanceListRoute implements Route {
                 // Study admins are allowed to view all the data, so if they're NOT admin then do filtering.
                 summaries = filterActivityInstancesFromDisplay(summaries);
             }
-            service.countQuestionsAndAnswers(handle, userGuid, operatorGuid, studyGuid, summaries);
-            service.renderInstanceSummaries(handle, found.getUser().getId(), summaries);
+            Map<String, FormResponse> responses = service.countQuestionsAndAnswers(
+                    handle, userGuid, operatorGuid, studyGuid, summaries);
+            service.renderInstanceSummaries(handle, found.getUser().getId(), studyGuid, summaries, responses);
             return summaries;
         });
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -149,8 +149,9 @@ public class ActivityInstanceService {
                 nestedSummaries = nestedSummaries.stream()
                         .filter(summary -> !summary.isHidden())
                         .collect(Collectors.toList());
-                countQuestionsAndAnswers(handle, userGuid, operatorGuid, studyGuid, nestedSummaries);
-                renderInstanceSummaries(handle, instance.getParticipantUserId(), nestedSummaries);
+                Map<String, FormResponse> nestedResponses = countQuestionsAndAnswers(
+                        handle, userGuid, operatorGuid, studyGuid, nestedSummaries);
+                renderInstanceSummaries(handle, instance.getParticipantUserId(), studyGuid, nestedSummaries, nestedResponses);
 
                 nestedActBlock.addInstanceSummaries(nestedSummaries);
             }
@@ -415,11 +416,12 @@ public class ActivityInstanceService {
      * @param userGuid  the user guid
      * @param studyGuid the study guid
      * @param summaries the list of activity summaries
+     * @return mapping of instance guid to object containing answer responses used for counting
      */
-    public void countQuestionsAndAnswers(Handle handle, String userGuid, String operatorGuid, String studyGuid,
-                                         List<ActivityInstanceSummary> summaries) {
+    public Map<String, FormResponse> countQuestionsAndAnswers(Handle handle, String userGuid, String operatorGuid, String studyGuid,
+                                                              List<ActivityInstanceSummary> summaries) {
         if (summaries.isEmpty()) {
-            return;
+            return new HashMap<>();
         }
 
         ActivityDefStore activityDefStore = ActivityDefStore.getInstance();
@@ -436,19 +438,7 @@ public class ActivityInstanceService {
 
         for (var summary : summaries) {
             if (ActivityType.valueOf(summary.getActivityType()) == ActivityType.FORMS) {
-                String activityCode = summary.getActivityCode();
-                String versionTag = summary.getVersionTag();
-                long versionId = summary.getVersionId();
-                long revisionStart = summary.getRevisionStart();
-
-                FormActivityDef formActivityDef = activityDefStore.getActivityDef(studyGuid, activityCode, versionTag);
-                if (formActivityDef == null) {
-                    ActivityDto activityDto = handle.attach(JdbiActivity.class)
-                            .findActivityByStudyGuidAndCode(studyGuid, activityCode).get();
-                    formActivityDef = handle.attach(FormActivityDao.class)
-                            .findDefByDtoAndVersion(activityDto, versionTag, versionId, revisionStart);
-                    activityDefStore.setActivityDef(studyGuid, activityCode, versionTag, formActivityDef);
-                }
+                FormActivityDef formActivityDef = getDefinitionForSummary(handle, activityDefStore, studyGuid, summary);
 
                 Pair<Integer, Integer> questionAndAnswerCounts = activityDefStore.countQuestionsAndAnswers(
                         handle, userGuid, operatorGuid, formActivityDef, summary.getActivityInstanceGuid(), instanceResponses);
@@ -457,6 +447,27 @@ public class ActivityInstanceService {
                 summary.setNumQuestionsAnswered(questionAndAnswerCounts.getRight());
             }
         }
+
+        return instanceResponses;
+    }
+
+    private FormActivityDef getDefinitionForSummary(Handle handle, ActivityDefStore activityDefStore,
+                                                    String studyGuid, ActivityInstanceSummary summary) {
+        String activityCode = summary.getActivityCode();
+        String versionTag = summary.getVersionTag();
+        long versionId = summary.getVersionId();
+        long revisionStart = summary.getRevisionStart();
+
+        FormActivityDef formActivityDef = activityDefStore.getActivityDef(studyGuid, activityCode, versionTag);
+        if (formActivityDef == null) {
+            ActivityDto activityDto = handle.attach(JdbiActivity.class)
+                    .findActivityByStudyGuidAndCode(studyGuid, activityCode).get();
+            formActivityDef = handle.attach(FormActivityDao.class)
+                    .findDefByDtoAndVersion(activityDto, versionTag, versionId, revisionStart);
+            activityDefStore.setActivityDef(studyGuid, activityCode, versionTag, formActivityDef);
+        }
+
+        return formActivityDef;
     }
 
     /**
@@ -466,11 +477,15 @@ public class ActivityInstanceService {
      * will be used to render the name, otherwise " #N" will be appended to the original name (where N is the instance
      * number).
      *
-     * @param handle    the database handle
-     * @param userId    the user who owns the activity instances
-     * @param summaries the list of summaries
+     * @param handle            the database handle
+     * @param userId            the user who owns the activity instances
+     * @param studyGuid         the study guid
+     * @param summaries         the list of summaries
+     * @param instanceResponses the mapping of instance guid to answer response objects
      */
-    public void renderInstanceSummaries(Handle handle, long userId, List<ActivityInstanceSummary> summaries) {
+    public void renderInstanceSummaries(Handle handle, long userId, String studyGuid,
+                                        List<ActivityInstanceSummary> summaries,
+                                        Map<String, FormResponse> instanceResponses) {
         if (summaries.isEmpty()) {
             return;
         }
@@ -480,18 +495,25 @@ public class ActivityInstanceService {
                 .collect(Collectors.toSet());
         var instanceDao = handle.attach(org.broadinstitute.ddp.db.dao.ActivityInstanceDao.class);
         Map<Long, Map<String, String>> substitutions;
-        try (var substitionStream = instanceDao.bulkFindSubstitutions(instanceIds)) {
-            substitutions = substitionStream
+        try (var substitutionStream = instanceDao.bulkFindSubstitutions(instanceIds)) {
+            substitutions = substitutionStream
                     .collect(Collectors.toMap(wrapper -> wrapper.getActivityInstanceId(), wrapper -> wrapper.unwrap()));
         }
         var sharedSnapshot = I18nContentRenderer
                 .newValueProviderBuilder(handle, userId)
                 .build().getSnapshot();
 
+        ActivityDefStore activityDefStore = ActivityDefStore.getInstance();
+
         for (var summary : summaries) {
+            FormResponse formResponse = instanceResponses.get(summary.getActivityInstanceGuid());
+            FormActivityDef formActivityDef = formResponse == null ? null
+                    : getDefinitionForSummary(handle, activityDefStore, studyGuid, summary);
+
             Map<String, String> subs = substitutions.getOrDefault(summary.getActivityInstanceId(), new HashMap<>());
             var provider = new RenderValueProvider.Builder()
                     .setActivityInstanceNumber(summary.getInstanceNumber())
+                    .withFormResponse(formResponse, formActivityDef, summary.getIsoLanguageCode())
                     .withSnapshot(sharedSnapshot)
                     .withSnapshot(subs)
                     .build();
@@ -512,10 +534,15 @@ public class ActivityInstanceService {
             }
             summary.setActivityName(nameText);
 
-            // Render the summary.
+            // Render other properties.
+            if (StringUtils.isNotBlank(summary.getActivityTitle())) {
+                summary.setActivityTitle(renderer.renderToString(summary.getActivityTitle(), context));
+            }
+            if (StringUtils.isNotBlank(summary.getActivitySubtitle())) {
+                summary.setActivitySubtitle(renderer.renderToString(summary.getActivitySubtitle(), context));
+            }
             if (StringUtils.isNotBlank(summary.getActivitySummary())) {
-                String summaryText = renderer.renderToString(summary.getActivitySummary(), context);
-                summary.setActivitySummary(summaryText);
+                summary.setActivitySummary(renderer.renderToString(summary.getActivitySummary(), context));
             }
         }
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -11,9 +11,11 @@ import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -236,6 +238,35 @@ public class FormInstanceTest extends TxnAwareBaseTest {
 
             handle.rollback();
         });
+    }
+
+    @Test
+    public void testRenderContent_answerSubstitutions() {
+        Map<Long, String> fixture = new HashMap<>();
+        fixture.put(1L, "some template");
+
+        var spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(any(), any());
+
+        String title = "$ddp.answer(\"Q_TITLE\",\"fallback\")";
+        String subtitle = "$ddp.answer(\"Q_SUBTITLE\",\"fallback\")";
+        var form = new FormInstance(1L, 1L, 1L, "ACT", FormType.GENERAL, "guid",
+                title, subtitle, "CREATED", null, ListStyleHint.NONE, null,
+                111L, 112L, 1L, null, null, null, false, false, false, false, 0);
+
+        var body = new FormSection(List.of(
+                new QuestionBlock(new TextQuestion("Q_TITLE", 1L, null, List.of(
+                        new TextAnswer(null, "Q_TITLE", null, "title-answer")),
+                        List.of(), TextInputType.TEXT)),
+                new QuestionBlock(new TextQuestion("Q_SUBTITLE", 1L, null, List.of(
+                        new TextAnswer(null, "Q_SUBTITLE", null, "subtitle-answer")),
+                        List.of(), TextInputType.TEXT))));
+        form.addBodySections(List.of(body));
+
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.BASIC);
+        assertEquals("title-answer", form.getTitle());
+        assertEquals("subtitle-answer", form.getSubtitle());
     }
 
     @Test

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/activity/instance/FormInstanceTest.java
@@ -103,15 +103,16 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "<p>this is title</p>");
         fixture.put(2L, "<p>this is body</p>");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.STANDARD);
         assertEquals(fixture.get(1L), content.getTitle());
         assertEquals(fixture.get(2L), content.getBody());
     }
@@ -122,15 +123,16 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "<p>this is title</p>");
         fixture.put(2L, "<p>this is body</p>");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         ContentBlock content = new ContentBlock(1L, 2L);
         FormSection s1 = new FormSection(Collections.singletonList(content));
         FormInstance form = buildEmptyTestInstanceWithHtmlInTitleAndSubtitle();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.BASIC);
         assertEquals("title", form.getTitle());
         assertEquals("subtitle", form.getSubtitle());
         assertEquals("this is title", content.getTitle());
@@ -143,8 +145,9 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         fixture.put(1L, "this is <strong>bold</strong> prompt");
         fixture.put(2L, "this is bold prompt");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -153,7 +156,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.STANDARD);
         assertTrue(HtmlConverter.hasSameValue(fixture.get(1L), question.getPrompt()));
         assertEquals(fixture.get(2L), question.getTextPrompt());
     }
@@ -163,8 +166,9 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         Map<Long, String> fixture = new HashMap<>();
         fixture.put(1L, "this is <b>bold</b> prompt");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         Question question = new TextQuestion("sid", 1, null, Collections.emptyList(), Collections.emptyList(),
                 TextInputType.TEXT);
@@ -173,7 +177,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.BASIC);
 
         assertTrue(HtmlConverter.hasSameValue(fixture.get(1L), question.getPrompt()));
         assertEquals("this is bold prompt", question.getTextPrompt());
@@ -184,14 +188,15 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         Map<Long, String> fixture = new HashMap<>();
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.STANDARD);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.STANDARD);
         assertEquals(fixture.get(1L), s1.getName());
     }
 
@@ -200,14 +205,15 @@ public class FormInstanceTest extends TxnAwareBaseTest {
         Map<Long, String> fixture = new HashMap<>();
         fixture.put(1L, "this is <strong>bold</strong> section name");
 
-        I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-        when(mockRenderer.bulkRender(any(), anySet(), anyLong(), any(), anyLong())).thenReturn(fixture);
+        I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+        doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         FormSection s1 = new FormSection(1L);
         FormInstance form = buildEmptyTestInstance();
         form.addBodySections(Collections.singletonList(s1));
 
-        form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
+        form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.BASIC);
         assertEquals("this is bold section name", s1.getName());
     }
 
@@ -218,14 +224,15 @@ public class FormInstanceTest extends TxnAwareBaseTest {
             handle.attach(UserProfileSql.class).upsertFirstName(testData.getUserId(), "foo");
             handle.attach(UserProfileSql.class).upsertLastName(testData.getUserId(), "bar");
 
-            I18nContentRenderer mockRenderer = mock(I18nContentRenderer.class);
-            doReturn(Collections.emptyMap()).when(mockRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+            I18nContentRenderer spyRenderer = spy(I18nContentRenderer.class);
+            doReturn(Collections.emptyMap()).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
+            doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
             doReturn(handle.attach(UserProfileDao.class)).when(mockHandle).attach(UserProfileDao.class);
 
             FormInstance form = buildEmptyTestInstance(testData.getUserId());
-            form.renderContent(mockHandle, mockRenderer, 1L, ContentStyle.BASIC);
+            form.renderContent(mockHandle, spyRenderer, 1L, ContentStyle.BASIC);
 
-            verify(mockRenderer, times(1)).bulkRender(any(), anySet(), anyLong(), argThat(context -> {
+            verify(spyRenderer, times(1)).bulkRender(any(), anySet(), anyLong(), argThat(context -> {
                 assertNotNull(context);
                 assertNotNull(context.get(I18nTemplateConstants.DDP));
                 RenderValueProvider provider = (RenderValueProvider) context.get(I18nTemplateConstants.DDP);
@@ -247,7 +254,7 @@ public class FormInstanceTest extends TxnAwareBaseTest {
 
         var spyRenderer = spy(I18nContentRenderer.class);
         doReturn(fixture).when(spyRenderer).bulkRender(any(), anySet(), anyLong(), any(), anyLong());
-        doCallRealMethod().when(spyRenderer).renderToString(any(), any());
+        doCallRealMethod().when(spyRenderer).renderToString(anyString(), any());
 
         String title = "$ddp.answer(\"Q_TITLE\",\"fallback\")";
         String subtitle = "$ddp.answer(\"Q_SUBTITLE\",\"fallback\")";

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceSummaryRouteTest.java
@@ -16,11 +16,18 @@ import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.AnswerDao;
 import org.broadinstitute.ddp.db.dao.AuthDao;
 import org.broadinstitute.ddp.db.dto.ActivityInstanceDto;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
+import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.model.activity.definition.template.Template;
+import org.broadinstitute.ddp.model.activity.instance.answer.TextAnswer;
 import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
+import org.broadinstitute.ddp.model.activity.types.TextInputType;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.jdbi.v3.core.Handle;
 import org.junit.AfterClass;
@@ -58,8 +65,13 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .setParentActivityCode(activityCode)
                 .setCanDeleteInstances(true)
                 .build();
+        TextQuestionDef textQuestion = TextQuestionDef
+                .builder(TextInputType.TEXT, activityCode + "_Q1", Template.text("q1"))
+                .build();
         parentActivity = FormActivityDef.generalFormBuilder(activityCode, "v1", testData.getStudyGuid())
                 .addName(new Translation("en", "parent activity"))
+                .addSubtitle(new Translation("en", "$ddp.answer(\"" + textQuestion.getStableId() + "\",\"fallback\")"))
+                .addSection(new FormSectionDef(null, List.of(new QuestionBlockDef(textQuestion))))
                 .build();
         handle.attach(ActivityDao.class).insertActivity(
                 parentActivity, List.of(nestedActivity),
@@ -69,11 +81,17 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
         parentInstanceDto = instanceDao.insertInstance(parentActivity.getActivityId(), testData.getUserGuid());
         nestedInstanceDto = instanceDao.insertInstance(nestedActivity.getActivityId(), testData.getUserGuid(),
                 testData.getUserGuid(), parentInstanceDto.getId());
+
+        var answerDao = handle.attach(AnswerDao.class);
+        answerDao.createAnswer(testData.getUserId(), parentInstanceDto.getId(),
+                new TextAnswer(null, textQuestion.getStableId(), null, "the answer!"));
     }
 
     @AfterClass
     public static void cleanup() {
         TransactionWrapper.useTxn(handle -> {
+            var answerDao = handle.attach(AnswerDao.class);
+            answerDao.deleteAllByInstanceIds(Set.of(parentInstanceDto.getId()));
             var instanceDao = handle.attach(ActivityInstanceDao.class);
             instanceDao.deleteByInstanceGuid(nestedInstanceDto.getGuid());
             instanceDao.deleteByInstanceGuid(parentInstanceDto.getGuid());
@@ -87,6 +105,7 @@ public class GetActivityInstanceSummaryRouteTest extends IntegrationTestSuite.Te
                 .when().get(url).then().assertThat()
                 .statusCode(200).contentType(ContentType.JSON)
                 .body("activityCode", equalTo(parentActivity.getActivityCode()))
+                .body("activitySubtitle", equalTo("the answer!"))
                 .body("instanceGuid", equalTo(parentInstanceDto.getGuid()))
                 .body("parentInstanceGuid", nullValue())
                 .body("canDelete", equalTo(false));

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
@@ -20,6 +21,7 @@ import org.broadinstitute.ddp.constants.LanguageConstants;
 import org.broadinstitute.ddp.content.ContentStyle;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.content.I18nTemplateConstants;
+import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.FormInstanceDao;
 import org.broadinstitute.ddp.db.SectionBlockDao;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -27,19 +29,28 @@ import org.broadinstitute.ddp.db.dao.ActivityDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
 import org.broadinstitute.ddp.db.dao.StudyLanguageCachedDao;
+import org.broadinstitute.ddp.db.dto.ActivityInstanceStatusDto;
 import org.broadinstitute.ddp.json.activity.ActivityInstanceSummary;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.definition.FormSectionDef;
+import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.i18n.SummaryTranslation;
 import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.template.Template;
 import org.broadinstitute.ddp.model.activity.definition.template.TemplateVariable;
 import org.broadinstitute.ddp.model.activity.instance.ActivityInstance;
 import org.broadinstitute.ddp.model.activity.instance.FormInstance;
+import org.broadinstitute.ddp.model.activity.instance.FormResponse;
+import org.broadinstitute.ddp.model.activity.instance.answer.PicklistAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
+import org.broadinstitute.ddp.model.activity.instance.answer.TextAnswer;
 import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
 import org.broadinstitute.ddp.model.activity.types.ActivityType;
 import org.broadinstitute.ddp.model.activity.types.FormType;
 import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
+import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
 import org.broadinstitute.ddp.model.activity.types.TemplateType;
 import org.broadinstitute.ddp.pex.PexInterpreter;
 import org.broadinstitute.ddp.pex.TreeWalkInterpreter;
@@ -348,8 +359,46 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
         summaries.get(0).setInstanceNumber(2);
 
         TransactionWrapper.useTxn(handle ->
-                service.renderInstanceSummaries(handle, testData.getUserId(), summaries));
+                service.renderInstanceSummaries(handle, testData.getUserId(), "study", summaries, Map.of()));
 
         assertEquals("name #2", summaries.get(0).getActivityName());
+    }
+
+    @Test
+    public void testRenderInstanceSummaries_rendersAnswerIntoTitleAndSubtitle() {
+        String title = "$ddp.answer(\"Q1\",\"text\") $ddp.answer(\"non-existing\", \"the-fallback\")";
+        String subtitle = "$ddp.answer(\"Q2\",\"picklist\")";
+        String activityCode = "ACT" + Instant.now().toEpochMilli();
+        var summaries = List.of(new ActivityInstanceSummary(
+                activityCode, 1L, "guid", "name", null, title, subtitle, null, null, "type", "form", "status",
+                null, false, "en", false, false, 1L, false, false, "v1", 1L, 1L));
+        summaries.get(0).setInstanceNumber(2);
+
+        var response = new FormResponse(1L, "guid", 1L, null, 1L, 1L, null, null, 1L, activityCode, "v1",
+                new ActivityInstanceStatusDto(1L, 1L, 1L, 1L, InstanceStatusType.CREATED));
+        response.putAnswer(new TextAnswer(1L, "Q1", "guid1", "some-name"));
+        response.putAnswer(new PicklistAnswer(2L, "Q2", "guid2", List.of(new SelectedPicklistOption("AUNT"))));
+
+        var optionAunt = Template.text("$aunt");
+        optionAunt.addVariable(TemplateVariable.single("aunt", "en", "My Aunt"));
+        var optionUncle = Template.text("$uncle");
+        optionUncle.addVariable(TemplateVariable.single("uncle", "en", "Should not use this one!"));
+        var activity = FormActivityDef.generalFormBuilder(activityCode, "v1", "study")
+                .addName(new Translation("en", "dummy activity"))
+                // No need to add definition for text question since that's not needed for use-friendly display.
+                .addSection(new FormSectionDef(null, List.of(new QuestionBlockDef(
+                        PicklistQuestionDef.buildSingleSelect(PicklistRenderMode.LIST, "Q2", Template.text("picklist"))
+                        .addOption(new PicklistOptionDef("AUNT", optionAunt))
+                        .addOption(new PicklistOptionDef("UNCLE", optionUncle))
+                        .build()))))
+                .build();
+
+        ActivityDefStore.getInstance().setActivityDef("study", activityCode, "v1", activity);
+        TransactionWrapper.useTxn(handle -> service.renderInstanceSummaries(
+                handle, testData.getUserId(), "study", summaries, Map.of("guid", response)));
+
+        assertEquals("name #2", summaries.get(0).getActivityName());
+        assertEquals("some-name the-fallback", summaries.get(0).getActivityTitle());
+        assertEquals("My Aunt", summaries.get(0).getActivitySubtitle());
     }
 }


### PR DESCRIPTION
## Context

See DDP-5587. This PR adds support for rendering answer values into an activity instance (or summary) title and subtitle.

The syntax is straightforward:
```
$ddp.answer("<question_stable_id>", "<fallback_value>")
```

Example usage:
```
You have selected: $ddp.answer("SOME_PICKLIST_QUESTION", "no option selected yet")
```

Behavior: this feature will render the answer value for the given question. `COMPOSITE` and `FILE` questions are currently not supported, `PICKLIST` will render the option text rather than option stable id since the former is more common use-case, and the other answer types will render a string representation of the answer value. The main change is in `RenderValueProvider::answer()`.

We currently only support answer rendering for metadata properties like `title` and `subtitle`. For instance summaries, we additionally support answer rendering for `name` and `summary` (which already supports other kinds of substitutions). There are two main scenarios when we'll be doing answer rendering/substitutions:

1. Fetching activity instance summaries. See changes in `ActivityInstanceService::renderInstanceSummaries()` for this.
2. Fetching whole activity instance object. See changes in `FormInstance::renderContent()` for this.

_Note: I intentionally did not implement support for answer rendering within templates inside sections/blocks. This can be implemented, however, a major issue here is that the answer substitutions WILL NOT BE DYNAMIC. This is due to the fact that rendering/substitutions are handled by the server, and the fact that our current interaction model is that client only fetches the activity once. Imagine if we have an answer substitution in a question prompt template that references a previous question. The client only fetches the activity once, so when this is called, server renders the activity, and since there's no answer to previous question yet, substitution is not done. User answers the previous question, but client doesn't reload the activity or make another API request to the server, so server has no way of telling client that a specific question prompt changed. I think we need to address this issue before we support answer rendering in sections/blocks._

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
