### PR TITLE
Change the bundled spec's extension to yaml

### DIFF
--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -10,12 +10,12 @@
     "speccy": "^0.11.0"
   },
   "scripts": {
-    "start": "npm run generate-bundle && \"$(npm bin)/redoc-cli\" serve --watch build/pepper.yml",
-    "lint": "npm run generate-bundle && \"$(npm bin)/speccy\" lint --rules=\"rules.yml\" build/pepper.yml",
+    "start": "npm run generate-bundle && \"$(npm bin)/redoc-cli\" serve --watch build/pepper.yaml",
+    "lint": "npm run generate-bundle && \"$(npm bin)/speccy\" lint --rules=\"rules.yml\" build/pepper.yaml",
     "generate-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext yaml src/pepper.yml",
     "generate-json-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext json src/pepper.yml",
     "generate-docs": "\"$(npm bin)/redoc-cli\" bundle --output build/pepper.html src/pepper.yml",
-    "generate-openapi-angular-client": "openapi-generator generate  -i  build/pepper.yml -g typescript-angular -o generated-sources/openapi --additional-properties=\"ngVersion=8.0.0\""
+    "generate-openapi-angular-client": "openapi-generator generate  -i  build/pepper.yaml -g typescript-angular -o generated-sources/openapi --additional-properties=\"ngVersion=8.0.0\""
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "1.0.2-4.2.0"

--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "start": "npm run generate-bundle && \"$(npm bin)/redoc-cli\" serve --watch build/pepper.yml",
     "lint": "npm run generate-bundle && \"$(npm bin)/speccy\" lint --rules=\"rules.yml\" build/pepper.yml",
-    "generate-bundle": "npx @redocly/openapi-cli bundle --output build/pepper.yml --ext yml src/pepper.yml",
-    "generate-json-bundle": "npx @redocly/openapi-cli bundle --output build/pepper.json --ext json src/pepper.yml",
+    "generate-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext yaml src/pepper.yml",
+    "generate-json-bundle": "npx @redocly/openapi-cli bundle --output build/pepper --ext json src/pepper.yml",
     "generate-docs": "\"$(npm bin)/redoc-cli\" bundle --output build/pepper.html src/pepper.yml",
     "generate-openapi-angular-client": "openapi-generator generate  -i  build/pepper.yml -g typescript-angular -o generated-sources/openapi --additional-properties=\"ngVersion=8.0.0\""
   },


### PR DESCRIPTION
## Context
Fixes a bug introduced by #792 where the bundled spec used a `yml` extension instead of `yaml`.

## Checklist
- [x] I have labeled the type of changes involved using the `C-*` labels.

## FUD Score
- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

See #792

## Testing
I have verified that the soft links in `docs/specification/deploy/spec` can successfully be accessed once the OpenAPI specification has been bundled.

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

