### PR TITLE
DDP-6641 set email as verified when updating via DSM task

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateEmailHandler.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateEmailHandler.java
@@ -60,7 +60,8 @@ public class UpdateEmailHandler {
      */
     private void updateEmailInAuth0(Handle handle, UserDto userDto, String email, String userGuid) {
         var mgmtAPI = Auth0Util.getManagementApiInstanceForUser(userDto.getUserGuid(), handle);
-        var status = Auth0Util.updateUserEmail(mgmtAPI, userDto, email);
+        // Note: when updating email administratively through DSM, we assume email has been verified.
+        var status = Auth0Util.updateUserEmail(mgmtAPI, userDto, email, true);
         String errMsg = null;
         switch (status.getAuth0Status()) {
             case SUCCESS:

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UpdateUserEmailRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/UpdateUserEmailRoute.java
@@ -37,7 +37,8 @@ public class UpdateUserEmailRoute extends ValidatedJsonInputRoute<UpdateUserEmai
 
             LOG.info("Attempting to change the email of the user {}", userGuid);
             ManagementAPI mgmtAPI = Auth0Util.getManagementApiInstanceForUser(userDto.getUserGuid(), handle);
-            Auth0CallResponse status = Auth0Util.updateUserEmail(mgmtAPI, userDto, newEmail);
+            // todo: investigate if this route should set email as verified or not
+            Auth0CallResponse status = Auth0Util.updateUserEmail(mgmtAPI, userDto, newEmail, null);
 
             String errMsg = null;
             switch (status.getAuth0Status()) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
@@ -187,18 +187,23 @@ public class Auth0Util {
     /**
      * Updates the user's email in Auth0
      *
-     * @param mgmtAPI  Auth0 Management API instance
-     * @param userDto  user for which you want to update the email
-     * @param newEmail A new email of this user
+     * @param mgmtAPI    Auth0 Management API instance
+     * @param userDto    user for which you want to update the email
+     * @param newEmail   A new email of this user
+     * @param isVerified Whether email is verified or not, will not set status if `null` (so we get the default behavior)
      * @return The result of the Auth0 call
      */
     public static Auth0CallResponse updateUserEmail(
             ManagementAPI mgmtAPI,
             UserDto userDto,
-            String newEmail
+            String newEmail,
+            Boolean isVerified
     ) {
         User payload = new User();
         payload.setEmail(newEmail);
+        if (isVerified != null) {
+            payload.setEmailVerified(isVerified);
+        }
         LOG.info("Trying to set the email to {} for the user {}", newEmail, userDto.getUserGuid());
         return updateUserData(mgmtAPI, userDto, payload);
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/UpdateUserLoginDataUtilTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/UpdateUserLoginDataUtilTest.java
@@ -49,7 +49,8 @@ public class UpdateUserLoginDataUtilTest extends TxnAwareBaseTest {
         return Auth0Util.updateUserEmail(
                 mgmtAPI,
                 convertTestingUserToDto(testingUser),
-                newEmail
+                newEmail,
+                null
         );
     }
 


### PR DESCRIPTION
## Context

Mark new email as verified when updating via DSM task.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## Testing

Haven't fully tested this yet, but will do so in `dev` where we have all the pubsub and DSM stuff setup.

How to test:
* Go to DSM and pick a study (e.g. Osteo)
* Pick a study and change the `E-Mail` field at the top of the Participant Page view.
* Wait for update to succeed.
* Go to Auth0 dashboard, find the user with new email.
* Confirm that email is marked as verified.

## Release

- [x] These changes require no special release procedures--just code!

