### PR TITLE
DDP-6933 - correct DataExport error message - remove random participant guid from it

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -349,8 +349,7 @@ public class DataExporter {
                             exportsSoFar, participants.size(), studyDto.getGuid());
                 }
             } catch (Exception e) {
-                LOG.error("[export] failed to export participant {} for study {}, continuing",
-                        participant.getUser().getGuid(), studyDto.getGuid(), e);
+                LOG.error("[export] failed to export participants for study {}, continuing... ", studyDto.getGuid(), e);
             }
         }
     }


### PR DESCRIPTION
## Context

The problem happens when a job `StudyDataExportJob` executed from app `Housekeeping`.
It started from August,11.
And the problem happens with one and the same user with guid=Q65OYCAE9PWQ1TGD62HZ of study crm-brain.
Q65OYCAE9PWQ1TGD62HZ - is a governed user (it’s proxy user is VC7GI09PYOQIRARYO265). 
It has no any activities connected to it therefore this bug happens:
```
[housekeeping] [export] failed to export participant E32984YN14Z9ME3EVJRB for study cmi-brain, continuing Cannot find question PREQUAL_SELF_DESCRIBE in form PREQUAL for user Q65OYCAE9PWQ1TGD62HZ and study cmi-brain 2`
```
This error message is not quite correct: the participant `E32984YN14Z9ME3EVJRB` is not connected to the user `Q65OYCAE9PWQ1TGD62HZ`. How it could happen that it mentioned in one error message? Because participants exported by batches: `DataExporter` iterates through study users and add them to a batch. As soon as batch size == upper limit, then it starts the process of exporting the users of the created batch. If any exception happens during this process then it caught and a message is added at the beginning of the root error: `"[export] failed to export participant {} for study {}, continuing..."` where placed a last participant in the batch.
So the fix is very simple: not to add the last added participant guid to the message.

In order to fix the error itself it is suggested to do the fix in dev DB: since August,11 the error reproduced for one and the same user. It looks like at some moment (around August, 11) the code (frontend or backend) containing some bug was deployed to dev and it was possible to create a `cmi-brain` user which is not connected to activity `PREQUAL`. 
Let's fix the data in DB by closing this problematic user enrollment:
`update user_study_enrollment set valid_to=1631035883375 where user_id=18203;`

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [x] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.


## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [x] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

