### PR TITLE
DDP-5587 support rendering answers into description

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/json/activity/ActivityInstanceSummary.java
@@ -178,6 +178,10 @@ public class ActivityInstanceSummary implements TranslatedSummary {
         return activityDescription;
     }
 
+    public void setActivityDescription(String activityDescription) {
+        this.activityDescription = activityDescription;
+    }
+
     public String getActivitySummary() {
         return activitySummary;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -541,6 +541,9 @@ public class ActivityInstanceService {
             if (StringUtils.isNotBlank(summary.getActivitySubtitle())) {
                 summary.setActivitySubtitle(renderer.renderToString(summary.getActivitySubtitle(), context));
             }
+            if (StringUtils.isNotBlank(summary.getActivityDescription())) {
+                summary.setActivityDescription(renderer.renderToString(summary.getActivityDescription(), context));
+            }
             if (StringUtils.isNotBlank(summary.getActivitySummary())) {
                 summary.setActivitySummary(renderer.renderToString(summary.getActivitySummary(), context));
             }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/ActivityInstanceServiceTest.java
@@ -365,18 +365,21 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
     }
 
     @Test
-    public void testRenderInstanceSummaries_rendersAnswerIntoTitleAndSubtitle() {
-        String title = "$ddp.answer(\"Q1\",\"text\") $ddp.answer(\"non-existing\", \"the-fallback\")";
-        String subtitle = "$ddp.answer(\"Q2\",\"picklist\")";
+    public void testRenderInstanceSummaries_rendersAnswer() {
+        String name = "Name: $ddp.answer(\"Q2\",\"picklist\")";
+        String title = "Title: $ddp.answer(\"Q1\",\"text\") $ddp.answer(\"non-existing\", \"the-fallback\")";
+        String subtitle = "Subtitle: $ddp.answer(\"Q2\",\"picklist\")";
+        String description = "Description: $ddp.answer(\"Q2\",\"picklist\")";
+        String summary = "Summary: $ddp.answer(\"Q2\",\"picklist\")";
         String activityCode = "ACT" + Instant.now().toEpochMilli();
         var summaries = List.of(new ActivityInstanceSummary(
-                activityCode, 1L, "guid", "name", null, title, subtitle, null, null, "type", "form", "status",
+                activityCode, 1L, "guid", name, null, title, subtitle, description, summary, "type", "form", "status",
                 null, false, "en", false, false, 1L, false, false, "v1", 1L, 1L));
         summaries.get(0).setInstanceNumber(2);
 
         var response = new FormResponse(1L, "guid", 1L, null, 1L, 1L, null, null, 1L, activityCode, "v1",
                 new ActivityInstanceStatusDto(1L, 1L, 1L, 1L, InstanceStatusType.CREATED));
-        response.putAnswer(new TextAnswer(1L, "Q1", "guid1", "some-name"));
+        response.putAnswer(new TextAnswer(1L, "Q1", "guid1", "some-text"));
         response.putAnswer(new PicklistAnswer(2L, "Q2", "guid2", List.of(new SelectedPicklistOption("AUNT"))));
 
         var optionAunt = Template.text("$aunt");
@@ -397,8 +400,10 @@ public class ActivityInstanceServiceTest extends TxnAwareBaseTest {
         TransactionWrapper.useTxn(handle -> service.renderInstanceSummaries(
                 handle, testData.getUserId(), "study", summaries, Map.of("guid", response)));
 
-        assertEquals("name #2", summaries.get(0).getActivityName());
-        assertEquals("some-name the-fallback", summaries.get(0).getActivityTitle());
-        assertEquals("My Aunt", summaries.get(0).getActivitySubtitle());
+        assertEquals("Name: My Aunt #2", summaries.get(0).getActivityName());
+        assertEquals("Title: some-text the-fallback", summaries.get(0).getActivityTitle());
+        assertEquals("Subtitle: My Aunt", summaries.get(0).getActivitySubtitle());
+        assertEquals("Description: My Aunt", summaries.get(0).getActivityDescription());
+        assertEquals("Summary: My Aunt", summaries.get(0).getActivitySummary());
     }
 }


### PR DESCRIPTION
## Context

I missed a requirement where we want to enable rendering the "description" for an activity instance summary object. This PR adds in support for it.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
