### PR TITLE
DDP-5938 prion: fix syntax error in password reset email

### DIFF
--- a/study-builder/tenants/prion/passwordResetEmail.html
+++ b/study-builder/tenants/prion/passwordResetEmail.html
@@ -13,7 +13,7 @@
     {% assign p3 = "Saludos cordiales," %}
     {% assign p4 = "Los administradores de Prion Registry" %}
     {% assign dir = "ltr" %}
-{% elsif user.user_metadata.language = "he" %}
+{% elsif user.user_metadata.language == "he" %}
     {% assign heading = "בקשה להחלפת סיסמה" %}
     {% assign p1 = "שלחתם בקשה להחלפת סיסמה." %}
     {% assign p2a = "כדי לאשר את החלפת הסיסמה," %}
@@ -22,7 +22,7 @@
     {% assign p3 = "טוב ביותר" %}
     {% assign p4 = "Prion Registry Administrators" %}
     {% assign dir = "rtl" %}
-{% elsif user.user_metadata.language = "zh" %}
+{% elsif user.user_metadata.language == "zh" %}
     {% assign heading = "密码变更请求" %}
     {% assign p1 = "您已发送密码变更请求。" %}
     {% assign p2a = "要确认密码变更，" %}

--- a/study-builder/tenants/prion/tenant.yaml
+++ b/study-builder/tenants/prion/tenant.yaml
@@ -22,9 +22,9 @@ emailTemplates:
     from: Prion <##STUDY_EMAIL##>
     resultUrl: '##SERVER_BASE_URL##/pepper/v1/post-password-reset?clientId={{ application.clientID }}'
     subject: >-
-      {% if user.user_metadata.language == "es" %} (es)Password Change Request
-      {% elsif user.user_metadata.language = "he" %} (he)Password Change Request
-      {% elsif user.user_metadata.language = "zh" %} (zh)Password Change Request
+      {% if user.user_metadata.language == "es" %} Solicitud de cambio de contraseña
+      {% elsif user.user_metadata.language == "he" %} בקשה להחלפת סיסמה
+      {% elsif user.user_metadata.language == "zh" %} 密码变更请求
       {% else %} Password Change Request {% endif %}
     urlLifetimeInSeconds: 432000
     syntax: liquid


### PR DESCRIPTION
## Context

There's a syntax error in Prion's password reset email, so instead of doing comparison it's doing a variable assignment.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] Getting dev into a state where this is user-visible requires some tech fiddling.
    - Need to put this into Auth0.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [xr] Releasing these changes requires special handling
    - Need to put this into Auth0.

