### PR TITLE
Modify Study Builder to recreate workflow from 

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowTransition.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowTransition.java
@@ -29,6 +29,7 @@ public interface JdbiWorkflowTransition extends SqlObject {
     @SqlUpdate("delete from workflow_transition where umbrella_study_id=:studyId")
     int deleteAllForStudy(@Bind("studyId") long studyId);
 
-    @SqlQuery("select precondition_expression_id from workflow_transition where umbrella_study_id=:studyId")
+    @SqlQuery("select precondition_expression_id from workflow_transition"
+            + " where umbrella_study_id=:studyId and precondition_expression_id is not null")
     List<Long> findAllExpressionIdsForStudy(@Bind("studyId") long studyId);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowTransition.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowTransition.java
@@ -1,8 +1,11 @@
 package org.broadinstitute.ddp.db.dao;
 
+import java.util.List;
+
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 public interface JdbiWorkflowTransition extends SqlObject {
@@ -22,4 +25,10 @@ public interface JdbiWorkflowTransition extends SqlObject {
 
     @SqlUpdate("delete from workflow_transition where workflow_transition_id = :transitionId")
     int deleteById(@Bind("transitionId") long transitionId);
+
+    @SqlUpdate("delete from workflow_transition where umbrella_study_id=:studyId")
+    int deleteAllForStudy(@Bind("studyId") long studyId);
+
+    @SqlQuery("select precondition_expression_id from workflow_transition where umbrella_study_id=:studyId")
+    List<Long> findAllExpressionIdsForStudy(@Bind("studyId") long studyId);
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/WorkflowDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/WorkflowDao.java
@@ -64,6 +64,13 @@ public interface WorkflowDao extends SqlObject {
         }
     }
 
+    default int deleteStudyWorkflow(long studyId) {
+        List<Long> expressionIds = getJdbiWorkflowTransition().findAllExpressionIdsForStudy(studyId);
+        int transitionsDeletedCount = getJdbiWorkflowTransition().deleteAllForStudy(studyId);
+        expressionIds.stream().forEach(getJdbiExpression()::deleteById);
+        return transitionsDeletedCount;
+    }
+
     default Optional<Long> findWorkflowStateId(WorkflowState state) {
         if (state.getType() == StateType.ACTIVITY) {
             long activityId = ((ActivityState) state).getActivityId();

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -132,6 +132,11 @@ public class StudyBuilder {
         new WorkflowBuilder(cfg, studyDto).run(handle);
     }
 
+    public void updateWorkflow(Handle handle) {
+        StudyDto studyDto = getStudy(handle);
+        new WorkflowBuilder(cfg, studyDto).runUpdate(handle);
+    }
+
     public void runEvents(Handle handle) {
         StudyDto studyDto = getStudy(handle);
         UserDto adminDto = getAdminUser(handle);

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -58,6 +58,7 @@ public class StudyBuilderCli {
         options.addOption(null, "dry-run", false, "run study setup or custom task without saving");
         options.addOption(null, "only-activity", true, "only run activity setup for given activity code");
         options.addOption(null, "only-workflow", false, "only run workflow setup");
+        options.addOption(null, "only-update-workflow", false, "recreate workflow from configuration file");
         options.addOption(null, "only-events", false, "only run events setup");
         options.addOption(null, "only-labeled-events", true, "only run events in comma-separated list of labels");
         options.addOption(null, "only-update-pdfs", false, "only run pdf template updates (deprecated)");
@@ -144,6 +145,11 @@ public class StudyBuilderCli {
         } else if (cmd.hasOption("only-workflow")) {
             log("executing workflow setup...");
             execute(builder::runWorkflow, isDryRun);
+            log("done");
+            return;
+        } else if (cmd.hasOption("only-update-workflow")) {
+            log("executing workflow setup...");
+            execute(builder::updateWorkflow, isDryRun);
             log("done");
             return;
         } else if (cmd.hasOption("only-events")) {

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -148,7 +148,7 @@ public class StudyBuilderCli {
             log("done");
             return;
         } else if (cmd.hasOption("only-update-workflow")) {
-            log("executing workflow setup...");
+            log("executing update of workflow...");
             execute(builder::updateWorkflow, isDryRun);
             log("done");
             return;

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilderCli.java
@@ -60,7 +60,7 @@ public class StudyBuilderCli {
         options.addOption(null, "dry-run", false, "run study setup or custom task without saving");
         options.addOption(null, "only-activity", true, "only run activity setup for given activity code");
         options.addOption(null, "only-workflow", false, "only run workflow setup");
-        options.addOption(null, "only-update-workflow", false, "recreate workflow from configuration file");
+        options.addOption(null, "only-recreate-workflow", false, "recreate workflow from configuration file");
         options.addOption(null, "only-events", false, "only run events setup");
         options.addOption(null, "only-labeled-events", true, "only run events in comma-separated list of labels");
         options.addOption(null, "only-update-pdfs", false, "only run pdf template updates (deprecated)");
@@ -149,7 +149,7 @@ public class StudyBuilderCli {
             execute(builder::runWorkflow, isDryRun);
             log("done");
             return;
-        } else if (cmd.hasOption("only-update-workflow")) {
+        } else if (cmd.hasOption("only-recreate-workflow")) {
             if (studyHasPatch(cfgPath) && !promptForConfirmation("There are patches for this study. Have you checked that workflow DOES "
                     + "NOT refer to any activities added in patches for this study?")) {
                 return;

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyPatcher.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyPatcher.java
@@ -17,7 +17,7 @@ import org.jdbi.v3.core.Handle;
  */
 public class StudyPatcher {
 
-    private static final String LOG_FILENAME = "patch-log.conf";
+    public static final String LOG_FILENAME = "patch-log.conf";
     private static final String PATCHES_KEY = "patches";
 
     private Path cfgPath;

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
@@ -29,13 +29,15 @@ public class WorkflowBuilder {
     }
 
     void run(Handle handle) {
-        insertTransitions(handle);
+        updateWorkflow(handle);
     }
 
-    private void insertTransitions(Handle handle) {
+    private void updateWorkflow(Handle handle) {
         if (!cfg.hasPath("workflowTransitions")) {
             return;
         }
+        int deletionCount = handle.attach(WorkflowDao.class).deleteStudyWorkflow(studyDto.getId());
+        LOG.info("Deleted {} workflow transitions PEX expressions", deletionCount);
         for (Config transitionCfg : cfg.getConfigList("workflowTransitions")) {
             insertTransitionSet(handle, transitionCfg);
         }
@@ -55,7 +57,6 @@ public class WorkflowBuilder {
             transitions.add(new WorkflowTransition(studyDto.getId(), fromState, toState, expr, order));
             order++;
         }
-
         workflowDao.insertTransitions(transitions);
         LOG.info("Created {} workflow transitions for state={}", transitions.size(), stateAsStr(fromCfg));
     }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
@@ -29,15 +29,23 @@ public class WorkflowBuilder {
     }
 
     void run(Handle handle) {
-        updateWorkflow(handle);
+        insertWorkflow(handle);
     }
 
-    private void updateWorkflow(Handle handle) {
+    void runUpdate(Handle handle) {
         if (!cfg.hasPath("workflowTransitions")) {
             return;
         }
         int deletionCount = handle.attach(WorkflowDao.class).deleteStudyWorkflow(studyDto.getId());
         LOG.info("Deleted {} workflow transitions PEX expressions", deletionCount);
+        insertWorkflow(handle);
+    }
+
+    private void insertWorkflow(Handle handle) {
+        if (!cfg.hasPath("workflowTransitions")) {
+            return;
+        }
+
         for (Config transitionCfg : cfg.getConfigList("workflowTransitions")) {
             insertTransitionSet(handle, transitionCfg);
         }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/WorkflowBuilder.java
@@ -37,7 +37,7 @@ public class WorkflowBuilder {
             return;
         }
         int deletionCount = handle.attach(WorkflowDao.class).deleteStudyWorkflow(studyDto.getId());
-        LOG.info("Deleted {} workflow transitions PEX expressions", deletionCount);
+        LOG.info("Deleted {} workflow transitions", deletionCount);
         insertWorkflow(handle);
     }
 


### PR DESCRIPTION
## Context
Tweaked study builder to add --only-update-workflow. Will delete existing workflow configuration in database and reload it from study.conf file


## FUD Score

_Overall, how are you feeling about these changes?_

- [ X] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous


## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [X ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ X] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

