### PR TITLE
DDP-4925 replace app-engine-dispatch with load-balancer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,6 @@ references:
       /home/circleci/repo/.circleci
   builds_bucket: &builds_bucket
       ddp-build-artifacts
-  dispatch_secret_id: &dispatch_secret_id
-      app-engine-dispatch
   jar_build_bucket_dir: &jar_build_bucket_dir
       /ddp-study-server-pepper-apis
   housekeeping_test_db: &housekeeping_test_db
@@ -339,25 +337,6 @@ commands:
               gcloud app versions delete --quiet --service "$SERVICE" "$CURRENT_VERSION" --project "broad-ddp-${ENVIRONMENT}"
             done;
             exit 0
-
-  update-dispatch-rules:
-    parameters:
-      dispatch_secret_id:
-        type: string
-        default: *dispatch_secret_id
-    steps:
-      - run:
-          name: Get dispatch.yaml file
-          command: |
-            set -u
-            echo "Reading dispatch file from Secret Manager secret id '<<parameters.dispatch_secret_id>>'"
-            gcloud secrets versions access latest --secret '<<parameters.dispatch_secret_id>>' --project "broad-ddp-${ENVIRONMENT}" > dispatch.yaml
-            cat dispatch.yaml
-      - run:
-          name: Update GAE dispatch config
-          command: |
-            set -u
-            gcloud app deploy --quiet --project "broad-ddp-${ENVIRONMENT}" dispatch.yaml
 
   update-deployment-sheet:
     parameters:
@@ -815,7 +794,6 @@ jobs:
       - deploy-jar:
           jar_base_name: DataDonationPlatform
           deploy_config_file_dir: ../output-config
-      - update-dispatch-rules
 
   deploy-stored-jar-job:
     executor:
@@ -837,7 +815,6 @@ jobs:
       - deploy-jar:
           jar_base_name: DataDonationPlatform
           deploy_config_file_dir: ../output-config
-      - update-dispatch-rules
 
   deploy-docs-job:
     executor:

--- a/scripts/load-balancer/add-study-to-lb.sh
+++ b/scripts/load-balancer/add-study-to-lb.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Setup the frontend, backend, and url mappings for a new study to the LB.
+
+set -e
+
+NAME="$(basename "$0")"
+if (( $# < 5 )); then
+  echo "usage: $NAME <GCP_PROJECT> <LB_NAME> <GAE_SERVICE> <STUDY_DOMAIN> <STUDY_IDENTIFIER>"
+  echo ""
+  echo "For STUDY_IDENTIFIER, choose a short concise name for the study."
+  echo "This identifier will be used to name various LB resources for the study."
+  exit 1
+fi
+
+PROJECT_ID="$1"
+REGION='us-central1'
+LB_NAME="$2"
+GAE_SERVICE="$3"
+STUDY_DOMAIN="$4"
+STUDY="$5"
+
+echo "using gcp project: $PROJECT_ID"
+echo "using region: $REGION"
+echo "using lb name: $LB_NAME"
+echo "using gae service: $GAE_SERVICE"
+echo "using study domain: $STUDY_DOMAIN"
+echo "using study identifier: $STUDY"
+echo ""
+
+echo_run() {
+  echo "+ $@"
+  "$@"
+  echo ""
+}
+
+echo "=> setting up backend..."
+
+neg_name="$STUDY-gae"
+service_name="$STUDY-service"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute network-endpoint-groups create "$neg_name" \
+  --network-endpoint-type=serverless \
+  --app-engine-service="$GAE_SERVICE" \
+  --region="$REGION"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute backend-services create "$service_name" --global
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute backend-services add-backend "$service_name" --global \
+  --network-endpoint-group="$neg_name" \
+  --network-endpoint-group-region="$REGION"
+
+echo "=> setting up frontend..."
+
+ip_name="$LB_NAME-$STUDY-ip"
+cert_name="$STUDY-cert"
+proxy_name="$LB_NAME-$STUDY-proxy"
+frontend_name="$LB_NAME-$STUDY-frontend"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute addresses create "$ip_name" --global
+ip_addr="$(gcloud --project="$PROJECT_ID" \
+  compute addresses describe "$ip_name" \
+  --global --format='get(address)')"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute ssl-certificates create "$cert_name" \
+  --global --domains="$STUDY_DOMAIN"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute target-https-proxies create "$proxy_name" \
+  --ssl-certificates="$cert_name" \
+  --url-map="$LB_NAME"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute forwarding-rules create "$frontend_name" \
+  --address="$ip_name" \
+  --target-https-proxy="$proxy_name" \
+  --global --ports=443
+
+echo "=> adding mappings for study..."
+
+matcher_name="$STUDY-matcher"
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps add-path-matcher "$LB_NAME" \
+  --path-matcher-name="$matcher_name" \
+  --default-service="$service_name" \
+  --new-hosts="$STUDY_DOMAIN"
+
+echo "=> adding http-to-https redirect..."
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute target-http-proxies create "$proxy_name-http" \
+  --global --url-map="$LB_NAME-http"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute forwarding-rules create "$frontend_name-http" \
+  --address="$ip_name" \
+  --target-http-proxy="$proxy_name-http" \
+  --global --ports=80
+
+echo "=> last step: please manually update DNS 'A' record and remove GAE custom domain when ready"
+echo "[$STUDY_DOMAIN] -> [$ip_addr]"

--- a/scripts/load-balancer/http-lb.tmpl.yaml
+++ b/scripts/load-balancer/http-lb.tmpl.yaml
@@ -1,0 +1,25 @@
+# This is the initial config for a http-to-https LB. To allow for simple
+# substituting of name, we have a placeholder here. Simply `cat` this through
+# `sed` to replace it. And load this config using the `--source` flag when
+# creating the LB.
+
+kind: compute#urlMap
+name: {{name}}
+defaultUrlRedirect:
+  redirectResponseCode: MOVED_PERMANENTLY_DEFAULT
+  httpsRedirect: true
+  stripQuery: false
+
+# Tests help make sure the config behaves correctly. They are not part of the
+# actual LB. Run these tests using `gcloud compute url-maps validate`.
+tests:
+- description: Test with no query parameters
+  host: foobar
+  path: /test/
+  expectedOutputUrl: https://foobar/test/
+  expectedRedirectResponseCode: 301
+- description: Test with query parameters
+  host: foobar
+  path: /test/?parameter1=value1&parameter2=value2
+  expectedOutputUrl: https://foobar/test/?parameter1=value1&parameter2=value2
+  expectedRedirectResponseCode: 301

--- a/scripts/load-balancer/http-lb.tmpl.yaml
+++ b/scripts/load-balancer/http-lb.tmpl.yaml
@@ -12,14 +12,19 @@ defaultUrlRedirect:
 
 # Tests help make sure the config behaves correctly. They are not part of the
 # actual LB. Run these tests using `gcloud compute url-maps validate`.
-tests:
-- description: Test with no query parameters
-  host: foobar
-  path: /test/
-  expectedOutputUrl: https://foobar/test/
-  expectedRedirectResponseCode: 301
-- description: Test with query parameters
-  host: foobar
-  path: /test/?parameter1=value1&parameter2=value2
-  expectedOutputUrl: https://foobar/test/?parameter1=value1&parameter2=value2
-  expectedRedirectResponseCode: 301
+#
+# This is commented out for now because the gcloud console doesn't yet support
+# editing these, so if we add these we'll be unable to edit the LB through the
+# UI. You can uncomment and validate locally to ensure configs work.
+#
+#tests:
+#- description: Test with no query parameters
+#  host: foobar
+#  path: /test/
+#  expectedOutputUrl: https://foobar/test/
+#  expectedRedirectResponseCode: 301
+#- description: Test with query parameters
+#  host: foobar
+#  path: /test/?parameter1=value1&parameter2=value2
+#  expectedOutputUrl: https://foobar/test/?parameter1=value1&parameter2=value2
+#  expectedRedirectResponseCode: 301

--- a/scripts/load-balancer/init-lb.sh
+++ b/scripts/load-balancer/init-lb.sh
@@ -111,6 +111,10 @@ echo "=> setting up second LB for http-to-https redirects..."
 # mostly just contains frontends with port 80 and same IPs, and no backends.
 # There doesn't seem to be a way to create this using cli interface, so we have
 # to import a YAML file.
+#
+# We're only going to use this http LB for redirecting the study site and not
+# our DSS and DSM backends. HTTP requests might contain credentials, so we want
+# to reject those requests.
 http_lb="$LB_NAME-http"
 
 cat "$DIR/http-lb.tmpl.yaml" \
@@ -173,17 +177,7 @@ for item in "${frontends[@]}"; do
     --target-https-proxy="$proxy_name" \
     --global --ports=443
 
-  # Now create the http frontends.
-
-  echo_run gcloud --project="$PROJECT_ID" \
-    compute target-http-proxies create "$proxy_name-http" \
-    --global --url-map="$http_lb"
-
-  echo_run gcloud --project="$PROJECT_ID" \
-    compute forwarding-rules create "$name-http" \
-    --address="$ip_name" \
-    --target-http-proxy="$proxy_name-http" \
-    --global --ports=80
+  # No http frontends will be created for DSS or DSM.
 done
 
 echo "=> last step: please manually update DNS 'A' records and remove GAE custom domains when ready"

--- a/scripts/load-balancer/init-lb.sh
+++ b/scripts/load-balancer/init-lb.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Setup load-balancer (LB) for routing traffic to our backend and to our study
+# apps. This handles putting together the DSS and DSM backends. For the various
+# studies, use the `add-study-to-lb.sh` script to add them.
+
+set -e
+
+NAME="$(basename "$0")"
+DIR="$(cd "$(dirname "$0")"; pwd)"
+if (( $# < 2 )); then
+  echo "usage: $NAME <GCP_PROJECT> <LB_NAME>"
+  exit 1
+fi
+
+PROJECT_ID="$1"
+ENV_NAME="${PROJECT_ID/broad-ddp-/}"
+REGION='us-central1'
+LB_NAME="$2"
+if [[ "$ENV_NAME" == "prod" ]]; then
+  DSS_DOMAIN='pepper.datadonationplatform.org'
+  DSM_DOMAIN='dsm.datadonationplatform.org'
+else
+  DSS_DOMAIN="pepper-$ENV_NAME.datadonationplatform.org"
+  DSM_DOMAIN="dsm-$ENV_NAME.datadonationplatform.org"
+fi
+
+echo "using gcp project: $PROJECT_ID"
+echo "using region: $REGION"
+echo "using lb name: $LB_NAME"
+echo "using dss domain: $DSS_DOMAIN"
+echo "using dsm domain: $DSM_DOMAIN"
+echo ""
+
+echo_run() {
+  echo "+ $@"
+  "$@"
+  echo ""
+}
+
+echo "=> setting up backend services..."
+
+# Notes about naming convention:
+# - using `-gae` suffix so we know it's backed by GAE
+services=(
+  'pepper-backend:dss-backend-gae:dss-backend-service'
+  'pepper-api-spec:dss-docs-gae:dss-docs-service'
+  'study-manager-backend:dsm-backend-gae:dsm-backend-service'
+  'study-manager-ui:dsm-ui-gae:dsm-ui-service'
+)
+
+for item in "${services[@]}"; do
+  IFS=':' read -r gae_service neg_name name <<< "$item"
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute network-endpoint-groups create "$neg_name" \
+    --network-endpoint-type=serverless \
+    --app-engine-service="$gae_service" \
+    --region="$REGION"
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute backend-services create $name --global
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute backend-services add-backend $name --global \
+    --network-endpoint-group="$neg_name" \
+    --network-endpoint-group-region="$REGION"
+done
+
+echo "=> setting up url-map..."
+
+# Note: the url-map is the core of the LB. It connects the frontends to the
+# backend services. If frontend request doesn't match a predefined backend,
+# then let's default to DSS service.
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps create "$LB_NAME" \
+  --default-service=dss-backend-service
+
+echo "=> adding mappings for dss..."
+
+# Note: these rules are paths off of the given domain. Anything else that
+# doesn't match these (e.g. /*) will fallback to the default service.
+dss_rules='/docs=dss-docs-service'
+dss_rules+=',/spec/*=dss-docs-service'
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps add-path-matcher "$LB_NAME" \
+  --path-matcher-name=dss-matcher \
+  --default-service=dss-backend-service \
+  --backend-service-path-rules="$dss_rules" \
+  --new-hosts="$DSS_DOMAIN"
+
+echo "=> adding mappings for dsm..."
+
+dsm_rules='/api/*=dsm-backend-service'
+dsm_rules+=',/app/*=dsm-backend-service'
+dsm_rules+=',/ddp/*=dsm-backend-service'
+dsm_rules+=',/info/*=dsm-backend-service'
+dsm_rules+=',/ui/*=dsm-backend-service'
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps add-path-matcher "$LB_NAME" \
+  --path-matcher-name=dsm-matcher \
+  --default-service=dsm-ui-service \
+  --backend-service-path-rules="$dsm_rules" \
+  --new-hosts="$DSM_DOMAIN"
+
+echo "=> setting up second LB for http-to-https redirects..."
+
+# Note: we use another LB to handle http-to-https redirects. The second LB
+# mostly just contains frontends with port 80 and same IPs, and no backends.
+# There doesn't seem to be a way to create this using cli interface, so we have
+# to import a YAML file.
+http_lb="$LB_NAME-http"
+
+cat "$DIR/http-lb.tmpl.yaml" \
+  | sed "s/{{name}}/$http_lb/g" \
+  > "/tmp/$http_lb.yaml"
+echo "created: /tmp/$http_lb.yaml"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps validate --source="/tmp/$http_lb.yaml"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute url-maps import "$http_lb" \
+  --global --source="/tmp/$http_lb.yaml"
+
+echo "=> setting up frontends..."
+
+dss_ip_name="$LB_NAME-dss-ip"
+dsm_ip_name="$LB_NAME-dsm-ip"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute addresses create "$dss_ip_name" --global
+dss_ip_addr="$(gcloud --project="$PROJECT_ID" \
+  compute addresses describe "$dss_ip_name" \
+  --global --format='get(address)')"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute addresses create "$dsm_ip_name" --global
+dsm_ip_addr="$(gcloud --project="$PROJECT_ID" \
+  compute addresses describe "$dsm_ip_name" \
+  --global --format='get(address)')"
+
+dss_cert_name="dss-cert"
+dsm_cert_name="dsm-cert"
+
+echo_run gcloud --project="$PROJECT_ID" \
+  compute ssl-certificates create "$dss_cert_name" \
+  --global --domains="$DSS_DOMAIN"
+echo_run gcloud --project="$PROJECT_ID" \
+  compute ssl-certificates create "$dsm_cert_name" \
+  --global --domains="$DSM_DOMAIN"
+
+# Notes about naming convention:
+# - using LB name as prefix so we know it's config for an LB
+frontends=(
+  "$dss_ip_name:$dss_cert_name:$LB_NAME-dss-proxy:$LB_NAME-dss-frontend"
+  "$dsm_ip_name:$dsm_cert_name:$LB_NAME-dsm-proxy:$LB_NAME-dsm-frontend"
+)
+
+for item in "${frontends[@]}"; do
+  IFS=':' read -r ip_name cert_name proxy_name name <<< "$item"
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute target-https-proxies create "$proxy_name" \
+    --ssl-certificates="$cert_name" \
+    --url-map="$LB_NAME"
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute forwarding-rules create "$name" \
+    --address="$ip_name" \
+    --target-https-proxy="$proxy_name" \
+    --global --ports=443
+
+  # Now create the http frontends.
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute target-http-proxies create "$proxy_name-http" \
+    --global --url-map="$http_lb"
+
+  echo_run gcloud --project="$PROJECT_ID" \
+    compute forwarding-rules create "$name-http" \
+    --address="$ip_name" \
+    --target-http-proxy="$proxy_name-http" \
+    --global --ports=80
+done
+
+echo "=> last step: please manually update DNS 'A' records and remove GAE custom domains when ready"
+echo "[$DSS_DOMAIN] -> [$dss_ip_addr]"
+echo "[$DSM_DOMAIN] -> [$dsm_ip_addr]"


### PR DESCRIPTION
## Context

Here are the scripts that will help us setup the initial load-balancer to replace app engine `dispatch.yaml`. Start by reading the `init-lb.sh` script. The `add-study-to-lb.sh` script can be used down the line to more easily add LB configs for a new study. See this [wiki page](https://broadinstitute.atlassian.net/wiki/spaces/DDP/pages/2635497487/Dispatch+Load+Balancer) for more details.

CC @bskinner since I saw we have a LB for Salt so I could probably use some advice here.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [ ] :relaxed: All good, business as usual!
- [x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

I have already setup the LB in `dev` environment so that it can be demo-ed there.

## Testing

Initial testing of the LB in `dev` did not show any issues. I was able to reach the various apps and services just fine.

## Release

TLDR: There will be downtime!

First, we need to run `init-lb.sh` to setup the load-balancer. Then, we can run `add-study-to-lb.sh` to add in all the various studies. We might need to do some custom/additional steps depending on the study.

The main source of downtime is switching DNS and provisioning SSL certs. From what I can tell in `dev`, updated DNS records seem to propagate pretty quickly, so downtime was mostly dominated by SSL cert provisioning which took anywhere from 8 - 12 mins. So I think a rough estimate of downtime is about 15 mins.

We should be able to apply this without having to create a new code release.

