### PR TITLE
DDP-6671 pacan: validations for dob in the consents

### DIFF
--- a/study-builder/studies/pancan/i18n/en.conf
+++ b/study-builder/studies/pancan/i18n/en.conf
@@ -351,7 +351,9 @@
   "dob_prompt": "Date of Birth",
   "signature_prompt": "Your Signature (Full Name)",
   "signature_label": "Full Name",
-  "address_title": "Your Mailing Address"
+  "address_title": "Your Mailing Address",
+  "err_dob_self": "Please check the date of birth you have entered. If the date is correct, then you are younger than the age required by local law to self-enroll in this study. However, you may ask your parent or guardian to enroll you in the study. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
+  "err_dob_ageup": "The date of birth you entered is different from what was previously entered by your parent or guardian. Please check the date you entered and correct any errors. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>."
 },
 
 "parental": {
@@ -449,7 +451,9 @@
   "name_prompt": "Your Name",
   "child_name_prompt": "Your Child's Name",
   "child_dob_prompt": "Your Child's Date of Birth",
-  "child_address_title": "Your Child's Mailing Address"
+  "child_address_title": "Your Child's Mailing Address",
+  "err_dob_need_self": "Please check the date of birth you entered for your child. If the date is correct, then your child has reached the age of majority and must self-enroll in order to participate in this study. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
+  "err_dob_need_assent": "Please check the date of birth you entered for your child. If the date is correct, then along with your consent, your child must give their own assent to participate in the study. In that case, please restart the process with a different email address, or contact us for help at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
 },
 
 "assent": {
@@ -467,6 +471,7 @@
   "s4_info6": "If you have any questions about this study, please have your parent contact the project team at <a href=\"tel:XXX-XXX-XXXX\" class=\"Link\">XXX-XXX-XXXX</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
   "s4_info7": "If you sign your name below, it means that you agree to take part in this research study.",
   "child_signature_prompt": "Child/Adolescent Assent",
+  "err_dob_need_parental": "Please check the date of birth you entered for your child. If the date is correct, then your child does not need to give their own assent to participate in the study. In that case, please restart the process with a different email address, or contact us for help at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
 },
 
 "release": {

--- a/study-builder/studies/pancan/i18n/es.conf
+++ b/study-builder/studies/pancan/i18n/es.conf
@@ -351,7 +351,9 @@
   "dob_prompt": "Date of Birth",
   "signature_prompt": "Your Signature (Full Name)",
   "signature_label": "Full Name",
-  "address_title": "Your Mailing Address"
+  "address_title": "Your Mailing Address",
+  "err_dob_self": "Please check the date of birth you have entered. If the date is correct, then you are younger than the age required by local law to self-enroll in this study. However, you may ask your parent or guardian to enroll you in the study. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
+  "err_dob_ageup": "The date of birth you entered is different from what was previously entered by your parent or guardian. Please check the date you entered and correct any errors. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>."
 },
 
 "parental": {
@@ -449,7 +451,9 @@
   "name_prompt": "Your Name",
   "child_name_prompt": "Your Child's Name",
   "child_dob_prompt": "Your Child's Date of Birth",
-  "child_address_title": "Your Child's Mailing Address"
+  "child_address_title": "Your Child's Mailing Address",
+  "err_dob_need_self": "Please check the date of birth you entered for your child. If the date is correct, then your child has reached the age of majority and must self-enroll in order to participate in this study. If you think there is a mistake, please reach out to us at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
+  "err_dob_need_assent": "Please check the date of birth you entered for your child. If the date is correct, then along with your consent, your child must give their own assent to participate in the study. In that case, please restart the process with a different email address, or contact us for help at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
 },
 
 "assent": {
@@ -467,6 +471,7 @@
   "s4_info6": "If you have any questions about this study, please have your parent contact the project team at <a href=\"tel:XXX-XXX-XXXX\" class=\"Link\">XXX-XXX-XXXX</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
   "s4_info7": "If you sign your name below, it means that you agree to take part in this research study.",
   "child_signature_prompt": "Child/Adolescent Assent",
+  "err_dob_need_parental": "Please check the date of birth you entered for your child. If the date is correct, then your child does not need to give their own assent to participate in the study. In that case, please restart the process with a different email address, or contact us for help at <a href=\"tel:651-403-5315\" class=\"Link\">651-403-5315</a> or <a href=\"mailto:info@joincountmein.org\" class=\"Link\">info@joincountmein.org</a>.",
 },
 
 "release": {

--- a/study-builder/studies/pancan/study-activities.conf
+++ b/study-builder/studies/pancan/study-activities.conf
@@ -149,6 +149,49 @@
           "type": "DATE_OF_BIRTH",
           "stableId": ${id.q.consent_dob}
         }
+      ],
+      "validations": [
+        {
+          # If adult participant's age derived from DOB is less than 18/19/21, then error.
+          "stableIds": [${id.q.consent_dob}],
+          "precondition": ${_pex.has_prequal}"&&"${_pex.is_self}"&&"${_pex.is_dob_answered},
+          "expression": ${_pex.is_dob_underage},
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$dob_self",
+            "variables": [
+              {
+                "name": "dob_self",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.consent.err_dob_self} },
+                  { "language": "es", "text": ${i18n.es.consent.err_dob_self} },
+                ]
+              }
+            ]
+          }
+        },
+        {
+          # If aged-up participant's DOB answer does not match what's in their profile, then error.
+          # Their profile should have already been populated with birth date as filled out previously by their parent.
+          "stableIds": [${id.q.consent_dob}],
+          "precondition": "(("${_pex.has_prequal}"&&"${_pex.is_child_only}")||"${_pex.has_addchild}")&&"${_pex.is_dob_answered},
+          "expression": """
+            user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.value() != user.profile.birthDate()
+          """,
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$validation_dob_ageup",
+            "variables": [
+              {
+                "name": "validation_dob_ageup",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.consent.err_dob_ageup} },
+                  { "language": "es", "text": ${i18n.es.consent.err_dob_ageup} },
+                ]
+              }
+            ]
+          }
+        },
       ]
     },
     {
@@ -166,6 +209,46 @@
           "type": "DATE_OF_BIRTH",
           "stableId": ${id.q.parental_child_dob}
         }
+      ],
+      "validations": [
+        {
+          # If child participant's age derived from DOB is at least 18/19/21, then error.
+          "stableIds": [${id.q.parental_child_dob}],
+          "precondition": ${_pex.is_parental_dob_answered},
+          "expression": "("${_pex.has_prequal}"&&"${_pex.is_parental_dob_of_majority}")||("${_pex.has_addchild}"&&"${_pex.addchild_is_parental_dob_of_majority}")",
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$dob_need_self",
+            "variables": [
+              {
+                "name": "dob_need_self",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.parental.err_dob_need_self} },
+                  { "language": "es", "text": ${i18n.es.parental.err_dob_need_self} },
+                ]
+              }
+            ]
+          }
+        },
+        {
+          # If child participant's age derived from DOB is 7 or older but less than 18/19/21, then error.
+          "stableIds": [${id.q.parental_child_dob}],
+          "precondition": ${_pex.is_parental_dob_answered},
+          "expression": "("${_pex.has_prequal}"&&"${_pex.is_parental_dob_of_assent}")||("${_pex.has_addchild}"&&"${_pex.addchild_is_parental_dob_of_assent}")",
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$dob_need_assent",
+            "variables": [
+              {
+                "name": "dob_need_assent",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.parental.err_dob_need_assent} },
+                  { "language": "es", "text": ${i18n.es.parental.err_dob_need_assent} },
+                ]
+              }
+            ]
+          }
+        },
       ]
     },
     {
@@ -183,6 +266,48 @@
           "type": "DATE_OF_BIRTH",
           "stableId": ${id.q.assent_child_dob}
         }
+      ],
+      "validations": [
+        {
+          # If child participant's age derived from DOB is at least 18/19/21, then error.
+          "stableIds": [${id.q.assent_child_dob}],
+          "precondition": ${_pex.is_assent_dob_answered},
+          "expression": "("${_pex.has_prequal}"&&"${_pex.is_assent_dob_of_majority}")||("${_pex.has_addchild}"&&"${_pex.addchild_is_assent_dob_of_majority}")",
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$dob_need_self",
+            "variables": [
+              {
+                "name": "dob_need_self",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.parental.err_dob_need_self} },
+                  { "language": "es", "text": ${i18n.es.parental.err_dob_need_self} },
+                ]
+              }
+            ]
+          }
+        },
+        {
+          # If child participant's age derived from DOB is less than 7, then error.
+          "stableIds": [${id.q.assent_child_dob}],
+          "precondition": ${_pex.is_assent_dob_answered},
+          "expression": """
+            !user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(7, YEARS)
+          """,
+          "messageTemplate": {
+            "templateType": "HTML",
+            "templateText": "$dob_need_parental",
+            "variables": [
+              {
+                "name": "dob_need_parental",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.assent.err_dob_need_parental} },
+                  { "language": "es", "text": ${i18n.es.assent.err_dob_need_parental} },
+                ]
+              }
+            ]
+          }
+        },
       ]
     },
     {

--- a/study-builder/studies/pancan/subs.conf
+++ b/study-builder/studies/pancan/subs.conf
@@ -263,6 +263,231 @@
         )
       ))
     """,
+    "is_dob_answered": """
+      user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].isAnswered()
+    """,
+    "is_parental_dob_answered": """
+      user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].isAnswered()
+    """,
+    "is_assent_dob_answered": """
+      user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].isAnswered()
+    """,
+    "is_dob_underage": """
+      (
+        ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              !user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("PR")
+          && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(21, YEARS)
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && !user.studies["cmi-pancan"].forms["CONSENT"].questions["CONSENT_DOB"].answers.ageAtLeast(18, YEARS)
+        )
+      )
+    """,
+    "is_parental_dob_of_majority": """
+      (
+        ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              !user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+        )
+      )
+    """,
+    "addchild_is_parental_dob_of_majority": """
+      (
+        ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+        )
+      )
+    """,
+    "is_parental_dob_of_assent": """
+      (
+        user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(7, YEARS)
+        && (
+          ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("US")
+            && (
+              ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+              ) || (
+                !user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+              )
+            )
+          ) || (
+            user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("CA")
+            && (
+              ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+              ) || (
+                user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+              )
+            )
+          ) || (
+            user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("PR")
+            && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+          ) || (
+            user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+            && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+          )
+        )
+      )
+    """,
+    "addchild_is_parental_dob_of_assent": """
+      (
+        user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(7, YEARS)
+        && (
+          ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+            && (
+              ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+              ) || (
+                !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+              )
+            )
+          ) || (
+            user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+            && (
+              ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+              ) || (
+                user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+              )
+            )
+          ) || (
+            user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR")
+            && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+          ) || (
+            user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+            && !user.studies["cmi-pancan"].forms["CONSENT_PARENTAL"].questions["PARENTAL_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+          )
+        )
+      )
+    """,
+    "is_assent_dob_of_majority": """
+      (
+        ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              !user.studies["cmi-pancan"].forms["PREQUAL"].questions["STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              user.studies["cmi-pancan"].forms["PREQUAL"].questions["PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+        ) || (
+          user.studies["cmi-pancan"].forms["PREQUAL"].questions["COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+        )
+      )
+    """,
+    "addchild_is_assent_dob_of_majority": """
+      (
+        ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              !user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_STATE"].answers.hasOption("AL")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
+          && (
+            ( user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(19, YEARS)
+            ) || (
+              user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+              && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+            )
+          )
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasOption("PR")
+          && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(21, YEARS)
+        ) || (
+          user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["CHILD_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+          && user.studies["cmi-pancan"].forms["CONSENT_ASSENT"].questions["ASSENT_CHILD_DOB"].answers.ageAtLeast(18, YEARS)
+        )
+      )
+    """,
     "has_prequal": """
       user.studies["cmi-pancan"].forms["PREQUAL"].hasInstance()
     """,


### PR DESCRIPTION
## Context

Somehow missed the "dob validations" that are in the consents. This PR adds those in.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.

## FUD Score
- [x] :relaxed: All good, business as usual!

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

