### PR TITLE
DDP-6537 pancan: mark address as verify required

### DIFF
--- a/study-builder/studies/pancan/consent-assent.conf
+++ b/study-builder/studies/pancan/consent-assent.conf
@@ -464,7 +464,7 @@
           },
           "subtitleTemplate": null,
           "hideNumber": true,
-          "requireVerified": false,
+          "requireVerified": true,
           "requirePhone": false,
           "blockType": "COMPONENT",
           "shownExpr": null

--- a/study-builder/studies/pancan/consent-parental.conf
+++ b/study-builder/studies/pancan/consent-parental.conf
@@ -463,7 +463,7 @@
           },
           "subtitleTemplate": null,
           "hideNumber": true,
-          "requireVerified": false,
+          "requireVerified": true,
           "requirePhone": false,
           "blockType": "COMPONENT",
           "shownExpr": null

--- a/study-builder/studies/pancan/consent-self.conf
+++ b/study-builder/studies/pancan/consent-self.conf
@@ -406,7 +406,7 @@
           },
           "subtitleTemplate": null,
           "hideNumber": true,
-          "requireVerified": false,
+          "requireVerified": true,
           "requirePhone": false,
           "blockType": "COMPONENT",
           "shownExpr": null


### PR DESCRIPTION
## Context

As part of the fix for DDP-6537, we'll mark the mailing-address as `requireVerified`.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Redeploy pancan to `dev` and wait for frontend fix.



