### PR TITLE
DDP-6295 ES: update participant_structured index template

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -330,18 +330,58 @@
             }
           }
         },
-        "workflows": {
+        "samples": {
           "properties": {
-            "date": {
+            "bspCollaboratorParticipantId": {
+              "type": "keyword"
+            },
+            "bspCollaboratorSampleId": {
+              "type": "keyword"
+            },
+            "carrier": {
+              "type": "keyword"
+            },
+            "kitRequestId": {
+              "type": "keyword"
+            },
+            "kitType": {
+              "type": "keyword"
+            },
+            "trackingIn": {
+              "type": "keyword"
+            },
+            "trackingOut": {
+              "type": "keyword"
+            },
+            "sent": {
               "type": "date",
               "ignore_malformed": false,
-              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+              "format": "strict_year_month_day"
+            },
+            "delivered": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_year_month_day"
+            },
+            "received": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_year_month_day"
+            }
+          }
+        },
+        "workflows": {
+          "properties": {
+            "workflow": {
+              "type": "keyword"
             },
             "status": {
               "type": "keyword"
             },
-            "workflow": {
-              "type": "keyword"
+            "date": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
             }
           }
         },
@@ -372,6 +412,29 @@
             "hasConsentedToTissueSample": {
               "type": "boolean"
             },
+            "medicalRecords": {
+              "properties": {
+                "medicalRecordId": {
+                  "type": "keyword"
+                },
+                "name": {
+                  "type": "text"
+                },
+                "type": {
+                  "type": "keyword"
+                },
+                "requested": {
+                  "type": "date",
+                  "ignore_malformed": false,
+                  "format": "strict_year_month_day"
+                },
+                "received": {
+                  "type": "date",
+                  "ignore_malformed": false,
+                  "format": "strict_year_month_day"
+                }
+              }
+            },
             "pdfs": {
               "properties": {
                 "configName":{
@@ -379,6 +442,43 @@
                 },
                 "displayName":{
                   "type": "text"
+                }
+              }
+            },
+            "tissueRecords": {
+              "properties": {
+                "tissueRecordId": {
+                  "type": "keyword"
+                },
+                "accessionNumber": {
+                  "type": "keyword"
+                },
+                "typePX": {
+                  "type": "text"
+                },
+                "locationPX": {
+                  "type": "text"
+                },
+                "datePX": {
+                  "type": "text"
+                },
+                "histology": {
+                  "type": "text"
+                },
+                "requested": {
+                  "type": "date",
+                  "ignore_malformed": false,
+                  "format": "strict_year_month_day"
+                },
+                "received": {
+                  "type": "date",
+                  "ignore_malformed": false,
+                  "format": "strict_year_month_day"
+                },
+                "sent": {
+                  "type": "date",
+                  "ignore_malformed": false,
+                  "format": "strict_year_month_day"
                 }
               }
             }

--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -330,6 +330,21 @@
             }
           }
         },
+        "workflows": {
+          "properties": {
+            "date": {
+              "type": "date",
+              "ignore_malformed": false,
+              "format": "strict_date_time||strict_date_time_no_millis||epoch_millis"
+            },
+            "status": {
+              "type": "keyword"
+            },
+            "workflow": {
+              "type": "keyword"
+            }
+          }
+        },
         "dsm": {
           "properties": {
             "dateOfBirth": {
@@ -347,6 +362,9 @@
             },
             "diagnosisMonth": {
               "type": "integer"
+            },
+            "familyId": {
+              "type": "long"
             },
             "hasConsentedToBloodDraw": {
               "type": "boolean"


### PR DESCRIPTION
## Context

ES is inferring the wrong data types, so we explicitly spell out the data types to use for these new fields.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## Release

Need to apply this to ES by running the `elastic.sh` script:

```
$ cd ddp-study-server/elasticsearch
$ ./elastic.sh v1 {env} upload-template templates/participants_structured.json
```

We should also make sure that the `dsm` ES user has the `pepper_index_admin_phi` role so it can write into ES.