### PR TITLE
Better handling of config loading when using CLI tools

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/TransactionWrapper.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/TransactionWrapper.java
@@ -36,7 +36,10 @@ public class TransactionWrapper {
     // https://bugs.mysql.com/bug.php?id=91112
     // Note 03/10/2020: Release of fixed Java connector is imminent and this might no longer be necessary
     static {
-        TimeZone.setDefault(TimeZone.getTimeZone(ConfigManager.getInstance().getConfig().getString(ConfigFile.DEFAULT_TIMEZONE)));
+        ConfigManager manager = ConfigManager.getInstance();
+        if (manager != null && manager.getConfig() != null) {
+            TimeZone.setDefault(TimeZone.getTimeZone(manager.getConfig().getString(ConfigFile.DEFAULT_TIMEZONE)));
+        }
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(TransactionWrapper.class);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/log/SlackAppender.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/log/SlackAppender.java
@@ -67,26 +67,6 @@ public class SlackAppender<E> extends AppenderBase<ILoggingEvent> {
                       String slackChannel,
                       Integer queueSize,
                       Integer intervalInMillis) {
-        httpClient = HttpClient.newHttpClient();
-        try {
-            this.slackHookUrl = new URI(slackHookUrl);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Could not parse " + slackHookUrl);
-        }
-
-        this.channel = slackChannel;
-        if (queueSize != null) {
-            this.queueSize = queueSize;
-        } else {
-            this.queueSize = 10;
-        }
-
-        if (intervalInMillis != null) {
-            this.intervalInMillis = intervalInMillis;
-        } else {
-            this.intervalInMillis = 60000;
-        }
-
         if (StringUtils.isBlank(slackHookUrl)) {
             LOG.warn("No logs will go to slack.");
             canLog = false;
@@ -96,6 +76,26 @@ public class SlackAppender<E> extends AppenderBase<ILoggingEvent> {
             canLog = false;
         }
         if (canLog) {
+            httpClient = HttpClient.newHttpClient();
+            try {
+                this.slackHookUrl = new URI(slackHookUrl);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Could not parse " + slackHookUrl);
+            }
+
+            this.channel = slackChannel;
+            if (queueSize != null) {
+                this.queueSize = queueSize;
+            } else {
+                this.queueSize = 10;
+            }
+
+            if (intervalInMillis != null) {
+                this.intervalInMillis = intervalInMillis;
+            } else {
+                this.intervalInMillis = 60000;
+            }
+
             LOG.info("At most {} slack alerts will be sent to {} every {} ms", queueSize, slackChannel, intervalInMillis);
             executorService = new ScheduledThreadPoolExecutor(1,
                     new ThreadFactory("SlackAppender", ThreadPriorities.SLACK_PRIORITY));
@@ -112,12 +112,13 @@ public class SlackAppender<E> extends AppenderBase<ILoggingEvent> {
      * Constructor used by deployments via logback.xml
      */
     public SlackAppender() {
-        Config cfg = ConfigManager.getInstance().getConfig();
         String slackHook = null;
         String slackChannel = null;
         Integer configQueueSize = null;
         Integer configIntervalInMillis = null;
-        if (cfg != null) {
+        ConfigManager manager = ConfigManager.getInstance();
+        if (manager != null && manager.getConfig() != null) {
+            Config cfg = manager.getConfig();
             if (cfg.hasPath(ConfigFile.SLACK_HOOK)) {
                 slackHook = cfg.getString(ConfigFile.SLACK_HOOK);
             }
@@ -132,8 +133,6 @@ public class SlackAppender<E> extends AppenderBase<ILoggingEvent> {
             }
             init(slackHook, slackChannel, configQueueSize, configIntervalInMillis);
         }
-
-
     }
 
     /**

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/security/AesUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/security/AesUtil.java
@@ -159,10 +159,12 @@ public class AesUtil {
 
         if (cmd.hasOption('d')) {
             System.out.println(AesUtil.decrypt(cmd.getOptionValue('s'), encryptionSecret));
+            return;
         }
 
         if (cmd.hasOption('e')) {
             System.out.println(AesUtil.encrypt(cmd.getOptionValue('s'), encryptionSecret));
+            return;
         }
 
         initializeDb(cfg);
@@ -204,8 +206,7 @@ public class AesUtil {
                 }
                 return null;
             });
-
-
+            return;
         }
 
         if (cmd.hasOption("convertall")) {
@@ -246,8 +247,6 @@ public class AesUtil {
 
                 return null;
             });
-
-
         }
     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -36,7 +36,7 @@ public class ConfigManager {
         if (configFileName == null) {
             configFileName = System.getProperty(TYPESAFE_CONFIG_SYSTEM_VAR);
         }
-        TYPESAFE_CONFIG_FILE = new File(configFileName);
+        TYPESAFE_CONFIG_FILE = configFileName != null ? new File(configFileName) : null;
     }
 
     private final Config cfg;
@@ -54,7 +54,7 @@ public class ConfigManager {
      * @return the config for the app
      */
     public static synchronized ConfigManager getInstance() {
-        if (configManager == null) {
+        if (configManager == null && TYPESAFE_CONFIG_FILE != null) {
             try {
                 configManager = new ConfigManager(parseConfig());
             } catch (Exception e) {


### PR DESCRIPTION
## Context

When we're running CLI tools, we get this annoying message about failing to initialize SlackAppender. This PR addresses that issue by fixing handling of config loading. Essentially, the idea is to handle nulls in our static blocks. See comments for more details.

_What about production config loading in study-server and housekeeping?_
* These use the config extensively, so we will have gotten NullPointerException very early in the process if config is not provided.

_What about the study-builder CLI tool?_
* I tried it out locally and study-builder CLI works as normal.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

