### PR TITLE
DDP-6501 support setting default auth0 connection

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudy.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudy.java
@@ -25,14 +25,16 @@ public interface JdbiUmbrellaStudy extends SqlObject {
     String findUmbrellaGuidForStudyId(@Bind("studyId") long studyId);
 
     @SqlQuery("select us.umbrella_study_id, us.umbrella_id, us.study_name, us.guid, us.irb_password, us.web_base_url, us.auth0_tenant_id,"
-            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key"
+            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key,"
+            + " us.default_auth0_connection"
             + " from umbrella_study us"
             + " left join olc_precision op on op.olc_precision_id = us.olc_precision_id")
     @RegisterConstructorMapper(StudyDto.class)
     List<StudyDto> findAll();
 
     @SqlQuery("select us.umbrella_study_id, us.umbrella_id, us.study_name, us.guid, us.irb_password, us.web_base_url, us.auth0_tenant_id,"
-            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key"
+            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key,"
+            + " us.default_auth0_connection"
             + " from umbrella_study us"
             + " left join olc_precision op on op.olc_precision_id = us.olc_precision_id"
             + " where us.guid = :studyGuid")
@@ -40,7 +42,8 @@ public interface JdbiUmbrellaStudy extends SqlObject {
     StudyDto findByStudyGuid(@Bind("studyGuid") String studyGuid);
 
     @SqlQuery("select us.umbrella_study_id, us.umbrella_id, us.study_name, us.guid, us.irb_password, us.web_base_url, us.auth0_tenant_id,"
-            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key"
+            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key,"
+            + " us.default_auth0_connection"
             + " from umbrella_study us"
             + " left join olc_precision op on op.olc_precision_id = us.olc_precision_id"
             + " where us.umbrella_study_id = :studyId")
@@ -48,7 +51,8 @@ public interface JdbiUmbrellaStudy extends SqlObject {
     StudyDto findById(@Bind("studyId") long studyId);
 
     @SqlQuery("select us.umbrella_study_id, us.umbrella_id, us.study_name, us.guid, us.irb_password, us.web_base_url, us.auth0_tenant_id,"
-            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key"
+            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key,"
+            + " us.default_auth0_connection"
             + " from umbrella_study as us"
             + " join umbrella as u on us.umbrella_id = u.umbrella_id"
             + " left join olc_precision op on op.olc_precision_id = us.olc_precision_id"
@@ -57,7 +61,8 @@ public interface JdbiUmbrellaStudy extends SqlObject {
     List<StudyDto> findByUmbrellaGuid(@Bind("umbrellaGuid") String umbrellaGuid);
 
     @SqlQuery("select us.umbrella_study_id, us.umbrella_id, us.study_name, us.guid, us.irb_password, us.web_base_url, us.auth0_tenant_id,"
-            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key"
+            + " op.olc_precision_code, us.share_participant_location, us.study_email, us.enable_data_export, us.recaptcha_site_key,"
+            + " us.default_auth0_connection"
             + " from umbrella_study as us"
             + " join auth0_tenant as t on t.auth0_tenant_id = us.auth0_tenant_id "
             + " left join olc_precision op on op.olc_precision_id = us.olc_precision_id"
@@ -84,9 +89,10 @@ public interface JdbiUmbrellaStudy extends SqlObject {
     String getIrbPasswordUsingStudyGuid(String studyGuid);
 
     @SqlUpdate("insert into umbrella_study(study_name, guid, umbrella_id, web_base_url, auth0_tenant_id,"
-            + " irb_password, olc_precision_id, share_participant_location, study_email, enable_data_export, recaptcha_site_key) "
+            + " irb_password, olc_precision_id, share_participant_location, study_email, enable_data_export, recaptcha_site_key,"
+            + " default_auth0_connection) "
             + "values(:studyName, :studyGuid, :umbrellaId, :webBaseUrl, :auth0TenantId, :irbPassword, :precisionId,"
-            + " :shareLocation, :studyEmail, true, :recaptchaSiteKey)")
+            + " :shareLocation, :studyEmail, true, :recaptchaSiteKey, :defaultAuth0Connection)")
     @GetGeneratedKeys
     long insert(@Bind("studyName") String studyName,
                 @Bind("studyGuid") String studyGuid,
@@ -97,10 +103,12 @@ public interface JdbiUmbrellaStudy extends SqlObject {
                 @Bind("precisionId") Long precisionId,
                 @Bind("shareLocation") boolean shareLocation,
                 @Bind("studyEmail") String studyEmail,
-                @Bind("recaptchaSiteKey") String recaptchaSiteKey);
+                @Bind("recaptchaSiteKey") String recaptchaSiteKey,
+                @Bind("defaultAuth0Connection") String defaultAuth0Connection);
 
     default long insert(String studyName, String studyGuid, long umbrellaId, String webBaseUrl, long auth0TenantId,
-                        OLCPrecision precision, boolean shareLocation, String studyEmail, String recaptchaSiteKey) {
+                        OLCPrecision precision, boolean shareLocation, String studyEmail, String recaptchaSiteKey,
+                        String defaultAuth0Connection) {
         Long precisionId;
         if (precision == null) {
             precisionId = null;
@@ -108,7 +116,7 @@ public interface JdbiUmbrellaStudy extends SqlObject {
             precisionId = getJdbiOLCPrecision().findDtoForCode(precision).getId();
         }
         return insert(studyName, studyGuid, umbrellaId, webBaseUrl, auth0TenantId, null, precisionId, shareLocation, studyEmail,
-                recaptchaSiteKey);
+                recaptchaSiteKey, defaultAuth0Connection);
     }
 
     @SqlUpdate("update umbrella_study set irb_password = :irbPassword where guid = :studyGuid")

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiUmbrellaStudyCached.java
@@ -187,18 +187,18 @@ public class JdbiUmbrellaStudyCached extends SQLObjectWrapper<JdbiUmbrellaStudy>
 
     @Override
     public long insert(String studyName, String studyGuid, long umbrellaId, String webBaseUrl, long auth0TenantId, String irbPassword,
-                       Long precisionId, boolean shareLocation, String studyEmail, String recaptchaSiteKey) {
+                       Long precisionId, boolean shareLocation, String studyEmail, String recaptchaSiteKey, String defaultAuth0Connection) {
         long studyId = delegate.insert(studyName, studyGuid, umbrellaId, webBaseUrl, auth0TenantId, irbPassword, precisionId, shareLocation,
-                studyEmail, recaptchaSiteKey);
+                studyEmail, recaptchaSiteKey, defaultAuth0Connection);
         notifyModelUpdated(ModelChangeType.STUDY, studyId);
         return studyId;
     }
 
     @Override
     public long insert(String studyName, String studyGuid, long umbrellaId, String webBaseUrl, long auth0TenantId, OLCPrecision precision,
-                       boolean shareLocation, String studyEmail, String recaptchaSiteKey) {
+                       boolean shareLocation, String studyEmail, String recaptchaSiteKey, String defaultAuth0Connection) {
         long studyId = delegate.insert(studyName, studyGuid, umbrellaId, webBaseUrl, auth0TenantId, precision, shareLocation,
-                studyEmail, recaptchaSiteKey);
+                studyEmail, recaptchaSiteKey, defaultAuth0Connection);
         notifyModelUpdated(ModelChangeType.STUDY, studyId);
         return studyId;
     }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/StudyDto.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dto/StudyDto.java
@@ -20,6 +20,7 @@ public class StudyDto implements Serializable {
     private String studyEmail;
     private String recaptchaSiteKey;
     private boolean dataExportEnabled;
+    private String defaultAuth0Connection;
 
     @JdbiConstructor
     public StudyDto(@ColumnName("umbrella_study_id") long id,
@@ -33,7 +34,8 @@ public class StudyDto implements Serializable {
                     @ColumnName("share_participant_location") boolean shareParticipantLocation,
                     @ColumnName("study_email") String studyEmail,
                     @ColumnName("recaptcha_site_key") String recaptchaSiteKey,
-                    @ColumnName("enable_data_export") boolean dataExportEnabled) {
+                    @ColumnName("enable_data_export") boolean dataExportEnabled,
+                    @ColumnName("default_auth0_connection") String defaultAuth0Connection) {
         this.id = id;
         this.guid = guid;
         this.name = name;
@@ -46,6 +48,7 @@ public class StudyDto implements Serializable {
         this.studyEmail = studyEmail;
         this.recaptchaSiteKey = recaptchaSiteKey;
         this.dataExportEnabled = dataExportEnabled;
+        this.defaultAuth0Connection = defaultAuth0Connection;
     }
 
     public long getId() {
@@ -98,5 +101,9 @@ public class StudyDto implements Serializable {
 
     public void setRecaptchaSiteKey(String key) {
         this.recaptchaSiteKey = key;
+    }
+
+    public String getDefaultAuth0Connection() {
+        return defaultAuth0Connection;
     }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -182,8 +182,8 @@ public class DataExporter {
         ExportUtil.clearCachedAuth0Emails(emailStore);
     }
 
-    public static void fetchAndCacheAuth0Emails(Handle handle, String studyGuid, Set<String> userIds) {
-        ExportUtil.fetchAndCacheAuth0Emails(handle, studyGuid, userIds, emailStore);
+    public static void fetchAndCacheAuth0Emails(Handle handle, StudyDto studyDto, Set<String> userIds) {
+        ExportUtil.fetchAndCacheAuth0Emails(handle, studyDto, userIds, emailStore);
     }
 
     /**
@@ -533,7 +533,7 @@ public class DataExporter {
                 .collect(Collectors.toMap(User::getGuid, user -> user));
 
         if (!usersMissingEmails.isEmpty()) {
-            ExportUtil.fetchAndCacheAuth0Emails(handle, studyDto.getGuid(), usersMissingEmails.keySet(), emailStore)
+            ExportUtil.fetchAndCacheAuth0Emails(handle, studyDto, usersMissingEmails.keySet(), emailStore)
                     .forEach((auth0UserId, email) -> users.get(usersMissingEmails.get(auth0UserId)).setEmail(email));
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/ExportUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/ExportUtil.java
@@ -29,11 +29,12 @@ public class ExportUtil {
         return TransactionWrapper.withTxn(TransactionWrapper.DB.APIS, callback);
     }
 
-    static Map<String, String> fetchAndCacheAuth0Emails(Handle handle, String studyGuid,
+    static Map<String, String> fetchAndCacheAuth0Emails(Handle handle, StudyDto studyDto,
                                                                Set<String> auth0UserIds, Map<String, String> emailStore) {
-        var mgmtClient = Auth0ManagementClient.forStudy(handle, studyGuid);
+        var mgmtClient = Auth0ManagementClient.forStudy(handle, studyDto.getGuid());
         Map<String, String> emailResults = new Auth0Util(mgmtClient.getDomain())
-                .getUserPassConnEmailsByAuth0UserIds(auth0UserIds, mgmtClient.getToken());
+                .getEmailsByAuth0UserIdsAndConnection(auth0UserIds, mgmtClient.getToken(),
+                        studyDto.getDefaultAuth0Connection());
         emailResults.forEach(emailStore::put);
         return emailResults;
     }
@@ -84,7 +85,7 @@ public class ExportUtil {
                 .collect(Collectors.toMap(pt -> pt.getUser().getGuid(), pt -> pt));
 
         if (!usersMissingEmails.isEmpty()) {
-            fetchAndCacheAuth0Emails(handle, studyDto.getGuid(), usersMissingEmails.keySet(), emailStore)
+            fetchAndCacheAuth0Emails(handle, studyDto, usersMissingEmails.keySet(), emailStore)
                     .forEach((auth0UserId, email) -> participants.get(usersMissingEmails.get(auth0UserId)).getUser().setEmail(email));
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/AdminLookupInvitationRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/AdminLookupInvitationRoute.java
@@ -69,7 +69,8 @@ public class AdminLookupInvitationRoute extends ValidatedJsonInputRoute<LookupIn
                 if (user.getAuth0UserId() != null) {
                     Auth0ManagementClient mgmtClient = Auth0ManagementClient.forStudy(handle, studyGuid);
                     Map<String, String> emailResults = new Auth0Util(mgmtClient.getDomain())
-                            .getUserPassConnEmailsByAuth0UserIds(Set.of(user.getAuth0UserId()), mgmtClient.getToken());
+                            .getEmailsByAuth0UserIdsAndConnection(Set.of(user.getAuth0UserId()), mgmtClient.getToken(),
+                                    studyDto.getDefaultAuth0Connection());
                     loginEmail = emailResults.get(user.getAuth0UserId());
                 }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.client.Auth0ManagementClient;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudyCached;
 import org.broadinstitute.ddp.db.dao.ParticipantDao;
 import org.broadinstitute.ddp.db.dao.PdfDao;
 import org.broadinstitute.ddp.db.dao.StudyLanguageDao;
@@ -269,9 +270,11 @@ public class PdfGenerationService {
 
         if (hasEmailSource) {
             var mgmtClient = Auth0ManagementClient.forStudy(handle, config.getStudyGuid());
+            var studyDto = new JdbiUmbrellaStudyCached(handle).findByStudyGuid(config.getStudyGuid());
             String auth0UserId = participant.getUser().getAuth0UserId();
             Map<String, String> emailResults = new Auth0Util(mgmtClient.getDomain())
-                    .getUserPassConnEmailsByAuth0UserIds(Sets.newHashSet(auth0UserId), mgmtClient.getToken());
+                    .getEmailsByAuth0UserIdsAndConnection(Sets.newHashSet(auth0UserId), mgmtClient.getToken(),
+                            studyDto.getDefaultAuth0Connection());
             participant.getUser().setEmail(emailResults.get(auth0UserId));
         }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
@@ -356,13 +356,13 @@ public class Auth0Util {
      * API errors during the process will be consumed. This means results might not contain all requested user emails and caller should
      * handle such scenario.
      *
-     * <p>Note: this is restricted to querying emails from the Username-Password-Authentication Connection.
-     *
-     * @param auth0UserIds the auth0UserIds to query emails for
-     * @param mgmtApiToken management token to access API
+     * @param auth0UserIds    the auth0UserIds to query emails for
+     * @param mgmtApiToken    management token to access API
+     * @param auth0Connection the auth0 connection, if not provided will fallback to 'Username-Password-Authentication'
      * @return mapping of auth0UserId to email
      */
-    public Map<String, String> getUserPassConnEmailsByAuth0UserIds(Set<String> auth0UserIds, String mgmtApiToken) {
+    public Map<String, String> getEmailsByAuth0UserIdsAndConnection(Set<String> auth0UserIds, String mgmtApiToken,
+                                                                    String auth0Connection) {
         if (auth0UserIds == null || auth0UserIds.isEmpty()) {
             return new HashMap<>();
         }
@@ -371,6 +371,8 @@ public class Auth0Util {
         Map<String, String> results = new HashMap<>();
         List<String> ids = new ArrayList<>(auth0UserIds);
         ManagementAPI auth0Mgmt = new ManagementAPI(baseUrl, mgmtApiToken);
+        String connection = auth0Connection == null || auth0Connection.isBlank()
+                ? USERNAME_PASSWORD_AUTH0_CONN_NAME : auth0Connection;
 
         // IMPORTANT: In order to satisfy certain limits and restrictions, especially URL length limits, we "pagination"
         // through the auth0UserIds. We had issues with 100 auth0UserIds, so 50 in the Lucene query seems like a safe bet.
@@ -381,7 +383,7 @@ public class Auth0Util {
 
             // NOTE: Lucene syntax likes OR operator, but using a space also works. We do the latter to save space on URL limit.
             String query = String.format("identities.connection:\"%s\" AND user_id:(%s)",
-                    USERNAME_PASSWORD_AUTH0_CONN_NAME, String.join(" ", subset));
+                    connection, String.join(" ", subset));
 
             UserFilter filter = new UserFilter()
                     .withFields("user_id,email", true)

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/DataExporterCli.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/DataExporterCli.java
@@ -162,7 +162,7 @@ public class DataExporterCli {
             System.out.println("[export] warming up caches...");
 
             StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
-            DataExporter.fetchAndCacheAuth0Emails(handle, studyGuid, handle
+            DataExporter.fetchAndCacheAuth0Emails(handle, studyDto, handle
                     .select("select auth0_user_id from user")
                     .mapTo(String.class)
                     .stream()
@@ -208,7 +208,7 @@ public class DataExporterCli {
             StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
 
             // Warm up the emails cache
-            DataExporter.fetchAndCacheAuth0Emails(handle, studyGuid,
+            DataExporter.fetchAndCacheAuth0Emails(handle, studyDto,
                     handle.select("select auth0_user_id from user").mapTo(String.class).stream().collect(Collectors.toSet()));
 
             System.out.println(String.format("[export] starting %s json elasticsearch export...",
@@ -227,7 +227,7 @@ public class DataExporterCli {
             StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
 
             // Warm up the emails cache
-            DataExporter.fetchAndCacheAuth0Emails(handle, studyGuid,
+            DataExporter.fetchAndCacheAuth0Emails(handle, studyDto,
                     handle.select("select auth0_user_id from user").mapTo(String.class).stream().collect(Collectors.toSet()));
 
             System.out.println("[export] starting elasticsearch user export...");

--- a/pepper-apis/src/main/resources/changelog-master.xml
+++ b/pepper-apis/src/main/resources/changelog-master.xml
@@ -268,4 +268,5 @@
     <include file="db-changes/schema/DDP-5750-new-enrollment-events.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-6278-create-update-custom-workflow-event-action-table.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-6281-add-picklist-render-mode-autocomplete.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-6501-study-default-auth0-connection.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/src/main/resources/db-changes/schema/DDP-6501-study-default-auth0-connection.xml
+++ b/pepper-apis/src/main/resources/db-changes/schema/DDP-6501-study-default-auth0-connection.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="yufeng" id="20210630-study-default-auth0-connection">
+        <addColumn tableName="umbrella_study">
+            <column name="default_auth0_connection" type="varchar(35)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExportCoordinatorTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/export/DataExportCoordinatorTest.java
@@ -90,7 +90,7 @@ public class DataExportCoordinatorTest {
 
         // minimal studyDto that will make this work. Really irrelevant for our tests except needed to avoid null pointer exceptions.
         StudyDto testStudyDto = new StudyDto(123, "theguid", "studyname", null,
-                "http://blah.boo.com", 2, 1, null, false, null, null, true);
+                "http://blah.boo.com", 2, 1, null, false, null, null, true, null);
 
         // run the real thing when we call this
         Iterator<Participant> iterator = Collections.emptyIterator();

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/OLCServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/OLCServiceTest.java
@@ -76,7 +76,7 @@ public class OLCServiceTest extends TxnAwareBaseTest {
     @Test
     public void testGetAllOLCsForEnrolledParticipantsInStudy() {
         var enabledStudy = new StudyDto(1L, "study", "name", "irb", "url", 1L, 1L,
-                OLCPrecision.MEDIUM, true, "email", null, true);
+                OLCPrecision.MEDIUM, true, "email", null, true, null);
 
         when(mockJdbiStudy.findByStudyGuid(any())).thenReturn(enabledStudy);
         when(mockEnrollment.findAllOLCsForEnrolledParticipantsInStudy(any())).thenReturn(List.of(PLUSCODE_FULL));
@@ -91,7 +91,7 @@ public class OLCServiceTest extends TxnAwareBaseTest {
     @Test
     public void testGetAllOLCsForEnrolledParticipantsInStudy_noParticipantsWithDefaultAddress() {
         var enabledStudy = new StudyDto(1L, "study", "name", "irb", "url", 1L, 1L,
-                OLCPrecision.MEDIUM, true, "email", null, true);
+                OLCPrecision.MEDIUM, true, "email", null, true, null);
 
         when(mockJdbiStudy.findByStudyGuid(any())).thenReturn(enabledStudy);
         when(mockEnrollment.findAllOLCsForEnrolledParticipantsInStudy(any())).thenReturn(Collections.emptyList());
@@ -103,7 +103,7 @@ public class OLCServiceTest extends TxnAwareBaseTest {
     @Test
     public void testGetAllOLCsForEnrolledParticipantsInStudy_publicDataSharingDisabled() {
         var disabledStudy = new StudyDto(1L, "study", "name", "irb", "url", 1L, 1L,
-                OLCPrecision.MEDIUM, false, "email", null, true);
+                OLCPrecision.MEDIUM, false, "email", null, true, null);
 
         when(mockJdbiStudy.findByStudyGuid(any())).thenReturn(disabledStudy);
 
@@ -113,7 +113,7 @@ public class OLCServiceTest extends TxnAwareBaseTest {
 
     @Test
     public void testGetAllOLCsForEnrolledParticipantsInStudy_noOlcPrecisionSet() {
-        var noPrecisionStudy = new StudyDto(1L, "study", "name", "irb", "url", 1L, 1L, null, false, "email", null, true);
+        var noPrecisionStudy = new StudyDto(1L, "study", "name", "irb", "url", 1L, 1L, null, false, "email", null, true, null);
 
         when(mockJdbiStudy.findByStudyGuid(any())).thenReturn(noPrecisionStudy);
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/StudyDataLoaderTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/StudyDataLoaderTest.java
@@ -372,7 +372,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
 
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);
@@ -463,7 +463,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);
         mockDataLoader.loadBloodReleaseSurveyData(
@@ -521,7 +521,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
 
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);
@@ -854,7 +854,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
 
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);
@@ -980,7 +980,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
 
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);
@@ -1042,7 +1042,7 @@ public class StudyDataLoaderTest {
         UserDto userDto = new UserDto(pretendUserId, pretendAuth0UserId, pretendUserGuid, pretendUserGuid, null,
                 null, now, now);
         StudyDto studyDto = new StudyDto(pretendStudyId, pretendStudyGuid, "MBC", null, null,
-                1L, 2L, null, false, null, null, false);
+                1L, 2L, null, false, null, null, false, null);
 
         ActivityInstanceDto instanceDto = new ActivityInstanceDto(1L, pretendInstanceGuid, 1L, 1L, "X",
                 null, null, null, null, 1L, 1L, 1L, true, false, null, null, null, true, 0);

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/TestDataSetupUtil.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/TestDataSetupUtil.java
@@ -541,10 +541,10 @@ public class TestDataSetupUtil {
                 encryptedSecret);
 
         long studyId = handle.attach(JdbiUmbrellaStudy.class).insert(studyName, studyGuid, umbrellaId, webBaseUrl,
-                auth0TenantDto.getId(), studyPrecision, shareParticipantLocation, null, null);
+                auth0TenantDto.getId(), studyPrecision, shareParticipantLocation, null, null, null);
         return new StudyDto(studyId, studyGuid, studyName, null, webBaseUrl, umbrellaId, auth0TenantDto.getId(),
                 studyPrecision,
-                shareParticipantLocation, null, null, false);
+                shareParticipantLocation, null, null, false, null);
     }
 
     public static FormActivityDef generateTestFormActivityForUser(Handle handle, String userGuid, String studyGuid) {

--- a/study-builder/config/rgp-config.json.ctmpl
+++ b/study-builder/config/rgp-config.json.ctmpl
@@ -26,11 +26,7 @@
   {{else}}
     "STUDY_EMAIL": "rgp@{{$environment}}.datadonationplatform.org",
   {{end}}
-  {{if eq $environment "prod"}}
-    "DB_NAME": "rgp-production",
-  {{else}}
-    "DB_NAME": "Username-Password-Authentication",
-  {{end}}
+    "DB_NAME": "{{$conf.auth0.connection}}",
     "BASE_URL": "{{$conf.baseWebUrl}}",
     "LOGIN_DOMAIN": "{{$conf.auth0.loginDomain}}",
     "ASSETS_BUCKET": "{{$conf.assetsBucketName}}",

--- a/study-builder/config/vars.conf.ctmpl
+++ b/study-builder/config/vars.conf.ctmpl
@@ -7,6 +7,7 @@
 
 {
     "auth0": {
+        "connection": "{{$auth.connection}}",
         "domain": "{{$auth.domain}}",
         "mgmtClientId": "{{$auth.mgmtClientId}}",
         "mgmtSecret": "{{$auth.mgmtSecret}}",

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/StudyBuilder.java
@@ -285,9 +285,8 @@ public class StudyBuilder {
         }
 
         String recaptchaSiteKey = ConfigUtil.getStrIfPresent(studyCfg, "recaptchaSiteKey");
-
-
         boolean shareLocationInformation = studyCfg.getBoolean("shareParticipantLocation");
+        String defaultAuth0Connection = ConfigUtil.getStrIfPresent(studyCfg, "defaultAuth0Connection");
 
         JdbiUmbrellaStudy jdbiStudy = handle.attach(JdbiUmbrellaStudy.class);
         StudyDto dto = jdbiStudy.findByStudyGuid(guid);
@@ -300,7 +299,8 @@ public class StudyBuilder {
                 olcPrecisionId = handle.attach(JdbiOLCPrecision.class).findDtoForCode(olcPrecision).getId();
             }
             long studyId = jdbiStudy.insert(name, guid, umbrellaId, baseWebUrl,
-                    tenantId, irbPassword, olcPrecisionId, shareLocationInformation, studyEmail, recaptchaSiteKey);
+                    tenantId, irbPassword, olcPrecisionId, shareLocationInformation, studyEmail, recaptchaSiteKey,
+                    defaultAuth0Connection);
             dto = handle.attach(JdbiUmbrellaStudy.class).findById(studyId);
             LOG.info("Created study with id={}, name={}, guid={}", studyId, name, guid);
         } else {

--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/AngioConsentVersion2.java
@@ -563,7 +563,7 @@ public class AngioConsentVersion2 implements CustomTask {
                 .collect(Collectors.toMap(UserDto::getUserId, userDto -> userDto));
 
         Map<String, String> emailsMap = new Auth0Util(cfg.getString("tenant.domain"))
-                .getUserPassConnEmailsByAuth0UserIds(auth0UserIds, getAuth0MgmtToken());
+                .getEmailsByAuth0UserIdsAndConnection(auth0UserIds, getAuth0MgmtToken(), null);
 
         String[] headers = new String[] {
                 "guid", "hruid", "legacy_altpid", "legacy_shortid",

--- a/study-builder/studies/rgp/study.conf
+++ b/study-builder/studies/rgp/study.conf
@@ -17,7 +17,8 @@
     "baseWebUrl": ${baseWebUrl},
     "irbPassword": ${irbPassword},
     "plusCodePrecision": MEDIUM,
-    "shareParticipantLocation": false
+    "shareParticipantLocation": false,
+    "defaultAuth0Connection": ${auth0.connection}
   },
 
   "client": {

--- a/study-builder/studies/study-example.conf
+++ b/study-builder/studies/study-example.conf
@@ -27,6 +27,9 @@
     "plusCodePrecision": "null | LEAST | LESS | MEDIUM | MORE | MOST",
     # Whether participant address plus codes can be retrieved via our public API.
     "shareParticipantLocation": "bool",
+    # Auth0 connection to use for the study, e.g for looking up emails.
+    # Optional, will fallback to the default 'Username-Password-Authentication'.
+    "defaultAuth0Connection": "string",
   },
 
   # Configuration of the statistics data available for the study


### PR DESCRIPTION
## Context

We have hardcoded to `Username-Password-Authentication` when fetching emails during data exports. RGP doesn't use that name, so we're not getting any emails in export to ES and thus no emails will show up in DSM for study staff. Idea here is to make this a configuration option so a study can set what db connection to use, otherwise we fallback to the default hardcoded value.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## Testing

I have tested this by creating a new `rgp-local` database connection in `rgp-dev` auth0 tenant, and then using that db connection name locally. I verified locally that we're able to fetch emails from that connection.

## Release

- [x] Releasing these changes requires special handling

After this is deployed as a hotfix, I'll fixup the configuration for RGP.

