### PR TITLE
Adds an Application flag to enable skipping Pepper registration [DDP-5719]

### DIFF
--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -16,9 +16,15 @@ function (user, context, callback) {
     // to the value of 'true' in their client metadata if the Pepper registration process
     // is not required.
     var m2mClients = ['dsm', 'Count Me In (Salt CMS)'];
-    var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || 'false'
-    if ((skipPepperRegistration === 'true') || (m2mClients.includes(context.clientName))) {
-        console.log('skipping Pepper registration for client \'' + context.clientName + '\'');
+
+    // The new flag is opt-in. If no value is defined, the legacy behavior will be used.
+    // If the value is non-null, then assume the client has opted in.
+    var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || null
+    if ((skipPepperRegistration === null) && (m2mClients.includes(context.clientName))) {
+        console.log('skipping Pepper registration for legacy client \'' + context.clientName + '\'');
+        return callback(null, user, context);
+    } else if (skipPepperRegistration === 'true') {
+        console.log('skipping Pepper registration for \'' + context.clientName + '\'');
         return callback(null, user, context);
     }
 

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -19,7 +19,7 @@ function (user, context, callback) {
 
     // The new flag is opt-in. If no value is defined, the legacy behavior will be used.
     // If the value is non-null, then assume the client has opted in.
-    var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || null
+    var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || null;
     if ((skipPepperRegistration === null) && (m2mClients.includes(context.clientName))) {
         console.log('skipping Pepper registration for legacy client \'' + context.clientName + '\'');
         return callback(null, user, context);

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -12,7 +12,9 @@ function (user, context, callback) {
     user.app_metadata.pepper_user_guids = user.app_metadata.pepper_user_guids || {};
 
     var m2mClients = ['dsm', 'Count Me In (Salt CMS)'];
-    if (m2mClients.includes(context.clientName)) {
+    var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || 'false'
+    if ((skipPepperRegistration === 'true') || (m2mClients.includes(context.clientName))) {
+        console.log('skipping Pepper registration for client \'' + context.clientName + '\'');
         return callback(null, user, context);
     }
 

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -11,6 +11,10 @@ function (user, context, callback) {
     user.app_metadata = user.app_metadata || {};
     user.app_metadata.pepper_user_guids = user.app_metadata.pepper_user_guids || {};
 
+    // Use of the m2mClients list below should be considered legacy behavior, and
+    // may be removed at any time. Any new clients should set the key 'skipPepperRegistration'
+    // to the value of 'true' in their client metadata if the Pepper registration process
+    // is not required.
     var m2mClients = ['dsm', 'Count Me In (Salt CMS)'];
     var skipPepperRegistration = context.clientMetadata.skipPepperRegistration || 'false'
     if ((skipPepperRegistration === 'true') || (m2mClients.includes(context.clientName))) {


### PR DESCRIPTION
[DDP-5719](https://broadinstitute.atlassian.net/browse/DDP-5719)

## Context

When handling Auth0 login attempts, all the logins result in a callback to the [registerUser](https://pepper.datadonationplatform.org/docs#operation/registerUser) operation. While necessary for Pepper, this is undesirable for clients which do not need to be registered. This PR adds `skipPepperRegistration` as an optional flag which can be added to an Application's client metadata in order to bypass this process.

In the case where:
* `skipPepperRegistration` is undefined or null
  * The script will use the legacy behavior and check to see if the client's name is in the `m2mClients` array
* `skipPepperRegistration` is set to the literal string `true` in the client metadata
  * The registration process with Pepper is skipped during authentication attempts
* `skipPepperRegistration` is set to any other string
  * Assumes the client has opted-in to the new behavior, and has declined to skip the registration process. Registration should continue as normal.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

This ticket does not make any explicitly user-visible changes.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

