### PR TITLE
DDP-5707 brain: fix copy event for Post Consent

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/copy/CopyExecutor.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/copy/CopyExecutor.java
@@ -61,6 +61,9 @@ public class CopyExecutor {
             if (source.getType() == CopyLocationType.ANSWER && target.getType() == CopyLocationType.ANSWER) {
                 String sourceStableId = ((CopyAnswerLocation) source).getQuestionStableId();
                 QuestionDto sourceQuestion = questionDtosByStableId.get(sourceStableId);
+                if (sourceQuestion == null) {
+                    continue; // Question might have been removed from activity, so we skip it.
+                }
                 FormResponse sourceInstance = responsesById.get(sourceQuestion.getActivityId());
 
                 String targetStableId = ((CopyAnswerLocation) target).getQuestionStableId();
@@ -71,6 +74,9 @@ public class CopyExecutor {
             } else if (source.getType() == CopyLocationType.ANSWER) {
                 String sourceStableId = ((CopyAnswerLocation) source).getQuestionStableId();
                 QuestionDto sourceQuestion = questionDtosByStableId.get(sourceStableId);
+                if (sourceQuestion == null) {
+                    continue;
+                }
                 FormResponse sourceInstance = responsesById.get(sourceQuestion.getActivityId());
 
                 ansToProfileCopier.copy(sourceInstance, sourceQuestion, target.getType());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/CopyConfigurationDao.java
@@ -108,6 +108,18 @@ public interface CopyConfigurationDao extends SqlObject {
         return locId;
     }
 
+    /**
+     * Add a copy pair to the configuration. Execution order should be set on the pair object beforehand by caller.
+     *
+     * @param studyId  the study id
+     * @param configId the copy configuration id
+     * @param pair     the pair to add
+     * @return id of the added pair
+     */
+    default long addCopyPairToConfig(long studyId, long configId, CopyConfigurationPair pair) {
+        return createCopyPair(studyId, configId, pair);
+    }
+
     default void removeCopyConfig(long configId) {
         CopyConfiguration config = findCopyConfigById(configId)
                 .orElseThrow(() -> new DaoException("Copy configuration with id " + configId + " does not exist"));

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -316,7 +316,7 @@ public class EventBuilder {
         }
     }
 
-    private CopyConfiguration buildCopyConfiguration(long studyId, boolean copyFromPreviousInstance,
+    public CopyConfiguration buildCopyConfiguration(long studyId, boolean copyFromPreviousInstance,
                                                      List<String> previousInstanceQuestionStableIds,
                                                      List<Config> pairsCfgList) {
         List<CopyPreviousInstanceFilter> filters = new ArrayList<>();

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainRenameFixPostConsentCopy.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/BrainRenameFixPostConsentCopy.java
@@ -1,0 +1,199 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.ActivityDao;
+import org.broadinstitute.ddp.db.dao.CopyConfigurationDao;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.JdbiActivity;
+import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.JdbiUser;
+import org.broadinstitute.ddp.db.dto.ActivityDto;
+import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.db.dto.UserDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
+import org.broadinstitute.ddp.model.activity.types.BlockType;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
+import org.broadinstitute.ddp.model.copy.CopyConfiguration;
+import org.broadinstitute.ddp.model.event.ActivityStatusChangeTrigger;
+import org.broadinstitute.ddp.model.event.CopyAnswerEventAction;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.studybuilder.EventBuilder;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Task to fix copy event for Post Consent due to new sex/gender questions.
+ */
+public class BrainRenameFixPostConsentCopy implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BrainRenameFixPostConsentCopy.class);
+    private static final String ACTIVITY_DATA_FILE = "patches/rename-activities.conf";
+    private static final String GENDER_DATA_FILE = "patches/rename-gender-questions.conf";
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+    private Config activityDataCfg;
+    private Config genderDataCfg;
+
+    private Handle handle;
+    private StudyDto studyDto;
+    private UserDto adminUser;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+
+        File file = cfgPath.getParent().resolve(ACTIVITY_DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        this.activityDataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+
+        file = cfgPath.getParent().resolve(GENDER_DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        this.genderDataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+    }
+
+    @Override
+    public void run(Handle handle) {
+        this.studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyCfg.getString("study.guid"));
+        this.adminUser = handle.attach(JdbiUser.class).findByUserGuid(studyCfg.getString("adminUser.guid"));
+        this.handle = handle;
+
+        fixChildPostConsentGenderPicklistOptionStableIds();
+        fixPostConsentCopyEvent();
+    }
+
+    private void fixChildPostConsentGenderPicklistOptionStableIds() {
+        Config activityCfg = activityDataCfg.getConfig("childPostConsent");
+        String activityCode = activityCfg.getString("activityCode");
+        LOG.info("Editing activity {}...", activityCode);
+
+        long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
+        ActivityVersionDto versionDto = findActivityLatestVersion(activityId);
+        FormActivityDef activity = findActivityDef(activityCode, versionDto.getVersionTag());
+
+        String childGenderStableId = genderDataCfg.getString("childGenderIdentity.stableId");
+        PicklistQuestionDef childGenderQuestion = null;
+        for (var section : activity.getAllSections()) {
+            for (var block : section.getBlocks()) {
+                if (block.getBlockType() == BlockType.QUESTION) {
+                    var questionBlock = (QuestionBlockDef) block;
+                    var question = questionBlock.getQuestion();
+                    if (childGenderStableId.equals(question.getStableId())) {
+                        childGenderQuestion = (PicklistQuestionDef) question;
+                        break;
+                    }
+                }
+            }
+        }
+        if (childGenderQuestion == null) {
+            throw new DDPException("Could not find question " + childGenderStableId);
+        }
+
+        // Picklist option stable ids need to match up in order for answer-copying to work.
+        // So we update the question's picklist options to match up with the adult Post Consent.
+        var mappings = Map.of(
+                "BOY", "MAN",
+                "GIRL", "WOMAN",
+                "TRANSGENDER_GIRL", "TRANSGENDER_WOMAN",
+                "TRANSGENDER_BOY", "TRANSGENDER_MAN");
+        var helper = handle.attach(SqlHelper.class);
+        for (var option : childGenderQuestion.getAllPicklistOptions()) {
+            String newStableId = mappings.get(option.getStableId());
+            if (newStableId != null) {
+                DBUtils.checkUpdate(1, helper.updatePicklistOptionStableId(option.getOptionId(), newStableId));
+                LOG.info("Updated picklist question {} option {} to new stable id {}",
+                        childGenderStableId, option.getStableId(), newStableId);
+            }
+        }
+
+        LOG.info("Finished updating picklist option stable ids for activity {}", activityCode);
+    }
+
+    private void fixPostConsentCopyEvent() {
+        Config activityCfg = activityDataCfg.getConfig("postConsent");
+        String activityCode = activityCfg.getString("activityCode");
+        LOG.info("Working on copy event for {}...", activityCode);
+
+        long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
+        long copyConfigId = handle.attach(EventDao.class)
+                .getAllEventConfigurationsByStudyId(studyDto.getId())
+                .stream()
+                .filter(event -> event.getEventActionType().equals(EventActionType.COPY_ANSWER))
+                .filter(event -> {
+                    if (event.getEventTriggerType().equals(EventTriggerType.ACTIVITY_STATUS)) {
+                        var trigger = (ActivityStatusChangeTrigger) event.getEventTrigger();
+                        return trigger.getStudyActivityId() == activityId
+                                && trigger.getInstanceStatusType() == InstanceStatusType.CREATED;
+                    }
+                    return false;
+                })
+                .map(event -> ((CopyAnswerEventAction) event.getEventAction()).getCopyConfigurationId())
+                .findFirst()
+                .orElseThrow(() -> new DDPException("Could not find copy event for activity " + activityCode));
+        LOG.info("Found copy event with copy configuration id " + copyConfigId);
+
+        var copyConfigDao = handle.attach(CopyConfigurationDao.class);
+        CopyConfiguration currentConfig = copyConfigDao
+                .findCopyConfigById(copyConfigId)
+                .orElseThrow(() -> new DDPException("Could not find copy configuration with id " + copyConfigId));
+
+        var eventBuilder = new EventBuilder(studyCfg, studyDto, adminUser.getUserId());
+        List<Config> copyConfigPairs = List.copyOf(genderDataCfg.getConfigList("copyConfigPairs"));
+        CopyConfiguration newCopyPairs = eventBuilder.buildCopyConfiguration(studyDto.getId(), false, List.of(), copyConfigPairs);
+
+        int executionOrder = currentConfig.getPairs().size();
+        for (var newPair : newCopyPairs.getPairs()) {
+            executionOrder++;
+            newPair.setOrder(executionOrder);
+            long id = copyConfigDao.addCopyPairToConfig(studyDto.getId(), copyConfigId, newPair);
+            LOG.info("Added copy pair with id={} to copy configuration {}", id, copyConfigId);
+        }
+
+        LOG.info("Finished updating copy event for {}", activityCode);
+    }
+
+    private ActivityVersionDto findActivityLatestVersion(long activityId) {
+        return handle.attach(JdbiActivityVersion.class)
+                .getActiveVersion(activityId)
+                .orElseThrow(() -> new DDPException("Could not find active version for activity " + activityId));
+    }
+
+    private FormActivityDef findActivityDef(String activityCode, String versionTag) {
+        ActivityDto activityDto = handle.attach(JdbiActivity.class)
+                .findActivityByStudyIdAndCode(studyDto.getId(), activityCode).get();
+        ActivityVersionDto versionDto = handle.attach(JdbiActivityVersion.class)
+                .findByActivityCodeAndVersionTag(studyDto.getId(), activityCode, versionTag).get();
+        return (FormActivityDef) handle.attach(ActivityDao.class)
+                .findDefByDtoAndVersion(activityDto, versionDto);
+    }
+
+    private interface SqlHelper extends SqlObject {
+        @SqlUpdate("update picklist_option set picklist_option_stable_id = :stableId where picklist_option_id = :optionId")
+        int updatePicklistOptionStableId(@Bind("optionId") long optionId, @Bind("stableId") String newStableId);
+    }
+}

--- a/study-builder/studies/brain/patch-log.conf
+++ b/study-builder/studies/brain/patch-log.conf
@@ -20,6 +20,7 @@
     "BrainPostConsentV2",
     "BrainPediatricsUpdates",
     "BrainRename",
-    "BrainRenameEdits"
+    "BrainRenameEdits",
+    "BrainRenameFixPostConsentCopy"
   ]
 }

--- a/study-builder/studies/brain/patches/rename-gender-questions.conf
+++ b/study-builder/studies/brain/patches/rename-gender-questions.conf
@@ -1,4 +1,27 @@
 {
+  "copyConfigPairs": [
+    {
+      "source": {
+        "type": "ANSWER",
+        "questionStableId": "CHILD_ASSIGNED_SEX"
+      },
+      "target": {
+        "type": "ANSWER",
+        "questionStableId": "ASSIGNED_SEX"
+      }
+    },
+    {
+      "source": {
+        "type": "ANSWER",
+        "questionStableId": "CHILD_GENDER_IDENTITY"
+      },
+      "target": {
+        "type": "ANSWER",
+        "questionStableId": "GENDER_IDENTITY"
+      }
+    },
+  ],
+
   "genderStableId": "GENDER",
   "assignedSex": {
     include required("../../snippets/picklist-question-single-list.conf"),
@@ -400,7 +423,7 @@
     },
     "picklistOptions": [
       {
-        "stableId": "BOY",
+        "stableId": "MAN",
         "optionLabelTemplate": {
           "templateType": "TEXT",
           "templateText": "$CHILD_GENDER_IDENTITY_boy",
@@ -418,7 +441,7 @@
         }
       },
       {
-        "stableId": "GIRL",
+        "stableId": "WOMAN",
         "optionLabelTemplate": {
           "templateType": "TEXT",
           "templateText": "$CHILD_GENDER_IDENTITY_girl",
@@ -454,7 +477,7 @@
         },
         "nestedOptions": [
           {
-            "stableId": "TRANSGENDER_GIRL",
+            "stableId": "TRANSGENDER_WOMAN",
             "optionLabelTemplate": {
               "templateType": "TEXT",
               "templateText": "$CHILD_GENDER_IDENTITY_transgender_girl",
@@ -472,7 +495,7 @@
             }
           },
           {
-            "stableId": "TRANSGENDER_BOY",
+            "stableId": "TRANSGENDER_MAN",
             "optionLabelTemplate": {
               "templateType": "TEXT",
               "templateText": "$CHILD_GENDER_IDENTITY_transgender_boy",


### PR DESCRIPTION
## Context

See DDP-5707.

The root issue is that we removed old sex/gender questions and added new ones as part of Brain Tumor rename. And the POST_CONSENT copy answer event was referencing the old questions. The fix is to check that questions actually exist in `CopyExecutor`.

Another issue is that in order to do proper copying for the sex/gender questions, the picklist options need to match up. So I added code to fix up those option stable ids.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] Getting dev into a state where this is user-visible requires some tech fiddling
    - Need to run `BrainRenameFixPostConsentCopy` patch.


## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
    - Need to run `BrainRenameFixPostConsentCopy` patch.

