### PR TITLE
Add gitignore rules to ignore more config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,8 @@ tcell/*.config
 tcell/logs/
 /cloud-functions/cf-emailer/target/
 /cloud-functions/cf-study-contact/target/
+
+# ignore any potential config files with secrets,
+# except study-builder configuration files
+*.conf
+!study-builder/**/*.conf

--- a/cf-file-scanner/.gitignore
+++ b/cf-file-scanner/.gitignore
@@ -11,3 +11,4 @@ target/
 
 config/
 !config/example.env
+!freshclam.conf


### PR DESCRIPTION
We had a hiccup where we checked in secret `.conf` files. Tweaking our gitignore rules so we don't run into this again.