### PR TITLE
DDP-5939 remove unused dsm batch kits endpoint

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/client/DsmClient.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/client/DsmClient.java
@@ -19,11 +19,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.typesafe.config.Config;
-import org.apache.commons.collections4.ListUtils;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;
-import org.broadinstitute.ddp.model.dsm.ParticipantKits;
 import org.broadinstitute.ddp.model.dsm.ParticipantStatus;
 import org.broadinstitute.ddp.util.Auth0Util;
 import org.broadinstitute.ddp.util.RouteUtil;
@@ -40,10 +38,7 @@ public class DsmClient {
     public static final String PATH_DRUGS = "/app/drugs";
     public static final String PATH_PARTICIPANT_STATUS = String.format(
             "/info/participantstatus/%s/%s", PathParam.STUDY_GUID, PathParam.USER_GUID);
-    public static final String PATH_BATCH_KITS_STATUS = String.format(
-            "/app/batchKitsStatus/%s", PathParam.STUDY_GUID);
     public static final int DEFAULT_TIMEOUT_SECS = 10;
-    public static final int DEFAULT_PAGE_SIZE = 100;
 
     private static final Logger LOG = LoggerFactory.getLogger(DsmClient.class);
     private static final Gson gson = new Gson();
@@ -155,75 +150,6 @@ public class DsmClient {
     }
 
     /**
-     * Fetches kit statuses for a list of participants.
-     *
-     * @param studyGuid the study guid
-     * @param userGuids list of participant guids
-     * @return result with list of kit statuses
-     */
-    public ApiResult<List<ParticipantKits>, Void> listParticipantKits(String studyGuid, List<String> userGuids) {
-        String path = PATH_BATCH_KITS_STATUS.replace(PathParam.STUDY_GUID, studyGuid);
-        try {
-            String auth = RouteUtil.makeAuthBearerHeader(generateToken());
-            String payload = gson.toJson(new ListParticipantKitsPayload(userGuids));
-            var request = HttpRequest.newBuilder()
-                    .uri(baseUrl.resolve(path))
-                    .header(RouteConstants.Header.AUTHORIZATION, auth)
-                    .timeout(Duration.ofSeconds(DEFAULT_TIMEOUT_SECS))
-                    .POST(HttpRequest.BodyPublishers.ofString(payload))
-                    .build();
-            var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            int statusCode = response.statusCode();
-            if (statusCode == 200) {
-                Type type = new TypeToken<List<ParticipantKits>>() {}.getType();
-                List<ParticipantKits> statuses = gson.fromJson(response.body(), type);
-                return ApiResult.ok(statusCode, statuses);
-            } else {
-                return ApiResult.err(statusCode, null);
-            }
-        } catch (JWTCreationException | IOException | InterruptedException | JsonSyntaxException e) {
-            return ApiResult.thrown(e);
-        }
-    }
-
-    /**
-     * Partition list of guids into batches and fetch each batch. Pagination may be stopped early by the callback.
-     *
-     * @param studyGuid the study guid
-     * @param userGuids the list of participant guids
-     * @param callback  handler for processing each batch results
-     * @return total number processed
-     */
-    public int paginateParticipantKits(String studyGuid, List<String> userGuids,
-                                       PageCallback<String, List<ParticipantKits>, Void> callback) {
-        return paginateParticipantKits(DEFAULT_PAGE_SIZE, studyGuid, userGuids, callback);
-    }
-
-    /**
-     * Partition list of guids into batches and fetch each batch. Pagination may be stopped early by the callback.
-     *
-     * @param pageSize  size of each batch
-     * @param studyGuid the study guid
-     * @param userGuids the list of participant guids
-     * @param callback  handler for processing each batch results
-     * @return total number processed
-     */
-    public int paginateParticipantKits(int pageSize, String studyGuid, List<String> userGuids,
-                                       PageCallback<String, List<ParticipantKits>, Void> callback) {
-        List<List<String>> partitions = ListUtils.partition(userGuids, pageSize);
-        int numProcessed = 0;
-        for (var batch : partitions) {
-            var result = listParticipantKits(studyGuid, batch);
-            boolean shouldContinue = callback.handlePage(batch, result);
-            numProcessed += batch.size();
-            if (!shouldContinue) {
-                break;
-            }
-        }
-        return numProcessed;
-    }
-
-    /**
      * Fetches a participant's tracking info for medical records and sample kits in given study. This does not check
      * whether user/study exists or if user is in study, which should be done by the caller.
      *
@@ -256,37 +182,6 @@ public class DsmClient {
         } catch (JWTCreationException | IOException | InterruptedException | JsonSyntaxException e) {
             LOG.error("Trouble looking up status for participant {} in study {}. Response was {}", userGuid, studyGuid, responseBody);
             return ApiResult.thrown(e);
-        }
-    }
-
-    /**
-     * A callback used during pagination.
-     *
-     * @param <I> the batch item type
-     * @param <B> the result body type
-     * @param <E> the result error type
-     */
-    @FunctionalInterface
-    public interface PageCallback<I, B, E> {
-        /**
-         * Consume the page result and respond whether to continue pagination or not.
-         *
-         * @param batch the batch that resulted in the page
-         * @param page  a page result
-         * @return true to continue pagination, false to stop
-         */
-        boolean handlePage(List<I> batch, ApiResult<B, E> page);
-    }
-
-    public static class ListParticipantKitsPayload {
-        private List<String> participantIds;
-
-        public ListParticipantKitsPayload(List<String> participantIds) {
-            this.participantIds = participantIds;
-        }
-
-        public List<String> getParticipantIds() {
-            return participantIds;
         }
     }
 }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/client/DsmClientTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/client/DsmClientTest.java
@@ -18,14 +18,12 @@ import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import javax.net.ssl.SSLSession;
 
 import com.google.gson.Gson;
 import com.typesafe.config.Config;
 import org.broadinstitute.ddp.constants.RouteConstants;
-import org.broadinstitute.ddp.model.dsm.ParticipantKits;
 import org.broadinstitute.ddp.model.dsm.ParticipantStatus;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.RouteUtil;
@@ -149,42 +147,6 @@ public class DsmClientTest {
         assertNotNull(result.getThrown());
         assertEquals(500, result.getStatusCode());
         assertEquals("from test", result.getThrown().getMessage());
-    }
-
-    @Test
-    public void testListParticipantKits() throws IOException, InterruptedException {
-        var fakeKits = List.of(new ParticipantKits("user1", List.of()));
-
-        when(mockHttp.send(any(), any())).thenReturn(TestResponse.of(200, gson.toJson(fakeKits)));
-        var result = dsm.listParticipantKits("study1", List.of("user1", "user2"));
-
-        assertNotNull(result);
-        assertNotNull(result.getBody());
-        assertNull(result.getError());
-        assertNull(result.getThrown());
-        assertEquals(200, result.getStatusCode());
-        assertEquals(1, result.getBody().size());
-        assertEquals("user1", result.getBody().get(0).getParticipantGuid());
-
-        String expectedPath = DsmClient.PATH_BATCH_KITS_STATUS
-                .replace(RouteConstants.PathParam.STUDY_GUID, "study1");
-        ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(mockHttp, times(1)).send(captor.capture(), any());
-
-        var actualRequest = captor.getValue();
-        assertEquals("POST", actualRequest.method());
-        assertEquals(expectedPath, actualRequest.uri().getPath());
-    }
-
-    @Test
-    public void testPaginateParticipantKits() throws IOException, InterruptedException {
-        when(mockHttp.send(any(), any())).thenReturn(TestResponse.of(200, gson.toJson(List.of())));
-
-        int batchSize = 1;
-        var numProcessed = dsm.paginateParticipantKits(batchSize, "study1", List.of("user1", "user2"), (subset, page) -> true);
-
-        assertEquals(2, numProcessed);
-        verify(mockHttp, times(2)).send(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Context

The DSM batch kits endpoint is not used anywhere is the code. DSM will be removing this endpoint, so we're removing code that references it in study-server

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?
- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

