### PR TITLE
DDP-5571 support canDeleteFistInstance flag for nested activities

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/FormActivityDao.java
@@ -92,6 +92,9 @@ public interface FormActivityDao extends SqlObject {
         if (activity.canDeleteInstances()) {
             throw new UnsupportedOperationException("canDeleteInstances can only be set on nested child activities");
         }
+        if (activity.getCanDeleteFirstInstance() != null) {
+            throw new UnsupportedOperationException("canDeleteFirstInstance can only be set on nested child activities");
+        }
 
         nestedActivities = ListUtils.defaultIfNull(nestedActivities, List.of());
         for (var nested : nestedActivities) {
@@ -135,7 +138,7 @@ public interface FormActivityDao extends SqlObject {
                 activity.getMaxInstancesPerUser(), activity.getDisplayOrder(), activity.isWriteOnce(), activity.getEditTimeoutSec(),
                 activity.isOndemandTriggerAllowed(), activity.isExcludeFromDisplay(), activity.isExcludeStatusIconFromDisplay(),
                 activity.isAllowUnauthenticated(), activity.isFollowup(), activity.isHideInstances(),
-                activity.isCreateOnParentCreation(), activity.canDeleteInstances());
+                activity.isCreateOnParentCreation(), activity.canDeleteInstances(), activity.getCanDeleteFirstInstance());
         activity.setActivityId(activityId);
         return activityId;
     }
@@ -249,6 +252,7 @@ public interface FormActivityDao extends SqlObject {
                 .setHideInstances(activityDto.isHideExistingInstancesOnCreation())
                 .setCreateOnParentCreation(activityDto.isCreateOnParentCreation())
                 .setCanDeleteInstances(activityDto.canDeleteInstances())
+                .setCanDeleteFirstInstance(activityDto.getCanDeleteFirstInstance())
                 .setIsFollowup(activityDto.isFollowup());
 
         List<Translation> names = new ArrayList<>();

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivity.java
@@ -28,12 +28,13 @@ public interface JdbiActivity extends SqlObject {
             + " (activity_type_id,study_id,study_activity_code,max_instances_per_user,display_order,"
             + "is_write_once, instantiate_upon_registration,edit_timeout_sec,allow_ondemand_trigger,"
             + "exclude_from_display, exclude_status_icon_from_display, allow_unauthenticated, "
-            + "is_followup, hide_existing_instances_on_creation, create_on_parent_creation, can_delete_instances)"
+            + "is_followup, hide_existing_instances_on_creation, create_on_parent_creation, "
+            + "can_delete_instances, can_delete_first_instance)"
             + " values((select activity_type_id from activity_type where activity_type_code = :activityType),"
             + ":studyId,:activityCode,"
             + ":maxInstancesPerUser,:displayOrder,:writeOnce,0,:editTimeoutSec,:allowOndemandTrigger,"
             + ":excludeFromDisplay, :excludeStatusIconFromDisplay, :allowUnauthenticated, :isFollowup, :hideExistingInstancesOnCreation,"
-            + ":createOnParentCreation, :canDeleteInstances)")
+            + ":createOnParentCreation, :canDeleteInstances, :canDeleteFirstInstance)")
     @GetGeneratedKeys()
     long insertActivity(
             @Bind("activityType") ActivityType activityType,
@@ -50,7 +51,8 @@ public interface JdbiActivity extends SqlObject {
             @Bind("isFollowup") boolean isFollowup,
             @Bind("hideExistingInstancesOnCreation") boolean hideExistingInstancesOnCreation,
             @Bind("createOnParentCreation") boolean createOnParentCreation,
-            @Bind("canDeleteInstances") boolean canDeleteInstances
+            @Bind("canDeleteInstances") boolean canDeleteInstances,
+            @Bind("canDeleteFirstInstance") Boolean canDeleteFirstInstance
     );
 
     @SqlUpdate("update study_activity"
@@ -65,7 +67,9 @@ public interface JdbiActivity extends SqlObject {
             + "        is_followup = :isFollowup,"
             + "        exclude_status_icon_from_display = :excludeStatusIconFromDisplay,"
             + "        hide_existing_instances_on_creation = :hideExistingInstancesOnCreation,"
-            + "        create_on_parent_creation = :createOnParentCreation"
+            + "        create_on_parent_creation = :createOnParentCreation,"
+            + "        can_delete_instances = :canDeleteInstances,"
+            + "        can_delete_first_instance = :canDeleteFirstInstance"
             + "  where study_activity_id = :activityId")
     int updateActivity(
             @Bind("activityId") long activityId,
@@ -80,7 +84,9 @@ public interface JdbiActivity extends SqlObject {
             @Bind("isFollowup") boolean isFollowup,
             @Bind("excludeStatusIconFromDisplay") boolean excludeStatusIconFromDisplay,
             @Bind("hideExistingInstancesOnCreation") boolean hideExistingInstancesOnCreation,
-            @Bind("createOnParentCreation") boolean createOnParentCreation
+            @Bind("createOnParentCreation") boolean createOnParentCreation,
+            @Bind("canDeleteInstances") boolean canDeleteInstances,
+            @Bind("canDeleteFirstInstance") Boolean canDeleteFirstInstance
     );
 
     @SqlUpdate("insert into form_activity(study_activity_id,form_type_id) values(?,?)")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/ActivityDto.java
@@ -25,6 +25,7 @@ public class ActivityDto {
     private final boolean hideExistingInstancesOnCreation;
     private final boolean createOnParentCreation;
     private final boolean canDeleteInstances;
+    private final Boolean canDeleteFirstInstance;
     private String activityCode;
 
     @JdbiConstructor
@@ -47,7 +48,8 @@ public class ActivityDto {
             @ColumnName("exclude_status_icon_from_display") boolean excludeStatusIconFromDisplay,
             @ColumnName("hide_existing_instances_on_creation") boolean hideExistingInstancesOnCreation,
             @ColumnName("create_on_parent_creation") boolean createOnParentCreation,
-            @ColumnName("can_delete_instances") boolean canDeleteInstances
+            @ColumnName("can_delete_instances") boolean canDeleteInstances,
+            @ColumnName("can_delete_first_instance") Boolean canDeleteFirstInstance
     ) {
         this.activityId = activityId;
         this.activityTypeId = activityTypeId;
@@ -68,6 +70,7 @@ public class ActivityDto {
         this.hideExistingInstancesOnCreation = hideExistingInstancesOnCreation;
         this.createOnParentCreation = createOnParentCreation;
         this.canDeleteInstances = canDeleteInstances;
+        this.canDeleteFirstInstance = canDeleteFirstInstance;
     }
 
     public long getActivityId() {
@@ -150,6 +153,10 @@ public class ActivityDto {
         return canDeleteInstances;
     }
 
+    public Boolean getCanDeleteFirstInstance() {
+        return canDeleteFirstInstance;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -177,7 +184,8 @@ public class ActivityDto {
                 && excludeStatusIconFromDisplay == that.excludeStatusIconFromDisplay
                 && hideExistingInstancesOnCreation == that.hideExistingInstancesOnCreation
                 && createOnParentCreation == that.createOnParentCreation
-                && canDeleteInstances == that.canDeleteInstances;
+                && canDeleteInstances == that.canDeleteInstances
+                && Objects.equals(canDeleteFirstInstance, that.canDeleteFirstInstance);
     }
 
     @Override
@@ -201,6 +209,7 @@ public class ActivityDto {
                 excludeStatusIconFromDisplay,
                 hideExistingInstancesOnCreation,
                 createOnParentCreation,
-                canDeleteInstances);
+                canDeleteInstances,
+                canDeleteFirstInstance);
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/ActivityDef.java
@@ -75,6 +75,9 @@ public abstract class ActivityDef {
     @SerializedName("canDeleteInstances")
     protected boolean canDeleteInstances;
 
+    @SerializedName("canDeleteFirstInstance")
+    protected Boolean canDeleteFirstInstance;
+
     @NotEmpty
     @SerializedName("translatedNames")
     protected List<@Valid @NotNull Translation> translatedNames;
@@ -280,6 +283,10 @@ public abstract class ActivityDef {
         return canDeleteInstances;
     }
 
+    public Boolean getCanDeleteFirstInstance() {
+        return canDeleteFirstInstance;
+    }
+
     /**
      * Builder that helps construct common elements of an activity definition.
      *
@@ -312,6 +319,7 @@ public abstract class ActivityDef {
         protected boolean hideExistingInstancesOnCreation;
         protected boolean createOnParentCreation;
         protected boolean canDeleteInstances;
+        protected Boolean canDeleteFirstInstance;
 
         /**
          * Returns the subclass builder instance to enable method chaining.
@@ -337,6 +345,7 @@ public abstract class ActivityDef {
             activity.translatedSecondNames.addAll(secondNames);
             activity.createOnParentCreation = createOnParentCreation;
             activity.canDeleteInstances = canDeleteInstances;
+            activity.canDeleteFirstInstance = canDeleteFirstInstance;
         }
 
         public T setParentActivityCode(String parentActivityCode) {
@@ -521,6 +530,11 @@ public abstract class ActivityDef {
 
         public T setCanDeleteInstances(boolean canDeleteInstances) {
             this.canDeleteInstances = canDeleteInstances;
+            return self();
+        }
+
+        public T setCanDeleteFirstInstance(Boolean canDeleteFirstInstance) {
+            this.canDeleteFirstInstance = canDeleteFirstInstance;
             return self();
         }
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
@@ -60,10 +60,12 @@ public class DeleteActivityInstanceRoute implements Route {
                     activityDef.getCanDeleteFirstInstance(),
                     isFirstInstance);
 
-            if (!activityDef.canDeleteInstances()) {
+            if (!canDelete && !activityDef.canDeleteInstances()) {
                 throwNotAllowed(response, "Activity does not allow deleting instances");
-            } else if (!canDelete) {
+            } else if (!canDelete && isFirstInstance) {
                 throwNotAllowed(response, "Activity does not allow deleting the first instance");
+            } else if (!canDelete) {
+                throwNotAllowed(response, "Activity instance is not allowed to be deleted");
             } else if (instanceDto.getParentActivityCode() == null) {
                 throwNotAllowed(response, "Deleting non-nested activity instances is not supported");
             }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/DeleteActivityInstanceRoute.java
@@ -53,16 +53,19 @@ public class DeleteActivityInstanceRoute implements Route {
             ActivityDefStore activityStore = ActivityDefStore.getInstance();
             FormActivityDef activityDef = ActivityInstanceUtil.getActivityDef(handle, activityStore, instanceDto, studyGuid);
 
+            Long previousInstanceId = ActivityInstanceUtil.getPreviousInstanceId(handle, instanceDto.getId());
+            boolean isFirstInstance = previousInstanceId == null;
+            boolean canDelete = ActivityInstanceUtil.computeCanDelete(
+                    activityDef.canDeleteInstances(),
+                    activityDef.getCanDeleteFirstInstance(),
+                    isFirstInstance);
+
             if (!activityDef.canDeleteInstances()) {
-                String msg = "Activity does not allow deleting instances";
-                LOG.warn(msg);
-                throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
-                        new ApiError(ErrorCodes.OPERATION_NOT_ALLOWED, msg));
+                throwNotAllowed(response, "Activity does not allow deleting instances");
+            } else if (!canDelete) {
+                throwNotAllowed(response, "Activity does not allow deleting the first instance");
             } else if (instanceDto.getParentActivityCode() == null) {
-                String msg = "Deleting non-nested activity instances is not supported";
-                LOG.warn(msg);
-                throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
-                        new ApiError(ErrorCodes.OPERATION_NOT_ALLOWED, msg));
+                throwNotAllowed(response, "Deleting non-nested activity instances is not supported");
             }
 
             service.deleteInstance(handle, instanceDto);
@@ -72,5 +75,11 @@ public class DeleteActivityInstanceRoute implements Route {
         LOG.info("Deleted activity instance {}", instanceGuid);
         response.status(HttpStatus.SC_NO_CONTENT);
         return null;
+    }
+
+    private void throwNotAllowed(Response response, String message) {
+        LOG.warn(message);
+        throw ResponseUtil.haltError(response, HttpStatus.SC_UNPROCESSABLE_ENTITY,
+                new ApiError(ErrorCodes.OPERATION_NOT_ALLOWED, message));
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/ActivityInstanceService.java
@@ -345,6 +345,12 @@ public class ActivityInstanceService {
                     def.isWriteOnce(),
                     summaryDto.getReadonly());
 
+            boolean isFirstInstance = StringUtils.isBlank(summaryDto.getPreviousInstanceGuid());
+            boolean canDelete = ActivityInstanceUtil.computeCanDelete(
+                    def.canDeleteInstances(),
+                    def.getCanDeleteFirstInstance(),
+                    isFirstInstance);
+
             var summary = new ActivityInstanceSummary(
                     def.getActivityCode(),
                     summaryDto.getId(),
@@ -364,7 +370,7 @@ public class ActivityInstanceService {
                     def.isExcludeFromDisplay(),
                     summaryDto.isHidden(),
                     summaryDto.getCreatedAtMillis(),
-                    def.canDeleteInstances(),
+                    canDelete,
                     def.isFollowup(),
                     versionDto.getVersionTag(),
                     versionDto.getId(),

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/FormInstanceCreator.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/FormInstanceCreator.java
@@ -40,6 +40,12 @@ public class FormInstanceCreator {
                 formActivityDef.isWriteOnce(),
                 formResponse.getReadonly());
 
+        boolean isFirstInstance = ctx.getPreviousInstanceId() == null;
+        boolean canDelete = ActivityInstanceUtil.computeCanDelete(
+                formActivityDef.canDeleteInstances(),
+                formActivityDef.getCanDeleteFirstInstance(),
+                isFirstInstance);
+
         var formInstance = new FormInstance(
                 formResponse.getParticipantId(),
                 formResponse.getId(),
@@ -59,7 +65,7 @@ public class FormInstanceCreator {
                 formResponse.getFirstCompletedAt(),
                 addAndRenderTemplate(ctx, formActivityDef.getLastUpdatedTextTemplate()),
                 formActivityDef.getLastUpdated(),
-                formActivityDef.canDeleteInstances(),
+                canDelete,
                 formActivityDef.isFollowup(),
                 formResponse.getHidden(),
                 formActivityDef.isExcludeFromDisplay(),

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ActivityInstanceUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ActivityInstanceUtil.java
@@ -129,4 +129,22 @@ public class ActivityInstanceUtil {
         long millisDiff = Instant.now().toEpochMilli() - createdAtMillis;
         return editTimeoutSec != null && millisDiff >= (editTimeoutSec * 1000L);
     }
+
+    /**
+     * An activity instance can be deleted if the definition allows deleting instances. And if it's the first instance,
+     * definition need to allow deleting the first instance as well.
+     *
+     * @param canDeleteInstance      whether instances can be deleted, based on activity definition
+     * @param canDeleteFirstInstance whether the first instance can be deleted, based on activity definition, will
+     *                               default to true if not set
+     * @param isFirstInstance        whether the instance is the first one or not
+     * @return true if activity instance can be deleted
+     */
+    public static boolean computeCanDelete(boolean canDeleteInstance, Boolean canDeleteFirstInstance, boolean isFirstInstance) {
+        boolean canDelete = canDeleteInstance;
+        if (canDeleteInstance && isFirstInstance) {
+            canDelete = canDeleteFirstInstance != null ? canDeleteFirstInstance : true;
+        }
+        return canDelete;
+    }
 }

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -258,4 +258,5 @@
     <include file="db-changes/schema/DDP-5679-add-event-configuration-label.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5045-sendgrid-event-message-id-nullable.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/DDP-5749-completed-status.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-5771-nested-activity-can-delete-first-instance.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-5771-nested-activity-can-delete-first-instance.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-5771-nested-activity-can-delete-first-instance.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210408-nested-activity-can-delete-first-instance-column">
+        <addColumn tableName="study_activity">
+            <column name="can_delete_first_instance" type="boolean">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/ActivityInstanceUtilTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/ActivityInstanceUtilTest.java
@@ -1,5 +1,8 @@
 package org.broadinstitute.ddp.util;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.TimeUnit;
 
 import org.broadinstitute.ddp.TxnAwareBaseTest;
@@ -45,7 +48,7 @@ public class ActivityInstanceUtilTest extends TxnAwareBaseTest {
                     TimeUnit.SECONDS.sleep(1L);
 
                     // ActivityInstanceUtil.isReadonly() evaluated to true but "isReadonly" flag overrides it
-                    Assert.assertFalse(ActivityInstanceUtil.isReadonly(handle, instanceDto.getGuid()));
+                    assertFalse(ActivityInstanceUtil.isReadonly(handle, instanceDto.getGuid()));
                     handle.rollback();
                 }
         );
@@ -69,5 +72,20 @@ public class ActivityInstanceUtilTest extends TxnAwareBaseTest {
                     handle.rollback();
                 }
         );
+    }
+
+    @Test
+    public void testComputeCanDelete() {
+        boolean actual = ActivityInstanceUtil.computeCanDelete(false, true, true);
+        assertFalse("should not allow delete since canDeleteInstances is false", actual);
+
+        actual = ActivityInstanceUtil.computeCanDelete(true, null, false);
+        assertTrue("not first instance so can delete", actual);
+
+        actual = ActivityInstanceUtil.computeCanDelete(true, null, true);
+        assertTrue("is first instance but since canDeleteFirstInstance is not set it should default to allow", actual);
+
+        actual = ActivityInstanceUtil.computeCanDelete(true, false, true);
+        assertFalse("is first instance and canDeleteFirstInstance is false", actual);
     }
 }

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateActivityBaseSettings.java
@@ -92,7 +92,8 @@ public class UpdateActivityBaseSettings implements CustomTask {
                 definition.getBoolean("excludeStatusIconFromDisplay"),
                 definition.getBoolean("hideExistingInstancesOnCreation"),
                 ConfigUtil.getBoolOrElse(definition, "createOnParentCreation", false),
-                ConfigUtil.getBoolOrElse(definition, "canDeleteInstances", false));
+                ConfigUtil.getBoolOrElse(definition, "canDeleteInstances", false),
+                ConfigUtil.getBoolIfPresent(definition, "canDeleteFirstInstance"));
         if (!currentDto.equals(latestDto)) {
             if (currentDto.canDeleteInstances() != latestDto.canDeleteInstances()) {
                 throw new UnsupportedOperationException("Updating `canDeleteInstances` setting is currently not supported"
@@ -111,7 +112,9 @@ public class UpdateActivityBaseSettings implements CustomTask {
                     latestDto.isFollowup(),
                     latestDto.shouldExcludeStatusIconFromDisplay(),
                     latestDto.isHideExistingInstancesOnCreation(),
-                    latestDto.isCreateOnParentCreation());
+                    latestDto.isCreateOnParentCreation(),
+                    latestDto.canDeleteInstances(),
+                    latestDto.getCanDeleteFirstInstance());
             LOG.info("Updated basic settings");
         } else {
             LOG.info("No changes to basic settings");


### PR DESCRIPTION
## Context

This adds a new flag, `canDeleteFirstInstance`, in backend activity definition that will control whether an instance of a nested activity can be deleted or not.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Need a study that uses this configuration, but you can try it out locally by tweaking existing activity definitions (such as Osteo's Family History).

## Testing

- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
