### PR TITLE
Adds iOS client to the pancan study

### DIFF
--- a/study-builder/config/vars.conf.ctmpl
+++ b/study-builder/config/vars.conf.ctmpl
@@ -15,6 +15,10 @@
         "clientSecret": "{{$auth.clientSecret}}",
         "adminClientId": "{{$auth.adminClientId}}",
         "adminClientSecret": "{{$auth.adminClientSecret}}",
+{{ if $auth.iosClientId }}
+        "iosClientId": "{{$auth.iosClientId}}",
+        "iosClientSecret": "{{$auth.iosClientSecret}}",
+{{ end }}
     },
     "baseWebUrl": "{{$conf.baseWebUrl}}",
     "passwordRedirectUrl": "{{$conf.passwordRedirectUrl}}",

--- a/study-builder/studies/pancan/study.conf
+++ b/study-builder/studies/pancan/study.conf
@@ -30,6 +30,11 @@
       "id": ${auth0.adminClientId},
       "secret": ${auth0.adminClientSecret},
       "passwordRedirectUrl": null
+    },
+    {
+      "id": ${auth0.iosClientId},
+      "secret": ${auth0.iosClientSecret},
+      "passwordRedirectUrl": null
     }
   ],
 


### PR DESCRIPTION
## Context

Adds two new opt-in keys for including the iOS client ID and client secret when deploying the Pancan study. This is necessary to prevent access to the study from being revoked after a deploy. If a study does not have the `iosClientId` key in their Vault config, the additional keys will not appear in the generated vars file.

If further changes are necessary, let me know and I'll incorporate them into this PR.

## FUD Score
- [x] :relaxed: All good, business as usual!

## How do we demo these changes?
On initial deployment or update, the `pancan` study should have a new client added, beginning with the string `1q8ZS...`.

## Testing
- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

Currently deployed Pancan stud\y instances will not pick up the changes until they have been re-deployed.

