### PR TITLE
Handle nestedOptions in study-builder generic task

### DIFF
--- a/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateTemplatesInPlace.java
+++ b/study-builder/src/main/java/org/broadinstitute/ddp/studybuilder/task/UpdateTemplatesInPlace.java
@@ -403,6 +403,11 @@ public class UpdateTemplatesInPlace implements CustomTask {
         Map<String, Config> allOptionCfgs = new HashMap<>();
         for (var optionCfg : questionCfg.getConfigList("picklistOptions")) {
             allOptionCfgs.put(optionCfg.getString("stableId"), optionCfg);
+            if (optionCfg.hasPath("nestedOptions")) {
+                for (var nestedOptionCfg : optionCfg.getConfigList("nestedOptions")) {
+                    allOptionCfgs.put(nestedOptionCfg.getString("stableId"), nestedOptionCfg);
+                }
+            }
         }
 
         for (int i = 0; i < groups.size(); i++) {


### PR DESCRIPTION
UpdateTemplatesInPlace task is used when template text/translations are updated for any existing deployed study.
Update Study Builder generic task UpdateTemplatesInPlace to load nestedOptions  during comparison between conf and DB . 
Without the change task runs into below validation failure because option(s) count doesn't match.
if (allOptions.size() != allOptionCfgs.size()) {
            throw new DDPException("Question " + questionStableId + " number of picklist options does not match");
}
