### PR TITLE
DDP-5938 prion: fix syntax issue in password reset page

### DIFF
--- a/study-builder/tenants/prion/passwordResetPage.html
+++ b/study-builder/tenants/prion/passwordResetPage.html
@@ -51,7 +51,7 @@
         csrf_token:        "{{csrf_token}}",                                  // DO NOT CHANGE THIS
         ticket:            "{{ticket}}",                                      // DO NOT CHANGE THIS
         password_policy:   "{{password_policy}}",                             // DO NOT CHANGE THIS
-        password_complexity_options:  "{{password_complexity_options}}",        // DO NOT CHANGE THIS
+        password_complexity_options:  {{password_complexity_options}},        // DO NOT CHANGE THIS
     theme: {
         icon: "{{tenant.picture_url | default: '//cdn.auth0.com/styleguide/1.0.0/img/badge.png'}}",
             primaryColor: "{{tenant.colors.primary | default: '#ea5323'}}"

--- a/study-builder/tenants/prion/tenant.yaml
+++ b/study-builder/tenants/prion/tenant.yaml
@@ -1,5 +1,6 @@
 tenant:
   default_directory: Username-Password-Authentication
+  picture_url: '##BASE_URL##/assets/images/project-logo-dark.svg'
 
 rules:
   - name: Register User in Pepper


### PR DESCRIPTION
Another syntax fix. `password_complexity_options` is an object, so when templating is done, we end up with something like this:

```
password_complexity_options:  "{"min_length": 8}",
```
which is an error due to the unescaped quotes. The fix is to remove the outer set of quotes since we want it to be substituted as a whole object.

See here for more: https://community.auth0.com/t/hosted-password-reset-page-with-custom-length-password-at-connection-level-not-working/21308.