### PR TITLE
Updates the Count Me In study names [DDP-6117]

### DIFF
--- a/study-builder/studies/angio/study.conf
+++ b/study-builder/studies/angio/study.conf
@@ -9,7 +9,7 @@
         "guid": "cmi"
     },
     "study": {
-        "name": "ascproject",
+        "name": "Angiosarcoma Project",
         "guid": "ANGIO",
         "studyEmail": "info@ascproject.org",
         "baseWebUrl": ${baseWebUrl},

--- a/study-builder/studies/brain/study.conf
+++ b/study-builder/studies/brain/study.conf
@@ -9,7 +9,7 @@
         "guid": "cmi"
     },
     "study": {
-        "name": "cmi-brain",
+        "name": "Brain Tumor Project",
         "guid": "cmi-brain",
         "studyEmail": "info@braintumorproject.org",
         "baseWebUrl": ${baseWebUrl},

--- a/study-builder/studies/esc/study.conf
+++ b/study-builder/studies/esc/study.conf
@@ -11,7 +11,7 @@
   },
 
   "study": {
-    "name": "escproject",
+    "name": "Esophageal and Stomach Cancer Project",
     "guid": "cmi-esc",
     "studyEmail": "info@escproject.org",
     "baseWebUrl": ${baseWebUrl},

--- a/study-builder/studies/mbc/study.conf
+++ b/study-builder/studies/mbc/study.conf
@@ -11,7 +11,7 @@
   },
 
   "study": {
-    "name": "mbcproject",
+    "name": "Metastatic Breast Cancer Project",
     "guid": "cmi-mbc",
     "studyEmail": "info@mbcproject.org",
     "baseWebUrl": ${baseWebUrl},

--- a/study-builder/studies/mpc/study.conf
+++ b/study-builder/studies/mpc/study.conf
@@ -11,7 +11,7 @@
   },
 
   "study": {
-    "name": "mpcproject",
+    "name": "Metastatic Prostate Cancer Project",
     "guid": "cmi-mpc",
     "studyEmail": "info@mpcproject.org",
     "baseWebUrl": ${baseWebUrl},

--- a/study-builder/studies/osteo/study.conf
+++ b/study-builder/studies/osteo/study.conf
@@ -11,7 +11,7 @@
   },
 
   "study": {
-    "name": "osproject",
+    "name": "Osteosarcoma Project",
     "guid": "CMI-OSTEO",
     "studyEmail": "info@osproject.org",
     "baseWebUrl": ${baseWebUrl},


### PR DESCRIPTION
[DDP-6117](https://broadinstitute.atlassian.net/browse/DDP-6117)

## Context
The iOS and Android apps use the names of the study to present a list of all available studies on signup and login. This PR replaces the initial names in the `ANGIO`, `cmi-brain`, `CMI-OSTEO`, `cmi-mbc`, `cmi-mpc`, `cmi-esc` projects with the full name of the project.

## How do we demo these changes?
These changes can be demoed by setting up a new server instance, and initializing one (or all) of the updated studies using `study-builder`. The names can then be checked by calling the [getStudies](https://pepper.datadonationplatform.org/docs#operation/getStudies) operation- with the `umbrella` parameter set to `cmi`- and checking the response JSON object. The updated value should match the `name` property for each study guid.

For example, with a server running on `127.0.0.1`, the url would be ``http://127.0.0.1:5555/pepper/v1/studies?umbrella=cmi`

## Release
Further steps are needed in order for these modifications to be visible in the public environments. This will require a manual database update. See the associated ticket for more details about what is needed.

