### PR TITLE
DDP-6044: Open Consent PDF in separate tab

### DIFF
--- a/study-builder/studies/rarex/snippets/consent-intro.conf
+++ b/study-builder/studies/rarex/snippets/consent-intro.conf
@@ -43,7 +43,7 @@
                   please contact us at <a href="tel:(716) 427-2739" class="Link">(716) 427-2739</a>
                   or <a href="mailto:support@rare-x.org" class="Link">support@rare-x.org</a>.
                   <p class="consent-download">We encourage you to
-                  <a href="https://storage.googleapis.com/"""${assetsBucketName}"""/RarexRegistry_ConsentForm.pdf"
+                  <a href="https://storage.googleapis.com/"""${assetsBucketName}"""/RarexRegistry_ConsentForm.pdf" target="_blank"
                   download class="consent-download__link">download</a> a PDF version of the consent form and read it carefully.</p>
                   """
               }


### PR DESCRIPTION
One specific item in https://broadinstitute.atlassian.net/browse/DDP-6044

Fixes first item in ticket, opening consent PDF in separate tab. Was easiest done in study configuration.

Rest of issues in same ticket dealt with on Angular side in this PR:
https://github.com/broadinstitute/ddp-angular/pull/544