### PR TITLE
DDP-6973 . Remove auth0 connection restriction during email lookup

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/util/Auth0Util.java
@@ -387,8 +387,7 @@ public class Auth0Util {
             List<String> subset = ids.subList(i, end);
 
             // NOTE: Lucene syntax likes OR operator, but using a space also works. We do the latter to save space on URL limit.
-            String query = String.format("identities.connection:\"%s\" AND user_id:(%s)",
-                    connection, String.join(" ", subset));
+            String query = String.format("user_id:(%s)", String.join(" ", subset));
 
             UserFilter filter = new UserFilter()
                     .withFields("user_id,email", true)


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-6973
Remove auth0 connection restriction during data export for Auth0 email lookup
This is is to include Auth0 users who use Google Authentication. Ex: A-T Google oAuth users