### PR TITLE
fix bug for consent of Circadia, redirect eligible participants to auth0

### DIFF
--- a/study-builder/studies/circadia/i18n/en.json
+++ b/study-builder/studies/circadia/i18n/en.json
@@ -4,12 +4,11 @@
   "prequal_header": "Prequalifier",
   "prequal_self_describe": "The following questions will determine if a participant is eligible to participate in the study. ",
 
-  "prequal_atypical_circadian_rhythm_question": "What atypical circadian rhythm have you been diagnosed with? ",
+  "prequal_atypical_circadian_rhythm_question": "Have you been diagnosed with an atypical circadian rhythm?",
   "prequal_aspd_answer": "Advanced Sleep Phase Disorder (ASPD)",
   "prequal_dspd_answer": "Delayed Sleep Phase Disorder (DSPD)",
   "prequal_non_24_answer": "Non-24",
   "prequal_other_ansawer": "Other",
-  "prequal_self_suspect_acr": "I suspect I have an atypical circadian rhythm but have not yet been diagnosed.",
   "prequal_none_answer": "None",
 
   "prequal_crd_symptoms_present_question": "Have the symptoms of your circadian rhythm disorder been present for at least three months?",

--- a/study-builder/studies/circadia/prequal.conf
+++ b/study-builder/studies/circadia/prequal.conf
@@ -623,7 +623,7 @@
             "hideNumber": true,
             "promptTemplate": {
               "templateType": "HTML",
-              "templateText": "<h3 class='question-title'> $$prequal_probable_medical_problems_2_question </h3>"
+              "templateText": "<h3 class='question-title'> $prequal_probable_medical_problems_2_question </h3>"
               "variables": [
                 {
                   "name": "prequal_probable_medical_problems_2_question",

--- a/study-builder/studies/circadia/study.conf
+++ b/study-builder/studies/circadia/study.conf
@@ -79,7 +79,7 @@
             ]
           },
           "stableIds": [
-            "ATYPICAL_CIRCADIAN_RHYTHM", "CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS", "PARTICIPANT_AGE_AND_EDUCATION", "PROBABLE_MEDICAL_PROBLEMS_1", "CHILD_AND_PREGNANCY", "PROBABLE_MEDICAL_PROBLEMS_2", "TRAVEL", "8_TH_GRADE_ENGLISH", "VISUAL_PROBLEM_1", "VISUAL_PROBLEM_2", "STUDY_REFRAIN_PROTOCOL",
+            "ATYPICAL_CIRCADIAN_RHYTHM", "CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS", "PARTICIPANT_AGE_AND_EDUCATION", "PROBABLE_MEDICAL_PROBLEMS_1", "CHILD_AND_PREGNANCY", "PROBABLE_MEDICAL_PROBLEMS_2", "TRAVEL", "8_TH_GRADE_ENGLISH", "VISUAL_PROBLEM_1", "VISUAL_PROBLEM_2",
           ],
           "precondition": """
             user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].isAnswered()
@@ -95,37 +95,40 @@
           """,
           "expression": """
 (
-user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_YES")
-)&&(
+(
+!user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NO")
+&& user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_YES")
+) || (
+user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NO")
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PARTICIPANT_AGE_AND_EDUCATION"].answers.hasOption("PAAE_NONE_OF_THE_ABOVE")
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_NONE_OF_THE_ABOVE")
-)&&(
+&& (
 !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_TBI_ANSWER")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_STROKE_ANSWER")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_BRAIN_SURGERY")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_SEIZURE_DISORDER")
-)&&(
+)
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_NONE_OF_THE_ABOVE")
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_NONE_OF_THE_ABOVE")
-)&&(
+&& (
 !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_GINGIVITIS")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_XEROSTOMIA")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_PERIODONTITIS")
-)&&(
-user.studies["circadia"].forms["PREQUAL"].questions["TRAVEL"].answers.hasOption("TRAVEL_NO")
-)&&(
-user.studies["circadia"].forms["PREQUAL"].questions["8_TH_GRADE_ENGLISH"].answers.hasOption("8_TH_GRADE_ENGLISH_YES")
-)&&(
-(
-user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_NO")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_YES")
-)||(
-user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_YES")
-&&(
-user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("COLOR_BLIND")
 )
+) && (
+user.studies["circadia"].forms["PREQUAL"].questions["TRAVEL"].answers.hasOption("TRAVEL_NO")
+) && (
+user.studies["circadia"].forms["PREQUAL"].questions["8_TH_GRADE_ENGLISH"].answers.hasOption("8_TH_GRADE_ENGLISH_YES")
+) && (
+(
+user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_YES")
+&& user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("COLOR_BLIND")
+) || (
+user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_NO")
 )
 )
 )
@@ -186,72 +189,44 @@ user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.
           "activityCode": "CONSENT",
           "expression": """
 (
-user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_ADVANCED_SLEEP_PHASE_DISORDER")
-&& user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_DELAYED_SLEEP_PHASE_DISORDER")
-&& user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NON-24")
-&& user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_OTHER")
-&& ( !user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_SELF_SUSPECT")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NONE")
-)&&(
-user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_YES")
-&& ( !user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_NO")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_UNSURE")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_NOT_APPLICABLE")
-)
-)&&(
+(
+!user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NO")
+&& user.studies["circadia"].forms["PREQUAL"].questions["CIRCADIAN_RHYTHM_DISORDER_SYMPTOMS"].answers.hasOption("CRDS_YES")
+) || (
+user.studies["circadia"].forms["PREQUAL"].questions["ATYPICAL_CIRCADIAN_RHYTHM"].answers.hasOption("ACR_NO")
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PARTICIPANT_AGE_AND_EDUCATION"].answers.hasOption("PAAE_NONE_OF_THE_ABOVE")
-&&(
-!user.studies["circadia"].forms["PREQUAL"].questions["PARTICIPANT_AGE_AND_EDUCATION"].answers.hasOption("PAAE_AGED_22_AND_UNDER")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["PARTICIPANT_AGE_AND_EDUCATION"].answers.hasOption("PAAE_CURRENT_STUDENT")
-)
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_NONE_OF_THE_ABOVE")
-&&(
+&& (
 !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_TBI_ANSWER")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_STROKE_ANSWER")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_BRAIN_SURGERY")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_1"].answers.hasOption("PMP1_SEIZURE_DISORDER")
 )
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_NONE_OF_THE_ABOVE")
-&&(
-!user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_CHILD_LIVES_WITH_SELF")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_CHILD_LIVES_WITH_SELF_PART_TIME")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_SELF_GIVEN_BIRTH_LAST_YEAR")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_SELF_CURRENTLY_PREGNANT")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["CHILD_AND_PREGNANCY"].answers.hasOption("CAP_SELF_CURRENTLY_BREASTFEEDING")
-)
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_NONE_OF_THE_ABOVE")
-&&(
+&& (
 !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_GINGIVITIS")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_XEROSTOMIA")
 && !user.studies["circadia"].forms["PREQUAL"].questions["PROBABLE_MEDICAL_PROBLEMS_2"].answers.hasOption("PMP2_PERIODONTITIS")
 )
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["TRAVEL"].answers.hasOption("TRAVEL_NO")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["TRAVEL"].answers.hasOption("TRAVEL_YES")
-)&&(
+) && (
 user.studies["circadia"].forms["PREQUAL"].questions["8_TH_GRADE_ENGLISH"].answers.hasOption("8_TH_GRADE_ENGLISH_YES")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["8_TH_GRADE_ENGLISH"].answers.hasOption("8_TH_GRADE_ENGLISH_NO")
-)&&(
-user.studies["circadia"].forms["PREQUAL"].questions["STUDY_REFRAIN_PROTOCOL"].answers.hasOption("STUDY_REFRAIN_PROTOCOL_YES")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["STUDY_REFRAIN_PROTOCOL"].answers.hasOption("STUDY_REFRAIN_PROTOCOL_NO")
-)&&(
+) && (
 (
+user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_YES")
+&& user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("COLOR_BLIND")
+) || (
 user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_NO")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_YES")
-)||(
-user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_1"].answers.hasOption("VISUAL_PROBLEM_1_NO")
-&&(
-user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("COLOR_BLIND")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("VISUALLY_IMPAIRED")
-&& !user.studies["circadia"].forms["PREQUAL"].questions["VISUAL_PROBLEM_2"].answers.hasOption("BLIND")
 )
 )
 )
-)
-          """
+"""
         },
         {
           "type": "MAILING_LIST",


### PR DESCRIPTION
## Context

There was a bug in consent for Circadia. both `eligible` and `not eligible` users were redirected to `mailing list modal` which was not correct, instead `eligible` participants should have been redirected to auth0. I had to change activity-wide logical expressions in order to fix this bug, also I modified some variables too, because Broad guys changed the requirements slightly for the new prequal.

These are the associated tickets:
1) fix bug - https://broadinstitute.atlassian.net/browse/DDP-6406
2) new version of prequal - https://broadinstitute.atlassian.net/browse/DDP-6285

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

