### PR TITLE
atcp: cleanup cf deploy script

### DIFF
--- a/cf-atcp-emailer/deploy.sh
+++ b/cf-atcp-emailer/deploy.sh
@@ -23,7 +23,6 @@ gcloud --project=$PROJECT_ID \
 gcloud --project=$PROJECT_ID functions deploy $CF_NAME \
   --entry-point org.broadinstitute.ddp.cf.ATCPContactEmailer \
   --trigger-topic $TOPIC \
-  --allow-unauthenticated \
   --service-account $SA_ACCT \
   --env-vars-file env.yaml \
   --region us-central1 \


### PR DESCRIPTION
The `cf-atcp-emailer` Cloud Function is triggered by pubsub message, so it's internal. It's not an externally exposed HTTP function, so we don't need `--allow-unauthenticated` flag. You can see in `broad-ddp-dev` that we don't have this and it's working fine.