### PR TITLE
DDP-6027 handle deleting nested instances for temp users

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.java
@@ -138,6 +138,12 @@ public interface JdbiActivityInstance extends SqlObject {
     List<ActivityInstanceDto> findAllByUserIdAndStudyId(@Bind("userId") long participantUserId, @Bind("studyId") long studyId);
 
     @UseStringTemplateSqlLocator
+    @SqlQuery("queryAllByUserIds")
+    @RegisterConstructorMapper(ActivityInstanceDto.class)
+    List<ActivityInstanceDto> findAllByUserIds(
+            @BindList(value = "userIds", onEmpty = BindList.EmptyHandling.NULL) Iterable<Long> userIds);
+
+    @UseStringTemplateSqlLocator
     @SqlQuery("findLatestInstanceFromUserGuidAndQuestionId")
     @RegisterConstructorMapper(ActivityInstanceDto.class)
     Optional<ActivityInstanceDto> findLatestInstanceFromUserGuidAndQuestionId(@Bind("userGuid") String userGuid,

--- a/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.sql.stg
+++ b/pepper-apis/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiActivityInstance.sql.stg
@@ -83,6 +83,10 @@ queryAllByUserIdAndStudyId() ::= <<
    and act.study_id = :studyId
 >>
 
+queryAllByUserIds(userIds) ::= <<
+<select_all_instances()> where ai.participant_id in (<userIds>)
+>>
+
 findLatestInstanceFromUserGuidAndQuestionId() ::= <<
 <select_all_instances()>
   join question as q on q.study_activity_id = act.study_activity_id


### PR DESCRIPTION
## Context

See description of bug in DDP-6027. Basically, we have a background job that deletes temp users and their data. They might have nested activity instance data, so we need to handle that case.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written automated positive tests

## Release

- [x] These changes require no special release procedures--just code!
