### PR TITLE
DDP-5588 rgp: add unsure option for sibling/child/relative can_participate question

### DIFF
--- a/study-builder/studies/rgp/enrollment-questions.conf
+++ b/study-builder/studies/rgp/enrollment-questions.conf
@@ -3299,7 +3299,7 @@
   },
 
   "sibling_can_participate": {
-    include required("snippets/rgp-can-participate-required.conf"),
+    include required("snippets/rgp-can-participate-unsure-required.conf"),
     "stableId": ${id.q.sibling_can_participate},
     "promptTemplate": {
       "templateType": "HTML",
@@ -3481,7 +3481,7 @@
   },
 
   "child_can_participate": {
-    include required("snippets/rgp-can-participate-required.conf"),
+    include required("snippets/rgp-can-participate-unsure-required.conf"),
     "stableId": ${id.q.child_can_participate},
     "promptTemplate": {
       "templateType": "HTML",
@@ -3645,7 +3645,7 @@
   },
 
   "relative_can_participate": {
-    include required("snippets/rgp-can-participate-required.conf"),
+    include required("snippets/rgp-can-participate-unsure-required.conf"),
     "stableId": ${id.q.relative_can_participate},
     "promptTemplate": {
       "templateType": "HTML",

--- a/study-builder/studies/rgp/snippets/rgp-can-participate-unsure-required.conf
+++ b/study-builder/studies/rgp/snippets/rgp-can-participate-unsure-required.conf
@@ -1,0 +1,21 @@
+{
+  include required("rgp-picklist-yn-unsure.conf"),
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$can_participate_required",
+        "variables": [
+          {
+            "name": "can_participate_required",
+            "translations": [
+              { "language": "en", "text": ${i18n.en.hint.select_one} },
+              { "language": "es", "text": ${i18n.es.hint.select_one} }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Found an issue while doing data loading into Pepper. Each of the biological family member sections has a "can participate" question that asks if the family member can participate in the study. Mother/father has yes/no options, and sibling/child/relative have an extra "unsure" option. I realized I missed the "unsure" option, so adding it in now.

Screenshots for confirmation (taken on Gen2 site):
![Screen Shot 2021-04-16 at 5 59 37 PM](https://user-images.githubusercontent.com/5713833/115088311-e4e36180-9edd-11eb-8781-ed72660b5514.png)
![Screen Shot 2021-04-16 at 5 59 51 PM](https://user-images.githubusercontent.com/5713833/115088322-ead94280-9edd-11eb-83aa-c778c8c39ef7.png)
