### PR TITLE
Fix initialzing cache when config file is not passed

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/cache/CacheService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/cache/CacheService.java
@@ -60,9 +60,10 @@ public class CacheService {
 
     private CacheService() {
         boolean cachingDisabled = System.getProperty("cachingDisabled", "false").toLowerCase().equals("true");
-        boolean configFileSet = ConfigManager.getInstance().getConfig().hasPath(ConfigFile.JCACHE_CONFIGURATION_FILE);
+        ConfigManager manager = ConfigManager.getInstance();
+        boolean configFileSet = manager != null && manager.getConfig().hasPath(ConfigFile.JCACHE_CONFIGURATION_FILE);
         if (configFileSet && !cachingDisabled) {
-            String configFileName = ConfigManager.getInstance().getConfig().getString(ConfigFile.JCACHE_CONFIGURATION_FILE);
+            String configFileName = manager.getConfig().getString(ConfigFile.JCACHE_CONFIGURATION_FILE);
             Path redissonConfigPath = Paths.get(configFileName);
             if (!redissonConfigPath.toFile().exists()) {
                 throw new DDPException("Path for configuration file: " + redissonConfigPath + " could not be found");


### PR DESCRIPTION
I recently made a change so that CLI tools doesn't need to pass a config file via `-Dconfig.file`, and part of the change is that `ConfigManager` may be null. We use some of the caching interfaces (without redis underneath) in some of CLI tools, so fixing the initialization of caching service.