### PR TITLE
DDP-6102 rarex: proxy emails

### DIFF
--- a/study-builder/studies/rarex/emails/consent-assent-completed.html
+++ b/study-builder/studies/rarex/emails/consent-assent-completed.html
@@ -85,7 +85,7 @@
         <td style="padding: 50px 0 0 0;">
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                -ddp.salutation-
+                Dear -ddp.proxy.firstName- -ddp.proxy.lastName-,
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">

--- a/study-builder/studies/rarex/emails/consent-parental-completed.html
+++ b/study-builder/studies/rarex/emails/consent-parental-completed.html
@@ -1,7 +1,6 @@
 <html>
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 <head>
-    <title></title>
     <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
     <style type="text/css">
             .ExternalClass,
@@ -66,6 +65,7 @@
                 font-style: normal;
             }
         </style>
+    <title></title>
 </head>
 <body style="background: #ffffff; width: 100%; height: 100%; padding-top: 60px; padding-left: 60px;">
 <table style="width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-family: 'Roboto', sans-serif; border-collapse: collapse !important;"
@@ -85,33 +85,25 @@
         <td style="padding: 50px 0 0 0;">
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                -ddp.salutation-
+                Dear -ddp.proxy.firstName- -ddp.proxy.lastName-,
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        Thank you for taking the time to sign up for the Data
-                        Collection Program (DCP). Your participation is vital to
-                        advancing rare disease research.
+                We have received your parental consent to contribute and share
+                your data that will be collected for the RARE-X Data Collection
+                Program (DCP). Thank you so much for helping us advance
+                research on your family member’s rare disease. Your participation is vital, and we couldn’t do this
+                without you!
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        It looks like you have started to answer the Quality of life Survey but did not complete it.</p>
-
-            <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                Please return to the Quality of Life Survey
-                at your earliest convenience to finish answering the questions.
+                For your convenience, we have attached a copy of your signed parental consent form.
             </p>
 
-            <div>
-                <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
-                   style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
-                           border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
-                           border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                   target="_blank">Quality of Life Survey</a>
-            </div>
-
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                We will notify you as more questions become available and you can answer them at your convenience.
+                You may return to the form in the DCP at any time if you wish to
+                update your contact information or to update your your
+                family member's data.
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
@@ -122,7 +114,7 @@
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                The information you submit will be stored in the secure
+                The information you submitted will be stored in the secure
                 Data Collection Program. If you would like your
                 information deleted from our database at any time, now or in
                 the future, please email us at

--- a/study-builder/studies/rarex/emails/consent-parental-reminder-1wk.html
+++ b/study-builder/studies/rarex/emails/consent-parental-reminder-1wk.html
@@ -1,6 +1,7 @@
 <html>
 <meta name="format-detection" content="telephone=no,date=no,address=no,email=no,url=no" />
 <head>
+    <title></title>
     <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
     <style type="text/css">
             .ExternalClass,
@@ -65,7 +66,6 @@
                 font-style: normal;
             }
         </style>
-    <title></title>
 </head>
 <body style="background: #ffffff; width: 100%; height: 100%; padding-top: 60px; padding-left: 60px;">
 <table style="width: 540px; padding: 0; -webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; font-family: 'Roboto', sans-serif; border-collapse: collapse !important;"
@@ -85,26 +85,28 @@
         <td style="padding: 50px 0 0 0;">
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                -ddp.salutation-
+                Dear -ddp.proxy.firstName- -ddp.proxy.lastName-,
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                We have received your parental consent to contribute and share
-                your data that will be collected for the RARE-X Data Collection
-                Program (DCP). Thank you so much for helping us advance
-                research on your family member’s rare disease. Your participation is vital, and we couldn’t do this
-                without you!
+                We are excited for you to begin contributing your information to
+                the RARE-X Data Collection Program (DCP). Although you
+                created an account you have not completed the Parental
+                Consent Form, so you are not yet enrolled in the DCP
+                and cannot share your information with us.
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                For your convenience, we have attached a copy of your signed parental consent form.
+                If you wish to fully enroll please review, sign, and submit the Parental Consent Form.
             </p>
 
-            <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                You may return to the form in the DCP at any time if you wish to
-                update your contact information or to update your your
-                family member's data.
-            </p>
+            <div>
+                <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
+                   style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
+                           border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
+                           border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
+                   target="_blank">Parental Consent Form</a>
+            </div>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                 Please contact us at
@@ -114,16 +116,11 @@
             </p>
 
             <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                The information you submitted will be stored in the secure
-                Data Collection Program. If you would like your
-                information deleted from our database at any time, now or in
-                the future, please email us at
+                The information you submit will be stored in the secure
+                Data Collection Program. If you would like your information
+                deleted from our database at any time, now or in the future, please email us at
                 <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
-                    support@rare-x.org.</a>
-            </p>
-
-            <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                We are so grateful for your participation - thank you again!
+                    support@rare-x.org</a>.
             </p>
         </td>
     </tr>

--- a/study-builder/studies/rarex/emails/data-sharing-complete-reminder-proxy.html
+++ b/study-builder/studies/rarex/emails/data-sharing-complete-reminder-proxy.html
@@ -89,22 +89,29 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        We are excited for you to begin contributing your information to the RARE-X Data Collection
-                        Program (DCP). Although you created an account you have not completed the Consent Assent Form, so
-                        you are not yet enrolled in the DCP and cannot share your information with us.
+                        Thank you for taking the time to sign up for the Data Collection Program (DCP). Your participation is vital to advancing rare disease research.
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        If you wish to fully enroll please review, sign, and submit the Consent Assent Form.
+                        It looks like you have started to answer the Data Sharing Survey but did not complete it.
+                    </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        Please return to the Data Sharing Survey
+                        at your earliest convenience to finish answering the questions.
                     </p>
 
                     <div>
                         <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
-                           style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
-                           border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
-                           border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                           target="_blank">Consent Assent Form</a>
-                    </div>
+                                                        style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
+                                   border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
+                                   border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
+                                                        target="_blank">Data Sharing Survey</a>
+                   </div>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We will notify you as more questions become available and you can answer them at your convenience.
+                    </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         Please contact us at
@@ -119,6 +126,10 @@
                         <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
                             support@rare-x.org.</a>
                     </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We are so grateful for your participation - thank you again!
+                    </p>
                 </td>
             </tr>
 
@@ -132,7 +143,6 @@
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         The RARE-X Team
                     </p>
-
                 </td>
             </tr>
 

--- a/study-builder/studies/rarex/emails/family-member-reminder-1wk-proxy.html
+++ b/study-builder/studies/rarex/emails/family-member-reminder-1wk-proxy.html
@@ -89,13 +89,16 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        We are excited for you to begin contributing your information to the RARE-X Data Collection
-                        Program (DCP). Although you created an account you have not completed the Consent Assent Form, so
-                        you are not yet enrolled in the DCP and cannot share your information with us.
+                        Thank you for enrolling in the Data Collection Program (DCP).
+                        Your participation is vital to advancing rare disease research.
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        If you wish to fully enroll please review, sign, and submit the Consent Assent Form.
+                        It looks like you have started to answer the Family Member Survey did not complete it.
+                    </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        Please return to Family Member Survey at your earliest convenience to finish answering the questions.
                     </p>
 
                     <div>
@@ -103,8 +106,12 @@
                            style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
                            border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
                            border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                           target="_blank">Consent Assent Form</a>
+                           target="_blank">Family Member Survey</a>
                     </div>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We will notify you as more questions become available and you can answer them at your convenience.
+                    </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         Please contact us at
@@ -119,6 +126,10 @@
                         <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
                             support@rare-x.org.</a>
                     </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We are so grateful for your participation - thank you again!
+                    </p>
                 </td>
             </tr>
 
@@ -132,7 +143,6 @@
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         The RARE-X Team
                     </p>
-
                 </td>
             </tr>
 

--- a/study-builder/studies/rarex/emails/general-information-complete-reminder-proxy.html
+++ b/study-builder/studies/rarex/emails/general-information-complete-reminder-proxy.html
@@ -89,22 +89,31 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        We are excited for you to begin contributing your information to the RARE-X Data Collection
-                        Program (DCP). Although you created an account you have not completed the Consent Assent Form, so
-                        you are not yet enrolled in the DCP and cannot share your information with us.
+                        Thank you for taking the time to sign up for the Data Collection Program (DCP).
+                        Your participation is vital to advancing rare disease research.
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        If you wish to fully enroll please review, sign, and submit the Consent Assent Form.
+                        It looks like you have started to answer the General Information Survey but did not complete it.
                     </p>
 
-                    <div>
-                        <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
-                           style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                Please return to the General Information Survey
+                at your earliest convenience to finish answering the questions.
+            </p>
+
+            <div>
+                <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
+                                                style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
                            border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
                            border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                           target="_blank">Consent Assent Form</a>
-                    </div>
+                                                target="_blank">General Information Survey</a>
+            </div>
+
+            <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                We will notify you as more questions become available and you
+                can answer them at your convenience.
+                    </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         Please contact us at
@@ -119,6 +128,10 @@
                         <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
                             support@rare-x.org.</a>
                     </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We are so grateful for your participation - thank you again!
+                    </p>
                 </td>
             </tr>
 
@@ -132,7 +145,6 @@
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         The RARE-X Team
                     </p>
-
                 </td>
             </tr>
 

--- a/study-builder/studies/rarex/emails/health-and-development-complete-reminder-proxy.html
+++ b/study-builder/studies/rarex/emails/health-and-development-complete-reminder-proxy.html
@@ -89,22 +89,31 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        We are excited for you to begin contributing your information to the RARE-X Data Collection
-                        Program (DCP). Although you created an account you have not completed the Consent Assent Form, so
-                        you are not yet enrolled in the DCP and cannot share your information with us.
+                        Thank you for taking the time to sign up for the Data
+                        Collection Program (DCP). Your participation is vital to
+                        advancing rare disease research.
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        If you wish to fully enroll please review, sign, and submit the Consent Assent Form.
+                        It looks like you have started to answer the Health and Development Survey but did not complete it.
+                    </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        Please return to the Health and Development Survey
+                        at your earliest convenience to finish answering the questions.
                     </p>
 
                     <div>
                         <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
-                           style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
-                           border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
-                           border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                           target="_blank">Consent Assent Form</a>
+                                                        style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
+                                   border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
+                                   border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
+                                                        target="_blank">Health and Development Survey</a>
                     </div>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We will notify you as more questions become available and you can answer them at your convenience.
+                    </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         Please contact us at
@@ -114,10 +123,16 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        The information you submit will be stored in the secure Data Collection Program.
-                        If you would like your information deleted from our database at any time, now or in the future, please email us at
+                        The information you submit will be stored in the secure
+                        Data Collection Program. If you would like your
+                        information deleted from our database at any time, now or in
+                        the future, please email us at
                         <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
                             support@rare-x.org.</a>
+                    </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We are so grateful for your participation - thank you again!
                     </p>
                 </td>
             </tr>
@@ -132,7 +147,6 @@
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         The RARE-X Team
                     </p>
-
                 </td>
             </tr>
 

--- a/study-builder/studies/rarex/emails/quality-of-life-complete-reminder-proxy.html
+++ b/study-builder/studies/rarex/emails/quality-of-life-complete-reminder-proxy.html
@@ -89,22 +89,30 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        We are excited for you to begin contributing your information to the RARE-X Data Collection
-                        Program (DCP). Although you created an account you have not completed the Consent Assent Form, so
-                        you are not yet enrolled in the DCP and cannot share your information with us.
+                        Thank you for taking the time to sign up for the Data
+                        Collection Program (DCP). Your participation is vital to
+                        advancing rare disease research.
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        If you wish to fully enroll please review, sign, and submit the Consent Assent Form.
+                        It looks like you have started to answer the Quality of life Survey but did not complete it.</p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        Please return to the Quality of Life Survey
+                        at your earliest convenience to finish answering the questions.
                     </p>
 
                     <div>
                         <a href="-ddp.baseWebUrl-/activity/-ddp.activityInstanceGuid-"
-                           style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
-                           border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
-                           border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
-                           target="_blank">Consent Assent Form</a>
+                                                        style="font-size:14px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#26355c;
+                                   border-top:15px solid #26355c;border-bottom:15px solid #26355c;border-left:25px solid #26355c;
+                                   border-right:25px solid #26355c;display:inline-block; text-transform: uppercase;"
+                                                        target="_blank">Quality of Life Survey</a>
                     </div>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We will notify you as more questions become available and you can answer them at your convenience.
+                    </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         Please contact us at
@@ -114,10 +122,16 @@
                     </p>
 
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
-                        The information you submit will be stored in the secure Data Collection Program.
-                        If you would like your information deleted from our database at any time, now or in the future, please email us at
+                        The information you submit will be stored in the secure
+                        Data Collection Program. If you would like your
+                        information deleted from our database at any time, now or in
+                        the future, please email us at
                         <a href="mailto:support@rare-x.org" target="_blank" style="color: #26355c; text-decoration: none; cursor: pointer;">
                             support@rare-x.org.</a>
+                    </p>
+
+                    <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
+                        We are so grateful for your participation - thank you again!
                     </p>
                 </td>
             </tr>
@@ -132,7 +146,6 @@
                     <p style="font-family: 'Roboto', sans-serif; text-align: left; font-weight: 400; font-size: 16px; line-height: 24px;">
                         The RARE-X Team
                     </p>
-
                 </td>
             </tr>
 
@@ -145,6 +158,6 @@
                     </div>
                 </td>
             </tr>
-        </table>
+            </table>
     </body>
 </html>

--- a/study-builder/studies/rarex/sendgrid-emails.conf
+++ b/study-builder/studies/rarex/sendgrid-emails.conf
@@ -17,10 +17,18 @@
       "isDynamic": false
     },
     {
-      "key": "finishConsent1wkReminder",
+      "key": "consent1wkReminder",
       "name": "RAREX_CONSENT_REMINDER",
       "subject": "You’re off to a good start, now please come back to the Consent form",
       "filepath": "emails/consent-reminder-1wk.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
+      "key": "consentParental1wkReminder",
+      "name": "RAREX_CONSENT_PARENTAL_REMINDER",
+      "subject": "You’re off to a good start, now please come back to the Parental Consent form",
+      "filepath": "emails/consent-parental-reminder-1wk.html",
       "render": true,
       "isDynamic": false
     },
@@ -33,6 +41,30 @@
       "isDynamic": false
     },
     {
+      "key": "consentCompleted",
+      "name": "RAREX_CONSENT_COMPLETED",
+      "subject": "Your Consent has been received",
+      "filepath": "emails/consent-completed.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
+      "key": "consentParentalCompleted",
+      "name": "RAREX_PARENTAL_CONSENT_COMPLETED",
+      "subject": "Consent Form Received",
+      "filepath": "emails/consent-parental-completed.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
+      "key": "consentAssentCompleted",
+      "name": "RAREX_CONSENT_ASSENT_COMPLETED",
+      "subject": "Consent Form Received",
+      "filepath": "emails/consent-assent-completed.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
       "key": "familyMember1wkReminder",
       "name": "RAREX_FAMILY_MEMBER_REMINDER",
       "subject": "You aren't enrolled yet. Please come back to the Family Member Survey",
@@ -41,26 +73,10 @@
       "isDynamic": false
     },
     {
-      "key": "consentCompletedNotification",
-      "name": "RAREX_CONSENT_COMPLETED_NOTIFICATION",
-      "subject": "Your Consent has been received",
-      "filepath": "emails/consent-completed.html",
-      "render": true,
-      "isDynamic": false
-    },
-    {
-      "key": "parentalConsentCompletedNotification",
-      "name": "RAREX_PARENTAL_CONSENT_COMPLETED_NOTIFICATION",
-      "subject": "Consent Form Received",
-      "filepath": "emails/parental-consent-completed.html",
-      "render": true,
-      "isDynamic": false
-    },
-    {
-      "key": "consentAssentCompletedNotification",
-      "name": "RAREX_CONSENT_ASSENT_COMPLETED_NOTIFICATION",
-      "subject": "Consent Form Received",
-      "filepath": "emails/consent-assent-completed.html",
+      "key": "proxyFamilyMember1wkReminder",
+      "name": "RAREX_PROXY_FAMILY_MEMBER_REMINDER",
+      "subject": "You aren't enrolled yet. Please come back to the Family Member Survey",
+      "filepath": "emails/family-member-reminder-1wk-proxy.html",
       "render": true,
       "isDynamic": false
     },
@@ -73,10 +89,26 @@
       "isDynamic": false
     },
     {
+      "key": "proxyFinishGeneralInformationReminder",
+      "name": "RAREX_PROXY_GENERAL_INFORMATION_COMPLETE_REMINDER",
+      "subject": "Reminder to Complete Survey",
+      "filepath": "emails/general-information-complete-reminder-proxy.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
       "key": "finishHealthAndDevelopmentReminder",
       "name": "RAREX_HEALTH_AND_DEVELOPMENT_COMPLETE_REMINDER",
       "subject": "Reminder to Complete Survey",
       "filepath": "emails/health-and-development-complete-reminder.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
+      "key": "proxyFinishHealthAndDevelopmentReminder",
+      "name": "RAREX_PROXY_HEALTH_AND_DEVELOPMENT_COMPLETE_REMINDER",
+      "subject": "Reminder to Complete Survey",
+      "filepath": "emails/health-and-development-complete-reminder-proxy.html",
       "render": true,
       "isDynamic": false
     },
@@ -89,6 +121,14 @@
       "isDynamic": false
     },
     {
+      "key": "proxyFinishQualityOfLifeReminder",
+      "name": "RAREX_PROXY_QUALITY_OF_LIFE_COMPLETE_REMINDER",
+      "subject": "Reminder to Complete Survey",
+      "filepath": "emails/quality-of-life-complete-reminder-proxy.html",
+      "render": true,
+      "isDynamic": false
+    },
+    {
       "key": "finishDataSharingReminder",
       "name": "RAREX_DATA_SHARING_COMPLETE_REMINDER",
       "subject": "Reminder to Complete Survey",
@@ -97,12 +137,20 @@
       "isDynamic": false
     },
     {
-      "key": "finishLegacyReminder",
-      "name": "RAREX_LEGACY_COMPLETE_REMINDER",
-      "subject": "Legacy DCP - Don't forget to complete the survey",
-      "filepath": "emails/legacy-complete-reminder.html",
+      "key": "proxyFinishDataSharingReminder",
+      "name": "RAREX_PROXY_DATA_SHARING_COMPLETE_REMINDER",
+      "subject": "Reminder to Complete Survey",
+      "filepath": "emails/data-sharing-complete-reminder-proxy.html",
       "render": true,
       "isDynamic": false
-    }
+    },
+//    {
+//      "key": "finishLegacyReminder",
+//      "name": "RAREX_LEGACY_COMPLETE_REMINDER",
+//      "subject": "Legacy DCP - Don't forget to complete the survey",
+//      "filepath": "emails/legacy-complete-reminder.html",
+//      "render": true,
+//      "isDynamic": false
+//    }
   ]
 }

--- a/study-builder/studies/rarex/study.conf
+++ b/study-builder/studies/rarex/study.conf
@@ -1140,7 +1140,7 @@
 
     # email events
 
-    ##welcome email
+    ## welcome email
     {
       "trigger": {
         "type": "USER_REGISTERED"
@@ -1175,12 +1175,12 @@
         ],
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["PREQUAL"].questions["PREQUAL_SELF_DESCRIBE"].answers.hasOption("DIAGNOSED")""",
+      "cancelExpr": """!user.studies["rarex"].forms["PREQUAL"].questions["PREQUAL_SELF_DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED")""",
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##finish consent 2 days reminder
+    ## finish consent reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1191,7 +1191,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consent1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1199,14 +1199,11 @@
         "linkedActivityCode": "CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##finish consent 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1217,7 +1214,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consent1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1225,14 +1222,13 @@
         "linkedActivityCode": "CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##finish parental consent 2 days reminder
+    ## finish parental consent reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1243,7 +1239,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consentParental1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1251,14 +1247,11 @@
         "linkedActivityCode": "PARENTAL_CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["PARENTAL_CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##finish parental consent 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1269,7 +1262,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consentParental1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1277,14 +1270,13 @@
         "linkedActivityCode": "PARENTAL_CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["PARENTAL_CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["PARENTAL_CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##finish consent assent 2 days reminder
+    ## finish consent assent reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1303,14 +1295,11 @@
         "linkedActivityCode": "CONSENT_ASSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].hasInstance()
-        && user.studies["rarex"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##finish consent assent 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1329,14 +1318,13 @@
         "linkedActivityCode": "CONSENT_ASSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].hasInstance()
-        && user.studies["rarex"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##finish lar consent 2 days reminder
+    ## finish lar consent reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1347,7 +1335,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consentParental1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1355,14 +1343,11 @@
         "linkedActivityCode": "LAR_CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["LAR_CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##finish parental consent 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1373,7 +1358,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.finishConsent1wkReminder},
+            "emailTemplate": ${emails.consentParental1wkReminder},
             "language": "en",
             "isDynamic": false
           }
@@ -1381,14 +1366,13 @@
         "linkedActivityCode": "LAR_CONSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT"].hasInstance()
-        && user.studies["rarex"].forms["LAR_CONSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##finish lar consent assent 2 days reminder
+    ## finish lar consent assent reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1407,14 +1391,11 @@
         "linkedActivityCode": "LAR_CONSENT_ASSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].hasInstance()
-        && user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##finish consent assent 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1433,9 +1414,8 @@
         "linkedActivityCode": "LAR_CONSENT_ASSENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].hasInstance()
-        && user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
@@ -1451,7 +1431,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.consentCompletedNotification},
+            "emailTemplate": ${emails.consentCompleted},
             "language": "en",
             "isDynamic": false
           }
@@ -1473,7 +1453,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.parentalConsentCompletedNotification},
+            "emailTemplate": ${emails.consentParentalCompleted},
             "language": "en",
             "isDynamic": false
           }
@@ -1495,7 +1475,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.consentAssentCompletedNotification},
+            "emailTemplate": ${emails.consentAssentCompleted},
             "language": "en",
             "isDynamic": false
           }
@@ -1506,6 +1486,7 @@
       "order": 1
     },
 
+    ## LAR consent finished notification
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1516,7 +1497,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.consentCompletedNotification},
+            "emailTemplate": ${emails.consentParentalCompleted},
             "language": "en",
             "isDynamic": false
           }
@@ -1526,6 +1507,8 @@
       "dispatchToHousekeeping": true,
       "order": 1
     },
+
+    ## LAR consent assent finished notification
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1536,7 +1519,7 @@
         "type": "SENDGRID_EMAIL",
         "templates": [
           {
-            "emailTemplate": ${emails.consentCompletedNotification},
+            "emailTemplate": ${emails.consentAssentCompleted},
             "language": "en",
             "isDynamic": false
           }
@@ -1547,7 +1530,7 @@
       "order": 1
     },
 
-    ## finish family member 2 days reminder
+    ## finish family member reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1566,14 +1549,12 @@
         "linkedActivityCode": "FAMILY_MEMBER",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["FAMILY_MEMBER"].hasInstance()
-        && user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ## finish family member 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1592,14 +1573,64 @@
         "linkedActivityCode": "FAMILY_MEMBER",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["FAMILY_MEMBER"].hasInstance()
-        && user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ## General Information 2 days reminder
+    ## proxy finish family member reminder
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "FAMILY_MEMBER",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFamilyMember1wkReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "FAMILY_MEMBER",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "FAMILY_MEMBER",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFamilyMember1wkReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "FAMILY_MEMBER",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["FAMILY_MEMBER"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    ## General Information reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1618,14 +1649,12 @@
         "linkedActivityCode": "GENERAL_INFORMATION",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["GENERAL_INFORMATION"].hasInstance()
-        && user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ## General Information 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1644,14 +1673,64 @@
         "linkedActivityCode": "GENERAL_INFORMATION",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["GENERAL_INFORMATION"].hasInstance()
-        && user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ## Data sharing 2 days reminder
+    ## Proxy General Information reminder
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "GENERAL_INFORMATION",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishGeneralInformationReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "GENERAL_INFORMATION",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "GENERAL_INFORMATION",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishGeneralInformationReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "GENERAL_INFORMATION",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["GENERAL_INFORMATION"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    ## Data sharing reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1670,14 +1749,12 @@
         "linkedActivityCode": "DATA_SHARING",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["DATA_SHARING"].hasInstance()
-        && user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ## Data sharing 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1696,14 +1773,64 @@
         "linkedActivityCode": "DATA_SHARING",
         "pdfAttachments": []
       },
-      "cancelExpr": """user.studies["rarex"].forms["DATA_SHARING"].hasInstance()
-        && user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ## Health and Development 2 days reminder
+    ## Proxy Data sharing reminder
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "DATA_SHARING",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishDataSharingReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "DATA_SHARING",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "DATA_SHARING",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishDataSharingReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "DATA_SHARING",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["DATA_SHARING"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    ## Health and Development reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1722,14 +1849,12 @@
         "linkedActivityCode": "HEALTH_AND_DEVELOPMENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """(user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].hasInstance()
-        && user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE"))""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ## health and development 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1748,14 +1873,64 @@
         "linkedActivityCode": "HEALTH_AND_DEVELOPMENT",
         "pdfAttachments": []
       },
-      "cancelExpr": """(user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].hasInstance()
-        && user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE"))""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##quality of life 2 days reminder
+    ## Proxy health and development reminder
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "HEALTH_AND_DEVELOPMENT",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishHealthAndDevelopmentReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "HEALTH_AND_DEVELOPMENT",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "HEALTH_AND_DEVELOPMENT",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishHealthAndDevelopmentReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "HEALTH_AND_DEVELOPMENT",
+        "pdfAttachments": []
+      },
+      "cancelExpr": """!user.studies["rarex"].isGovernedParticipant()
+        || user.studies["rarex"].forms["HEALTH_AND_DEVELOPMENT"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    ## quality of life reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1774,14 +1949,11 @@
         "linkedActivityCode": "QUALITY_OF_LIFE",
         "pdfAttachments": []
       },
-      "cancelExpr": """(user.studies["rarex"].forms["QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
-    ##quality of life 7 days reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1800,14 +1972,13 @@
         "linkedActivityCode": "QUALITY_OF_LIFE",
         "pdfAttachments": []
       },
-      "cancelExpr": """(user.studies["rarex"].forms["QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
 
-    ##proxy quality of life 2 days reminder
+    ## child quality of life reminder
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1827,9 +1998,58 @@
         "pdfAttachments": []
       },
       "preconditionExpr": null,
-      "cancelExpr": """(user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 172800,
+      "cancelExpr": """user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CHILD_QUALITY_OF_LIFE",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishQualityOfLifeReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "CHILD_QUALITY_OF_LIFE",
+        "pdfAttachments": []
+      },
+      "preconditionExpr": null,
+      "cancelExpr": """user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    ## patient quality of life reminder
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "PATIENT_QUALITY_OF_LIFE",
+        "statusType": "CREATED"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          {
+            "emailTemplate": ${emails.proxyFinishQualityOfLifeReminder},
+            "language": "en",
+            "isDynamic": false
+          }
+        ],
+        "linkedActivityCode": "PATIENT_QUALITY_OF_LIFE",
+        "pdfAttachments": []
+      },
+      "preconditionExpr": null,
+      "cancelExpr": """user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.two_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },
@@ -1852,61 +2072,8 @@
         "pdfAttachments": []
       },
       "preconditionExpr": null,
-      "cancelExpr": """(user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 172800,
-      "dispatchToHousekeeping": true,
-      "order": 1
-    },
-
-    ##proxy quality of life 7 days reminder
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "CHILD_QUALITY_OF_LIFE",
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          {
-            "emailTemplate": ${emails.proxyFinishQualityOfLifeReminder},
-            "language": "en",
-            "isDynamic": false
-          }
-        ],
-        "linkedActivityCode": "CHILD_QUALITY_OF_LIFE",
-        "pdfAttachments": []
-      },
-      "preconditionExpr": null,
-      "cancelExpr": """(user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["CHILD_QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 604800,
-      "dispatchToHousekeeping": true,
-      "order": 1
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "PATIENT_QUALITY_OF_LIFE",
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          {
-            "emailTemplate": ${emails.proxyFinishQualityOfLifeReminder},
-            "language": "en",
-            "isDynamic": false
-          }
-        ],
-        "linkedActivityCode": "PATIENT_QUALITY_OF_LIFE",
-        "pdfAttachments": []
-      },
-      "preconditionExpr": null,
-      "cancelExpr": """(user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].hasInstance()
-        && user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].isStatus("COMPLETE"))""",
-      "delaySeconds": 604800,
+      "cancelExpr": """user.studies["rarex"].forms["PATIENT_QUALITY_OF_LIFE"].isStatus("COMPLETE")""",
+      "delaySeconds": ${delay.seven_days},
       "dispatchToHousekeeping": true,
       "order": 1
     },

--- a/study-builder/studies/rarex/substitutions.conf
+++ b/study-builder/studies/rarex/substitutions.conf
@@ -8,6 +8,12 @@
     "firstName": "$ddp.participantFirstName()"
     "disease": "RARE-X",
   },
+  "delay": {
+    "two_days": 172800,
+    "seven_days": 604800,
+    # "two_days": 120, # 2 mins, for testing
+    # "seven_days": 420, # 7 mins, for testing
+  },
   "subs": {
     "primary_diagnosis": { include required("snippets/picklist-primary-diagnosis.conf") },
     "question_difficulty": { include required("snippets/picklist-question-difficulty.conf") },


### PR DESCRIPTION
## Context

PR to add "proxy" versions of some of the emails. Honestly, I'm not too confident about the changes because I don't actually know what the emails are supposed to say. However, that's not the goal here. My focus is to just add new proxy versions where the salutation says "Dear proxy". 

## Release

1. Delete all rarex emails in dev sendgrid.
2. Use study-builder to create brand new email templates.
3. Put new email template ids into Vault.

