### PR TITLE
DDP-6115: Add missing state code from Guam in country info table used by mail address component

### DIFF
--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -263,4 +263,5 @@
     <include file="db-changes/schema/DDP-5973-add-confirm-placeholder-template-id.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-6032-add-studymailinglist-language.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-5096-custom-export-last-completed.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-6115-fix-guam-state-code.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-6115-fix-guam-state-code.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-6115-fix-guam-state-code.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="mocana" id="2021-fix-guam-state-code">
+        <update tableName="country_address_info">
+            <column name="state_code" value="GU"/>
+            <where>
+                name='Guam'
+            </where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
For mailing address component to work as expected regarding US territories like Puerto Rico (and in this case Guam) we need to have a state code entered for it (territories are a special case, we treat them as countries for mailing address but states for everything else).
At any rate, we had a state code for all territories except Guam and this caused the bug that Kiara found in corresponding ticket.
