### PR TITLE
DDP-5710 rgp: add dashboard summaries

### DIFF
--- a/study-builder/studies/rgp/enrollment.conf
+++ b/study-builder/studies/rgp/enrollment.conf
@@ -15,6 +15,14 @@
     { "language": "en", "text": ${i18n.en.enrollment_title} },
     { "language": "es", "text": ${i18n.es.enrollment_title} }
   ],
+  "translatedSummaries": [
+    { "statusCode": "CREATED", "language": "en", "text": ${i18n.en.enrollment_summary_created} },
+    { "statusCode": "CREATED", "language": "es", "text": ${i18n.es.enrollment_summary_created} },
+    { "statusCode": "IN_PROGRESS", "language": "en", "text": ${i18n.en.enrollment_summary_in_progress} },
+    { "statusCode": "IN_PROGRESS", "language": "es", "text": ${i18n.es.enrollment_summary_in_progress} },
+    { "statusCode": "COMPLETE", "language": "en", "text": ${i18n.en.enrollment_summary_complete} },
+    { "statusCode": "COMPLETE", "language": "es", "text": ${i18n.es.enrollment_summary_complete} }
+  ],
   "introduction": {
     "nameTemplate": null,
     "icons": [],

--- a/study-builder/studies/rgp/i18n/en.conf
+++ b/study-builder/studies/rgp/i18n/en.conf
@@ -12,6 +12,9 @@
   //Enrollment
   "enrollment_name": "Tell us about your family",
   "enrollment_title": "Tell us about your family",
+  "enrollment_summary_created": "Thank you for your interest in the Rare Genomes Project! Please complete your enrollment application by clicking on the \"Start\" button.",
+  "enrollment_summary_in_progress": "Please complete your application.",
+  "enrollment_summary_complete": "Your application is complete. Thank you for applying!",
   "enrollment_intro_p1": """Thank you for providing information about your family. The Rare Genomes Project is a
     patient-driven research study that empowers families to have a direct impact on research into the undiagnosed,
     rare disease affecting the study by sharing health information and a blood or DNA sample with researchers.

--- a/study-builder/studies/rgp/i18n/es.conf
+++ b/study-builder/studies/rgp/i18n/es.conf
@@ -12,6 +12,9 @@
   //Enrollment
   "enrollment_name": "[es]Tell us about your family",
   "enrollment_title": "[es]Tell us about your family",
+  "enrollment_summary_created": "[es]Thank you for your interest in the Rare Genomes Project! Please complete your enrollment application by clicking on the \"Start\" button.",
+  "enrollment_summary_in_progress": "[es]Please complete your application.",
+  "enrollment_summary_complete": "[es]Your application is complete. Thank you for applying!",
   "enrollment_intro_p1": """[es]Thank you for providing information about your family. The Rare Genomes Project is a
     patient-driven research study that empowers families to have a direct impact on research into the undiagnosed,
     rare disease affecting the study by sharing health information and a blood or DNA sample with researchers.


### PR DESCRIPTION
Add dashboard summaries per DDP-5710.

Example of what it looks like now:

![Screen Shot 2021-06-10 at 5 13 19 PM](https://user-images.githubusercontent.com/5713833/121598169-8931e200-ca0f-11eb-93b4-7e602ca98787.png)
