### PR TITLE
DDP-6105 pex: support getting age from user profile

### DIFF
--- a/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
+++ b/pepper-apis/src/main/antlr4/org/broadinstitute/ddp/pex/lang/Pex.g4
@@ -78,6 +78,7 @@ predicate
 // Queries to pull out various pieces of profile data
 profileDataQuery
   : 'birthDate' '(' ')'   # ProfileBirthDateQuery
+  | 'age' '(' ')'         # ProfileAgeQuery
   ;
 
 // Queries for current kit event.

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
@@ -784,6 +784,13 @@ public class TreeWalkInterpreter implements PexInterpreter {
             } else {
                 return birthDate;
             }
+        } else if (queryCtx instanceof PexParser.ProfileAgeQueryContext) {
+            LocalDate birthDate = profile.getBirthDate();
+            if (birthDate == null) {
+                String msg = String.format("User %s does not have birth date in profile", ictx.getUserGuid());
+                throw new PexFetchException(msg);
+            }
+            return ChronoUnit.YEARS.between(birthDate, LocalDate.now());
         } else {
             throw new PexUnsupportedException("Unhandled profile data query: " + queryCtx.getText());
         }


### PR DESCRIPTION
## Context

Add new PEX feature to get age from profile.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Will need study configuration that uses this. RareX study will use this when it's available.

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!


