### PR TITLE
DDP-5760 testboston: disable kit prep email

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/TestBostonDisableKitPrepEmail.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/TestBostonDisableKitPrepEmail.java
@@ -1,0 +1,55 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import com.typesafe.config.Config;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.event.EventConfiguration;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestBostonDisableKitPrepEmail implements CustomTask {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TestBostonDisableKitPrepEmail.class);
+    private static final String STUDY_GUID = "testboston";
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        if (!studyCfg.getString("study.guid").equals(STUDY_GUID)) {
+            throw new DDPException("This task is only for the " + STUDY_GUID + " study!");
+        }
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(STUDY_GUID);
+
+        List<EventConfiguration> events = handle.attach(EventDao.class)
+                .getAllEventConfigurationsByStudyId(studyDto.getId());
+
+        EventConfiguration kitPrepEmail = events.stream()
+                .filter(event -> event.getEventTriggerType() == EventTriggerType.KIT_PREP)
+                .filter(event -> event.getEventActionType() == EventActionType.NOTIFICATION)
+                .findFirst().orElseThrow(() -> new DDPException("Could not find kit prep email event"));
+
+        DBUtils.checkUpdate(1, handle.attach(JdbiEventConfiguration.class)
+                .updateIsActiveById(kitPrepEmail.getEventConfigurationId(), false));
+        LOG.info("Disabled kit prep email event with id {}", kitPrepEmail.getEventConfigurationId());
+    }
+}

--- a/study-builder/studies/testboston/patch-log.conf
+++ b/study-builder/studies/testboston/patch-log.conf
@@ -2,6 +2,7 @@
   "patches": [
     "TestBostonConsentV2",
     "TestBostonLongitudinalV2",
-    "TestBostonAddNoSymptionsOption"
+    "TestBostonAddNoSymptionsOption",
+    "TestBostonDisableKitPrepEmail"
   ]
 }


### PR DESCRIPTION
## Context

See DDP-5760. Added a custom task for disabling the kit prep email event.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] Getting dev into a state where this is user-visible requires some tech fiddling.
    - Run the custom task.

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] Releasing these changes requires special handling and I have documented the special procedures in the release plan document
    - Run the custom task.

