### PR TITLE
DDP-6392 demote log to warn in dsm auth filter

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/filter/DsmAuthFilter.java
@@ -50,10 +50,9 @@ public class DsmAuthFilter implements Filter {
                 return;
             }
         } else {
-            LOG.error("Missing {} header on request with URL: {}", AUTHORIZATION, request.url());
+            LOG.warn("Missing {} header on request to path: {}", AUTHORIZATION, request.pathInfo());
         }
         throw halt(401);
-
     }
 
     boolean isAuthorizationHeaderValid(String authorizationHeader) {


### PR DESCRIPTION
## Context

Small change to turn a log message from `error` -> `warn`. Also switched from logging full URL to just the path so we avoid bombarded by Slack unfurling.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!

