### PR TITLE
DDP-6511 clear child instances on parent activity submit

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -2,7 +2,9 @@ package org.broadinstitute.ddp.route;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,6 +19,7 @@ import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;
 import org.broadinstitute.ddp.content.I18nContentRenderer;
 import org.broadinstitute.ddp.db.ActivityDefStore;
+import org.broadinstitute.ddp.db.DBUtils;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceDao;
 import org.broadinstitute.ddp.db.dao.ActivityInstanceStatusDao;
@@ -145,8 +148,9 @@ public class PutFormAnswersRoute implements Route {
                         throw ResponseUtil.haltError(response, 422, new ApiError(ErrorCodes.QUESTION_REQUIREMENTS_NOT_MET, msg));
                     }
 
+                    Map<Long, List<ActivityInstanceDto>> hiddenChildInstances = null;
                     if (parentInstanceDto == null) {
-                        checkChildInstancesCompleteness(
+                        hiddenChildInstances = checkStateOfChildInstances(
                                 response, handle, userGuid, operatorGuid, studyGuid, instanceGuid,
                                 form, preferredUserLangDto, instanceSummary);
                     }
@@ -192,15 +196,8 @@ public class PutFormAnswersRoute implements Route {
                                 Instant.now().toEpochMilli(), operatorUser, participantUser);
                     }
 
-                    // Cleanup hidden answers.
-                    Set<Long> answerIdsToDelete = form.collectHiddenAnswers()
-                            .stream()
-                            .map(Answer::getAnswerId)
-                            .filter(Objects::nonNull)
-                            .collect(Collectors.toSet());
-                    handle.attach(AnswerDao.class).deleteAnswers(answerIdsToDelete);
-                    LOG.info("Deleted {} hidden answers for user {} and activity instance {}",
-                            answerIdsToDelete.size(), userGuid, instanceGuid);
+                    cleanupHiddenAnswers(handle, userGuid, form);
+                    cleanupHiddenChildInstances(handle, activityStore, userGuid, form, hiddenChildInstances);
 
                     WorkflowState fromState = new ActivityState(form.getActivityId());
                     WorkflowResponse workflowResp = workflowService
@@ -251,29 +248,41 @@ public class PutFormAnswersRoute implements Route {
     }
 
     // For a parent instance, check if there are any child instances that are not hidden and if those are complete.
-    private void checkChildInstancesCompleteness(Response response,
-                                                 Handle handle,
-                                                 String userGuid,
-                                                 String operatorGuid,
-                                                 String studyGuid,
-                                                 String instanceGuid,
-                                                 FormInstance form,
-                                                 LanguageDto preferredLangDto,
-                                                 UserActivityInstanceSummary instanceSummary) {
+    // For efficiency, we also keep track of which child instances are hidden so we can clean them up later.
+    private Map<Long, List<ActivityInstanceDto>> checkStateOfChildInstances(Response response,
+                                                                            Handle handle,
+                                                                            String userGuid,
+                                                                            String operatorGuid,
+                                                                            String studyGuid,
+                                                                            String instanceGuid,
+                                                                            FormInstance form,
+                                                                            LanguageDto preferredLangDto,
+                                                                            UserActivityInstanceSummary instanceSummary) {
         Map<String, List<ActivityInstanceDto>> childInstances = new HashMap<>();
+        Map<Long, List<ActivityInstanceDto>> hiddenChildInstances = new HashMap<>();
         instanceSummary.getInstancesStream()
                 .filter(instance -> instanceGuid.equals(instance.getParentInstanceGuid()))
                 .forEach(instance -> childInstances
                         .computeIfAbsent(instance.getActivityCode(), key -> new ArrayList<>())
                         .add(instance));
+
         for (FormSection section : form.getAllSections()) {
             for (FormBlock block : section.getBlocks()) {
-                if (block.getBlockType() != BlockType.ACTIVITY || !block.isShown()) {
+                if (block.getBlockType() != BlockType.ACTIVITY) {
                     continue;
                 }
+
                 var nestedActivityBlock = (NestedActivityBlock) block;
                 List<ActivityInstanceDto> childInstanceDtos = childInstances
                         .getOrDefault(nestedActivityBlock.getActivityCode(), new ArrayList<>());
+                if (!nestedActivityBlock.isShown()) {
+                    if (!childInstanceDtos.isEmpty()) {
+                        long childActivityId = childInstanceDtos.get(0).getActivityId();
+                        hiddenChildInstances.put(childActivityId, childInstanceDtos);
+                    }
+                    continue;
+                }
+
                 for (var childInstanceDto : childInstanceDtos) {
                     if (childInstanceDto.getStatusType() != InstanceStatusType.COMPLETE) {
                         // Child instance is not finished but it might not have required questions, so check it.
@@ -290,6 +299,70 @@ public class PutFormAnswersRoute implements Route {
                     }
                 }
             }
+        }
+
+        return hiddenChildInstances;
+    }
+
+    public void cleanupHiddenAnswers(Handle handle, String userGuid, FormInstance form) {
+        Set<Long> answerIdsToDelete = form.collectHiddenAnswers()
+                .stream()
+                .map(Answer::getAnswerId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        handle.attach(AnswerDao.class).deleteAnswers(answerIdsToDelete);
+        LOG.info("Deleted {} hidden answers for user {} and activity instance {}",
+                answerIdsToDelete.size(), userGuid, form.getGuid());
+    }
+
+    private void cleanupHiddenChildInstances(Handle handle,
+                                             ActivityDefStore activityStore,
+                                             String userGuid,
+                                             FormInstance form,
+                                             Map<Long, List<ActivityInstanceDto>> hiddenChildInstances) {
+        if (hiddenChildInstances == null || hiddenChildInstances.isEmpty()) {
+            return;
+        }
+
+        var answerDao = handle.attach(AnswerDao.class);
+        var instanceDao = handle.attach(ActivityInstanceDao.class);
+        for (var entry : hiddenChildInstances.entrySet()) {
+            var childInstanceDtos = entry.getValue();
+            if (childInstanceDtos.isEmpty()) {
+                continue;
+            }
+            var childActivity = activityStore.findActivityDto(handle, entry.getKey())
+                    .orElseThrow(() -> new DDPException("Could not find child activity with id " + entry.getKey()));
+            if (!childActivity.canDeleteInstances()) {
+                continue;
+            }
+
+            childInstanceDtos.sort(Comparator.comparing(ActivityInstanceDto::getCreatedAtMillis));
+            Set<Long> deletableInstanceIds = new HashSet<>();
+            Set<Long> deleteOnlyAnswers = new HashSet<>();
+
+            for (int i = 0; i < childInstanceDtos.size(); i++) {
+                boolean isFirstInstance = (i == 0);
+                boolean canDelete = ActivityInstanceUtil.computeCanDelete(
+                        childActivity.canDeleteInstances(),
+                        childActivity.getCanDeleteFirstInstance(),
+                        isFirstInstance);
+                if (canDelete) {
+                    // Should delete the instance and all its answers.
+                    deletableInstanceIds.add(childInstanceDtos.get(i).getId());
+                } else {
+                    // Can't delete the instance itself, but let's at the very least cleanup its answers.
+                    deleteOnlyAnswers.add(childInstanceDtos.get(i).getId());
+                }
+            }
+
+            DBUtils.checkDelete(deletableInstanceIds.size(), instanceDao.deleteAllByIds(deletableInstanceIds));
+            LOG.info("Deleted {} hidden child instances for user {}, parent instance {}, child activity {}",
+                    deletableInstanceIds.size(), userGuid, form.getGuid(), childActivity.getActivityCode());
+
+            answerDao.deleteAllByInstanceIds(deleteOnlyAnswers);
+            LOG.info("Cleared answers for {} hidden child instances for user {}, parent instance {}, child activity {}",
+                    deleteOnlyAnswers.size(), userGuid, form.getGuid(), childActivity.getActivityCode());
         }
     }
 


### PR DESCRIPTION
## Context

When a question is hidden, we delete the hidden answer on activity submit. When an embedded child activity is hidden, then we should delete all the hidden child instances (if possible). This PR adds support for that. This will also fix DDP-6511, where RGP staff is concerned that hidden information are not getting removed.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

You may try out the RGP study and see this working. The `ENROLLMENT` activity contains a bunch of embedded child activities.

## Testing

- [x] I have written automated positive tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!
