### PR TITLE
Fix error "Using existing user to upgrade..." in registration rule

### DIFF
--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -90,11 +90,17 @@ function (user, context, callback) {
         } else if (context.request.body.temp_user_guid) {
             pepper_params.tempUserGuid = context.request.body.temp_user_guid;
             console.log('Temp user guid passed in (via body) = ' + pepper_params.tempUserGuid);
-        } else if (user.user_metadata.temp_user_guid) {
-            pepper_params.tempUserGuid = user.user_metadata.temp_user_guid;
-            console.log('No temp user guid found in request, taking one from user metadata');
         } else {
-            console.log('No temp user guid found in request nor user metadata');
+            console.log('No temp user guid passed in request');
+        }
+
+        /**
+         * If `tempUserGuid` was not set with value from request
+         * AND user is not yet registered in pepper (`user.app_metadata.user_guid` is empty)
+         * take `tempUserGuid` from `user_metadata`
+         */
+        if (!pepper_params.tempUserGuid && !user.app_metadata.user_guid) {
+            pepper_params.tempUserGuid = user.user_metadata.temp_user_guid;
         }
 
         if (context.request.query.mode) {

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -97,9 +97,13 @@ function (user, context, callback) {
         /**
          * If `tempUserGuid` was not set with value from request
          * AND user is not yet registered in pepper (`user.app_metadata.user_guid` is empty)
-         * take `tempUserGuid` from `user_metadata`
+         * take `tempUserGuid` from `user_metadata` (if one exists)
          */
-        if (!pepper_params.tempUserGuid && !user.app_metadata.user_guid) {
+        if (
+            !pepper_params.tempUserGuid &&
+            !user.app_metadata.user_guid &&
+            !!user.user_metadata.temp_user_guid
+        ) {
             pepper_params.tempUserGuid = user.user_metadata.temp_user_guid;
         }
 


### PR DESCRIPTION
My previous update to this rule introduced a bug that wouldn't allow users to log in after first attempt.
I've added a couple of checks to append `temp_user_guid` from `user_metadata` only when no value was found in request AND user wasn't registered previously. This way subsequent log in attempts will no longer send `temp_user_guid` alongside normal request payload.