### PR TITLE
pancan: make proxy announcement msg not permanent

### DIFF
--- a/study-builder/studies/pancan/study-events.conf
+++ b/study-builder/studies/pancan/study-events.conf
@@ -1046,7 +1046,8 @@
       },
       "action": {
         "type": "ANNOUNCEMENT",
-        "permanent": true,
+        # Proxy might have other children and they can add more, so it should not be a permanent message.
+        "permanent": false,
         "createForProxies": true,
         "msgTemplate": ${_includes.announcement_proxy},
       },


### PR DESCRIPTION
Follow-up on discussion around dashboard announcement messages. Since proxy can have other children and can add more, after one of their child ages-up, the message we create for the proxy shouldn't be permanent.