### PR TITLE
load-balancer: update scripts to handle already reserved IP

### DIFF
--- a/scripts/load-balancer/reserve-ip.sh
+++ b/scripts/load-balancer/reserve-ip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Script to help reserve an IP for an upcoming study.
+
+set -e
+
+NAME="$(basename "$0")"
+if (( $# < 3 )); then
+  echo "usage: $NAME <GCP_PROJECT> <LB_NAME> <STUDY_IDENTIFIER>"
+  echo ""
+  echo "For STUDY_IDENTIFIER, it should be same one as will be passed to"
+  echo "add-study-to-lb.sh script when we add the study for real."
+  exit 1
+fi
+
+PROJECT_ID="$1"
+LB_NAME="$2"
+STUDY="$3"
+
+echo "using gcp project: $PROJECT_ID"
+echo "using lb name: $LB_NAME"
+echo "using study identifier: $STUDY"
+echo ""
+
+echo_run() {
+  echo "+ $@"
+  "$@"
+  echo ""
+}
+
+ip_name="$LB_NAME-$STUDY-ip"
+echo_run gcloud --project="$PROJECT_ID" \
+  compute addresses create "$ip_name" --global
+ip_addr="$(gcloud --project="$PROJECT_ID" \
+  compute addresses describe "$ip_name" \
+  --global --format='get(address)')"
+
+echo "=> IP address has been reserved!"
+echo "[$ip_name] -> [$ip_addr]"


### PR DESCRIPTION
## Context

For some studies, we don't manage the DNS records. Therefore, we'll need to reserve an IP for the study ahead of time so we can work with study staff to plan DNS switch. I updated the load-balancer scripts to handle this case.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## Testing

I tested this by running it for the basil study:

```
$ ./reserve-ip.sh broad-ddp-dev pepper-lb basil
$ ./add-study-to-lb.sh broad-ddp-dev pepper-lb basil basil.dev.datadonationplatform.org basil
```
