### PR TITLE
rarex: fix title block in assents

### DIFF
--- a/study-builder/studies/rarex/snippets/consent-assent-unable-to-consent-title.conf
+++ b/study-builder/studies/rarex/snippets/consent-assent-unable-to-consent-title.conf
@@ -89,5 +89,10 @@
     ]
   },
   "blockType": "CONTENT",
-  "shownExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].questions["ASSENT_ABLE_READ"].isAnswered()"""
+  // This title block is used in both the "consent parental assent" and the "consent LAR assent",
+  // so the expression here accounts for that. Participant should only have one of these consents,
+  // so we won't get into any funny situations with the OR expression.
+  "shownExpr": """user.studies["rarex"].forms["CONSENT_ASSENT"].questions["ASSENT_ABLE_READ"].isAnswered()
+    || user.studies["rarex"].forms["LAR_CONSENT_ASSENT"].questions["LAR_ASSENT_ABLE_READ"].isAnswered()
+  """
 }


### PR DESCRIPTION
Found and fixed an issue in rarex study where the "unable to consent title" block is not showing up for the "consent LAR assent".

Before:
![consent_lar_assent](https://user-images.githubusercontent.com/5713833/121574461-48789f80-c9f4-11eb-9f4a-8165de8a1126.png)

After:
![Screen Shot 2021-06-10 at 1 58 38 PM](https://user-images.githubusercontent.com/5713833/121574484-4dd5ea00-c9f4-11eb-950d-c68dd32837e7.png)
