### PR TITLE
DDP-6885-add rule of type UNIQUE to PanCan cancer list

### DIFF
--- a/study-builder/studies/pancan/i18n/en.conf
+++ b/study-builder/studies/pancan/i18n/en.conf
@@ -703,6 +703,7 @@
 "label_firstname": "First Name",
 "label_lastname": "Last Name",
 "hint_diagnosed_cancers": "Please provide diagnosed cancer(s)"
+"hint_duplicated_cancers": "Please do not provide duplicated cancer(s)"
 "hint_choose_above": "Please choose one of the above options",
 "hint_age_range": "Please enter an age between 0 and 110"
 "hint_req_country": "Country is required",

--- a/study-builder/studies/pancan/i18n/es.conf
+++ b/study-builder/studies/pancan/i18n/es.conf
@@ -704,6 +704,7 @@
 "label_firstname": "Nombre",
 "label_lastname": "Apellido",
 "hint_diagnosed_cancers": "Indique el o los tipos de cáncer diagnosticado(s)"
+"hint_duplicated_cancers": "Please do not provide duplicated cancer(s)"
 "hint_choose_above": "Elija una de las opciones anteriores",
 "hint_age_range": "Ingrese una edad entre 0 y 110"
 "hint_req_country": "El país es obligatorio",

--- a/study-builder/studies/pancan/snippets/question-primary-cancer-list-self.conf
+++ b/study-builder/studies/pancan/snippets/question-primary-cancer-list-self.conf
@@ -55,6 +55,23 @@
           }
         ]
       }
+    },
+    {
+      "ruleType": "UNIQUE",
+      "allowSave": false,
+      "hintTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$hint",
+        "variables": [
+          {
+            "name": "hint",
+            "translations": [
+              { "language": "en", "text": ${i18n.en.hint_duplicated_cancers} },
+              { "language": "es", "text": ${i18n.es.hint_duplicated_cancers} },
+            ]
+          }
+        ]
+      }
     }
   ]
   "children": [


### PR DESCRIPTION
## Context (DRAFT)

As I understand the configuration changes in prod needs to be done as SB custom tasks, correct?
But this PR contains changes in study-builder conf files only.
The problem is that **still not clear how to apply this `UNIQUE` rule**.
In the SB configuration there is a parameter `"allowSave": false` which affects when an `answer validation rule` is checked:
- if `allowSave=true` then `answer validation rule` is checked in `PUT /answers` and in case of failure it returns a general error: `{"code":"QUESTION_REQUIREMENTS_NOT_MET","message":"The status cannot be set to COMPLETE because the question requirements are not met"}`;
- if `allowSave=false` then `answer validation rule` is checked in `PATCH /answers` and in case of failure it returns an error:
`{"violations":[{"stableId":"PRIMARY_CANCER_LIST_SELF","rules":["UNIQUE"]}],"code":"ANSWER_VALIDATION","message":"One or more answer submission(s) failed validation for their question(s)"}`.

We discussed validation rules with Anastasiia (@aglushko-broad) and she thinks that better to have only one approach of validation handling - that one which used during `activity form validation` check (`validationFailures`), for example: 
`{"answers":...,"validationFailures":[{"message":"\u003cspan class\u003d\"bold\"\u003eIn order to participate in the project, a parent needs to help you.\u003c/span\u003e When your parent is with you, click back and select \"My child has been diagnosed\" and complete the registration together.","stableIds":["AGE","COUNTRY","STATE","PROVINCE"]}]}`

**Here is what she wrote in Slack about this task (and her suggestion):**

Hey folks, I want to discuss https://broadinstitute.atlassian.net/browse/DDP-6885
Evgenii is working on this task and asking us about frontend implementation for backend validation errors. So for backend validation treatment we have `validationFailures` field which comes from answers  `PATCH` api response.
So we expect that new validation would use the same approach. But Evgenii told me today that you agreed to use new response format for UNIQUE rule (e.g. from Evgenii `{"violations":[{"stableId":"PRIMARY_CANCER_LIST_SELF","rules":["UNIQUE"]}],"code":"ANSWER_VALIDATION","message":"One or more answer submission(s) failed validation for their question(s)"}`).
FE doesn't need to know code and rule names.
That requires adding some adapter on frontend to handle both models of validation errors and normalize to the one model
@MocanaAtBroad I want to ask why we can't normalize the data on backend and give us the same response for every validation rule?

**I wrote in Slack channel my understanding of validation handling in Pepper:**

In Pepper there are:
- 2 types of validations: `answer validation rules` (`REQUIRED, LENGTH, AGE_RANGE, UNIQUE`...) and `activity forms validations` (where `PEX-expressions` are validated).
- 2 places where validation is done: `PATCH /answers` (validated when answer data entered/selected); `PUT /answers` - validated on form submit.
- 3 approached of validation: 1) `on front-end` (currently all answer validation rules (except `UNIQUE`) are validated on front-end side); 2) `activity forms validation on backend`: it is validated in PATCH /answers and in case of failure in returns info in response in section `validationFailure`; 3) `answer validation on backend`: **seems it still never used (!)** because answer rules validated on a frontend: but for rule `UNIQUE` the check is done on the backend side only (and the place where to validate `answer validation rules` depends on SF parameter `allowSave`.
Currently there are **2 possibilities** to validate `UNIQUE`:
if to set SB config param `"allowSave": true` then it is validated on submit (in `PUT /answers`) and in case of failure returns: `{"code":"QUESTION_REQUIREMENTS_NOT_MET","message":"The status cannot be set to COMPLETE because the question requirements are not met"}`;
if to set SB config param `"allowSave": false` then it is validated once the option is selected in a list - in `PATCH /answers` and in case of failure it returns in response: `{"violations":[{"stableId":"PRIMARY_CANCER_LIST_SELF","rules":["UNIQUE"]}],"code":"ANSWER_VALIDATION","message":"One or more answer submission(s) failed validation for their question(s)"}` which differs from format which used for activity forms validation (where result is returned in section  validationFailure ).
Btw, `"allowSave": false` is never used - I didn't found it in any study. In all cases `"allowSave": true` is used.

**Possible solutions:**

**_1) Redesign validation on backend side and in all cases return validation result in a section `validationFailure` (this is more convenient for FE because they already have a handler for this)._**

**_2) Use the rule with `"allowSave": false` and ask FE to handle a validation failure returned in `{"violations":[..]}` section._**
