### PR TITLE
rgp: enable phone question confirm

### DIFF
--- a/study-builder/studies/rgp/enrollment-questions.conf
+++ b/study-builder/studies/rgp/enrollment-questions.conf
@@ -174,34 +174,38 @@
         }
       ]
     },
-    //TODO: Add confirmation field
-    //"confirmEntry": true,
-    //            "confirmPromptTemplate": {
-    //              "templateType": "HTML",
-    //              "templateText": "$filler_phone_confirm",
-    //              "variables": [
-    //                {
-    //                  "name": "filler_phone_confirm",
-    //                  "translations": [
-    //                    { "language": "en", "text": ${i18n.en.filler_phone_confirm} },
-    //                    { "language": "es", "text": ${i18n.es.filler_phone_confirm} }
-    //                  ]
-    //                }
-    //              ]
-    //            },
-    //            "mismatchMessageTemplate": {
-    //              "templateType": "HTML",
-    //              "templateText": "$filler_phone_mismatch",
-    //              "variables": [
-    //                {
-    //                  "name": "filler_phone_mismatch",
-    //                  "translations": [
-    //                    { "language": "en", "text": ${i18n.en.filler_phone_mismatch} },
-    //                    { "language": "es", "text": ${i18n.es.filler_phone_mismatch} }
-    //                  ]
-    //                }
-    //              ]
-    //            },
+    "confirmEntry": true,
+    "confirmPromptTemplate": {
+      "templateType": "HTML",
+      "templateText": "",
+      "variables": []
+    },
+    "confirmPlaceholderTemplate": {
+      "templateType": "HTML",
+      "templateText": "$filler_phone_confirm",
+      "variables": [
+        {
+          "name": "filler_phone_confirm",
+          "translations": [
+            { "language": "en", "text": ${i18n.en.filler_phone_confirm} },
+            { "language": "es", "text": ${i18n.es.filler_phone_confirm} }
+          ]
+        }
+      ]
+    },
+    "mismatchMessageTemplate": {
+      "templateType": "HTML",
+      "templateText": "$filler_phone_mismatch",
+      "variables": [
+        {
+          "name": "filler_phone_mismatch",
+          "translations": [
+            { "language": "en", "text": ${i18n.en.filler_phone_mismatch} },
+            { "language": "es", "text": ${i18n.es.filler_phone_mismatch} }
+          ]
+        }
+      ]
+    },
     "validations": [
       {
         "ruleType": "REGEX",


### PR DESCRIPTION
Update RGP study configuration to enable confirmation for the phone question. This is what the frontend will see:

![Screen Shot 2021-04-27 at 2 40 16 PM](https://user-images.githubusercontent.com/5713833/116295112-bc255c80-a766-11eb-83a2-7c393df381c0.png)
