### PR TITLE
DDP-6950 Sort elastic activity instances to load latest instance first

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -793,7 +793,9 @@ public class DataExporter {
         List<ActivityInstanceRecord> activityInstanceRecords = new ArrayList<>();
         Map<String, Set<String>> userActivityVersions = new HashMap<>();
         for (ActivityExtract activityExtract : studyExtract.getActivities()) {
-            List<ActivityResponse> instances = participant.getResponses(activityExtract.getTag());
+            List<ActivityResponse> instances = participant.getResponses(activityExtract.getTag()).stream()
+                    .sorted(Comparator.comparing(ActivityResponse::getCreatedAt).reversed())
+                    .collect(Collectors.toList());
             for (ActivityResponse instance : instances) {
                 ActivityInstanceStatusDto lastStatus = instance.getLatestStatus();
                 List<QuestionRecord> questionsAnswers = createQuestionRecordsForActivity(activityExtract.getDefinition(),


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-6950

DSM seem to be looking for activities from elastic data and incases where any activity has multiple instances, its getting whatever first instance is in elastic.
DSS DataExport is loading by default order (instances created) , DSM is finding oldest activity instance.

Made change to export "latest" activity instance first and that fixed DDP-6950 issue