### PR TITLE
DDP-6440 update participant-status endpoint to return new data

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -2247,6 +2247,9 @@ ParticipantStatusTrackingInfo.Workflow:
       format: YYYY-MM-DDThh:mm:ss.sssZ (ISO-8601)
       description: Last changed
       example: 2021-04-18T14:09:37.123Z
+    data:
+      type: object
+      description: Additional participant data, actual key-value pairs might vary depending on study
 ParticipantStatusTrackingInfo.Record:
   type: object
   required:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/ParticipantStatusES.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/dsm/ParticipantStatusES.java
@@ -1,7 +1,9 @@
 package org.broadinstitute.ddp.model.dsm;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -46,6 +48,8 @@ public class ParticipantStatusES {
         protected String status;
         @SerializedName("date")
         protected String date;
+        @SerializedName("data")
+        protected Map<String, String> data = new HashMap<>();
 
         public Workflow(String workflow, String status) {
             this.workflow = workflow;
@@ -62,6 +66,10 @@ public class ParticipantStatusES {
 
         public String getDate() {
             return date;
+        }
+
+        public Map<String, String> getData() {
+            return data;
         }
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetDsmParticipantStatusRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetDsmParticipantStatusRouteTest.java
@@ -71,7 +71,8 @@ public class GetDsmParticipantStatusRouteTest extends IntegrationTestSuite.TestC
                 new ParticipantStatus.Sample("a", "BLOOD", 6L, 7L, 8L, "tracking9", "carrier10")));
         GetResponse getResponse = new GetResponse(new GetResult("index", "id", "id01", 0,
                 1, 1, true,
-                new BytesArray("{\"workflows\":[{\"workflow\":\"ACCEPTANCE_STATUS\",\"status\":\"ACCEPTED\"}],"
+                new BytesArray("{\"workflows\":[{\"workflow\":\"ACCEPTANCE_STATUS\",\"status\":\"ACCEPTED\","
+                        + "\"data\":{\"subjectId\":\"XYZ\",\"name\":\"foobar\"}}],"
                         + "\"samples\": [{\"trackingIn\": \"testtrackingIn\",\"kitType\": \"testType\",\"carrier\": "
                         + "\"testCarrier\",\"kitRequestId\": \"5729\",\"trackingOut\": \"testtrackingOut\",\"delivered\":"
                         + " \"2020-02-29\",\"received\": \"2020-02-29\",\"sent\": \"2020-02-29\"}],"
@@ -95,10 +96,15 @@ public class GetDsmParticipantStatusRouteTest extends IntegrationTestSuite.TestC
         assertEquals(RecordStatus.RECEIVED, actual.getTissueRecord().getStatus());
         assertEquals(expected.getTissueRequestedEpochTimeSec(), actual.getTissueRecord().getRequestedAt());
         assertEquals(expected.getTissueReceivedEpochTimeSec(), actual.getTissueRecord().getReceivedBackAt());
+
         assertNotNull(actual.getWorkflows());
         assertEquals(1, actual.getWorkflows().size());
-        assertEquals("ACCEPTANCE_STATUS", actual.getWorkflows().get(0).getWorkflow());
-        assertEquals("ACCEPTED", actual.getWorkflows().get(0).getStatus());
+        var actualWorkflow = actual.getWorkflows().get(0);
+        assertEquals("ACCEPTANCE_STATUS", actualWorkflow.getWorkflow());
+        assertEquals("ACCEPTED", actualWorkflow.getStatus());
+        assertEquals(2, actualWorkflow.getData().size());
+        assertEquals("XYZ", actualWorkflow.getData().get("subjectId"));
+        assertEquals("foobar", actualWorkflow.getData().get("name"));
     }
 
     @Test

--- a/study-builder/studies/rgp/study.conf
+++ b/study-builder/studies/rgp/study.conf
@@ -211,13 +211,12 @@
       "order": 1
     },
 
-    # When they first login, we want to have the "application/pre-review" message available for them in the dashboard.
-    # DSM writes this into the "workflows" in ES, but this write doesn't happen until later on. So we push a "update"
-    # message to DSM to force it to write out this value. The only good extension point we can hook into will be when
-    # they register: using activity status triggers will be too late because they can navigate directly to the dashboard
-    # without starting to fill out the survey, and we also need to account for migrated users (migrated ones won't have
-    # "registered" event triggered). For the RGP study, this "registered" event happens only after user has verified
-    # their email and logs in for the first time, which is exactly when we want this messaging to happen.
+    # DSM writes "workflows" into ES and generates things like family_id, but this doesn't happen
+    # until the participant list page is visited. So we push an "update" message to DSM to force it
+    # to generate/write out these values. A good extension point we can hook into will be when they
+    # register. We also need to account for migrated users (migrated ones won't have "registered"
+    # event triggered). For the RGP study, this "registered" event happens only after user has
+    # verified their email and logs in for the first time, which is an ideal time to initiate this.
     {
       "trigger": {
         "type": "USER_REGISTERED"


### PR DESCRIPTION
## Context

We now have some new `data` for the workflows that's needed in RGP.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## Testing

- [x] I have written automated positive tests

## Release

- [x] These changes require no special release procedures--just code!
