### PR TITLE
DDP-6674 - provide synchronous execution of default address creation and the address snapshotting

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -422,7 +422,7 @@ public class DataDonationPlatform {
 
         // User mailing address routes
         AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), true);
 
         post(API.PARTICIPANT_ADDRESS, new CreateMailAddressRoute(addressService), responseSerializer);
         get(API.PARTICIPANT_ADDRESS, new GetParticipantMailAddressRoute(addressService), responseSerializer);

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.export;
 
-import static org.broadinstitute.ddp.export.ExportUtil.getSnapshottedMailAddress;
 import static org.broadinstitute.ddp.export.ExportUtil.extractParticipantsFromResultSet;
+import static org.broadinstitute.ddp.export.ExportUtil.getSnapshottedMailAddress;
 import static org.broadinstitute.ddp.model.activity.types.ComponentType.MAILING_ADDRESS;
 
 import java.io.BufferedWriter;
@@ -170,7 +170,7 @@ public class DataExporter {
         this.pdfService = new PdfService();
         this.fileService = FileUploadService.fromConfig(cfg);
         this.addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), false);
         try {
             this.esClient = ElasticsearchServiceUtil.getElasticsearchClient(cfg);
         } catch (MalformedURLException e) {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -188,6 +188,13 @@ public class PutFormAnswersRoute implements Route {
                                 LOG.error("Address snapshotting failed - default address is not found. User {}, activity instance {}",
                                         userGuid, instanceGuid);
                             }
+                        } else {
+                            // if address snapshotting not executed then removed lock which
+                            // is created for this user during the default address creation
+                            // (if no such lock was added then no problem anyway)
+                            if (addressService.isUseMailAddressLocks()) {
+                                addressService.getAddMailAddressLocks().remove(userGuid);
+                            }
                         }
                     }
 

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/NamedLocksMap.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/NamedLocksMap.java
@@ -1,0 +1,86 @@
+package org.broadinstitute.ddp.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Contains map of {@link ReentrantLock}'s.
+ * The locks can be added to the map with assigned name (key).
+ * For example, userGuid.<br>
+ * Scenario: method M2 of service S2 should be called after method M2 of service S2 and this sequence should be met
+ * for a certain user. Pseudocode example:
+ * <pre>
+ *   NamedLocksMap locksMap = new NamedLocksMap();
+ *   S1.m1() {
+ *       try {
+ *         Lock lock = lockMap.addAndLock(userGuid);
+ *         ...
+ *       } finally {
+ *         lock.unlock();
+ *       }
+ *   }
+ *   ...
+ *   S2.m2() {
+ *       try {
+ *         lockMap.lockIfExists(userGuid);
+ *         ...
+ *       } finally {
+ *         lockMap.unlockAndRemove();
+ *       }
+ *   }
+ * </pre>
+ * In above example:
+ * <pre>
+ * - method M1 creates a new lock, locks it and saves to the map with key=`userGuid`;
+ * - when M1 completed it unlocks the created lock;
+ * - method M2 searches for a lock for the same `userGuid`;
+ * - if lock is found then it tries to lock it too (if M1 still in progress then M2 blocked until M1 completed);
+ * - after method M1 completion method M2 started and at the end it unlocks the lock and removes it from the map.
+ * </pre>
+ * NOTE: for each user created a separate lock.
+ */
+public class NamedLocksMap {
+
+    private final Map<String, Lock> locks = new HashMap<>();
+
+    /**
+     * Find in the map a lock by key.
+     * If lock is found then call lock() (try to set a lock).
+     * If lock is not found in the map - nothing happens.
+     */
+    public synchronized Lock lockIfExists(String key) {
+        Lock lock = locks.get(key);
+        if (lock != null) {
+            lock.lock();
+        }
+        return lock;
+    }
+
+    /**
+     * Create a new {@link ReentrantLock} and add to the map.
+     * Call lock() (try to set a lock).
+     */
+    public synchronized Lock addAndLock(String key) {
+        Lock lock = locks.get(key);
+        if (lock == null) {
+            lock = new ReentrantLock();
+            locks.put(key, lock);
+        }
+        lock.lock();
+        return lock;
+    }
+
+    /**
+     * Find in the map a lock by key.
+     * If lock is found the run unlock() and remove the lock from the map.
+     */
+    public synchronized void unlockAndRemove(String key) {
+        Lock lock = locks.get(key);
+        if (lock != null) {
+            lock.unlock();
+            locks.remove(key);
+        }
+    }
+}

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/NamedLocksMap.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/NamedLocksMap.java
@@ -83,4 +83,14 @@ public class NamedLocksMap {
             locks.remove(key);
         }
     }
+
+    /**
+     * Remove the lock from the map.
+     */
+    public synchronized void remove(String key) {
+        Lock lock = locks.get(key);
+        if (lock != null) {
+            locks.remove(key);
+        }
+    }
 }

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/StudyDataLoaderMain.java
@@ -400,7 +400,7 @@ public class StudyDataLoaderMain {
         StudyDataLoader dataLoader = new StudyDataLoader(cfg);
         final OLCService olcService = new OLCService(cfg.getString(ConfigFile.GEOCODING_API_KEY));
         final AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), false);
 
         //load mapping data
         Map<String, JsonElement> mappingData = loadDataMapping(mappingFileName);
@@ -436,7 +436,7 @@ public class StudyDataLoaderMain {
         Map<String, MailAddress> userAddressMap = new HashMap<>();
         final OLCService olcService = new OLCService(cfg.getString(ConfigFile.GEOCODING_API_KEY));
         final AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), false);
         //load all Bucket data into memory
         Map<String, Map> altpidBucketDataMap = new HashMap<>();
         for (Blob file : bucket.list().iterateAll()) {
@@ -543,7 +543,7 @@ public class StudyDataLoaderMain {
         Map<String, JsonElement> mappingData = loadDataMapping(mappingFileName);
         final OLCService olcService = new OLCService(cfg.getString(ConfigFile.GEOCODING_API_KEY));
         final AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), false);
 
         Map<String, Map> altpidBucketDataMap = preProcessedData.getAltpidBucketDataMap();
         for (String altpid : altpidBucketDataMap.keySet()) {

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/DsmKitRequestDaoTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/db/dao/DsmKitRequestDaoTest.java
@@ -339,7 +339,7 @@ public class DsmKitRequestDaoTest extends TxnAwareBaseTest {
         testAddress.setPhone("999-232-5522");
         testAddress.setDefault(true);
         AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), true);
         return TransactionWrapper.withTxn(handle -> addressService.addAddress(handle, testAddress, TEST_USER_GUID, TEST_USER_GUID));
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/model/kit/KitConfigurationTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/model/kit/KitConfigurationTest.java
@@ -67,7 +67,7 @@ public class KitConfigurationTest extends TxnAwareBaseTest {
             JdbiCountry country = handle.attach(JdbiCountry.class);
             JdbiExpression expression = handle.attach(JdbiExpression.class);
             AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                    cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                    cfg.getString(ConfigFile.GEOCODING_API_KEY), true);
             ActivityInstanceDao activityInstanceDao = handle.attach(ActivityInstanceDao.class);
 
             long studyId = data.getStudyId();
@@ -152,7 +152,7 @@ public class KitConfigurationTest extends TxnAwareBaseTest {
 
             activityInstanceDao.deleteByInstanceGuid(activityInstanceGuid);
             AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                    cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                    cfg.getString(ConfigFile.GEOCODING_API_KEY), true);
             assertTrue(addressService.deleteAddress(handle, mailAddress.getGuid()));
         });
     }

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyStatisticsRouteTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/route/GetStudyStatisticsRouteTest.java
@@ -109,7 +109,7 @@ public class GetStudyStatisticsRouteTest extends IntegrationTestSuite.TestCase {
         testAddress.setDefault(true);
         Config cfg = ConfigManager.getInstance().getConfig();
         AddressService addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), true);
         return addressService.addAddress(handle, testAddress, userGuid, userGuid);
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AddressServiceTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/service/AddressServiceTest.java
@@ -58,7 +58,7 @@ public class AddressServiceTest extends TxnAwareBaseTest {
     @Before
     public void init() {
         mockOLC = mock(OLCService.class);
-        service = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY), mockOLC);
+        service = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY), mockOLC, true);
         when(mockOLC.calculateFullPlusCode(any())).thenReturn(TEST_PLUSCODE);
     }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/StudyDataLoaderTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/StudyDataLoaderTest.java
@@ -22,8 +22,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -127,7 +127,7 @@ public class StudyDataLoaderTest {
         Config cfg = ConfigManager.getInstance().getConfig();
         olcService = new OLCService(cfg.getString(ConfigFile.GEOCODING_API_KEY));
         addressService = new AddressService(cfg.getString(ConfigFile.EASY_POST_API_KEY),
-                cfg.getString(ConfigFile.GEOCODING_API_KEY));
+                cfg.getString(ConfigFile.GEOCODING_API_KEY), false);
         try {
             sourceData = new String(Files.readAllBytes(Paths.get(PARTICIPANT_DATA_TEST_DATA_LOCATION)));
         } catch (IOException e) {


### PR DESCRIPTION
## Context

Provided synchronous execution of default address creation and the address snapshotting (use reentrant locking mechanism for this).
There are 2 places in the code:
- `CreateMailAddressRoute#handleInputRequest()` - default address created (the process can be slower because it's called `easyPost` service);
- `AddressService#snapshotAddress()` (called from `PutFormAnswersRoute`) - created a copy of a default address (which should exist in DB at this moment).

Until the fix the `snapshotAddress()` was started before the default address creation completed. And this caused fatal error.
The fix is: it is used ReentrantLock mechanism (from the concurrency library) to lock bot places of code and ensure that  `snapshotAddress()` is started only after the default address creation completed.
The approach takes into account that it should be synchronized address creation/snapshotting for the same user. Therefore it is created a separate lock for each user (and this lock is deleted when it is not needed).


## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

