### PR TITLE
Add enrollment actions to rarex study

### DIFF
--- a/study-builder/studies/rarex/study.conf
+++ b/study-builder/studies/rarex/study.conf
@@ -1106,6 +1106,72 @@
       "dispatchToHousekeeping": false,
       "order": 1
     },
+    # user enrollment
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ASSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "PARENTAL_CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "LAR_CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "LAR_CONSENT_ASSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "USER_ENROLLED"
+      },
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
 
     # email events
 


### PR DESCRIPTION
The way study is configured it appears that just completing any of the different consent/consent activities meets requirement for enrollment, without additional PEX conditions added.