### PR TITLE
DDP-6546 fix validating child activities during parent activity submission

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -284,18 +284,15 @@ public class PutFormAnswersRoute implements Route {
                 }
 
                 for (var childInstanceDto : childInstanceDtos) {
-                    if (childInstanceDto.getStatusType() != InstanceStatusType.COMPLETE) {
-                        // Child instance is not finished but it might not have required questions, so check it.
-                        FormInstance childForm = loadFormInstance(
-                                response, handle, userGuid, operatorGuid, studyGuid,
-                                childInstanceDto.getGuid(), preferredLangDto, instanceSummary);
-                        if (!childForm.isComplete()) {
-                            String msg = "Status for instance " + instanceGuid + " cannot be set to COMPLETE because the"
-                                    + " question requirements are not met for child instance " + childInstanceDto.getGuid();
-                            LOG.info(msg);
-                            throw ResponseUtil.haltError(response, 422,
-                                    new ApiError(ErrorCodes.QUESTION_REQUIREMENTS_NOT_MET, msg));
-                        }
+                    FormInstance childForm = loadFormInstance(
+                            response, handle, userGuid, operatorGuid, studyGuid,
+                            childInstanceDto.getGuid(), preferredLangDto, instanceSummary);
+                    if (!childForm.isComplete()) {
+                        String msg = "Status for instance " + instanceGuid + " cannot be set to COMPLETE because the"
+                                + " question requirements are not met for child instance " + childInstanceDto.getGuid();
+                        LOG.info(msg);
+                        throw ResponseUtil.haltError(response, 422,
+                                new ApiError(ErrorCodes.QUESTION_REQUIREMENTS_NOT_MET, msg));
                     }
                 }
             }


### PR DESCRIPTION
## Context

See DDP-6546.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score
- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Try out RGP study.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

- [x] These changes require no special release procedures--just code!


