### PR TITLE
DDP-6932 - improve 'Accept-Language' parsing error handling

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/I18nUtil.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/I18nUtil.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.ddp.util;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -14,6 +12,8 @@ import java.util.Locale;
 import java.util.Locale.LanguageRange;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -31,6 +31,8 @@ public class I18nUtil {
     // Might want to pull this from a config file at some point, although
     // there is also Locale.getDefault() (bskinner)
     public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+
+    private static final String DEFAULT_ACCEPTE_LANGUAGE_HEADER = "en-US";
 
     private static final Logger LOG = LoggerFactory.getLogger(I18nUtil.class);
 
@@ -114,7 +116,9 @@ public class I18nUtil {
             try {
                 acceptedRanges = Locale.LanguageRange.parse(acceptLanguageHeader);
             } catch (Exception e) {
-                LOG.warn("Error while parsing Accept-Language header '{}', will disregard and continue", acceptLanguageHeader, e);
+                acceptedRanges = Locale.LanguageRange.parse(DEFAULT_ACCEPTE_LANGUAGE_HEADER);
+                LOG.warn("Error while parsing Accept-Language header '{}', fallback to default Accept-Language header '{}'."
+                            + " StudyGuid '{}'.", acceptLanguageHeader, DEFAULT_ACCEPTE_LANGUAGE_HEADER, studyGuid);
             }
         }
 

--- a/pepper-apis/src/test/java/org/broadinstitute/ddp/util/I18nUtilTest.java
+++ b/pepper-apis/src/test/java/org/broadinstitute/ddp/util/I18nUtilTest.java
@@ -159,4 +159,22 @@ public class I18nUtilTest {
         Locale locale = I18nUtil.resolvePreferredLanguage(preferredLocale, testLocale, acceptedLanguages, supportedLocales);
         Assert.assertEquals(testLocale, locale);
     }
+
+    /**
+     * Check method resolveLocale() with 1 valid and 2 invalid values of AcceptLanguage
+     */
+    @Test
+    public void test_resolveLocale() {
+        Locale locale = I18nUtil.resolveLocale(null, null, Locale.ENGLISH,
+                "ru-RU,ru;q=0.9,en-US;q=0.8,en;q=0.7,fi;q=0.6,lv;q=0.5,nl;q=0.4,et;q=0.3");
+        Assert.assertEquals(Locale.ENGLISH, locale);
+
+        locale = I18nUtil.resolveLocale(null, null, Locale.ENGLISH,
+                "en-US.UTF-8");
+        Assert.assertEquals(Locale.ENGLISH, locale);
+
+        locale = I18nUtil.resolveLocale(null, null, Locale.ENGLISH,
+                "zh;q=0.9;q=0.9");
+        Assert.assertEquals(Locale.ENGLISH, locale);
+    }
 }


### PR DESCRIPTION
## Context

Improve 'Accept-Language' parsing error handling (do not write stacktrace to log, fallback to default Accept-Language)

The improvement is required because the following kind of error detected in prod log:
`java.lang.IllegalArgumentException: range=en_us.utf-8`
This value comes from HTTP request header parameter `'Accept-Language'` (which set on client side).
The examples of invalid values causing the error:
`'Accept-Language': 'en_us.utf-8'`
`'Accept-Language': 'zh;q=0.9;q=0.9'`
`'Accept-Language': 'ko;q=0.9;q=0.9'`
The assumption about the invalid `'Accept-Language'` origin: "It looks like the requests that included the unusual Accept-Language headers were likely malicious requests probing for vulnerabilities.".

It is decided to to catch the error and fallback to default `'Accept-Language'` `(en-US)`.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [x] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [x] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

