### PR TITLE
pancan prequal refactoring to handle self/child prompts

### DIFF
--- a/study-builder/studies/pancan/prequal.conf
+++ b/study-builder/studies/pancan/prequal.conf
@@ -87,61 +87,14 @@
       "icons": [],
       "blocks": [
         {
-          "bodyTemplate": {
-            "templateType": "HTML",
-            "templateText": """
-              <p class="ddp-question-prompt">$prompt *<br/> <small><em>$note</em></small></p>
-            """
-            "variables": [
-              {
-                "name": "prompt",
-                "translations": [
-                  { "language": "en", "text": ${i18n.en.prequal.primary_cancer_prompt_self} },
-                  { "language": "es", "text": ${i18n.es.prequal.primary_cancer_prompt_self} },
-                ]
-              },
-              {
-                "name": "note",
-                "translations": [
-                  { "language": "en", "text": ${i18n.en.prequal.primary_cancer_note_self} },
-                  { "language": "es", "text": ${i18n.es.prequal.primary_cancer_note_self} },
-                ]
-              }
-            ]
-          },
-          "blockType": "CONTENT",
+          "question": ${_includes.question_primary_cancer_list_self},
+          "blockType": "QUESTION",
           "shownExpr": ${_pex.is_self}
         },
         {
-          "bodyTemplate": {
-            "templateType": "HTML",
-            "templateText": """
-              <p class="ddp-question-prompt">$prompt *<br/> <small><em>$note</em></small></p>
-            """
-            "variables": [
-              {
-                "name": "prompt",
-                "translations": [
-                  { "language": "en", "text": ${i18n.en.prequal.primary_cancer_prompt_child} },
-                  { "language": "es", "text": ${i18n.es.prequal.primary_cancer_prompt_child} },
-                ]
-              },
-              {
-                "name": "note",
-                "translations": [
-                  { "language": "en", "text": ${i18n.en.prequal.primary_cancer_note_child} },
-                  { "language": "es", "text": ${i18n.es.prequal.primary_cancer_note_child} },
-                ]
-              }
-            ]
-          },
-          "blockType": "CONTENT",
-          "shownExpr": ${_pex.is_child_only}
-        },
-        {
-          "question": ${_includes.question_primary_cancer_list},
+          "question": ${_includes.question_primary_cancer_list_child},
           "blockType": "QUESTION",
-          "shownExpr": null
+          "shownExpr": ${_pex.is_child_only}
         },
         {
           "question": ${_includes.question_advanced_breast},

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-child.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-child.conf
@@ -1,0 +1,10 @@
+{
+  include required("../../snippets/picklist-question-single-autocomplete.conf"),
+  include required("common/cancer-picklist-options.conf"),
+  "stableId": ${id.q.primary_cancer_child},
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": ""
+    "variables": []
+  }
+}

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-list-child.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-list-child.conf
@@ -1,0 +1,65 @@
+{
+  include required("../../snippets/composite-question.conf"),
+  "stableId": ${id.q.primary_cancer_list_child},
+  "hideNumber": true,
+  "allowMultiple": true,
+  "childOrientation": "VERTICAL",
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": """
+              <p class="ddp-question-prompt">$prompt *<br/> <small><em>$note</em></small></p>
+            """
+    "variables": [
+      {
+        "name": "prompt",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_prompt_child} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_prompt_child} },
+        ]
+      },
+      {
+        "name": "note",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_note_child} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_note_child} },
+        ]
+      }
+    ]
+  },
+  "addButtonTemplate": {
+    "templateType": "TEXT",
+    "templateCode": null,
+    "templateText": "$add",
+    "variables": [
+      {
+        "name": "add",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_add} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_add} },
+        ]
+      }
+    ]
+  },
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "allowSave": true,
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$hint",
+        "variables": [
+          {
+            "name": "hint",
+            "translations": [
+              { "language": "en", "text": ${i18n.en.hint_diagnosed_cancers} },
+              { "language": "es", "text": ${i18n.es.hint_diagnosed_cancers} },
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  "children": [
+    ${_includes.question_primary_cancer_child}
+  ]
+}

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-list-self.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-list-self.conf
@@ -1,0 +1,65 @@
+{
+  include required("../../snippets/composite-question.conf"),
+  "stableId": ${id.q.primary_cancer_list_self},
+  "hideNumber": true,
+  "allowMultiple": true,
+  "childOrientation": "VERTICAL",
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": """
+              <p class="ddp-question-prompt">$prompt *<br/> <small><em>$note</em></small></p>
+            """
+    "variables": [
+      {
+        "name": "prompt",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_prompt_self} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_prompt_self} },
+        ]
+      },
+      {
+        "name": "note",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_note_self} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_note_self} },
+        ]
+      }
+    ]
+  },
+  "addButtonTemplate": {
+    "templateType": "TEXT",
+    "templateCode": null,
+    "templateText": "$add",
+    "variables": [
+      {
+        "name": "add",
+        "translations": [
+          { "language": "en", "text": ${i18n.en.prequal.primary_cancer_add} },
+          { "language": "es", "text": ${i18n.es.prequal.primary_cancer_add} },
+        ]
+      }
+    ]
+  },
+  "validations": [
+    {
+      "ruleType": "REQUIRED",
+      "allowSave": true,
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$hint",
+        "variables": [
+          {
+            "name": "hint",
+            "translations": [
+              { "language": "en", "text": ${i18n.en.hint_diagnosed_cancers} },
+              { "language": "es", "text": ${i18n.es.hint_diagnosed_cancers} },
+            ]
+          }
+        ]
+      }
+    }
+  ]
+  "children": [
+    ${_includes.question_primary_cancer_self}
+  ]
+}

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-self.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-self.conf
@@ -1,0 +1,10 @@
+{
+  include required("../../snippets/picklist-question-single-autocomplete.conf"),
+  include required("common/cancer-picklist-options.conf"),
+  "stableId": ${id.q.primary_cancer_self},
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": ""
+    "variables": []
+  }
+}

--- a/study-builder/studies/pancan/study-events.conf
+++ b/study-builder/studies/pancan/study-events.conf
@@ -101,14 +101,36 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": ${id.act.about_cancer},
         "createFromAnswer": true,
-        "sourceQuestionStableId": ${id.q.primary_cancer_list},
+        "sourceQuestionStableId": ${id.q.primary_cancer_list_self},
         "targetQuestionStableId": ${id.q.diagnosis_type}
       },
       # If there's already about-cancer instances, then don't create any more.
-      "preconditionExpr": """!user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()""",
+      "preconditionExpr": """!user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()
+      && (user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("DIAGNOSED"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": ${id.act.about_cancer},
+        "createFromAnswer": true,
+        "sourceQuestionStableId": ${id.q.primary_cancer_list_child},
+        "targetQuestionStableId": ${id.q.diagnosis_type}
+      },
+      # If there's already about-cancer instances, then don't create any more.
+      "preconditionExpr": """!user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()
+      && (!user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("DIAGNOSED")
+            && user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
     },
     {
       "trigger": {
@@ -120,7 +142,7 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": ${id.act.about_cancer},
         "createFromAnswer": true,
-        "sourceQuestionStableId": ${id.q.primary_cancer_list},
+        "sourceQuestionStableId": ${id.q.primary_cancer_list_self},
         "targetQuestionStableId": ${id.q.diagnosis_type}
       },
       # If there's already about-cancer instances, then don't create any more.

--- a/study-builder/studies/pancan/subs.conf
+++ b/study-builder/studies/pancan/subs.conf
@@ -30,8 +30,12 @@
     },
     "q": {
       "describe": "DESCRIBE",
-      "primary_cancer_list": "PRIMARY_CANCER_LIST",
-      "primary_cancer": "PRIMARY_CANCER",
+      #"primary_cancer_list": "PRIMARY_CANCER_LIST",
+      "primary_cancer_list_self": "PRIMARY_CANCER_LIST_SELF",
+      "primary_cancer_list_child": "PRIMARY_CANCER_LIST_CHILD",
+      #"primary_cancer": "PRIMARY_CANCER",
+      "primary_cancer_self": "PRIMARY_CANCER_SELF",
+      "primary_cancer_child": "PRIMARY_CANCER_CHILD",
       "advanced_breast": "ADVANCED_BREAST",
       "advanced_prostate": "ADVANCED_PROSTATE",
       "age": "AGE",
@@ -108,47 +112,52 @@
       (user.studies["cmi-pancan"].forms["PREQUAL"].questions["ADVANCED_PROSTATE"].answers.hasOption("YES"))
     """,
     "has_angio": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("ANGIOSARCOMA"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("ANGIOSARCOMA"))
     """,
     "has_esc": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("ESOPHAGEAL_STOMACH_CANCER"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("ESOPHAGEAL_STOMACH_CANCER"))
     """,
     "has_lms": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("LEIOMYOSARCOMA"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("LEIOMYOSARCOMA"))
     """,
     "has_ccp": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("COLORECTAL_CANCER"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("COLORECTAL_CANCER"))
     """,
     "has_brain": """
-      user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("BRAIN_TUMOR")
+      user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("BRAIN_TUMOR")
+      || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOption("BRAIN_TUMOR")
     """,
     "has_breast": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("BREAST"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("BREAST"))
     """,
     "has_osteo": """
-      user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("OSTEOSARCOMA")
-    """,
+      user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("OSTEOSARCOMA")
+      || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOption("OSTEOSARCOMA")
+      """
     "has_prostate": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasOption("PROSTATE"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("PROSTATE"))
     """,
     "is_lang_en": """(user.profile.language() == "en")""",
     "is_lang_es": """(user.profile.language() == "es")""",
     "is_not_redirect": """
-      !( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"]
+      !( (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"]
             .answers.hasAnyOption("BRAIN_TUMOR", "OSTEOSARCOMA")
-     || ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-            && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"]
+        || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"]
+            .answers.hasAnyOption("BRAIN_TUMOR", "OSTEOSARCOMA")
+        )
+     || ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+            && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"]
             .answers.hasAnyOption("ANGIOSARCOMA", "ESOPHAGEAL_STOMACH_CANCER", "COLORECTAL_CANCER", "LEIOMYOSARCOMA")
             && !user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED")
          )
-     || ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].numChildAnswers("PRIMARY_CANCER") == 1
-            && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST"].children["PRIMARY_CANCER"].answers.hasAnyOption("BREAST", "PROSTATE")
+     || ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
+            && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasAnyOption("BREAST", "PROSTATE")
             && !user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED")
             && (user.studies["cmi-pancan"].forms["PREQUAL"].questions["ADVANCED_BREAST"].answers.hasOption("YES")
                 || user.studies["cmi-pancan"].forms["PREQUAL"].questions["ADVANCED_PROSTATE"].answers.hasOption("YES"))
@@ -258,8 +267,12 @@
     "question_text_signature_req": { include required("snippets/question-text-signature-req.conf") },
 
     "question_describe": { include required("snippets/question-describe.conf") },
-    "question_primary_cancer": { include required("snippets/question-primary-cancer.conf") },
-    "question_primary_cancer_list": { include required("snippets/question-primary-cancer-list.conf") },
+    #"question_primary_cancer": { include required("snippets/question-primary-cancer.conf") },
+    "question_primary_cancer_self": { include required("snippets/question-primary-cancer-self.conf") },
+    "question_primary_cancer_child": { include required("snippets/question-primary-cancer-child.conf") },
+    # "question_primary_cancer_list": { include required("snippets/question-primary-cancer-list.conf") },
+    "question_primary_cancer_list_self": { include required("snippets/question-primary-cancer-list-self.conf") },
+    "question_primary_cancer_list_child": { include required("snippets/question-primary-cancer-list-child.conf") },
     "question_advanced_breast": { include required("snippets/question-advanced-breast.conf") },
     "question_advanced_prostate": { include required("snippets/question-advanced-prostate.conf") },
     "question_age": { include required("snippets/question-age.conf") },


### PR DESCRIPTION
refactored prequal cancer list collection question as two separate questions:
Some background:
Initially question_primary_cancer_list collects all diagnosed cancer list of self and child.
Question prompt was designed as content block so that diff text/prompt was displayed for self and child.
This caused issues for mobile while it looked fine in angular.

Refactor/Redesign
Separated  question_primary_cancer_list as question_primary_cancer_list_self and question_primary_cancer_list_child
Also had to separate question_primary_cancer which has ALL cancer list/options) into two questions: question_primary_cancer_self and question_primary_cancer_child
What this means:
Chosen cancer list options / answers are in two different questions/answers.
Other conf entries like study-events, pexx, workflow or anything else which refer to cancer list need to look at two question/answers.
DataExport (elastic and CSV) will contain two questions and answers with cancer list.
DSM will show as two questions/answers. Study staff user experience has impact with this design.

Some alternate thoughts:
Can we just show generic message which applies to both self/child/both and avoid designing as two questions ? 

