### PR TITLE
DDP-6657 pancan: add-child flow

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowState.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/db/dao/JdbiWorkflowState.java
@@ -36,9 +36,9 @@ public interface JdbiWorkflowState extends SqlObject {
             + " where study_activity_id = :activityId and check_each_instance = :check")
     Optional<Long> findActivityStateId(@Bind("activityId") long activityId, @Bind("check") boolean checkEachInstance);
 
-    @SqlQuery("select workflow_state_id, study_guid, study_name, redirect_url from workflow_study_redirect_state "
-            + " where (study_guid is null or study_guid = :studyGuid) and (study_name is null or study_name = :studyName) "
-            + " and redirect_url = :redirectUrl")
+    @SqlQuery("select * from workflow_study_redirect_state"
+            + " where (study_guid = :studyGuid and redirect_url = :redirectUrl)"
+            + "    or (study_name = :studyName and redirect_url = :redirectUrl)")
     @RegisterConstructorMapper(StudyRedirectState.class)
     Optional<StudyRedirectState> findByStudyGuidNameAndRedirectUrl(@Bind("studyGuid") String studyGuid,
                                                                    @Bind("studyName") String studyName,

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/workflow/StudyRedirectState.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/workflow/StudyRedirectState.java
@@ -11,7 +11,7 @@ public class StudyRedirectState implements WorkflowState {
     String redirectUrl;
 
     @JdbiConstructor
-    public StudyRedirectState(@ColumnName("workflow_state_id") Long workflowStateId,
+    public StudyRedirectState(@ColumnName("workflow_state_id") long workflowStateId,
                               @ColumnName("study_guid") String studyGuid,
                               @ColumnName("study_name") String studyName,
                               @ColumnName("redirect_url")String redirectUrl) {

--- a/study-builder/studies/pancan/add-child.conf
+++ b/study-builder/studies/pancan/add-child.conf
@@ -1,0 +1,94 @@
+{
+  include required("../snippets/activity-general-form.conf"),
+  "studyGuid": ${id.study},
+  "activityCode": ${id.act.add_child},
+  "versionTag": "v1",
+  "displayOrder": 1,
+  "writeOnce": true,
+  "maxInstancesPerUser": 1,
+  # This activity should not be shown in dashboard -- only used for kicking off Add Child flow.
+  "excludeFromDisplay": true,
+  # Used by logged-in proxy to add child, so not going to allow unauthenticated.
+  "allowUnauthenticated": false,
+  "translatedNames": [
+    { "language": "en", "text": ${i18n.en.add_child.name} },
+    { "language": "es", "text": ${i18n.es.add_child.name} },
+  ],
+  "translatedTitles": [
+    { "language": "en", "text": ${i18n.en.prequal.title} },
+    { "language": "es", "text": ${i18n.es.prequal.title} },
+  ],
+  "sections": [
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "question": ${_includes.question_primary_cancer_list_add_child},
+          "blockType": "QUESTION",
+          "shownExpr": null
+        }
+      ]
+    },
+    {
+      "nameTemplate": null,
+      "icons": [],
+      "blocks": [
+        {
+          "question": ${_includes.question_age} {
+            "stableId": ${id.q.child_age},
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": "$prompt",
+              "variables": [
+                {
+                  "name": "prompt",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.prequal.age_prompt_child} },
+                    { "language": "es", "text": ${i18n.es.prequal.age_prompt_child} },
+                  ]
+                }
+              ]
+            }
+          },
+          "blockType": "QUESTION",
+          "shownExpr": ${_pex.addchild_is_not_redirect}
+        },
+        {
+          "question": ${_includes.question_country} {
+            "stableId": ${id.q.child_country},
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": "$prompt",
+              "variables": [
+                {
+                  "name": "prompt",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.prequal.location_prompt_child} },
+                    { "language": "es", "text": ${i18n.es.prequal.location_prompt_child} },
+                  ]
+                }
+              ]
+            }
+          },
+          "blockType": "QUESTION",
+          "shownExpr": ${_pex.addchild_is_not_redirect}
+        },
+        {
+          "question": ${_includes.question_state} {
+            "stableId": ${id.q.child_state}
+          },
+          "blockType": "QUESTION",
+          "shownExpr": ${_pex.addchild_is_not_redirect}"&&"${_pex.addchild_is_country_us}
+        },
+        {
+          "question": ${_includes.question_province} {
+            "stableId": ${id.q.child_province}
+          },
+          "blockType": "QUESTION",
+          "shownExpr": ${_pex.addchild_is_not_redirect}"&&"${_pex.addchild_is_country_ca}
+        },
+      ]
+    }
+  ]
+}

--- a/study-builder/studies/pancan/i18n/en.conf
+++ b/study-builder/studies/pancan/i18n/en.conf
@@ -27,6 +27,10 @@
   "err_need_self": "In order to participate in the project, your child must consent and register on their own.",
 },
 
+"add_child": {
+  "name": "Add Child",
+},
+
 "cancer": {
   "brain_tumor_group_prompt": "Brain or Central Nervous ",
   "atrt" : "Atypical teratoid rhabdoid tumor",

--- a/study-builder/studies/pancan/i18n/es.conf
+++ b/study-builder/studies/pancan/i18n/es.conf
@@ -27,6 +27,10 @@
   "err_need_self": "In order to participate in the project, your child must consent and register on their own.",
 },
 
+"add_child": {
+  "name": "Add Child",
+},
+
 "cancer": {
   "brain_tumor_group_prompt": "Brain or Central Nervous ",
   "atrt" : "Atypical teratoid rhabdoid tumor",

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-groups-add-child.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-groups-add-child.conf
@@ -1,0 +1,10 @@
+{
+  include required("../../snippets/picklist-question-single-autocomplete.conf"),
+  include required("common/cancer-picklist-groups.conf"),
+  "stableId": ${id.q.primary_cancer_add_child},
+  "promptTemplate": {
+    "templateType": "HTML",
+    "templateText": ""
+    "variables": []
+  }
+}

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-list-add-child.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-list-add-child.conf
@@ -1,0 +1,7 @@
+{
+  include required("question-primary-cancer-list-child.conf"),
+  "stableId": ${id.q.primary_cancer_list_add_child},
+  "children": [
+    ${_includes.question_primary_cancer_groups_add_child}
+  ]
+}

--- a/study-builder/studies/pancan/study-activities.conf
+++ b/study-builder/studies/pancan/study-activities.conf
@@ -19,7 +19,7 @@
       "mappings": [],
       "validations": [
         {
-          "stableIds": ["COUNTRY"],
+          "stableIds": [${id.q.country}],
           "precondition": ${_pex.is_self}"&&"${_pex.is_country_answered},
           "expression": "!"${_pex.is_country_supported},
           "messageTemplate": {
@@ -37,7 +37,7 @@
           }
         },
         {
-          "stableIds": ["COUNTRY"],
+          "stableIds": [${id.q.country}],
           "precondition": ${_pex.is_child_only}"&&"${_pex.is_country_answered},
           "expression": "!"${_pex.is_country_supported},
           "messageTemplate": {
@@ -55,7 +55,7 @@
           }
         },
         {
-          "stableIds": ["AGE", "COUNTRY", "STATE", "PROVINCE"],
+          "stableIds": [${id.q.age}, ${id.q.country}, ${id.q.state}, ${id.q.province}],
           "precondition": ${_pex.is_self}"&&"${_pex.is_age_location_answered},
           "expression": ${_pex.is_country_supported}" && !"${_pex.is_age_of_majority},
           "messageTemplate": {
@@ -73,9 +73,51 @@
           }
         },
         {
-          "stableIds": ["AGE", "COUNTRY", "STATE", "PROVINCE"],
+          "stableIds": [${id.q.age}, ${id.q.country}, ${id.q.state}, ${id.q.province}],
           "precondition": ${_pex.is_child_only}"&&"${_pex.is_age_location_answered},
           "expression": ${_pex.is_country_supported}"&&"${_pex.is_age_of_majority},
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$need_self",
+            "variables": [
+              {
+                "name": "need_self",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.prequal.err_need_self} },
+                  { "language": "es", "text": ${i18n.es.prequal.err_need_self} },
+                ]
+              }
+            ]
+          }
+        },
+      ]
+    },
+    {
+      "filepath": "add-child.conf",
+      "mappings": [],
+      "validations": [
+        {
+          "stableIds": [${id.q.child_country}],
+          "precondition": ${_pex.addchild_is_country_answered},
+          "expression": "!"${_pex.addchild_is_country_supported},
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$international",
+            "variables": [
+              {
+                "name": "international",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.prequal.err_international_child} },
+                  { "language": "es", "text": ${i18n.es.prequal.err_international_child} },
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "stableIds": [${id.q.child_age}, ${id.q.child_country}, ${id.q.child_state}, ${id.q.child_province}],
+          "precondition": ${_pex.addchild_is_age_location_answered},
+          "expression": ${_pex.addchild_is_country_supported}"&&"${_pex.addchild_is_age_of_majority},
           "messageTemplate": {
             "templateType": "HTML",
             "templateText": "$need_self",

--- a/study-builder/studies/pancan/study-events.conf
+++ b/study-builder/studies/pancan/study-events.conf
@@ -44,10 +44,47 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": ${id.act.assent}
       },
+      # No need for country check here because `is_age_assent` already covers it.
       "preconditionExpr": ${_pex.is_child_only}"&&"${_pex.is_age_assent},
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 3
+    },
+
+    # When add-child submitted
+    ## Create consent activities
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.add_child},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": ${id.act.parental}
+      },
+      # We want to make sure we did not redirect. Other consent cases check the country, which is a
+      # good indicator of not-redirected. We do the same here for parental case.
+      "preconditionExpr": ${_pex.addchild_is_country_answered}"&&"${_pex.addchild_is_age_parental},
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.add_child},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": ${id.act.assent}
+      },
+      # No need for country check here because `addchild_is_age_assent` already covers it.
+      "preconditionExpr": ${_pex.addchild_is_age_assent},
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
     },
 
     # When user registered
@@ -590,7 +627,7 @@
     },
 
     # When release submitted
-    ## Create about-cancer instances based on cancer selections from prequal
+    ## Create about-cancer instances based on cancer selections from prequal or add-child
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -605,6 +642,7 @@
         "targetQuestionStableId": ${id.q.diagnosis_type}
       },
       # If there's already about-cancer instances, then don't create any more.
+      # Only way to get release is through prequal normal registration, so no need to check add-child.
       "preconditionExpr": """!user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
@@ -624,7 +662,26 @@
         "targetQuestionStableId": ${id.q.diagnosis_type}
       },
       # If there's already about-cancer instances, then don't create any more.
-      "preconditionExpr": """!user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()""",
+      "preconditionExpr": ${_pex.has_prequal}"""&& !user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": ${id.act.release_minor},
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": ${id.act.about_cancer},
+        "createFromAnswer": true,
+        "sourceQuestionStableId": ${id.q.primary_cancer_list_add_child},
+        "targetQuestionStableId": ${id.q.diagnosis_type}
+      },
+      # If there's already about-cancer instances, then don't create any more.
+      "preconditionExpr": ${_pex.has_addchild}"""&& !user.studies["cmi-pancan"].forms["ABOUT_CANCER"].hasInstance()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 1

--- a/study-builder/studies/pancan/study-workflows.conf
+++ b/study-builder/studies/pancan/study-workflows.conf
@@ -69,7 +69,7 @@
         {
           "type": "STUDY_REDIRECT",
           "studyGuid": null,
-          "studyName": "Leiosarcoma Project"
+          "studyName": "Leiomyosarcoma Project"
           "redirectUrl": ${lmsRedirectUrl},
           "expression": ${_pex.is_self}"&&"${_pex.has_lms},
         },
@@ -230,6 +230,62 @@
           "type": "DASHBOARD",
           "expression": "true"
         }
+      ]
+    },
+
+    # add child workflow
+    {
+      "from": {
+        "type": "PARTICIPANT_LIST"
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.add_child},
+          "expression": "true"
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY",
+        "activityCode": ${id.act.add_child}
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.add_child},
+          "expression": """!user.studies["cmi-pancan"].forms["ADD_CHILD"].isStatus("COMPLETE")"""
+        },
+        {
+          "type": "STUDY_REDIRECT",
+          "studyGuid": "cmi-brain",
+          "redirectUrl": ${brainRedirectUrl},
+          "expression": ${_pex.addchild_has_brain},
+        },
+        {
+          "type": "STUDY_REDIRECT",
+          "studyGuid": "CMI-OSTEO",
+          "redirectUrl": ${osteoRedirectUrl},
+          "expression": ${_pex.addchild_has_osteo},
+        },
+        {
+          "type": "STUDY_REDIRECT",
+          "studyGuid": null,
+          "studyName": "Leiomyosarcoma Project"
+          "redirectUrl": ${lmsRedirectUrl},
+          "expression": ${_pex.addchild_has_lms},
+        },
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.parental},
+          "expression": """user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].hasInstance()""",
+        },
+        {
+          "type": "ACTIVITY",
+          "activityCode": ${id.act.assent},
+          "expression": """user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].hasInstance()""",
+        },
       ]
     },
 

--- a/study-builder/studies/pancan/study-workflows.conf
+++ b/study-builder/studies/pancan/study-workflows.conf
@@ -71,14 +71,14 @@
           "studyGuid": null,
           "studyName": "Leiomyosarcoma Project"
           "redirectUrl": ${lmsRedirectUrl},
-          "expression": ${_pex.is_self}"&&"${_pex.has_lms},
+          "expression": ${_pex.has_lms},
         },
         {
           "type": "STUDY_REDIRECT",
           "studyGuid": null,
           "studyName": "Colorectal Cancer Project"
           "redirectUrl": ${ccpRedirectUrl},
-          "expression": ${_pex.is_self}"&&"${_pex.has_ccp},
+          "expression": ${_pex.has_ccp},
         },
         {
           "type": "ACTIVITY",
@@ -275,6 +275,13 @@
           "studyName": "Leiomyosarcoma Project"
           "redirectUrl": ${lmsRedirectUrl},
           "expression": ${_pex.addchild_has_lms},
+        },
+        {
+          "type": "STUDY_REDIRECT",
+          "studyGuid": null,
+          "studyName": "Colorectal Cancer Project"
+          "redirectUrl": ${ccpRedirectUrl},
+          "expression": ${_pex.addchild_has_ccp},
         },
         {
           "type": "ACTIVITY",

--- a/study-builder/studies/pancan/study.conf
+++ b/study-builder/studies/pancan/study.conf
@@ -81,22 +81,28 @@
   },
 
   "governance": {
+    # This rule here is only used in the normal registration flow, not the add-child flow.
     "shouldCreateGovernedUserExpr": ${_pex.is_child_only}"""
       && (user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].hasInstance()
         || user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].hasInstance())
     """,
+    # These rules apply to both normal registration and add-child flows, so check both.
     "ageOfMajorityRules": [
       # AoM for U.S.
       {
-        "condition": ${_pex.is_child_only}"&&"${_pex.is_country_us}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"&&"${_pex.is_country_us}"""
           && user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+          ) || ("""${_pex.has_addchild}"&&"${_pex.addchild_is_country_us}"""
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL"))
         """,
         "age": 19,
         "prepMonths": 4
       },
       {
-        "condition": ${_pex.is_child_only}"&&"${_pex.is_country_us}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"&&"${_pex.is_country_us}"""
           && !user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+          ) || ("""${_pex.has_addchild}"&&"${_pex.addchild_is_country_us}"""
+          && !user.studies["cmi-pancan"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("AL"))
         """,
         "age": 18,
         "prepMonths": 4
@@ -104,15 +110,19 @@
 
       # AoM for Canada
       {
-        "condition": ${_pex.is_child_only}"&&"${_pex.is_country_ca}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"&&"${_pex.is_country_ca}"""
           && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+          ) || ("""${_pex.has_addchild}"&&"${_pex.addchild_is_country_ca}"""
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT"))
         """,
         "age": 19,
         "prepMonths": 4
       },
       {
-        "condition": ${_pex.is_child_only}"&&"${_pex.is_country_ca}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"&&"${_pex.is_country_ca}"""
           && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+          ) || ("""${_pex.has_addchild}"&&"${_pex.addchild_is_country_ca}"""
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK"))
         """,
         "age": 18,
         "prepMonths": 4
@@ -120,8 +130,10 @@
 
       # AoM for Puerto Rico
       {
-        "condition": ${_pex.is_child_only}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"""
           && user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("PR")
+          ) || ("""${_pex.has_addchild}"""
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR"))
         """,
         "age": 21,
         "prepMonths": 4
@@ -129,8 +141,10 @@
 
       # AoM for other U.S. Territories
       {
-        "condition": ${_pex.is_child_only}"""
+        "condition": "("${_pex.has_prequal}"&&"${_pex.is_child_only}"""
           && user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          ) || ("""${_pex.has_addchild}"""
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS"))
         """,
         "age": 18,
         "prepMonths": 4

--- a/study-builder/studies/pancan/subs.conf
+++ b/study-builder/studies/pancan/subs.conf
@@ -132,12 +132,12 @@
       && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasAnyOption("ESOPHAGEAL_CANCER", "STOMACH_CANCER"))
     """,
     "has_lms": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("LEIOMYOSARCOMA"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("LEIOMYOSARCOMA")
+      || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOption("LEIOMYOSARCOMA"))
     """,
     "has_ccp": """
-      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
-      && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("COLORECTAL_CANCER"))
+      (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("COLORECTAL_CANCER")
+      || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOption("COLORECTAL_CANCER"))
     """,
     "has_brain": """
       user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasAnyOption("ATRT", "ASTROCYTOMA", "BRAINSTEM_GLIOMA", "CHOROID_PLEXUS_TUMOR", "CRANIOPHARYNGIOMA", "DIFFUSE_ASTROCYTOMA", "DIFFUSE_MIDLINE_GLIOMA", "ETMR", "EPENDYMOMA")
@@ -338,6 +338,9 @@
     """,
     "addchild_has_lms": """
       user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOption("LEIOMYOSARCOMA")
+    """,
+    "addchild_has_ccp": """
+      user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOption("COLORECTAL_CANCER")
     """,
     "addchild_is_age_parental": """
       (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 7)

--- a/study-builder/studies/pancan/subs.conf
+++ b/study-builder/studies/pancan/subs.conf
@@ -25,6 +25,7 @@
     "study": "cmi-pancan",
     "act": {
       "prequal": "PREQUAL",
+      "add_child": "ADD_CHILD",
       "consent": "CONSENT",
       "parental": "CONSENT_PARENTAL",
       "assent": "CONSENT_ASSENT",
@@ -36,19 +37,22 @@
     },
     "q": {
       "describe": "DESCRIBE",
-      #"primary_cancer_list": "PRIMARY_CANCER_LIST",
-      #"primary_cancer_groups_self": "PRIMARY_CANCER_GROUPS_SELF",
       "primary_cancer_list_self": "PRIMARY_CANCER_LIST_SELF",
       "primary_cancer_list_child": "PRIMARY_CANCER_LIST_CHILD",
-      #"primary_cancer": "PRIMARY_CANCER",
+      "primary_cancer_list_add_child": "PRIMARY_CANCER_LIST_ADD_CHILD",
       "primary_cancer_self": "PRIMARY_CANCER_SELF",
       "primary_cancer_child": "PRIMARY_CANCER_CHILD",
+      "primary_cancer_add_child": "PRIMARY_CANCER_ADD_CHILD",
       "advanced_breast": "ADVANCED_BREAST",
       "advanced_prostate": "ADVANCED_PROSTATE",
       "age": "AGE",
       "country": "COUNTRY",
       "state": "STATE",
       "province": "PROVINCE",
+      "child_age": "CHILD_AGE",
+      "child_country": "CHILD_COUNTRY",
+      "child_state": "CHILD_STATE",
+      "child_province": "CHILD_PROVINCE",
       "consent_blood": "CONSENT_BLOOD",
       "consent_tissue": "CONSENT_TISSUE",
       "consent_firstname": "CONSENT_FIRSTNAME",
@@ -146,7 +150,7 @@
     "has_osteo": """
       user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("OSTEOSARCOMA")
       || user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOption("OSTEOSARCOMA")
-      """
+    """,
     "has_prostate": """
       (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
       && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOption("PROSTATE"))
@@ -259,6 +263,115 @@
         )
       ))
     """,
+    "has_prequal": """
+      user.studies["cmi-pancan"].forms["PREQUAL"].hasInstance()
+    """,
+    "has_addchild": """
+      user.studies["cmi-pancan"].forms["ADD_CHILD"].hasInstance()
+    """,
+    "addchild_is_not_redirect": """
+     !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"]
+          .answers.hasAnyOption("OSTEOSARCOMA", "ATRT", "ASTROCYTOMA", "BRAINSTEM_GLIOMA", "CHOROID_PLEXUS_TUMOR", "CRANIOPHARYNGIOMA", "DIFFUSE_ASTROCYTOMA", "DIFFUSE_MIDLINE_GLIOMA", "ETMR", "EPENDYMOMA")
+    """,
+    "addchild_is_country_us": """
+      (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US"))
+    """,
+    "addchild_is_country_ca": """
+      (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA"))
+    """,
+    "addchild_is_country_answered": """
+      (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].isAnswered())
+    """,
+    "addchild_is_country_supported": """
+      (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("US", "CA", "PR", "GU", "VI", "MP", "AS"))
+    """,
+    "addchild_is_age_location_answered": """
+      ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].isAnswered()
+      && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].isAnswered()
+      && (
+        !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("US", "CA")
+        || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].isAnswered()
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].isAnswered()
+        )
+      ))
+    """,
+    "addchild_is_age_of_majority": """
+      (
+        ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 19
+            ) || (
+              !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 18
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 19
+            ) || (
+              user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 18
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 21
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 18
+        )
+      )
+    """,
+    "addchild_has_brain": """
+      user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"]
+          .answers.hasAnyOption("ATRT", "ASTROCYTOMA", "BRAINSTEM_GLIOMA", "CHOROID_PLEXUS_TUMOR", "CRANIOPHARYNGIOMA", "DIFFUSE_ASTROCYTOMA", "DIFFUSE_MIDLINE_GLIOMA", "ETMR", "EPENDYMOMA")
+    """,
+    "addchild_has_osteo": """
+      user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOption("OSTEOSARCOMA")
+    """,
+    "addchild_has_lms": """
+      user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOption("LEIOMYOSARCOMA")
+    """,
+    "addchild_is_age_parental": """
+      (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 7)
+    """,
+    "addchild_is_age_assent": """
+      ((
+        ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 19
+            ) || (
+              !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 18
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 19
+            ) || (
+              user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 18
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 21
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() < 18
+        )
+      ) && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_AGE"].answers.value() >= 7)
+    """,
   },
 
   "_includes": {
@@ -287,15 +400,13 @@
     "cancer_groups_leukemia": { include required("snippets/common/cancer-picklist-groups-leukemia.conf") },
     "cancer_groups_lungs": { include required("snippets/common/cancer-picklist-groups-lungs.conf") },
 
-    #"question_primary_cancer": { include required("snippets/question-primary-cancer.conf") },
     "question_primary_cancer_groups_self": { include required("snippets/question-primary-cancer-groups-self.conf") },
     "question_primary_cancer_groups_child": { include required("snippets/question-primary-cancer-groups-child.conf") },
+    "question_primary_cancer_groups_add_child": { include required("snippets/question-primary-cancer-groups-add-child.conf") },
 
-    #"question_primary_cancer_self": { include required("snippets/question-primary-cancer-self.conf") },
-    #"question_primary_cancer_child": { include required("snippets/question-primary-cancer-child.conf") },
-    # "question_primary_cancer_list": { include required("snippets/question-primary-cancer-list.conf") },
     "question_primary_cancer_list_self": { include required("snippets/question-primary-cancer-list-self.conf") },
     "question_primary_cancer_list_child": { include required("snippets/question-primary-cancer-list-child.conf") },
+    "question_primary_cancer_list_add_child": { include required("snippets/question-primary-cancer-list-add-child.conf") },
     "question_advanced_breast": { include required("snippets/question-advanced-breast.conf") },
     "question_advanced_prostate": { include required("snippets/question-advanced-prostate.conf") },
     "question_age": { include required("snippets/question-age.conf") },


### PR DESCRIPTION
## Context

This PR sets up the "Add Child" flow for PanCan. This is based on the similar flow in other studies such as RareX.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score

- [x] :relaxed: All good, business as usual!

## How do we demo these changes?

Need to wait for frontend support, but in the meantime you can call the APIs directly.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

