### PR TITLE
DDP-6369 pancan: survey email reminder

### DIFF
--- a/study-builder/studies/pancan/emails/survey_reminder.tmpl.html
+++ b/study-builder/studies/pancan/emails/survey_reminder.tmpl.html
@@ -103,7 +103,7 @@
     </tr>
     <tr style="width: 540px;">
       <td style="border-left:solid #ffffff 1px;border-right:solid #ffffff 1px;border-bottom:solid #ffffff 1px;border-top:solid #ffffff 1px;vertical-align:top;background-color:#ffffff;padding:20px 0px 0px 0px">
-        <div>&nbsp; <a href="{{baseWebUrl}}/activity-link/{{activityInstanceGuid}}" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#7154ff;border-top:15px solid #7154ff;border-bottom:15px solid #7154ff;border-left:25px solid #7154ff;border-right:25px solid #7154ff;border-radius:3px;display:inline-block"
+        <div>&nbsp; <a href="{{baseWebUrl}}/dashboard" style="font-size:16px;font-family:Helvetica,Arial,sans-serif;font-weight:normal;color:#ffffff;text-decoration:none;background-color:#7154ff;border-top:15px solid #7154ff;border-bottom:15px solid #7154ff;border-left:25px solid #7154ff;border-right:25px solid #7154ff;border-radius:3px;display:inline-block"
                        target="_blank">${text["button"]}</a>&nbsp;&nbsp;</div>
       </td>
     </tr>

--- a/study-builder/studies/pancan/study-events.conf
+++ b/study-builder/studies/pancan/study-events.conf
@@ -221,68 +221,6 @@
       "dispatchToHousekeeping": true,
       "order": 2
     },
-    ## Queue up 3 week reminders
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": ${id.act.consent},
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          { "emailTemplate": ${emails.en_consentReminder}, "language": "en", "isDynamic": true },
-          { "emailTemplate": ${emails.es_consentReminder}, "language": "es", "isDynamic": true },
-        ],
-        "linkedActivityCode": ${id.act.consent},
-        "pdfAttachments": []
-      },
-      "cancelExpr": """user.studies["cmi-pancan"].forms["CONSENT"].isStatus("COMPLETE")
-        || user.studies["cmi-pancan"].hasAgedUp()""",
-      "delaySeconds": ${timeout.secs_3_week},
-      "dispatchToHousekeeping": true,
-      "order": 3
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": ${id.act.parental},
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          { "emailTemplate": ${emails.en_consentReminder}, "language": "en", "isDynamic": true },
-          { "emailTemplate": ${emails.es_consentReminder}, "language": "es", "isDynamic": true },
-        ],
-        "linkedActivityCode": ${id.act.parental},
-        "pdfAttachments": []
-      },
-      "cancelExpr": """user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].isStatus("COMPLETE")""",
-      "delaySeconds": ${timeout.secs_3_week},
-      "dispatchToHousekeeping": true,
-      "order": 3
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": ${id.act.assent},
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          { "emailTemplate": ${emails.en_consentReminder}, "language": "en", "isDynamic": true },
-          { "emailTemplate": ${emails.es_consentReminder}, "language": "es", "isDynamic": true },
-        ],
-        "linkedActivityCode": ${id.act.assent},
-        "pdfAttachments": []
-      },
-      "cancelExpr": """user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].isStatus("COMPLETE")""",
-      "delaySeconds": ${timeout.secs_3_week},
-      "dispatchToHousekeeping": true,
-      "order": 3
-    },
 
     # When consent submitted
     ## Copy answers to profile
@@ -614,48 +552,6 @@
       "dispatchToHousekeeping": true,
       "order": 2
     },
-    ## Queue up 3 week reminders
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": ${id.act.release},
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          { "emailTemplate": ${emails.en_releaseReminder}, "language": "en", "isDynamic": true },
-          { "emailTemplate": ${emails.es_releaseReminder}, "language": "es", "isDynamic": true },
-        ],
-        "linkedActivityCode": ${id.act.release},
-        "pdfAttachments": []
-      },
-      "cancelExpr": """user.studies["cmi-pancan"].forms["RELEASE"].isStatus("COMPLETE")
-        || user.studies["cmi-pancan"].hasAgedUp()""",
-      "delaySeconds": ${timeout.secs_3_week},
-      "dispatchToHousekeeping": true,
-      "order": 3
-    },
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": ${id.act.release_minor},
-        "statusType": "CREATED"
-      },
-      "action": {
-        "type": "SENDGRID_EMAIL",
-        "templates": [
-          { "emailTemplate": ${emails.en_releaseReminder}, "language": "en", "isDynamic": true },
-          { "emailTemplate": ${emails.es_releaseReminder}, "language": "es", "isDynamic": true },
-        ],
-        "linkedActivityCode": ${id.act.release_minor},
-        "pdfAttachments": []
-      },
-      "cancelExpr": """user.studies["cmi-pancan"].forms["RELEASE_MINOR"].isStatus("COMPLETE")""",
-      "delaySeconds": ${timeout.secs_3_week},
-      "dispatchToHousekeeping": true,
-      "order": 3
-    },
 
     # When release submitted
     ## Create about-cancer instances based on cancer selections from prequal
@@ -765,6 +661,89 @@
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 3
+    },
+    ## Queue up 1 week survey reminders (since this email looks at both about-cancer and about-you, we create it here after release)
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          { "emailTemplate": ${emails.en_surveyReminder}, "language": "en", "isDynamic": true },
+          { "emailTemplate": ${emails.es_surveyReminder}, "language": "es", "isDynamic": true },
+        ],
+        "pdfAttachments": []
+      },
+      # todo: we should look at all instances of about-cancer and not just latest one
+      "cancelExpr": """user.studies["cmi-pancan"].forms["ABOUT_CANCER"].isStatus("COMPLETE")
+        && user.studies["cmi-pancan"].forms["ABOUT_YOU"].isStatus("COMPLETE")""",
+      "delaySeconds": ${timeout.secs_1_week},
+      "dispatchToHousekeeping": true,
+      "order": 4
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release_minor},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          { "emailTemplate": ${emails.en_surveyReminder}, "language": "en", "isDynamic": true },
+          { "emailTemplate": ${emails.es_surveyReminder}, "language": "es", "isDynamic": true },
+        ],
+        "pdfAttachments": []
+      },
+      "cancelExpr": """user.studies["cmi-pancan"].forms["ABOUT_CANCER"].isStatus("COMPLETE")
+        && user.studies["cmi-pancan"].forms["ABOUT_YOU"].isStatus("COMPLETE")""",
+      "delaySeconds": ${timeout.secs_1_week},
+      "dispatchToHousekeeping": true,
+      "order": 4
+    },
+    ## Queue up 2 week survey reminders
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          { "emailTemplate": ${emails.en_surveyReminder}, "language": "en", "isDynamic": true },
+          { "emailTemplate": ${emails.es_surveyReminder}, "language": "es", "isDynamic": true },
+        ],
+        "pdfAttachments": []
+      },
+      "cancelExpr": """user.studies["cmi-pancan"].forms["ABOUT_CANCER"].isStatus("COMPLETE")
+        && user.studies["cmi-pancan"].forms["ABOUT_YOU"].isStatus("COMPLETE")""",
+      "delaySeconds": ${timeout.secs_2_week},
+      "dispatchToHousekeeping": true,
+      "order": 5
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release_minor},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "SENDGRID_EMAIL",
+        "templates": [
+          { "emailTemplate": ${emails.en_surveyReminder}, "language": "en", "isDynamic": true },
+          { "emailTemplate": ${emails.es_surveyReminder}, "language": "es", "isDynamic": true },
+        ],
+        "pdfAttachments": []
+      },
+      "cancelExpr": """user.studies["cmi-pancan"].forms["ABOUT_CANCER"].isStatus("COMPLETE")
+        && user.studies["cmi-pancan"].forms["ABOUT_YOU"].isStatus("COMPLETE")""",
+      "delaySeconds": ${timeout.secs_2_week},
+      "dispatchToHousekeeping": true,
+      "order": 5
     },
 
     # When DSM notifications received

--- a/study-builder/studies/pancan/subs.conf
+++ b/study-builder/studies/pancan/subs.conf
@@ -19,7 +19,6 @@
   "timeout": {
     "secs_1_week": 604800,
     "secs_2_week": 1209600,
-    "secs_3_week": 1814400,
   },
 
   "id": {


### PR DESCRIPTION
## Context

See DDP-6369. One caveat here is that we don't have pex expression to look at all instances, so right now the email event is not triggering exactly as we want, but it should be a good start.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Redeploy pancan.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

