### PR TITLE
DSS API specification cleanup & update

### DIFF
--- a/pepper-apis/docs/specification/package-lock.json
+++ b/pepper-apis/docs/specification/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@redocly/openapi-cli": "v1.0.0-beta.49",
         "redoc": "2.0.0-rc.53",
-        "redoc-cli": "^0.11.4",
-        "speccy": "^0.11.0"
+        "redoc-cli": "~0.11.4"
       },
       "devDependencies": {
         "@openapitools/openapi-generator-cli": "1.0.2-4.2.0"
@@ -186,11 +185,6 @@
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
-    },
-    "node_modules/@cloudflare/json-schema-walker": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/json-schema-walker/-/json-schema-walker-0.1.1.tgz",
-      "integrity": "sha512-P3n0hEgk1m6uKWgL4Yb1owzXVG4pM70G4kRnDQxZXiVvfCRtaqiHu+ZRiRPzmwGBiLTO1LWc2yR1M8oz0YkXww=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -483,18 +477,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
       "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
-    "node_modules/accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "dependencies": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -504,14 +486,6 @@
         "fast-deep-equal": "^1.0.0",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-styles": {
@@ -545,11 +519,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
     "node_modules/assert-node-version": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/assert-node-version/-/assert-node-version-1.0.3.tgz",
@@ -561,11 +530,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "node_modules/babel-plugin-styled-components": {
       "version": "1.12.0",
@@ -615,40 +579,12 @@
         "node": ">=6"
       }
     },
-    "node_modules/big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-      "dependencies": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/brace-expansion": {
@@ -669,14 +605,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/call-me-maybe": {
@@ -747,16 +675,6 @@
         "tiny-emitter": "^2.0.0"
       }
     },
-    "node_modules/cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "dependencies": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
     "node_modules/clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -782,14 +700,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -808,47 +718,10 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "node_modules/content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/core-js": {
       "version": "3.13.1",
@@ -858,21 +731,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
       }
     },
     "node_modules/css-color-keywords": {
@@ -895,14 +753,6 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -922,62 +772,10 @@
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "optional": true
     },
-    "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "node_modules/dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
-    "node_modules/dompurify": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.11.tgz",
-      "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ=="
-    },
-    "node_modules/ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "node_modules/ejs": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-      "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
@@ -991,11 +789,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
@@ -1017,82 +810,12 @@
         "node": ">=4"
       }
     },
-    "node_modules/etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
-    },
-    "node_modules/execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-      "dependencies": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/expected-node-version": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/expected-node-version/-/expected-node-version-1.0.2.tgz",
       "integrity": "sha1-uNIlub9nap6H4G29YVtS/J0eOGs=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-      "dependencies": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1104,11 +827,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
@@ -1126,59 +844,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "node_modules/format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-    },
-    "node_modules/forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1196,19 +865,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
-    "node_modules/get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/glob": {
@@ -1253,15 +909,6 @@
       },
       "peerDependencies": {
         "glob": "*"
-      }
-    },
-    "node_modules/global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dependencies": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
       }
     },
     "node_modules/globals": {
@@ -1327,40 +974,15 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/http2-client": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.2.tgz",
       "integrity": "sha512-CY9yoIetaoblM5CTrzHc7mJvH1Fo9/XmO6kxRkTCnWbSPq5brQYbtJ7hJrI5nKMYpyqPJYdPN9mkQbRBVvsoSQ=="
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -1375,30 +997,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1419,14 +1017,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -1445,19 +1035,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/js-levenshtein": {
       "version": "1.1.6",
@@ -1504,14 +1081,6 @@
         "foreach": "^2.0.4"
       }
     },
-    "node_modules/json-schema-to-openapi-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema-to-openapi-schema/-/json-schema-to-openapi-schema-0.3.0.tgz",
-      "integrity": "sha512-UaaAmmbAq61yQM5yLoVOM99GP1JI8YNVEv3QWbD/79YDNNKk99uGn1k2pa+ZSfdLILi/euGguVG8URmv5gR/Bw==",
-      "dependencies": {
-        "@cloudflare/json-schema-walker": "^0.1.1"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -1529,59 +1098,12 @@
         "node": ">= 4"
       }
     },
-    "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
     "node_modules/jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "dependencies": {
-        "invert-kv": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/lodash": {
@@ -1605,122 +1127,10 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q=="
-    },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
-    },
-    "node_modules/marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
-      "dependencies": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/memoize-one": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
-      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
-    },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "dependencies": {
-        "mime-db": "1.40.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dependencies": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -1759,169 +1169,10 @@
         "url": "https://opencollective.com/mobx"
       }
     },
-    "node_modules/mobx-react": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.4.3.tgz",
-      "integrity": "sha512-WC8yFlwvJ91hy8j6CrydAuFteUafcuvdITFQeHl3LRIf5ayfT/4W3M/byhEYD2BcJWejeXr8y4Rh2H26RunCRQ==",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.0.0",
-        "react-lifecycles-compat": "^3.0.2"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "node_modules/nconf": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-      "dependencies": {
-        "async": "^1.4.0",
-        "ini": "^1.3.0",
-        "secure-keys": "^1.0.0",
-        "yargs": "^3.19.0"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/nconf-yaml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nconf-yaml/-/nconf-yaml-1.0.2.tgz",
-      "integrity": "sha1-/qBlMzz0K3el6AYFF5aXmdQVZXU=",
-      "dependencies": {
-        "js-yaml": "^3.2.3"
-      }
-    },
-    "node_modules/nconf/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
-    "node_modules/nconf/node_modules/invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dependencies": {
-        "invert-kv": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/os-locale": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dependencies": {
-        "lcid": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nconf/node_modules/y18n": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-    },
-    "node_modules/nconf/node_modules/yargs": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-      "dependencies": {
-        "camelcase": "^2.0.1",
-        "cliui": "^3.0.3",
-        "decamelize": "^1.1.1",
-        "os-locale": "^1.4.0",
-        "string-width": "^1.0.1",
-        "window-size": "^0.1.4",
-        "y18n": "^3.2.0"
-      }
-    },
-    "node_modules/negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "node_modules/nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -1954,25 +1205,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dependencies": {
-        "path-key": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2161,23 +1393,6 @@
         "url": "https://github.com/Mermade/oas-kit?sponsor=1"
       }
     },
-    "node_modules/oas-validator": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.4.0.tgz",
-      "integrity": "sha512-l/SxykuACi2U51osSsBXTxdsFc8Fw41xI7AsZkzgVgWJAzoEFaaNptt35WgY9C3757RUclsm6ye5GvSyYoozLQ==",
-      "dependencies": {
-        "ajv": "^5.5.2",
-        "better-ajv-errors": "^0.6.7",
-        "call-me-maybe": "^1.0.1",
-        "oas-kit-common": "^1.0.7",
-        "oas-linter": "^3.1.0",
-        "oas-resolver": "^2.3.0",
-        "oas-schema-walker": "^1.1.3",
-        "reftools": "^1.1.0",
-        "should": "^13.2.1",
-        "yaml": "^1.8.3"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2186,76 +1401,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "dependencies": {
-        "format-util": "^1.0.3"
-      }
-    },
-    "node_modules/openapi-sampler": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
-      "integrity": "sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==",
-      "dependencies": {
-        "json-pointer": "^0.6.0"
-      }
-    },
-    "node_modules/os-locale": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
-      "dependencies": {
-        "execa": "^0.10.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -2272,39 +1423,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2314,19 +1438,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/perfect-scrollbar": {
       "version": "1.4.0",
@@ -2403,14 +1514,6 @@
         "clipboard": "^2.0.0"
       }
     },
-    "node_modules/process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -2421,32 +1524,12 @@
         "react-is": "^16.8.1"
       }
     },
-    "node_modules/proxy-addr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-      "dependencies": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -2474,28 +1557,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-      "dependencies": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/react": {
@@ -2527,41 +1588,10 @@
         "react": "^16.14.0"
       }
     },
-    "node_modules/react-dropdown": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.6.4.tgz",
-      "integrity": "sha512-zTlNRZ6vzjEPsodBNgh6Xjp9IempEx9sReH3crT2Jw4S6KW2wS/BRIH3d/grYf/iXARadDRD91//uUCs9yjoLg==",
-      "dependencies": {
-        "classnames": "^2.2.3"
-      }
-    },
-    "node_modules/react-hot-loader": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.9.tgz",
-      "integrity": "sha512-lWT3JpWUN7nGHSoI9c4MV+42ov79bd8aqwDzhoyKev3owIh+hbEivT6Mb81lCV6tWuqm9trKo2/Th2/YDhFCdw==",
-      "dependencies": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-tabs": {
       "version": "3.2.2",
@@ -5088,20 +4118,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/scheduler": {
       "version": "0.19.1",
@@ -5112,11 +4132,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "node_modules/secure-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
     "node_modules/select": {
       "version": "1.1.2",
@@ -5132,81 +4147,16 @@
         "semver": "bin/semver"
       }
     },
-    "node_modules/send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
-        "mime": "1.6.0",
-        "ms": "2.1.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
-    "node_modules/serve-static": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-      "dependencies": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "node_modules/setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
-    "node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "peer": true
     },
     "node_modules/should": {
       "version": "13.2.3",
@@ -5255,11 +4205,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM="
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "node_modules/simple-websocket": {
       "version": "9.1.0",
@@ -5316,93 +4261,10 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/speccy": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/speccy/-/speccy-0.11.0.tgz",
-      "integrity": "sha512-f9XXngfae43WR9uz8m3yk935nsJIJH1YaRNNjEYqF+uL3yNlabFgixPKncJKXT2LfiMhhszwVSgrDgUaUvGBVQ==",
-      "dependencies": {
-        "commander": "^2.18.0",
-        "ejs": "^2.5.2",
-        "express": "^4.14.0",
-        "json-schema-to-openapi-schema": "^0.3.0",
-        "nconf": "^0.10.0",
-        "nconf-yaml": "^1.0.2",
-        "node-fetch": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-linter": "^3.0.0",
-        "oas-resolver": "^2.2.4",
-        "oas-validator": "^3.0.1",
-        "redoc": "v2.0.0-rc.8-1",
-        "yaml": "^1.5.0"
-      },
-      "bin": {
-        "speccy": "speccy.js"
-      }
-    },
-    "node_modules/speccy/node_modules/json-schema-ref-parser": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
-    "node_modules/speccy/node_modules/redoc": {
-      "version": "2.0.0-rc.8-1",
-      "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.8-1.tgz",
-      "integrity": "sha512-/YoCdcl2QtveKz4CTXaqtOfCIaVgZZgcnfUNC5xK7xBl/LxTiNj3tUbgFmrYMLTZGzNdQ9TUJpsa7lXDKcr8Pw==",
-      "dependencies": {
-        "classnames": "^2.2.6",
-        "decko": "^1.2.0",
-        "dompurify": "^1.0.10",
-        "eventemitter3": "^3.0.0",
-        "json-pointer": "^0.6.0",
-        "json-schema-ref-parser": "^6.1.0",
-        "lunr": "2.3.6",
-        "mark.js": "^8.11.1",
-        "marked": "^0.6.1",
-        "memoize-one": "^5.0.0",
-        "mobx-react": "^5.4.3",
-        "openapi-sampler": "1.0.0-beta.14",
-        "perfect-scrollbar": "^1.4.0",
-        "polished": "^3.0.3",
-        "prismjs": "^1.15.0",
-        "prop-types": "^15.7.2",
-        "react-dropdown": "^1.6.4",
-        "react-hot-loader": "^4.8.0",
-        "react-tabs": "^3.0.0",
-        "slugify": "^1.3.4",
-        "stickyfill": "^1.1.1",
-        "swagger2openapi": "^5.2.3",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6.9",
-        "npm": ">=3.0.0"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/stickyfill": {
       "version": "1.1.1",
@@ -5435,37 +4297,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/strip-eof": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/styled-components": {
       "version": "5.3.0",
@@ -5508,29 +4339,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/swagger2openapi": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.4.0.tgz",
-      "integrity": "sha512-f5QqfXawiVijhjMtYqWZ55ESHPZFqrPC8L9idhIiuSX8O2qsa1i4MVGtCM3TQF+Smzr/6WfT/7zBuzG3aTgPAA==",
-      "dependencies": {
-        "better-ajv-errors": "^0.6.1",
-        "call-me-maybe": "^1.0.1",
-        "node-fetch-h2": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-kit-common": "^1.0.7",
-        "oas-resolver": "^2.3.0",
-        "oas-schema-walker": "^1.1.3",
-        "oas-validator": "^3.4.0",
-        "reftools": "^1.1.0",
-        "yaml": "^1.8.3",
-        "yargs": "^12.0.5"
-      },
-      "bin": {
-        "boast": "boast.js",
-        "oas-validate": "oas-validate.js",
-        "swagger2openapi": "swagger2openapi.js"
-      }
-    },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -5557,31 +4365,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
-    "node_modules/tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-    },
-    "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/uglify-js": {
       "version": "3.13.8",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
@@ -5592,14 +4375,6 @@
       },
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/uri-js": {
@@ -5620,108 +4395,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
-    },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
-    "node_modules/window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
-      "bin": {
-        "window-size": "cli.js"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "node_modules/wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dependencies": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -5765,34 +4447,6 @@
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
-    },
-    "node_modules/yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-      "dependencies": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
     }
   },
   "dependencies": {
@@ -5952,11 +4606,6 @@
         "@babel/helper-validator-identifier": "^7.14.0",
         "to-fast-properties": "^2.0.0"
       }
-    },
-    "@cloudflare/json-schema-walker": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/json-schema-walker/-/json-schema-walker-0.1.1.tgz",
-      "integrity": "sha512-P3n0hEgk1m6uKWgL4Yb1owzXVG4pM70G4kRnDQxZXiVvfCRtaqiHu+ZRiRPzmwGBiLTO1LWc2yR1M8oz0YkXww=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.8.8",
@@ -6196,15 +4845,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
       "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
-    "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
-      "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      }
-    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -6215,11 +4855,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
       }
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -6246,11 +4881,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
-    },
     "assert-node-version": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/assert-node-version/-/assert-node-version-1.0.3.tgz",
@@ -6259,11 +4889,6 @@
         "expected-node-version": "^1.0.0",
         "semver": "^5.0.3"
       }
-    },
-    "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "babel-plugin-styled-components": {
       "version": "1.12.0",
@@ -6309,32 +4934,10 @@
         }
       }
     },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
-    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
-      "requires": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6352,11 +4955,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "call-me-maybe": {
       "version": "1.0.1",
@@ -6415,16 +5013,6 @@
         "tiny-emitter": "^2.0.0"
       }
     },
-    "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-      "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
-      }
-    },
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -6439,11 +5027,6 @@
       "version": "0.0.230",
       "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
       "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw=="
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -6463,55 +5046,15 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "content-disposition": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
-      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "cookie": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
     "core-js": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.13.1.tgz",
       "integrity": "sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ=="
-    },
-    "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -6530,14 +5073,6 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -6554,50 +5089,10 @@
       "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "optional": true
     },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
-    },
-    "dompurify": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.11.tgz",
-      "integrity": "sha512-XywCTXZtc/qCX3iprD1pIklRVk/uhl8BKpkTxr+ZyMVUzSUg7wkQXRBp/euJ5J5moa1QvfpvaPQVP71z1O59dQ=="
-    },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "ejs": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
-      "integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
-    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "es6-promise": {
       "version": "3.3.1",
@@ -6609,11 +5104,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -6624,71 +5114,10 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "eventemitter3": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
-    },
-    "execa": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
-    },
     "expected-node-version": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/expected-node-version/-/expected-node-version-1.0.2.tgz",
       "integrity": "sha1-uNIlub9nap6H4G29YVtS/J0eOGs="
-    },
-    "express": {
-      "version": "4.17.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
-      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
-      "requires": {
-        "accepts": "~1.3.7",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.19.0",
-        "content-disposition": "0.5.3",
-        "content-type": "~1.0.4",
-        "cookie": "0.4.0",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "~1.1.2",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.5",
-        "qs": "6.7.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.1.2",
-        "send": "0.17.1",
-        "serve-static": "1.14.1",
-        "setprototypeof": "1.1.1",
-        "statuses": "~1.5.0",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      }
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -6699,11 +5128,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -6718,47 +5142,10 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.3",
-        "statuses": "~1.5.0",
-        "unpipe": "~1.0.0"
-      }
-    },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
-    "format-util": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
-      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -6770,16 +5157,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "optional": true
-    },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "glob": {
       "version": "7.1.7",
@@ -6808,15 +5185,6 @@
       "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
       "requires": {
         "@types/glob": "*"
-      }
-    },
-    "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
       }
     },
     "globals": {
@@ -6867,34 +5235,15 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "peer": true,
       "requires": {
         "react-is": "^16.7.0"
-      }
-    },
-    "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
       }
     },
     "http2-client": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.2.tgz",
       "integrity": "sha512-CY9yoIetaoblM5CTrzHc7mJvH1Fo9/XmO6kxRkTCnWbSPq5brQYbtJ7hJrI5nKMYpyqPJYdPN9mkQbRBVvsoSQ=="
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -6910,21 +5259,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
-    "ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
-    },
-    "invert-kv": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-    },
-    "ipaddr.js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6938,11 +5272,6 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-    },
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
@@ -6955,16 +5284,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -6999,14 +5318,6 @@
         "foreach": "^2.0.4"
       }
     },
-    "json-schema-to-openapi-schema": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/json-schema-to-openapi-schema/-/json-schema-to-openapi-schema-0.3.0.tgz",
-      "integrity": "sha512-UaaAmmbAq61yQM5yLoVOM99GP1JI8YNVEv3QWbD/79YDNNKk99uGn1k2pa+ZSfdLILi/euGguVG8URmv5gR/Bw==",
-      "requires": {
-        "@cloudflare/json-schema-walker": "^0.1.1"
-      }
-    },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
@@ -7021,45 +5332,10 @@
         "grapheme-splitter": "^1.0.4"
       }
     },
-    "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-    },
-    "lcid": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-      "requires": {
-        "invert-kv": "^2.0.0"
-      }
-    },
-    "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      }
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      }
     },
     "lodash": {
       "version": "4.17.21",
@@ -7079,89 +5355,10 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "lunr": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.6.tgz",
-      "integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q=="
-    },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
       "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U="
-    },
-    "marked": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-      "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ=="
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "mem": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.0.0.tgz",
-      "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
-      "requires": {
-        "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
-        "p-is-promise": "^1.1.0"
-      }
-    },
-    "memoize-one": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
-      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
-    },
-    "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
-    },
-    "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-      "requires": {
-        "mime-db": "1.40.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7190,141 +5387,10 @@
       "integrity": "sha512-xGPM9dIE1qkK9Nrhevp0gzpsmELKU4MFUJRORW/jqxVFIHHWIoQrjDjL8vkwoJYY3C2CeVJqgvl38hgKTalTWg==",
       "peer": true
     },
-    "mobx-react": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-5.4.3.tgz",
-      "integrity": "sha512-WC8yFlwvJ91hy8j6CrydAuFteUafcuvdITFQeHl3LRIf5ayfT/4W3M/byhEYD2BcJWejeXr8y4Rh2H26RunCRQ==",
-      "requires": {
-        "hoist-non-react-statics": "^3.0.0",
-        "react-lifecycles-compat": "^3.0.2"
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
-    "nconf": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
-      "requires": {
-        "async": "^1.4.0",
-        "ini": "^1.3.0",
-        "secure-keys": "^1.0.0",
-        "yargs": "^3.19.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "os-locale": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "requires": {
-            "lcid": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
-        },
-        "yargs": {
-          "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "requires": {
-            "camelcase": "^2.0.1",
-            "cliui": "^3.0.3",
-            "decamelize": "^1.1.1",
-            "os-locale": "^1.4.0",
-            "string-width": "^1.0.1",
-            "window-size": "^0.1.4",
-            "y18n": "^3.2.0"
-          }
-        }
-      }
-    },
-    "nconf-yaml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/nconf-yaml/-/nconf-yaml-1.0.2.tgz",
-      "integrity": "sha1-/qBlMzz0K3el6AYFF5aXmdQVZXU=",
-      "requires": {
-        "js-yaml": "^3.2.3"
-      }
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
-    },
     "neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -7351,19 +5417,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "requires": {
-        "path-key": "^2.0.0"
-      }
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oas-kit-common": {
       "version": "1.0.8",
@@ -7500,35 +5553,10 @@
       "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
       "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ=="
     },
-    "oas-validator": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.4.0.tgz",
-      "integrity": "sha512-l/SxykuACi2U51osSsBXTxdsFc8Fw41xI7AsZkzgVgWJAzoEFaaNptt35WgY9C3757RUclsm6ye5GvSyYoozLQ==",
-      "requires": {
-        "ajv": "^5.5.2",
-        "better-ajv-errors": "^0.6.7",
-        "call-me-maybe": "^1.0.1",
-        "oas-kit-common": "^1.0.7",
-        "oas-linter": "^3.1.0",
-        "oas-resolver": "^2.3.0",
-        "oas-schema-walker": "^1.1.3",
-        "reftools": "^1.1.0",
-        "should": "^13.2.1",
-        "yaml": "^1.8.3"
-      }
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
     },
     "once": {
       "version": "1.4.0",
@@ -7538,47 +5566,6 @@
         "wrappy": "1"
       }
     },
-    "ono": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
-      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
-      "requires": {
-        "format-util": "^1.0.3"
-      }
-    },
-    "openapi-sampler": {
-      "version": "1.0.0-beta.14",
-      "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
-      "integrity": "sha512-NNmH9YAN5AaCE4w6MQXdCrmsOJJQTswHVSp075+h+iiG+OTonpZE8HzwocozovD2imx4lamkuxGLs4E4bO4Z+g==",
-      "requires": {
-        "json-pointer": "^0.6.0"
-      }
-    },
-    "os-locale": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
-      "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
-      "requires": {
-        "execa": "^0.10.0",
-        "lcid": "^2.0.0",
-        "mem": "^4.0.0"
-      }
-    },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
-    "p-is-promise": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -7587,43 +5574,15 @@
         "p-try": "^2.0.0"
       }
     },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "requires": {
-        "p-limit": "^2.0.0"
-      }
-    },
     "p-try": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
       "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
-    "parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
-    },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "perfect-scrollbar": {
       "version": "1.4.0",
@@ -7690,11 +5649,6 @@
         "clipboard": "^2.0.0"
       }
     },
-    "process": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -7705,24 +5659,10 @@
         "react-is": "^16.8.1"
       }
     },
-    "proxy-addr": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
-      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
-      "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.9.0"
-      }
-    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -7735,22 +5675,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
-      "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
       }
     },
     "react": {
@@ -7776,38 +5700,10 @@
         "scheduler": "^0.19.1"
       }
     },
-    "react-dropdown": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/react-dropdown/-/react-dropdown-1.6.4.tgz",
-      "integrity": "sha512-zTlNRZ6vzjEPsodBNgh6Xjp9IempEx9sReH3crT2Jw4S6KW2wS/BRIH3d/grYf/iXARadDRD91//uUCs9yjoLg==",
-      "requires": {
-        "classnames": "^2.2.3"
-      }
-    },
-    "react-hot-loader": {
-      "version": "4.12.9",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.9.tgz",
-      "integrity": "sha512-lWT3JpWUN7nGHSoI9c4MV+42ov79bd8aqwDzhoyKev3owIh+hbEivT6Mb81lCV6tWuqm9trKo2/Th2/YDhFCdw==",
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.1.0",
-        "source-map": "^0.7.3"
-      }
-    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-tabs": {
       "version": "3.2.2",
@@ -10241,20 +8137,10 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
-    "require-main-filename": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "scheduler": {
       "version": "0.19.1",
@@ -10265,11 +8151,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "secure-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
     "select": {
       "version": "1.1.2",
@@ -10282,71 +8163,16 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
     },
-    "send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.7.2",
-        "mime": "1.6.0",
-        "ms": "2.1.1",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.1",
-        "statuses": "~1.5.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
-      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
-      "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.17.1"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
-    "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
-    },
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "peer": true
     },
     "should": {
       "version": "13.2.3",
@@ -10396,11 +8222,6 @@
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
       "integrity": "sha1-yYzaN0qmsZDfi6h8mInCtNtiAGM="
     },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
     "simple-websocket": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/simple-websocket/-/simple-websocket-9.1.0.tgz",
@@ -10433,82 +8254,10 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.3.tgz",
       "integrity": "sha512-/HkjRdwPY3yHJReXu38NiusZw2+LLE2SrhkWJtmlPDB1fqFSvioYj62NkPcrKiNCgRLeGcGK7QBvr1iQwybeXw=="
     },
-    "source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-    },
-    "speccy": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/speccy/-/speccy-0.11.0.tgz",
-      "integrity": "sha512-f9XXngfae43WR9uz8m3yk935nsJIJH1YaRNNjEYqF+uL3yNlabFgixPKncJKXT2LfiMhhszwVSgrDgUaUvGBVQ==",
-      "requires": {
-        "commander": "^2.18.0",
-        "ejs": "^2.5.2",
-        "express": "^4.14.0",
-        "json-schema-to-openapi-schema": "^0.3.0",
-        "nconf": "^0.10.0",
-        "nconf-yaml": "^1.0.2",
-        "node-fetch": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-linter": "^3.0.0",
-        "oas-resolver": "^2.2.4",
-        "oas-validator": "^3.0.1",
-        "redoc": "v2.0.0-rc.8-1",
-        "yaml": "^1.5.0"
-      },
-      "dependencies": {
-        "json-schema-ref-parser": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
-          "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
-          "requires": {
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^3.12.1",
-            "ono": "^4.0.11"
-          }
-        },
-        "redoc": {
-          "version": "2.0.0-rc.8-1",
-          "resolved": "https://registry.npmjs.org/redoc/-/redoc-2.0.0-rc.8-1.tgz",
-          "integrity": "sha512-/YoCdcl2QtveKz4CTXaqtOfCIaVgZZgcnfUNC5xK7xBl/LxTiNj3tUbgFmrYMLTZGzNdQ9TUJpsa7lXDKcr8Pw==",
-          "requires": {
-            "classnames": "^2.2.6",
-            "decko": "^1.2.0",
-            "dompurify": "^1.0.10",
-            "eventemitter3": "^3.0.0",
-            "json-pointer": "^0.6.0",
-            "json-schema-ref-parser": "^6.1.0",
-            "lunr": "2.3.6",
-            "mark.js": "^8.11.1",
-            "marked": "^0.6.1",
-            "memoize-one": "^5.0.0",
-            "mobx-react": "^5.4.3",
-            "openapi-sampler": "1.0.0-beta.14",
-            "perfect-scrollbar": "^1.4.0",
-            "polished": "^3.0.3",
-            "prismjs": "^1.15.0",
-            "prop-types": "^15.7.2",
-            "react-dropdown": "^1.6.4",
-            "react-hot-loader": "^4.8.0",
-            "react-tabs": "^3.0.0",
-            "slugify": "^1.3.4",
-            "stickyfill": "^1.1.1",
-            "swagger2openapi": "^5.2.3",
-            "tslib": "^1.9.3"
-          }
-        }
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stickyfill": {
       "version": "1.1.1",
@@ -10529,28 +8278,6 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "styled-components": {
       "version": "5.3.0",
@@ -10578,24 +8305,6 @@
         "has-flag": "^3.0.0"
       }
     },
-    "swagger2openapi": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.4.0.tgz",
-      "integrity": "sha512-f5QqfXawiVijhjMtYqWZ55ESHPZFqrPC8L9idhIiuSX8O2qsa1i4MVGtCM3TQF+Smzr/6WfT/7zBuzG3aTgPAA==",
-      "requires": {
-        "better-ajv-errors": "^0.6.1",
-        "call-me-maybe": "^1.0.1",
-        "node-fetch-h2": "^2.3.0",
-        "node-readfiles": "^0.2.0",
-        "oas-kit-common": "^1.0.7",
-        "oas-resolver": "^2.3.0",
-        "oas-schema-walker": "^1.1.3",
-        "oas-validator": "^3.4.0",
-        "reftools": "^1.1.0",
-        "yaml": "^1.8.3",
-        "yargs": "^12.0.5"
-      }
-    },
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -10616,35 +8325,11 @@
         "is-number": "^7.0.0"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
-    },
-    "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
-      }
-    },
     "uglify-js": {
       "version": "3.13.8",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
       "integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
       "optional": true
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -10664,80 +8349,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
-    "window-size": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
-    "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        }
-      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -10764,34 +8384,6 @@
       "version": "0.0.43",
       "resolved": "https://registry.npmjs.org/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz",
       "integrity": "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="
-    },
-    "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-      "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
-      }
-    },
-    "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
     }
   }
 }

--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -6,13 +6,12 @@
   "dependencies": {
     "@redocly/openapi-cli": "v1.0.0-beta.49",
     "redoc": "2.0.0-rc.53",
-    "redoc-cli": "^0.11.4",
-    "speccy": "^0.11.0"
+    "redoc-cli": "~0.11.4"
   },
   "scripts": {
-    "start": "npm run generate-bundle && \"$(npm bin)/redoc-cli\" serve --watch build/pepper.yaml",
-    "lint": "npm run generate-bundle && \"$(npm bin)/speccy\" lint --rules=\"rules.yml\" build/pepper.yaml",
-    "generate-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext yaml src/pepper.yml",
+    "start": "npx @redocly/openapi-cli preview-docs src/pepper.yml",
+    "lint": "npx @redocly/openapi-cli lint src/pepper.yml",
+    "generate-bundle": "npx @redocly/openapi-cli bundle --dereferenced --output build/pepper --ext yaml src/pepper.yml",
     "generate-json-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext json src/pepper.yml",
     "generate-docs": "\"$(npm bin)/redoc-cli\" bundle --output build/pepper.html src/pepper.yml",
     "generate-openapi-angular-client": "openapi-generator generate  -i  build/pepper.yaml -g typescript-angular -o generated-sources/openapi --additional-properties=\"ngVersion=8.0.0\""

--- a/pepper-apis/docs/specification/src/components/responses.yml
+++ b/pepper-apis/docs/specification/src/components/responses.yml
@@ -202,12 +202,6 @@ CancerSuggestionResponse:
             description: a list of `Cancer` suggestions with a possible list of substring matches of the query within the cancer name
             items:
               $ref: '../pepper.yml#/components/schemas/Suggestion.Cancer'
-ConsentErrorResponse:
-  description: failed to
-  content:
-    application/json:
-      schema:
-        $ref: '../pepper.yml#/components/schemas/Error.Consent'
 ErrorResponse:
   description: general server error
   content:
@@ -316,14 +310,6 @@ StudyDetailResponse:
     application/json:
       schema:
         $ref: '../pepper.yml#/components/schemas/Study.Detail'
-StudyWorkflowsResponse:
-  description: workflows and allowed statuses for a study
-  content:
-    application/json:
-      schema:
-        type: array
-        items:
-          $ref: '../pepper.yml#/components/schemas/Study.Workflow'
 StudySummaryResponse:
   description: summary information for a list of studies
   content:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -132,9 +132,9 @@ Activity:
     - sectionIndex
   properties:
     activityType:
-      $ref: '../pepper.yml#/components/schemas/ActivityType'
+      $ref: '#/ActivityType'
     formType:
-      $ref: '../pepper.yml#/components/schemas/FormType'
+      $ref: '#/FormType'
     activityCode:
       type: string
       format: guid
@@ -148,7 +148,7 @@ Activity:
       nullable: true
       description: guid for the parent activity instance in case this is a child activity instance
     statusCode:
-      $ref: "../pepper.yml#/components/schemas/ActivityInstanceStatusType"
+      $ref: "#/ActivityInstanceStatusType"
     title:
       type: string
       description: title of the activity to be displayed
@@ -171,15 +171,15 @@ Activity:
         `readonly` flag is `true`). If the `ddp-Content-Style` header is set to
         `BASIC`, this field will contain unstructured text.
     listStyleHint:
-      $ref: '../pepper.yml#/components/schemas/ListStyle'
+      $ref: '#/ListStyle'
     introduction:
-      $ref: '../pepper.yml#/components/schemas/Section'
+      $ref: '#/Section'
     sections:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/Section'
+        $ref: '#/Section'
     closing:
-      $ref: '../pepper.yml#/components/schemas/Section'
+      $ref: '#/Section'
     lastUpdatedText:
       type: string
       nullable: true
@@ -235,9 +235,9 @@ Activity.Summary:
       type: string
       format: guid
     activityType:
-      $ref: "../pepper.yml#/components/schemas/ActivityType"
+      $ref: "#/ActivityType"
     activitySubtype:
-      $ref: "../pepper.yml#/components/schemas/FormType"
+      $ref: "#/FormType"
     activityName:
       type: string
       description: name of the activity
@@ -289,7 +289,7 @@ Activity.Summary:
       example: false
       type: boolean
     statusCode:
-      $ref: "../pepper.yml#/components/schemas/ActivityInstanceStatusType"
+      $ref: "#/ActivityInstanceStatusType"
     canDelete:
       type: boolean
       description: whether the activity instance can be deleted
@@ -322,7 +322,7 @@ Answer:
       format: guid
 Answer.String:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
@@ -332,16 +332,16 @@ Answer.String:
           nullable: true
 Answer.Date:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
       properties:
         value:
-          $ref: '../pepper.yml#/components/schemas/DateValue'
+          $ref: '#/DateValue'
 Answer.Composite:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
@@ -352,12 +352,12 @@ Answer.Composite:
             type: array
             items:
               anyOf:
-                - $ref: '../pepper.yml#/components/schemas/Answer.Date'
-                - $ref: '../pepper.yml#/components/schemas/Answer.Picklist'
-                - $ref: '../pepper.yml#/components/schemas/Answer.String'
+                - $ref: '#/Answer.Date'
+                - $ref: '#/Answer.Picklist'
+                - $ref: '#/Answer.String'
 Answer.Boolean:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
@@ -366,31 +366,29 @@ Answer.Boolean:
           type: boolean
 Answer.File:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
       properties:
         value:
-          $ref: '../pepper.yml#/components/schemas/FileInfo'
+          $ref: '#/FileInfo'
 Answer.Numeric:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       discriminator:
         propertyName: numericType
         mapping:
-          INTEGER: '../pepper.yml#/components/schemas/Answer.Numeric.Integer'
+          INTEGER: '#/Answer.Numeric.Integer'
       required:
         - numericType
       properties:
         numericType:
           type: string
-          enum:
-            - INTEGER
 Answer.Numeric.Integer:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer.Numeric'
+    - $ref: '#/Answer.Numeric'
     - type: object
       required:
         - value
@@ -398,14 +396,12 @@ Answer.Numeric.Integer:
         numericType:
           type: string
           default: INTEGER
-          enum:
-            - INTEGER
         value:
           type: integer
           nullable: true
 Answer.Picklist:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Answer'
+    - $ref: '#/Answer'
     - type: object
       required:
         - value
@@ -413,7 +409,7 @@ Answer.Picklist:
         value:
           type: array
           items:
-            $ref: '../pepper.yml#/components/schemas/SelectedOption'
+            $ref: '#/SelectedOption'
 SelectedOption:
   type: object
   required:
@@ -475,7 +471,7 @@ AnswerSubmission:
       description: the identifier for the answer to update
 AnswerSubmission.Boolean:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -484,7 +480,7 @@ AnswerSubmission.Boolean:
           type: boolean
 AnswerSubmission.Composite:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -495,21 +491,21 @@ AnswerSubmission.Composite:
             type: array
             items:
               anyOf:
-                - $ref: '../pepper.yml#/components/schemas/AnswerSubmission.Date'
-                - $ref: '../pepper.yml#/components/schemas/AnswerSubmission.Picklist'
-                - $ref: '../pepper.yml#/components/schemas/AnswerSubmission.String'
+                - $ref: '#/AnswerSubmission.Date'
+                - $ref: '#/AnswerSubmission.Picklist'
+                - $ref: '#/AnswerSubmission.String'
 AnswerSubmission.Date:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
       properties:
         value:
-          $ref: '../pepper.yml#/components/schemas/DateValue'
+          $ref: '#/DateValue'
 AnswerSubmission.File:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -523,7 +519,7 @@ AnswerSubmission.File:
             value will unassociate it and the uploaded file will subsequently get deleted.
 AnswerSubmission.Numeric.Integer:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -533,7 +529,7 @@ AnswerSubmission.Numeric.Integer:
           nullable: true
 AnswerSubmission.Picklist:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -541,10 +537,10 @@ AnswerSubmission.Picklist:
         value:
           type: array
           items:
-            $ref: '../pepper.yml#/components/schemas/SelectedOption'
+            $ref: '#/SelectedOption'
 AnswerSubmission.String:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/AnswerSubmission'
+    - $ref: '#/AnswerSubmission'
     - type: object
       required:
         - value
@@ -574,7 +570,7 @@ Block:
       type: boolean
 Block.Component:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - component
@@ -586,7 +582,7 @@ Block.Component:
           enum:
             - COMPONENT
         component:
-          $ref: '../pepper.yml#/components/schemas/Component'
+          $ref: '#/Component'
         displayNumber:
           type: integer
           minimum: 1
@@ -594,7 +590,7 @@ Block.Component:
           description: the number to label this block, `null` if it shouldn't be numbered
 Block.Activity:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - renderHint
@@ -639,10 +635,10 @@ Block.Activity:
             (so the value will be `null` for the `icon` property).
           type: array
           items:
-            $ref: '../pepper.yml#/components/schemas/Activity.Summary'
+            $ref: '#/Activity.Summary'
 Block.Conditional:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - control
@@ -655,14 +651,14 @@ Block.Conditional:
           enum:
             - CONDITIONAL
         control:
-          $ref: '../pepper.yml#/components/schemas/Question'
+          $ref: '#/Question'
         nested:
           type: array
           items:
             anyOf:
-              - $ref: '../pepper.yml#/components/schemas/Block.Component'
-              - $ref: '../pepper.yml#/components/schemas/Block.Question'
-              - $ref: '../pepper.yml#/components/schemas/Block.Content'
+              - $ref: '#/Block.Component'
+              - $ref: '#/Block.Question'
+              - $ref: '#/Block.Content'
         displayNumber:
           type: integer
           minimum: 1
@@ -670,7 +666,7 @@ Block.Conditional:
           description: the number to label this block, `null` if it shouldn't be numbered
 Block.Grouped:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - listStyleHint
@@ -684,21 +680,21 @@ Block.Grouped:
           enum:
             - GROUP
         listStyleHint:
-          $ref: '../pepper.yml#/components/schemas/ListStyle'
+          $ref: '#/ListStyle'
         presentation:
-          $ref: '../pepper.yml#/components/schemas/Presentation'
+          $ref: '#/Presentation'
         title:
           type: string
         nested:
           type: array
           items:
             anyOf:
-              - $ref: '../pepper.yml#/components/schemas/Block.Component'
-              - $ref: '../pepper.yml#/components/schemas/Block.Question'
-              - $ref: '../pepper.yml#/components/schemas/Block.Content'
+              - $ref: '#/Block.Component'
+              - $ref: '#/Block.Question'
+              - $ref: '#/Block.Content'
 Block.Question:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - question
@@ -710,7 +706,7 @@ Block.Question:
           enum:
             - QUESTION
         question:
-          $ref: '../pepper.yml#/components/schemas/Question'
+          $ref: '#/Question'
         displayNumber:
           type: integer
           minimum: 1
@@ -718,7 +714,7 @@ Block.Question:
           description: the number to label this block, `null` if it shouldn't be numbered
 Block.Content:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Block'
+    - $ref: '#/Block'
     - type: object
       required:
         - body
@@ -754,7 +750,7 @@ Component:
       type: object
 Component.Physician:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Component'
+    - $ref: '#/Component'
     - type: object
       required:
         - componentType
@@ -785,7 +781,7 @@ Component.Physician:
               type: boolean
 Component.Institution:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Component'
+    - $ref: '#/Component'
     - type: object
       required:
         - componentType
@@ -817,7 +813,7 @@ Component.Institution:
               type: boolean
 Component.MailingAddress:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Component'
+    - $ref: '#/Component'
     - type: object
       required:
         - componentType
@@ -879,7 +875,7 @@ ConsentModel:
     elections:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/ElectionModel'
+        $ref: '#/ElectionModel'
 ElectionModel:
   type: object
   title: Election
@@ -897,7 +893,7 @@ ElectionModel:
       example: false
 Error.Activity:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -906,7 +902,7 @@ Error.Activity:
             - MALFORMED_ACCEPT_LANGUAGE_HEADER
 Error.ActivityNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -929,7 +925,7 @@ ValidationFailure:
       type: string
 Error.Consent:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -938,7 +934,7 @@ Error.Consent:
             - ACTIVITY_NOT_FOUND
 Error.ProfileGet:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -947,7 +943,7 @@ Error.ProfileGet:
             - MISSING_PROFILE
 Error.ProfileUpdate:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -961,7 +957,7 @@ Error.ProfileUpdate:
             - INVALID_DATE
 Error.ProfileAdd:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -974,7 +970,7 @@ Error.ProfileAdd:
             - INVALID_DATE
 Error.ProviderNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -983,7 +979,7 @@ Error.ProviderNotFound:
             - NOT_FOUND
 Error.StudyNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -992,7 +988,7 @@ Error.StudyNotFound:
             - STUDY_NOT_FOUND
 Error.UmbrellaNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1011,7 +1007,7 @@ Error:
       type: string
 Error.ActivityAnswersPatchBadPayload:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1025,7 +1021,7 @@ Error.ActivityAnswersPatchBadPayload:
             - UNEXPECTED_NUMBER_OF_ELEMENTS
 Error.ActivityAnswersInternalServerError:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1035,7 +1031,7 @@ Error.ActivityAnswersInternalServerError:
             - SERVER_ERROR
 Error.ActivityAnswersPatchInvalid:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1061,10 +1057,10 @@ Error.ActivityAnswersPatchInvalid:
               rules:
                 type: array
                 items:
-                  $ref: '../pepper.yml#/components/schemas/ValidationType'
+                  $ref: '#/ValidationType'
 Error.ActivityAnswersPatchNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1077,7 +1073,7 @@ Error.ActivityAnswersPatchNotFound:
             - USER_NOT_FOUND
 Error.ActivityAnswersPutInvalid:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1088,7 +1084,7 @@ Error.ActivityAnswersPutInvalid:
             - QUESTION_REQUIREMENTS_NOT_MET
 Error.ActivityAnswersPutNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1099,7 +1095,7 @@ Error.ActivityAnswersPutNotFound:
             - USER_NOT_FOUND
 Error.ActivityDetailNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1110,7 +1106,7 @@ Error.ActivityDetailNotFound:
             - USER_NOT_FOUND
 Error.BadPayload:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1119,7 +1115,7 @@ Error.BadPayload:
             - BAD_PAYLOAD
 Error.NotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1128,7 +1124,7 @@ Error.NotFound:
             - NOT_FOUND
 Error.OperationNotAllowed:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1137,7 +1133,7 @@ Error.OperationNotAllowed:
             - OPERATION_NOT_ALLOWED
 Error.RegisterNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1147,7 +1143,7 @@ Error.RegisterNotFound:
             - USER_NOT_FOUND
 Error.RegisterNotValid:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1157,7 +1153,7 @@ Error.RegisterNotValid:
             - NOT_SUPPORTED
 Error.StudyExit:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1167,7 +1163,7 @@ Error.StudyExit:
             - NOT_SUPPORTED
 Error.CreateActivityInstance:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1177,7 +1173,7 @@ Error.CreateActivityInstance:
             - TOO_MANY_INSTANCES
 Error.UserStudyActivityNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1188,7 +1184,7 @@ Error.UserStudyActivityNotFound:
             - USER_NOT_FOUND
 Error.UserStudyActivityQuestionNotFound:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Error'
+    - $ref: '#/Error'
     - type: object
       properties:
         code:
@@ -1226,7 +1222,7 @@ Participant:
       type: string
       example: Y9JJVE1MLN8AIZL8DO7D
     userProfile:
-      $ref: '../pepper.yml#/components/schemas/ProfileModel'
+      $ref: '#/ProfileModel'
 PicklistOption:
   type: object
   required:
@@ -1257,7 +1253,7 @@ PicklistOption:
     nestedOptions:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/PicklistOption'
+          $ref: '#/PicklistOption'
 PrequalifierModel:
   type: object
   required:
@@ -1367,18 +1363,18 @@ Question:
     validations:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/Validation'
+        $ref: '#/Validation'
     postConditionals:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/ConditionalRule'
+        $ref: '#/ConditionalRule'
     validationFailures:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/ValidationFailure'
+        $ref: '#/ValidationFailure'
 Question.Agreement:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - answers
@@ -1391,10 +1387,10 @@ Question.Agreement:
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Boolean'
+          $ref: '#/Answer.Boolean'
 Question.Boolean:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - answers
@@ -1415,10 +1411,10 @@ Question.Boolean:
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Boolean'
+          $ref: '#/Answer.Boolean'
 Question.Composite:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - allowMultiple
@@ -1448,9 +1444,9 @@ Question.Composite:
         description: 'The child questions to present'
         items:
           anyOf:
-            - $ref: '../pepper.yml#/components/schemas/Question.Date'
-            - $ref: '../pepper.yml#/components/schemas/Question.Picklist'
-            - $ref: '../pepper.yml#/components/schemas/Question.Text'
+            - $ref: '#/Question.Date'
+            - $ref: '#/Question.Picklist'
+            - $ref: '#/Question.Text'
       childOrientation:
         type: string
         nullable: true
@@ -1461,10 +1457,10 @@ Question.Composite:
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Composite'
+          $ref: '#/Answer.Composite'
 Question.Date:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - answers
@@ -1504,10 +1500,10 @@ Question.Date:
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Date'
+          $ref: '#/Answer.Date'
 Question.File:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Question'
+    - $ref: '#/Question'
     - type: object
       required:
         - answers
@@ -1532,10 +1528,10 @@ Question.File:
         answers:
           type: array
           items:
-            $ref: '../pepper.yml#/components/schemas/Answer.File'
+            $ref: '#/Answer.File'
 Question.Numeric:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - answers
@@ -1550,14 +1546,14 @@ Question.Numeric:
         type: string
         description: if present, this text string can be used as a placeholder hint
       numericType:
-        $ref: '../pepper.yml#/components/schemas/NumericType'
+        $ref: '#/NumericType'
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Numeric.Integer'
+          $ref: '#/Answer.Numeric.Integer'
 Question.Picklist:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - selectMode
@@ -1600,14 +1596,14 @@ Question.Picklist:
       picklistOptions:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/PicklistOption'
+          $ref: '#/PicklistOption'
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.Picklist'
+          $ref: '#/Answer.Picklist'
 Question.Text:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/Question'
+  - $ref: '#/Question'
   - type: object
     required:
       - answers
@@ -1656,7 +1652,7 @@ Question.Text:
       answers:
         type: array
         items:
-          $ref: '../pepper.yml#/components/schemas/Answer.String'
+          $ref: '#/Answer.String'
 Section:
   type: object
   required:
@@ -1665,11 +1661,11 @@ Section:
     name:
       type: string
     icon:
-      $ref: '../pepper.yml#/components/schemas/Image'
+      $ref: '#/Image'
     blocks:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/Block'
+        $ref: '#/Block'
 Study.Workflow:
   type: object
   properties:
@@ -1680,7 +1676,7 @@ Study.Workflow:
       type: array
       description: List of allowed states for this workflow
       items:
-        $ref: '../pepper.yml#/components/schemas/Study.WorkflowState'
+        $ref: '#/Study.WorkflowState'
 Study.WorkflowState:
   type: object
   description: A state within a workflow
@@ -1718,7 +1714,7 @@ Study.Summary:
       format: email
 Study.Detail:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Study.Summary'
+    - $ref: '#/Study.Summary'
     - type: object
       properties:
         summary:
@@ -1739,7 +1735,7 @@ Validation:
     - message
   properties:
     rule:
-      $ref: '../pepper.yml#/components/schemas/ValidationType'
+      $ref: '#/ValidationType'
     message:
       type: string
     allowSave:
@@ -1748,7 +1744,7 @@ Validation:
       default: false
 Validation.Required:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       properties:
         rule:
@@ -1758,7 +1754,7 @@ Validation.Required:
             - REQUIRED
 Validation.Complete:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       properties:
         rule:
@@ -1768,7 +1764,7 @@ Validation.Complete:
             - COMPLETE
 Validation.Length:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       required:
@@ -1788,7 +1784,7 @@ Validation.Length:
           minimum: 0
 Validation.RegularExpression:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       required:
@@ -1803,7 +1799,7 @@ Validation.RegularExpression:
           type: string
 Validation.OptionsSelected:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       properties:
@@ -1820,7 +1816,7 @@ Validation.OptionsSelected:
           minimum: 0
 Validation.DayRequired:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       properties:
@@ -1831,7 +1827,7 @@ Validation.DayRequired:
             - DAY_REQUIRED
 Validation.MonthRequired:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       properties:
@@ -1842,7 +1838,7 @@ Validation.MonthRequired:
             - MONTH_REQUIRED
 Validation.YearRequired:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       deprecated: true
       properties:
@@ -1853,7 +1849,7 @@ Validation.YearRequired:
             - YEAR_REQUIRED
 Validation.DateRange:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       required:
         - startDate
@@ -1876,7 +1872,7 @@ Validation.DateRange:
           format: date
 Validation.AgeRange:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       properties:
         rule:
@@ -1894,7 +1890,7 @@ Validation.AgeRange:
           nullable: true
 Validation.IntRange:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/Validation'
+    - $ref: '#/Validation'
     - type: object
       properties:
         rule:
@@ -1946,13 +1942,13 @@ Suggestion.Drug:
   type: object
   properties:
     drug:
-      $ref: '../pepper.yml#/components/schemas/Drug'
+      $ref: '#/Drug'
     matches:
       type: array
       description: Contains a list of substring matches for the given `Drug`. The substrings are based within the drug's `name` property.
       minItems: 0
       items:
-        $ref: '../pepper.yml#/components/schemas/Suggestion.Match'
+        $ref: '#/Suggestion.Match'
 Cancer:
   type: object
   required:
@@ -1974,13 +1970,13 @@ Suggestion.Cancer:
   type: object
   properties:
     cancer:
-      $ref: '../pepper.yml#/components/schemas/Cancer'
+      $ref: '#/Cancer'
     matches:
       type: array
       description: Contains a list of substring matches for the given `Cancer` name. The substrings are based within the cancer `name` property.
       minItems: 0
       items:
-        $ref: '../pepper.yml#/components/schemas/Suggestion.Match'
+        $ref: '#/Suggestion.Match'
 Suggestion.Institution:
   type: object
   required:
@@ -2034,7 +2030,7 @@ BaseMailAddress:
       type: string
 MailingAddress:
   allOf:
-    - $ref: '../pepper.yml#/components/schemas/BaseMailAddress'
+    - $ref: '#/BaseMailAddress'
     - type: object
       description: a participant's mailing address, to be used for delivery.
       properties:
@@ -2099,7 +2095,7 @@ AddressVerifyError:
       type: array
       description: errors for specific fields of the address
       items:
-        $ref: '../pepper.yml#/components/schemas/AddressFieldError'
+        $ref: '#/AddressFieldError'
 AddressFieldError:
   type: object
   required:
@@ -2206,7 +2202,7 @@ ParticipantStatus:
       description: Contains a list samples records for the participant
       minItems: 0
       items:
-        $ref: '../pepper.yml#/components/schemas/ParticipantStatus.Sample'
+        $ref: '#/ParticipantStatus.Sample'
 ParticipantStatus.Sample:
   type: object
   required:
@@ -2230,20 +2226,20 @@ ParticipantStatusTrackingInfo:
     - kits
   properties:
     medicalRecord:
-      $ref: '../pepper.yml#/components/schemas/ParticipantStatusTrackingInfo.Record'
+      $ref: '#/ParticipantStatusTrackingInfo.Record'
     tissueRecord:
-      $ref: '../pepper.yml#/components/schemas/ParticipantStatusTrackingInfo.Record'
+      $ref: '#/ParticipantStatusTrackingInfo.Record'
     kits:
       type: array
       description: Contains a list of kits sent to the participant
       minItems: 0
       items:
-        $ref: '../pepper.yml#/components/schemas/ParticipantStatusTrackingInfo.Kit'
+        $ref: '#/ParticipantStatusTrackingInfo.Kit'
     workflows:
       type: array
       minItems: 0
       items:
-        $ref: '../pepper.yml#/components/schemas/ParticipantStatusTrackingInfo.Workflow'
+        $ref: '#/ParticipantStatusTrackingInfo.Workflow'
 ParticipantStatusTrackingInfo.Workflow:
   type: object
   properties:
@@ -2366,7 +2362,7 @@ WorkflowNextSuggestion:
         - UNKNOWN
 WorkflowNextSuggestion.Activity:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/WorkflowNextSuggestion'
+  - $ref: '#/WorkflowNextSuggestion'
   - type: object
     required:
       - activityCode
@@ -2384,7 +2380,7 @@ WorkflowNextSuggestion.Activity:
         description: Whether the next activity allows access to temporary users. If `false`, user will need to authenticate in order to access activity.
 WorkflowNextSuggestion.Static:
   allOf:
-  - $ref: '../pepper.yml#/components/schemas/WorkflowNextSuggestion'
+  - $ref: '#/WorkflowNextSuggestion'
   - type: object
     properties:
       next:
@@ -2423,7 +2419,7 @@ Statistics.Figure.Item.Data:
     count:
       type: string
     optionDetails:
-      $ref: '../pepper.yml#/components/schemas/PicklistOption'
+      $ref: '#/PicklistOption'
 Statistics.Figure.Item:
   type: object
   properties:
@@ -2431,20 +2427,20 @@ Statistics.Figure.Item:
       type: string
       description: Statistics item title
     data:
-      $ref: '../pepper.yml#/components/schemas/Statistics.Figure.Item.Data'
+      $ref: '#/Statistics.Figure.Item.Data'
 Statistics.Figure:
   type: object
   properties:
     configuration:
-      $ref: '../pepper.yml#/components/schemas/Statistics.Configuration'
+      $ref: '#/Statistics.Configuration'
     statistics:
       type: array
       items:
-        $ref: '../pepper.yml#/components/schemas/Statistics.Figure.Item'
+        $ref: '#/Statistics.Figure.Item'
 Statistics:
   type: array
   items:
-    $ref: '../pepper.yml#/components/schemas/Statistics.Figure'
+    $ref: '#/Statistics.Figure'
 
 EnrollmentStatusType:
   description: Participant's enrollment status
@@ -2485,7 +2481,7 @@ ParticipantsLookupResultItem:
       type: string
       nullable: true
     status:
-      $ref: '../pepper.yml#/components/schemas/EnrollmentStatusType'
+      $ref: '#/EnrollmentStatusType'
     firstName:
       description: Participant's first name, if available
       type: string
@@ -2504,7 +2500,7 @@ ParticipantsLookupResultItem:
       type: string
       nullable: true
     proxy:
-      $ref: '../pepper.yml#/components/schemas/ParticipantsLookupProxyItem'
+      $ref: '#/ParticipantsLookupProxyItem'
 ParticipantsLookupProxyItem:
   description: The proxy if the participant is a govnerned user
   type: object

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -189,7 +189,7 @@ Activity:
         will contain unstructured text.
     lastUpdated:
       type: string
-      format: YYYY-MM-DDThhmmss.sss (ISO-8601)
+      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
       nullable: true
       description: The date time the activity definition (NOT the instance) was last updated
     canDelete:
@@ -2146,24 +2146,27 @@ Invitation:
       description: the id of the invitation
       type: string
     createdAt:
-      description: timestamp of when invitation was created, in ISO-8601 UTC format
+      description: timestamp of when invitation was created.
       type: string
       example: 2020-05-13T17:58:33.887Z
+      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
     voidedAt:
-      description: timestamp of when invitation was voided, making the invitation invalid, in ISO-8601 UTC format
+      description: timestamp of when invitation was voided, making the invitation invalid.
       type: string
       nullable: true
       example: null
     verifiedAt:
-      description: timestamp of when invitation was verified, indicating user has acknowledged receiving the invitation, in ISO-8601 UTC format
+      description: timestamp of when invitation was verified, indicating user has acknowledged receiving the invitation.
       type: string
       nullable: true
       example: 2020-05-13T18:58:33.887Z
+      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
     acceptedAt:
-      description: timestamp of when invitation was accepted, in ISO-8601 UTC format
+      description: timestamp of when invitation was accepted.
       type: string
       nullable: true
       example: 2020-05-13T19:58:33.887Z
+      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
 
 MedicalProvider:
   type: object
@@ -2252,7 +2255,7 @@ ParticipantStatusTrackingInfo.Workflow:
       description: The current state in the workflow
     date:
       type: string
-      format: YYYY-MM-DDThhmmss.sss (ISO-8601)
+      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
       description: Last changed
       example: 2021-04-18T14:09:37.123Z
 ParticipantStatusTrackingInfo.Record:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -6,6 +6,7 @@ ActivityType:
 ActivityInstanceStatusType:
   title: ActivityInstanceStatusType
   type: string
+  example: IN_PROGRESS
   enum:
     - COMPLETE
     - CREATED
@@ -143,7 +144,6 @@ Activity:
       description: guid for the parent activity instance in case this is a child activity instance
     statusCode:
       $ref: "../pepper.yml#/components/schemas/ActivityInstanceStatusType"
-      example: IN_PROGRESS
     title:
       type: string
       description: title of the activity to be displayed
@@ -276,7 +276,6 @@ Activity.Summary:
       type: boolean
     statusCode:
       $ref: "../pepper.yml#/components/schemas/ActivityInstanceStatusType"
-      example: IN_PROGRESS
     canDelete:
       type: boolean
       description: whether the activity instance can be deleted

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -296,8 +296,10 @@ Activity.Summary:
     isFollowup:
       description: true if the activity is generally considered to be an activity that comes after the "main" activities
       type: boolean
+      default: false
     isHidden:
       type: boolean
+      default: false
       description: |
         Whether the activity instance is hidden from the participant. When
         true, client should prefer to show some indicator to operator that

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -18,13 +18,6 @@ FormType:
     - CONSENT
     - GENERAL
     - PREQUALIFIER
-InstitutionType:
-  title: InstitutionType
-  type: string
-  enum:
-    - INITIAL_BIOPSY
-    - INSTITUTION
-    - PHYSICIAN
 JoinMailingListPayload:
   type: object
   title: JoinMailingListPayload
@@ -1708,24 +1701,6 @@ Section:
       type: array
       items:
         $ref: '#/Block'
-Study.Workflow:
-  type: object
-  properties:
-    name:
-      type: string
-      description: the name of the workflow, for example "DEVICE_REGISTRATION"
-    states:
-      type: array
-      description: List of allowed states for this workflow
-      items:
-        $ref: '#/Study.WorkflowState'
-Study.WorkflowState:
-  type: object
-  description: A state within a workflow
-  properties:
-    name:
-      type: string
-      description: the name of the state, such as "Accepted" or "Scheduled"
 Study.Summary:
   type: object
   required:
@@ -2235,43 +2210,6 @@ MedicalProvider:
       type: string
     state:
       type: string
-### Participant status
-ParticipantStatus:
-  type: object
-  required:
-    - samples
-  properties:
-    mrRequested:
-      type: integer
-    mrReceived:
-      type: integer
-    tissueRequested:
-      type: integer
-    tissueSent:
-      type: integer
-    tissueReceived:
-      type: integer
-    samples:
-      type: array
-      description: Contains a list samples records for the participant
-      minItems: 0
-      items:
-        $ref: '#/ParticipantStatus.Sample'
-ParticipantStatus.Sample:
-  type: object
-  required:
-    - sent
-  properties:
-    kitType:
-      type: string
-    sent:
-      type: integer
-    trackingId:
-      type: string
-    carrier:
-      type: string
-    received:
-      type: integer
 ParticipantStatusTrackingInfo:
   type: object
   required:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -189,7 +189,7 @@ Activity:
         will contain unstructured text.
     lastUpdated:
       type: string
-      format: date-time
+      format: YYYY-MM-DDThhmmss.sss (ISO-8601)
       nullable: true
       description: The date time the activity definition (NOT the instance) was last updated
     canDelete:
@@ -1868,10 +1868,12 @@ Validation.DateRange:
           type: string
           description: the minimum date required to be considered valid. This value is inclusive. The date format is a full, extended ISO-8601 Calendar date in the format `YYYY-MM-DD` in the UTC time zone.
           nullable: true
+          format: date
         endDate:
           type: string
           description: the maximum date required to be considered valid. This value is inclusive. The date format is a full, extended ISO-8601 Calendar date in the format `YYYY-MM-DD` in the UTC time zone.
           nullable: true
+          format: date
 Validation.AgeRange:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Validation'
@@ -2250,7 +2252,7 @@ ParticipantStatusTrackingInfo.Workflow:
       description: The current state in the workflow
     date:
       type: string
-      format: date-time
+      format: YYYY-MM-DDThhmmss.sss (ISO-8601)
       description: Last changed
       example: 2021-04-18T14:09:37.123Z
 ParticipantStatusTrackingInfo.Record:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -33,17 +33,17 @@ JoinMailingListPayload:
     - emailAddress
   properties:
     firstName:
-      description: users first name
+      description: user's first name
       type: string
       example: John
       minLength: 0
     lastName:
-      description: users last name
+      description: user's last name
       type: string
       example: Doe
       minLength: 0
     emailAddress:
-      description: users email address
+      description: user's email address
       type: string
       example: john.doe@example.com
     info:
@@ -1655,7 +1655,7 @@ Study.Workflow:
   properties:
     name:
       type: string
-      description: the name of the worklflow, for example "DEVICE_REGISTRATION"
+      description: the name of the workflow, for example "DEVICE_REGISTRATION"
     states:
       type: array
       description: List of allowed states for this workflow

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -182,7 +182,7 @@ Activity:
         will contain unstructured text.
     lastUpdated:
       type: string
-      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
+      format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
       nullable: true
       description: The date time the activity definition (NOT the instance) was last updated
     canDelete:
@@ -2174,7 +2174,7 @@ Invitation:
       description: timestamp of when invitation was created.
       type: string
       example: 2020-05-13T17:58:33.887Z
-      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
+      format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
     voidedAt:
       description: timestamp of when invitation was voided, making the invitation invalid.
       type: string
@@ -2185,13 +2185,13 @@ Invitation:
       type: string
       nullable: true
       example: 2020-05-13T18:58:33.887Z
-      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
+      format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
     acceptedAt:
       description: timestamp of when invitation was accepted.
       type: string
       nullable: true
       example: 2020-05-13T19:58:33.887Z
-      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
+      format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
 
 MedicalProvider:
   type: object
@@ -2243,7 +2243,7 @@ ParticipantStatusTrackingInfo.Workflow:
       description: The current state in the workflow
     date:
       type: string
-      format: YYYY-MM-DDThhmmss.sssZ (ISO-8601)
+      format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
       description: Last changed
       example: 2021-04-18T14:09:37.123Z
 ParticipantStatusTrackingInfo.Record:

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -314,12 +314,26 @@ Activity.Summary:
 ###
 Answer:
   type: object
+  discriminator:
+    propertyName: type
+    mapping:
+      AGREEMENT: '#/Answer.Boolean'
+      BOOLEAN: '#/Answer.Boolean'
+      COMPOSITE: '#/Answer.Composite'
+      DATE: '#/Answer.Date'
+      FILE: '#/Answer.File'
+      NUMERIC: '#/Answer.Numeric'
+      PICKLIST: '#/Answer.Picklist'
+      TEXT: '#/Answer.String'
   required:
     - answerGuid
+    - type
   properties:
     answerGuid:
       type: string
       format: guid
+    type:
+      type: string
 Answer.String:
   allOf:
     - $ref: '#/Answer'
@@ -458,17 +472,29 @@ FileInfo:
 AnswerSubmission:
   type: object
   discriminator:
-    propertyName: value
+    propertyName: type
+    mapping:
+      AGREEMENT: '#/AnswerSubmission.Boolean'
+      BOOLEAN: '#/AnswerSubmission.Boolean'
+      COMPOSITE: '#/AnswerSubmission.Composite'
+      DATE: '#/AnswerSubmission.Date'
+      FILE: '#/AnswerSubmission.File'
+      NUMERIC: '#/AnswerSubmission.Numeric.Integer'
+      PICKLIST: '#/AnswerSubmission.Picklist'
+      TEXT: '#/AnswerSubmission.String'
   required:
     - stableId
-    - value
   properties:
     stableId:
       type: string
       description: question identifier that the answer is for
     answerGuid:
       type: string
-      description: the identifier for the answer to update
+      format: guid
+      nullable: true
+      description: the existing answer guid if this is an update
+    type:
+      type: string
 AnswerSubmission.Boolean:
   allOf:
     - $ref: '#/AnswerSubmission'
@@ -556,6 +582,13 @@ Block:
   type: object
   discriminator:
     propertyName: blockType
+    mapping:
+      ACTIVITY: '#/Block.Activity'
+      COMPONENT: '#/Block.Component'
+      CONDITIONAL: '#/Block.Conditional'
+      CONTENT: '#/Block.Content'
+      GROUP: '#/Block.Grouped'
+      QUESTION: '#/Block.Question'
   required:
     - blockType
     - blockGuid
@@ -737,15 +770,15 @@ Component:
   type: object
   discriminator:
     propertyName: componentType
+    mapping:
+      PHYSICIAN: '#/Component.Physician'
+      INSTITUTION: '#/Component.Institution'
+      MAILING_ADDRESS:  '#/Component.MailingAddress'
   required:
     - componentType
   properties:
     componentType:
       type: string
-      enum:
-        - PHYSICIAN
-        - INSTITUTION
-        - MAILING_ADDRESS
     parameters:
       type: object
 Component.Physician:
@@ -1327,6 +1360,15 @@ Question:
   type: object
   discriminator:
     propertyName: questionType
+    mapping:
+      AGREEMENT: '#/Question.Agreement'
+      BOOLEAN: '#/Question.Boolean'
+      COMPOSITE: '#/Question.Composite'
+      DATE: '#/Question.Date'
+      FILE: '#/Question.File'
+      NUMERIC: '#/Question.Numeric'
+      PICKLIST: '#/Question.Picklist'
+      TEXT: '#/Question.Text'
   required:
   - questionType
   - stableId
@@ -1730,6 +1772,18 @@ Validation:
   type: object
   discriminator:
     propertyName: rule
+    mapping:
+      AGE_RANGE: '#/Validation.AgeRange'
+      COMPLETE: '#/Validation.Complete'
+      DATE_RANGE: '#/Validation.DateRange'
+      DAY_REQUIRED: '#/Validation.DayRequired'
+      INT_RANGE: '#/Validation.IntRange'
+      LENGTH: '#/Validation.Length'
+      MONTH_REQUIRED: '#/Validation.MonthRequired'
+      NUM_OPTIONS_SELECTED: '#/Validation.OptionsSelected'
+      REGEX: '#/Validation.RegularExpression'
+      REQUIRED: '#/Validation.Required'
+      YEAR_REQUIRED: '#/Validation.YearRequired'
   required:
     - rule
     - message
@@ -2341,6 +2395,13 @@ WorkflowNextSuggestion:
   type: object
   discriminator:
     propertyName: next
+    mapping:
+      ACTIVITY: '#/WorkflowNextSuggestion.Activity'
+      DASHBOARD: '#/WorkflowNextSuggestion.Static'
+      MAILING_LIST: '#/WorkflowNextSuggestion.Static'
+      PARTICIPANT_LIST: '#/WorkflowNextSuggestion.Static'
+      THANK_YOU: '#/WorkflowNextSuggestion.Static'
+      UNKNOWN: '#/WorkflowNextSuggestion.Static'
   required:
     - next
   properties:
@@ -2353,13 +2414,6 @@ WorkflowNextSuggestion:
         * `THANK_YOU` - Indicates end of workflow and a thank you message should be shown.
         * `PARTICIPANT_LIST` - Indicates the list of governed users.
         * `UNKNOWN` - No suggestions available.
-      enum:
-        - ACTIVITY
-        - DASHBOARD
-        - MAILING_LIST
-        - THANK_YOU
-        - PARTICIPANT_LIST
-        - UNKNOWN
 WorkflowNextSuggestion.Activity:
   allOf:
   - $ref: '#/WorkflowNextSuggestion'
@@ -2387,8 +2441,9 @@ WorkflowNextSuggestion.Static:
         type: string
         enum:
           - DASHBOARD
-          - THANK_YOU
+          - MAILING_LIST
           - PARTICIPANT_LIST
+          - THANK_YOU
           - UNKNOWN
 Statistics.Configuration:
   type: object

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -161,6 +161,8 @@ Activity:
         unstructured text.
     readonly:
       type: boolean
+      default: false
+      description: false if the activity can be modified.
     readonlyHint:
       type: string
       nullable: true

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -46,6 +46,7 @@ JoinMailingListPayload:
     emailAddress:
       description: user's email address
       type: string
+      format: email
       example: john.doe@example.com
     info:
       description: Strings providing context about which umbrella based mailing list the user is interested in. Usually list of diseases
@@ -58,15 +59,17 @@ JoinMailingListPayload:
       description: The umbrella id of the mailing list the user is interested in (one of umbrellaId OR studyGuid but not both is required)
       example: cmi
       type: string
+      format: guid
     studyGuid:
       description: The studyGuid of the mailing list the user is interested in (one of umbrellaId OR studyGuid but not both is required)
       example: ANGIO
       type: string
+      format: guid
     isoLanguageCode:
       description: preferred language code of join mailing list user. If language code is not set, defaults to study default language.
       type: string
       nullable: true
-      format: ISO 639-1 standard
+      format: ISO 639-1
       example: en
 
 ListStyle:
@@ -134,9 +137,11 @@ Activity:
       $ref: '../pepper.yml#/components/schemas/FormType'
     activityCode:
       type: string
+      format: guid
       description: unique identifier of the activity
     guid:
       type: string
+      format: guid
       description: unique identifier for this instance of the activity
     parentInstanceGuid:
       type: string
@@ -226,6 +231,7 @@ Activity.Summary:
       description: the source activity for this instance
       example: ABCDEFGH12
       type: string
+      format: guid
     activityType:
       $ref: "../pepper.yml#/components/schemas/ActivityType"
     activitySubtype:
@@ -249,26 +255,32 @@ Activity.Summary:
       nullable: true
     createdAt:
       type: integer
+      format: int64
       description: The creation timestamp of the activity instance, in milliseconds since `1970-01-01T00:00:00Z` (UNIX time)
     icon:
       description: a Base64 encoded png or jpg image
       example: YW55IGN...BwbGVhc3VyZQ==
       type: string
+      format: base64
       nullable: true
     instanceGuid:
       example: 6B03213FD0
       type: string
+      format: guid
     parentInstanceGuid:
       description: guid for the parent activity instance in case this is a child activity instance
       type: string
+      format: guid
       nullable: true
     numQuestions:
       description: number of questions in this activity
       example: 4
       type: integer
+      minimum: 0
     numQuestionsAnswered:
       description: number of questions that have been answered in this activity
       example: 1
+      minimum: 0
       type: integer
     readonly:
       description: false if the activity can be modified
@@ -291,6 +303,7 @@ Activity.Summary:
     previousInstanceGuid:
       description: GUID of previous instance
       type: string
+      format: guid
 ######
 #
 # Answers
@@ -302,6 +315,7 @@ Answer:
   properties:
     answerGuid:
       type: string
+      format: guid
 Answer.String:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Answer'
@@ -404,6 +418,7 @@ SelectedOption:
   properties:
     stableId:
       type: string
+      format: guid
     detail:
       type: string
       nullable: true
@@ -439,6 +454,7 @@ FileInfo:
     fileSize:
       type: integer
       description: Size of the file in bytes
+      minimum: 0
 AnswerSubmission:
   type: object
   discriminator:
@@ -549,6 +565,7 @@ Block:
       type: string
     blockGuid:
       type: string
+      format: guid
     shown:
       type: boolean
 Block.Component:
@@ -1676,18 +1693,25 @@ Study.Summary:
   properties:
     studyGuid:
       type: string
+      format: guid
     name:
       type: string
     participantCount:
       type: integer
       minimum: 0
+      description: The total number of consented participants in a study. This is a subset of the registered users.
     registeredCount:
       type: integer
       minimum: 0
+      description: The total number of registered users in a study.
     restricted:
       type: boolean
+      default: false
+      description: |
+        `true` if the study requires an IRB password for access.
     studyEmail:
-        type: string
+      type: string
+      format: email
 Study.Detail:
   allOf:
     - $ref: '../pepper.yml#/components/schemas/Study.Summary'
@@ -2143,6 +2167,7 @@ MedicalProvider:
     medicalProviderGuid:
       type: string
       readOnly: true
+      format: guid
     institutionName:
       type: string
     physicianName:

--- a/pepper-apis/docs/specification/src/endpoints/autocomplete.institution.yml
+++ b/pepper-apis/docs/specification/src/endpoints/autocomplete.institution.yml
@@ -2,7 +2,7 @@ get:
   operationId: getInstitutionSuggestions
   tags:
     - Suggestion
-  description: fetches a list of medical institution suggestions
+  summary: fetches a list of medical institution suggestions
   parameters:
     - in: query
       name: namePattern

--- a/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
+++ b/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
@@ -2,8 +2,8 @@ post:
   operationId: joinMailingList
   tags:
     - Studies
-  summary: Add a user to a email list
-  description: add a user to a study's email list or to a mailing list for a study that does not exist
+  summary: Add a user to an email list
+  description: add a user to a study's email list, or to a mailing list for a study that does not exist
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/JoinMailingListPayload'
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
+++ b/pepper-apis/docs/specification/src/endpoints/join.mailing.list.yml
@@ -2,8 +2,8 @@ post:
   operationId: joinMailingList
   tags:
     - Studies
-  summary: joinMailingList
-  description: add a user to a studies email list or to a mailing list for a study that does not exist
+  summary: Add a user to a email list
+  description: add a user to a study's email list or to a mailing list for a study that does not exist
   requestBody:
     $ref: '../pepper.yml#/components/requestBodies/JoinMailingListPayload'
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.email.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.email.yml
@@ -2,8 +2,8 @@ patch:
   operationId: updateUserEmail
   tags:
     - Operator & Participant
-  summary: update email for a user
-  description: updates user email in Auth0
+  summary: Update a user's email address
+  description: Update a user's Auth0 email address.
   parameters:
     - in: path
       name: user

--- a/pepper-apis/docs/specification/src/endpoints/user.password.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.password.yml
@@ -2,8 +2,8 @@ patch:
   operationId: updateUserPassword
   tags:
     - Operator & Participant
-  summary: update password for a user
-  description: updates user password in Auth0
+  summary: Update a user's password
+  description: Update a user's Auth0 password
   parameters:
     - in: path
       name: user

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.default.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.default.yml
@@ -8,7 +8,7 @@ parameters:
 
 get:
   operationId: getDefaultMailingAddress
-  description: fetch the default mailing address for a participant 
+  summary: Get the default mailing address for a participant
   tags:
     - Mailing Address
   responses:
@@ -19,7 +19,7 @@ get:
 
 post:
   operationId: setDefaultMailingAddress
-  description: set the new default mailing address for a participant
+  summary: Set the default mailing address for a participant
   tags:
     - Mailing Address
   requestBody:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.temp.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.temp.yml
@@ -14,7 +14,7 @@ parameters:
 
 get:
   operationId: getTemporaryMailingAddress
-  summary: fetch the temporary mailing address for a participant
+  summary: Get a participant's temporary mailing address
   description: Fetches the current temporary mailing address for a given participant and study, if one exists.
   tags:
     - Mailing Address
@@ -26,7 +26,7 @@ get:
 
 put:
   operationId: updateTemporaryMailingAddress
-  description: update a participant's temporary mailing address
+  summary: Update a participant's temporary mailing address
   tags:
     - Mailing Address
   requestBody:
@@ -39,7 +39,7 @@ put:
 
 delete:
   operationId: deleteTemporaryMailingAddress
-  description: removed the temporary mailing address for a participant
+  summary: Delete a patient's temporary mailing address
   tags:
     - Mailing Address
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.temp.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.temp.yml
@@ -39,7 +39,7 @@ put:
 
 delete:
   operationId: deleteTemporaryMailingAddress
-  summary: Delete a patient's temporary mailing address
+  summary: Delete a participant's temporary mailing address
   tags:
     - Mailing Address
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.address.yml
@@ -14,7 +14,7 @@ parameters:
 
 get:
   operationId: getMailingAddress
-  description: fetch the specified saved address for a participant
+  summary: Get the specified mailing address for a participant
   tags:
     - Mailing Address
   responses:
@@ -25,7 +25,7 @@ get:
 
 put:
   operationId: updateMailingAddress
-  description: updates the specified saved address
+  summary: Update an existing mailing address for a participant
   tags:
     - Mailing Address
   parameters:
@@ -52,6 +52,7 @@ put:
 
 delete:
   operationId: deleteMailingAddress
+  summary: Delete an existing mailing address for a participant
   description: removes the specified saved address for a participant. If this address is the participant's default address, the participant will no longer have a default address set.
   tags:
     - Mailing Address

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.verify.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.verify.yml
@@ -8,6 +8,7 @@ parameters:
 
 post:
   operationId: verifyMailingAddress
+  summary: Check a mailing address for deliverability
   description: verify address for a participant to ensure deliverability
   tags:
     - Mailing Address

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.addresses.yml
@@ -8,7 +8,7 @@ parameters:
 
 get:
   operationId: getMailingAddresses
-  description: fetch all saved addresses for a participant
+  summary: Get all the mailing addresses for a participant
   tags:
     - Mailing Address
   responses:
@@ -19,7 +19,7 @@ get:
 
 post:
   operationId: createMailingAddress
-  description: save a new address for a participant
+  summary: Create a new mailing address for a participant
   tags:
     - Mailing Address
   parameters:

--- a/pepper-apis/docs/specification/src/endpoints/user.profile.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.profile.yml
@@ -2,6 +2,7 @@ get:
   operationId: getUserProfile
   tags:
     - Operator & Participant
+  summary: Get the profile for a user
   description: |
     return the user's profile
 
@@ -24,7 +25,7 @@ post:
   operationId: createUserProfile
   tags:
     - Operator & Participant
-  description: create a new profile for a user
+  summary: Create a new user profile
   parameters:
     - in: path
       name: user
@@ -45,7 +46,7 @@ patch:
   operationId: updateUserProfile
   tags:
     - Operator & Participant
-  description: update the user's profile
+  summary: Update a user's profile
   parameters:
     - in: path
       name: user

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.medical-provider.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.medical-provider.yml
@@ -30,7 +30,7 @@ parameters:
 
 patch:
   operationId: updateMedicalProvider
-  description: Updates the specified medical provider
+  summary: Update the specified medical provider
   tags:
     - Medical Providers
   requestBody:
@@ -43,7 +43,7 @@ patch:
 
 delete:
   operationId: deleteMedicalProvider
-  description: Deletes the specified saved medical provider for a participant
+  summary: Delete the specified medical provider for a participant
   tags:
     - Medical Providers
   responses:

--- a/pepper-apis/docs/specification/src/endpoints/user.studies.medical-providers.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.studies.medical-providers.yml
@@ -24,7 +24,7 @@ parameters:
 
 get:
   operationId: fetchAllMedicalProviders
-  description: fetches all of a participant's saved medical providers
+  summary: Fetch all a participant's saved medical providers
   tags:
     - Medical Providers
   responses:
@@ -35,7 +35,7 @@ get:
 
 post:
   operationId: createMedicalProvider
-  description: saves a new medical provider for a participant
+  summary: Create a new medical provider for a participant
   tags:
     - Medical Providers
   requestBody:

--- a/pepper-apis/docs/specification/src/endpoints/user.yml
+++ b/pepper-apis/docs/specification/src/endpoints/user.yml
@@ -8,6 +8,7 @@ parameters:
 
 delete:
   operationId: deleteUser
+  summary: Delete a user
   description: |
     Remove user.
 

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -1,11 +1,18 @@
-openapi: 3.0.0
-servers: []
+openapi: 3.0.3
+servers:
+  - url: https://pepper-dev.datadonationplatform.org/pepper/v1
+    description: Development server (uses test data)
+  - url: https://pepper.datadonationplatform.org/pepper/v1
+    description: Production server (uses real data)
 info:
   description: 'Pepper API specification'
   version: 1.9.8
   title: Pepper
   contact:
     email: info@datadonationplatform.org
+  license:
+    name: BSD 3-Clause (Revised)
+    url: https://raw.githubusercontent.com/broadinstitute/ddp-study-server/develop/LICENSE
 tags:
   - name: Admin
     description: administrative & internal calls


### PR DESCRIPTION
## Context

* Cleanup of discriminator use
* Cleanup of some date/time format descriptions
* Adds more `format` and `description` elements
* Removes `speccy` and switches to [redocly/openapi-cli](https://github.com/Redocly/openapi-cli)
* Updates summaries to fix linter errors, and prevent operation ids from appearing in the index column
* Removed unreferenced types & schemas

![Mailing Address Before & After](https://user-images.githubusercontent.com/274456/121087446-78386500-c7b2-11eb-8549-abcbee134237.png)


Cc. @yufengwng @ssettipalli 

## FUD Score

- [x] :relaxed: All good, business as usual

## How do we demo these changes?

in `docs/specification` run `npm run start`. The docs can then be accessed at `http://127.0.0.1:8080`

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

