### PR TITLE
DDP-6155 pex: fix loading of activity definitions

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/pex/TreeWalkInterpreter.java
@@ -67,6 +67,7 @@ import org.broadinstitute.ddp.pex.lang.PexParser.QuestionPredicateContext;
 import org.broadinstitute.ddp.pex.lang.PexParser.QuestionQueryContext;
 import org.broadinstitute.ddp.pex.lang.PexParser.StudyPredicateContext;
 import org.broadinstitute.ddp.pex.lang.PexParser.StudyQueryContext;
+import org.broadinstitute.ddp.util.ActivityInstanceUtil;
 import org.jdbi.v3.core.Handle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -446,8 +447,11 @@ public class TreeWalkInterpreter implements PexInterpreter {
         if (ictx.getActivityInstanceSummary() != null) {
             questionType = ictx.getActivityInstanceSummary()
                     .getLatestActivityInstance(activityCode)
-                    .flatMap(instanceDto -> ActivityDefStore.getInstance()
-                            .findActivityDef(ictx.getHandle(), studyGuid, instanceDto))
+                    .map(instanceDto -> ActivityInstanceUtil.getActivityDef(
+                            ictx.getHandle(),
+                            ActivityDefStore.getInstance(),
+                            instanceDto,
+                            studyGuid))
                     .map(def -> def.getQuestionByStableId(stableId))
                     .map(question -> {
                         QuestionType type = null;


### PR DESCRIPTION
## Context

See DDP-6155 for details. Will cherry-pick this into upcoming release.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!


