### PR TITLE
DDP-5749 add COMPLETED enrollment status

### DIFF
--- a/pepper-apis/docs/specification/src/endpoints/user.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.yml
@@ -15,7 +15,7 @@ delete:
 
     * _Only the proxy user is allowed to delete one of their managed user._
     * _The user to be deleted cannot have an Auth0 account._
-    * _The user cannot yet have reached the ENROLLED status._
+    * _The user cannot yet have reached an enrolled status._
     * _The user shouldn't have any kit request._
   tags:
     - Operator & Participant

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUserStudyEnrollment.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUserStudyEnrollment.java
@@ -107,7 +107,7 @@ public interface JdbiUserStudyEnrollment extends SqlObject {
             + " JOIN umbrella_study us ON us.umbrella_study_id = usen.study_id "
             + " WHERE "
             + " us.guid = :studyGuid "
-            + " AND est.enrollment_status_type_code = 'ENROLLED'"
+            + " AND est.enrollment_status_type_code in ('ENROLLED', 'COMPLETED')"
             + " AND usen.valid_to is null"
     )
     List<String> findAllOLCsForEnrolledParticipantsInStudy(@Bind("studyGuid") String studyGuid);
@@ -350,7 +350,7 @@ public interface JdbiUserStudyEnrollment extends SqlObject {
         }
 
         EnrollmentStatusType newEnrollmentStatus = EnrollmentStatusType.EXITED_BEFORE_ENROLLMENT;
-        if (currentEnrollmentStatus == EnrollmentStatusType.ENROLLED) {
+        if (currentEnrollmentStatus != null && currentEnrollmentStatus.isEnrolled()) {
             newEnrollmentStatus = EnrollmentStatusType.EXITED_AFTER_ENROLLMENT;
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/MedicalProviderDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/MedicalProviderDao.java
@@ -58,10 +58,10 @@ public interface MedicalProviderDao extends SqlObject {
         Optional<EnrollmentStatusType> enrollmentStatus = getJdbiUserStudyEnrollment()
                 .getEnrollmentStatusByUserAndStudyIds(userId, studyId);
         if (enrollmentStatus.isPresent()
-                && enrollmentStatus.get() == EnrollmentStatusType.ENROLLED
+                && enrollmentStatus.get().isEnrolled()
                 && !medicalProviderDto.isBlank()) {
             getJdbiUserStudyEnrollment()
-                    .changeUserStudyEnrollmentStatus(userId, studyId, EnrollmentStatusType.ENROLLED);
+                    .changeUserStudyEnrollmentStatus(userId, studyId, enrollmentStatus.get());
 
             int numQueued = getHandle().attach(EventDao.class).addMedicalUpdateTriggeredEventsToQueue(studyId, userId);
             LOG.info("Queued {} medical-update events for participantId={} studyId={}", numQueued, userId, studyId);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/ParticipantStatusTrackingInfo.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/ParticipantStatusTrackingInfo.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Optional;
 
 import com.google.gson.annotations.SerializedName;
-
 import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +37,7 @@ public class ParticipantStatusTrackingInfo {
             Long received
     ) {
         // Is it possible? Should we check for it here?
-        if (enrollmentStatusType != EnrollmentStatusType.ENROLLED) {
+        if (!enrollmentStatusType.isEnrolled()) {
             return RecordStatus.INELIGIBLE;
         } else if (requested == null && received == null) {
             return RecordStatus.PENDING;
@@ -203,7 +201,7 @@ public class ParticipantStatusTrackingInfo {
         ) {
             // Is it possible? Should we check for it here?
             String entityName = "kit";
-            if (enrollmentStatusType != EnrollmentStatusType.ENROLLED) {
+            if (!enrollmentStatusType.isEnrolled()) {
                 return RecordStatus.INELIGIBLE;
             } else if (delivered == null && received == null) {
                 return RecordStatus.SENT;

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/study/EnrollmentStatusCount.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/study/EnrollmentStatusCount.java
@@ -29,7 +29,8 @@ public class EnrollmentStatusCount {
         int registeredCount = 0;
         for (EnrollmentStatusDto enrollment : enrollments) {
             switch (enrollment.getEnrollmentStatus()) {
-                case ENROLLED:
+                case ENROLLED: // fall-through
+                case COMPLETED:
                     ++participantCount;
                     break;
                 case REGISTERED:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/user/EnrollmentStatusType.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/user/EnrollmentStatusType.java
@@ -7,18 +7,39 @@ import org.broadinstitute.ddp.model.activity.instance.ActivityInstance;
 
 public enum EnrollmentStatusType {
 
+    /**
+     * Means participant is registered with study but not yet enrolled. Typically this is after they have created an
+     * account but before giving consent.
+     */
     REGISTERED(true, false, false, true),
+    /**
+     * Means participant is fully enrolled in study. Typically this is after they have completed consent.
+     */
     ENROLLED(true, false, false,  true),
+    /**
+     * Means participant withdrew from study before being enrolled.
+     */
     EXITED_BEFORE_ENROLLMENT(false, true, true, false),
+    /**
+     * Means participant withdrew from study after being enrolled.
+     */
     EXITED_AFTER_ENROLLMENT(false, true, true, false),
-    CONSENT_SUSPENDED(true, false, false, true);
+    /**
+     * Means the consent participant given is no longer valid, and thus suspended. Participant is no longer considered
+     * enrolled until they re-consent. Typically this can happen when a minor participant ages up. Their parental
+     * consent will be suspended and they will need to give their own consent.
+     */
+    CONSENT_SUSPENDED(true, false, false, true),
+    /**
+     * Means participant has reached the end of participation in the study. This is very similar to `ENROLLED`. They are
+     * considered to be fully enrolled in the study and can continue to view/edit their data, but will not be
+     * participating in future activities (e.g. will not receive any more kits).
+     */
+    COMPLETED(true, false, false, true);
 
     private final boolean shouldReceiveCommunications;
-
     private final boolean isExited;
-
     private final boolean shouldMarkActivitiesAsReadOnly;
-
     private final boolean isDSMVisible;
 
     /**
@@ -39,7 +60,7 @@ public enum EnrollmentStatusType {
      *                     return information.  If false, such calls should return not data.
      *
      */
-    private EnrollmentStatusType(boolean shouldReceiveCommunications,
+    EnrollmentStatusType(boolean shouldReceiveCommunications,
                                  boolean isExited,
                                  boolean shouldMarkActivitiesAsReadOnly,
                                  boolean isDSMVisible) {
@@ -94,5 +115,12 @@ public enum EnrollmentStatusType {
      */
     public boolean isDSMVisible() {
         return isDSMVisible;
+    }
+
+    /**
+     * Returns whether this status represents being enrolled in study or not.
+     */
+    public boolean isEnrolled() {
+        return this == ENROLLED || this == COMPLETED;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateMailAddressRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/CreateMailAddressRoute.java
@@ -10,7 +10,6 @@ import org.broadinstitute.ddp.db.dao.DataExportDao;
 import org.broadinstitute.ddp.db.dao.EventDao;
 import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.model.address.MailAddress;
-import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.service.AddressService;
 import org.broadinstitute.ddp.util.RouteUtil;
 import org.slf4j.Logger;
@@ -38,7 +37,7 @@ public class CreateMailAddressRoute extends ValidatedMailAddressInputRoute {
             EventDao eventDao = handle.attach(EventDao.class);
             handle.attach(JdbiUserStudyEnrollment.class)
                     .getAllLatestEnrollmentsForUser(participantGuid).stream()
-                    .filter(enrollmentStatusDto -> enrollmentStatusDto.getEnrollmentStatus() == EnrollmentStatusType.ENROLLED)
+                    .filter(enrollmentStatusDto -> enrollmentStatusDto.getEnrollmentStatus().isEnrolled())
                     .forEach(enrollmentStatusDto -> {
                         int numQueued = eventDao.addMedicalUpdateTriggeredEventsToQueue(
                                 enrollmentStatusDto.getStudyId(), enrollmentStatusDto.getUserId());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteUserRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteUserRoute.java
@@ -1,5 +1,9 @@
 package org.broadinstitute.ddp.route;
 
+import static org.broadinstitute.ddp.constants.RouteConstants.PathParam.USER_GUID;
+
+import java.io.IOException;
+
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.constants.ErrorCodes;
@@ -9,7 +13,6 @@ import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.db.dao.UserDao;
 import org.broadinstitute.ddp.db.dao.UserGovernanceDao;
 import org.broadinstitute.ddp.json.errors.ApiError;
-import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.model.user.User;
 import org.broadinstitute.ddp.security.DDPAuth;
 import org.broadinstitute.ddp.service.UserService;
@@ -21,10 +24,6 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 import spark.Route;
-
-import java.io.IOException;
-
-import static org.broadinstitute.ddp.constants.RouteConstants.PathParam.USER_GUID;
 
 public class DeleteUserRoute implements Route {
     private static final Logger LOG = LoggerFactory.getLogger(DeleteUserRoute.class);
@@ -103,7 +102,7 @@ public class DeleteUserRoute implements Route {
 
         // The user cannot yet have reached the ENROLLED status
         if (handle.attach(JdbiUserStudyEnrollment.class).findByUserGuid(userGuid).stream().anyMatch(
-                enrollment -> EnrollmentStatusType.ENROLLED.equals(enrollment.getEnrollmentStatus()))) {
+                enrollment -> enrollment.getEnrollmentStatus().isEnrolled())) {
             String message = "User with guid '" + userGuid
                     + "' has at least one enrollment completed. Deleting of such users is not supported.";
             return new CheckError(HttpStatus.SC_UNPROCESSABLE_ENTITY,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DsmPdfRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DsmPdfRoute.java
@@ -147,7 +147,7 @@ public abstract class DsmPdfRoute implements Route {
                     return ResponseUtil.haltError(response, HttpStatus.SC_INTERNAL_SERVER_ERROR, err);
                 });
 
-        if (enrollmentStatusType != EnrollmentStatusType.ENROLLED) {
+        if (!enrollmentStatusType.isEnrolled()) {
             String msg = "User " + user.getGuid() + " was not enrolled in study " + studyDto.getGuid();
             ApiError err = new ApiError(ErrorCodes.UNSATISFIED_PRECONDITION, msg);
             LOG.error(err.getMessage());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmInstitutionRequestsRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmInstitutionRequestsRoute.java
@@ -28,7 +28,6 @@ import org.broadinstitute.ddp.db.dto.UserDto;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.model.dsm.Institution;
 import org.broadinstitute.ddp.model.dsm.InstitutionRequests;
-import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.jdbi.v3.core.Handle;
 import org.slf4j.Logger;
@@ -86,7 +85,7 @@ public class GetDsmInstitutionRequestsRoute implements Route {
                     .findByStudyGuidAfterOrEqualToInstant(studyGuid, createdSince)
                     .stream()
                     .filter(enrollmentStatusDto ->
-                            enrollmentStatusDto.getEnrollmentStatus() == EnrollmentStatusType.ENROLLED)
+                            enrollmentStatusDto.getEnrollmentStatus().isEnrolled())
                     .collect(Collectors.toList());
 
             return buildJsonForUsers(handle, enrollmentStatuses, studyIdOpt.get());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmMedicalRecordRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmMedicalRecordRoute.java
@@ -67,8 +67,8 @@ public class GetDsmMedicalRecordRoute implements Route {
             // look for the participant by guid or legacy altpid
             DsmStudyParticipantDao dsmStudyParticipantDao = handle.attach(DsmStudyParticipantDao.class);
             DsmStudyParticipant dsmParticipant = dsmStudyParticipantDao
-                    .findStudyParticipant(userGuidOrAltpid, studyGuid,
-                            Arrays.asList(EnrollmentStatusType.ENROLLED, EnrollmentStatusType.EXITED_AFTER_ENROLLMENT))
+                    .findStudyParticipant(userGuidOrAltpid, studyGuid, Arrays.asList(
+                            EnrollmentStatusType.ENROLLED, EnrollmentStatusType.COMPLETED, EnrollmentStatusType.EXITED_AFTER_ENROLLMENT))
                     .orElse(null);
             if (dsmParticipant == null) {
                 throw ResponseUtil.haltError(response, HttpStatus.SC_NOT_FOUND, new ApiError(ErrorCodes.NOT_FOUND,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmParticipantInstitutionsRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetDsmParticipantInstitutionsRoute.java
@@ -73,7 +73,7 @@ public class GetDsmParticipantInstitutionsRoute implements Route {
 
             List<EnrollmentStatusDto> includedUsers = allUsers.stream()
                     .filter(enrollmentStatusDto ->
-                            enrollmentStatusDto.getEnrollmentStatus() == EnrollmentStatusType.ENROLLED
+                            enrollmentStatusDto.getEnrollmentStatus().isEnrolled()
                                     || enrollmentStatusDto.getEnrollmentStatus() == EnrollmentStatusType.EXITED_AFTER_ENROLLMENT)
                     .collect(Collectors.toList());
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetPdfRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/GetPdfRoute.java
@@ -154,7 +154,7 @@ public class GetPdfRoute implements Route {
 
         EnrollmentStatusType currentStatus = statuses.get(0).getEnrollmentStatus();
         boolean hasEnrolledBefore = statuses.stream()
-                .anyMatch(status -> status.getEnrollmentStatus() == EnrollmentStatusType.ENROLLED);
+                .anyMatch(status -> status.getEnrollmentStatus().isEnrolled());
 
         if (currentStatus.isExited() || !hasEnrolledBefore) {
             String msg = "User " + user.getGuid() + " was not enrolled in study " + studyDto.getGuid();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRoute.java
@@ -70,7 +70,7 @@ public class ReceiveDsmNotificationRoute extends ValidatedJsonInputRoute<DsmNoti
             EnrollmentStatusType status = handle.attach(JdbiUserStudyEnrollment.class)
                     .getEnrollmentStatusByUserAndStudyIds(user.getId(), studyDto.getId())
                     .orElse(null);
-            if (status != EnrollmentStatusType.ENROLLED) {
+            if (status == null || !status.isEnrolled()) {
                 String msg = String.format(
                         "User %s with status %s is not enrolled in study %s, will not process DSM notification event %s",
                         userGuid, status == null ? "<null>" : status, studyGuid, payload.getEventType());

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UpdateMailAddressRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UpdateMailAddressRoute.java
@@ -13,7 +13,6 @@ import org.broadinstitute.ddp.db.dao.EventDao;
 import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
 import org.broadinstitute.ddp.json.errors.ApiError;
 import org.broadinstitute.ddp.model.address.MailAddress;
-import org.broadinstitute.ddp.model.user.EnrollmentStatusType;
 import org.broadinstitute.ddp.service.AddressService;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
@@ -49,7 +48,7 @@ public class UpdateMailAddressRoute extends ValidatedMailAddressInputRoute {
                 EventDao eventDao = handle.attach(EventDao.class);
                 handle.attach(JdbiUserStudyEnrollment.class)
                         .getAllLatestEnrollmentsForUser(participantGuid).stream()
-                        .filter(enrollmentStatusDto -> enrollmentStatusDto.getEnrollmentStatus() == EnrollmentStatusType.ENROLLED)
+                        .filter(enrollmentStatusDto -> enrollmentStatusDto.getEnrollmentStatus().isEnrolled())
                         .forEach(enrollmentStatusDto -> {
                             int numQueued = eventDao.addMedicalUpdateTriggeredEventsToQueue(
                                     enrollmentStatusDto.getStudyId(), enrollmentStatusDto.getUserId());

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -257,4 +257,5 @@
     <include file="db-changes/schema/DDP-5604-activity-can-delete-instances.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5679-add-event-configuration-label.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5045-sendgrid-event-message-id-nullable.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/DDP-5749-completed-status.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/seed/DDP-5749-completed-status.xml
+++ b/pepper-apis/src/main/resources/db-changes/seed/DDP-5749-completed-status.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210401-completed-status">
+        <insert tableName="enrollment_status_type">
+            <column name="enrollment_status_type_code" value="COMPLETED"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/KitScheduleDao.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/KitScheduleDao.sql.stg
@@ -1,5 +1,8 @@
 group KitScheduleDao;
 
+/**
+ * Users with COMPLETED status are not included here, so we don't create additional kits for them.
+ */
 select_all_pending_records() ::= <<
 select usen.study_id,
        (select guid from umbrella_study where umbrella_study_id = usen.study_id) as study_guid,

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/service/KitCheckService.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/service/KitCheckService.sql.stg
@@ -4,6 +4,8 @@ group KitCheckService;
  * Get user and address info of all participants enrolled in given study and has not received a kit of given type yet.
  * This returns list based on batch size. Callers will need to apply more filtering criteria, such as pex expressions
  * and geographic limitations from kit configuration information to narrow the list.
+ *
+ * Users with COMPLETED status are not included here, so we don't create any new kits for them.
  */
 queryAddressInfoForEnrolledUsersWithoutKits() ::= <<
 select user.user_id,

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/util/StatisticsUtil.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/util/StatisticsUtil.sql.stg
@@ -12,7 +12,7 @@ from
     join enrollment_status_type est on est.enrollment_status_type_id = se.enrollment_status_type_id
 where
     se.study_id = :studyId and
-    est.enrollment_status_type_code = 'ENROLLED' and
+    est.enrollment_status_type_code in ('ENROLLED', 'COMPLETED') and
     se.valid_to is null
 group by 1
 >>
@@ -36,7 +36,7 @@ from
 where 
     se.study_id = :studyId and
     qsc.stable_id = :stableId and 
-    est.enrollment_status_type_code = 'ENROLLED' and
+    est.enrollment_status_type_code in ('ENROLLED', 'COMPLETED') and
     se.valid_to is null and
     r.start_date \<= ai.created_at and
     (r.end_date is null or ai.created_at \< r.end_date) and
@@ -74,7 +74,7 @@ from
 where 
     qsc.umbrella_study_id = :studyId and
     qsc.stable_id = :stableId and 
-    est.enrollment_status_type_code = 'ENROLLED' and
+    est.enrollment_status_type_code in ('ENROLLED', 'COMPLETED') and
     se.valid_to is null and
     :value = coalesce(po.picklist_option_stable_id, export_set(ba.answer, 'true', 'false', '', 1)) and
     ai_ex.activity_instance_id is null

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetPdfRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetPdfRouteTest.java
@@ -179,6 +179,26 @@ public class GetPdfRouteTest extends DsmRouteTest {
     }
 
     @Test
+    public void test_givenUserEnrolledButNowCompleted_thenReturns200() {
+        TransactionWrapper.useTxn(handle -> {
+            TestDataSetupUtil.setUserEnrollmentStatus(handle, generatedTestData, EnrollmentStatusType.ENROLLED);
+            TestDataSetupUtil.setUserEnrollmentStatus(handle, generatedTestData, EnrollmentStatusType.COMPLETED);
+        });
+
+        given().auth().oauth2(dsmClientAccessToken)
+                .pathParam("studyGuid", generatedTestData.getStudyGuid())
+                .pathParam("userGuid", generatedTestData.getUserGuid())
+                .pathParam("configName", configurationName)
+                .when().get(url)
+                .then().assertThat()
+                .statusCode(HttpStatus.SC_OK);
+
+        TransactionWrapper.useTxn(handle ->
+                removeEnrollmentForUserAndStudy(handle, generatedTestData.getStudyGuid(), generatedTestData.getUserGuid())
+        );
+    }
+
+    @Test
     public void test_givenUserDoesntExist_whenEndpointIsCalled_thenItReturns404_andBodyConstainsErrorExplanation() {
         given().auth().oauth2(dsmClientAccessToken)
                 .pathParam("studyGuid", generatedTestData.getStudyGuid())

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyStatisticsRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyStatisticsRouteTest.java
@@ -156,7 +156,7 @@ public class GetStudyStatisticsRouteTest extends IntegrationTestSuite.TestCase {
         userStudyEnrollment.changeUserStudyEnrollmentStatus(
                 user2Guid,
                 testData.getStudyGuid(),
-                EnrollmentStatusType.ENROLLED);
+                EnrollmentStatusType.COMPLETED);
 
         // Configuring study statistics
         StatisticsConfigurationDao statConfigDao = handle.attach(StatisticsConfigurationDao.class);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/ReceiveDsmNotificationRouteTest.java
@@ -356,6 +356,24 @@ public class ReceiveDsmNotificationRouteTest extends DsmRouteTest {
         }
     }
 
+    @Test
+    public void testEvents_canStillReceiveEvents_whenEnrollmentStatusIsCompleted() {
+        TransactionWrapper.useTxn(handle -> TestDataSetupUtil
+                .setUserEnrollmentStatus(handle, testData, EnrollmentStatusType.COMPLETED));
+
+        var payload = new DsmNotificationPayload(TEST_RESULT.name(), "kit-1", KitReasonType.NORMAL);
+        var result = new TestResult("NEGATIVE", Instant.now(), false);
+        payload.setEventData(GsonUtil.standardGson().toJsonTree(result));
+
+        given().auth().oauth2(dsmClientAccessToken)
+                .pathParam("study", testData.getStudyGuid())
+                .pathParam("user", testData.getUserGuid())
+                .body(payload, ObjectMapperType.GSON)
+                .when().post(urlTemplate)
+                .then().assertThat()
+                .statusCode(200);
+    }
+
     private boolean checkIfNotificationQueued() {
         return TransactionWrapper.withTxn(handle -> {
             var eventDao = handle.attach(EventDao.class);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/KitCheckServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/KitCheckServiceTest.java
@@ -190,6 +190,23 @@ public class KitCheckServiceTest extends TxnAwareBaseTest {
     }
 
     @Test
+    public void testCheckForKits_userEnrolled_butIsCompleted() {
+        TransactionWrapper.useTxn(handle -> {
+            enrollTestUser(handle);
+            createTestMailAddress(handle);
+            handle.attach(JdbiUserStudyEnrollment.class)
+                    .changeUserStudyEnrollmentStatus(userGuid, studyGuid, EnrollmentStatusType.COMPLETED);
+
+            int numRecipients = new InjectedKitCheckService(handle)
+                    .checkForInitialKits()
+                    .getTotalNumberOfParticipantsQueuedForKit();
+            assertEquals("should not have any recipients", 0L, numRecipients);
+
+            handle.rollback();
+        });
+    }
+
+    @Test
     public void testCheckForKits_userEnrolled_meetsKitCriteria() {
         TransactionWrapper.useTxn(handle -> {
             enrollTestUser(handle);


### PR DESCRIPTION
## Context

See DDP-5749. This PR adds a new "enrollment" status `COMPLETED`. It is meant to indicate that participant has finished enrollment steps for a study -- they are treated as fully enrolled, can continue to edit/view data, but will no longer be counted towards future things like kits. How and when this status gets used is up to study configuration.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] Does not require other features to demo this, but might want to look at DDP-5750.

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

