### PR TITLE
DDP-7033 - in case if dsm.familyId is null - skip this user

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/customexport/export/CustomExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/customexport/export/CustomExporter.java
@@ -90,7 +90,12 @@ public class CustomExporter {
         List<CustomExportParticipant> customExportParticipants = new ArrayList<>();
         for (Participant p : participants) {
             String familyId = getFamilyId(handle, studyDto, p.getUser().getGuid(), esClient);
-            customExportParticipants.add(new CustomExportParticipant(familyId, p));
+            if (familyId != null) {
+                customExportParticipants.add(new CustomExportParticipant(familyId, p));
+            } else {
+                LOG.error("Exclude participant with GUID = '{}' from the export batch: "
+                        + "Failed to get family ID for the participant because dsm.familyId is null", p.getUser().getGuid());
+            }
         }
         return customExportParticipants;
     }
@@ -114,11 +119,9 @@ public class CustomExporter {
                     + "ElasticSearch is null");
         }
 
-        Object familyId = ((Map) source.get("dsm")).get("familyId");
-        if (familyId == null) {
-            throw new DDPException("Failed to get family ID for participant with guid " + userGuid + " because dsm.familyId is null");
-        }
-        return familyId.toString();
+        Object familyId = source.get("dsm") == null ? null : ((Map) source.get("dsm")).get("familyId");
+
+        return familyId == null ? null : familyId.toString();
     }
 
     public static void clearCachedAuth0Emails() {

--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/customexport/export/CustomExporter.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/customexport/export/CustomExporter.java
@@ -93,8 +93,8 @@ public class CustomExporter {
             if (familyId != null) {
                 customExportParticipants.add(new CustomExportParticipant(familyId, p));
             } else {
-                LOG.error("Exclude participant with GUID = '{}' from the export batch: "
-                        + "Failed to get family ID for the participant because dsm.familyId is null", p.getUser().getGuid());
+                LOG.error("Skipped participant with GUID = '{}' from the export batch because dsm.familyId is null",
+                        p.getUser().getGuid());
             }
         }
         return customExportParticipants;


### PR DESCRIPTION
FIX SUGGESTION:

## Context

In case if `dsm.familyId` is null - skip this user (do not export).

I tested the method `CustomExporter.getFamilyId()` with the following test:
```
package org.broadinstitute.ddp.customexport.export;

import java.net.MalformedURLException;
import java.util.Set;

import com.typesafe.config.Config;
import com.typesafe.config.ConfigFactory;
import org.broadinstitute.ddp.cache.LanguageStore;
import org.broadinstitute.ddp.constants.ConfigFile;
import org.broadinstitute.ddp.db.TransactionWrapper;
import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
import org.broadinstitute.ddp.db.dao.UserDao;
import org.broadinstitute.ddp.db.dto.StudyDto;
import org.broadinstitute.ddp.exception.DDPException;
import org.broadinstitute.ddp.model.user.User;
import org.broadinstitute.ddp.util.ElasticsearchServiceUtil;
import org.elasticsearch.client.RestHighLevelClient;
import org.jdbi.v3.core.Handle;
import org.slf4j.Logger;
import org.slf4j.LoggerFactory;

public class CustomExporterCli {

    private static final Logger LOG = LoggerFactory.getLogger(CustomExporterCli.class);

    private String studyGuid = "RGP";

    private RestHighLevelClient esClient;
    private Config cfg;
    private StudyDto studyDto;
    private Set<Long> userIds;

    public static void main(String[] args) {
        try {
            new CustomExporterCli().run();
        } catch (MalformedURLException e) {
            throw new DDPException(e);
        }
    }

    private void run() throws MalformedURLException {
        initDbConnection();
        TransactionWrapper.useTxn(handle -> {
            prepareData(handle);
            runTest(handle);
        });
    }

    private void initDbConnection() throws MalformedURLException {
        cfg = ConfigFactory.load();
        TransactionWrapper.reset();
        String dbUrl = cfg.getString(ConfigFile.DB_URL);
        System.out.println("DB connection: " + dbUrl);
        TransactionWrapper.init(new TransactionWrapper.DbConfiguration(TransactionWrapper.DB.APIS, 1, dbUrl));
        TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, LanguageStore::init);
        esClient = ElasticsearchServiceUtil.getElasticsearchClient(cfg);
    }

    private void prepareData(Handle handle) {
        studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
        System.out.println("Study data name: " + studyDto.getName());
        userIds = handle.attach(JdbiUserStudyEnrollment.class).findUserIdsByStudyIdAndLimit(studyDto.getId(), 0, 1000);
        System.out.println("Users: " + userIds);
    }

    private void runTest(Handle handle) {
        userIds.forEach(uId -> {
            User user = handle.attach(UserDao.class).findUserById(uId).orElse(null);
            processUser(handle, user);
        });
    }

    private void processUser(Handle handle, User user) {
        String familyId = CustomExporter.getFamilyId(handle, studyDto, user.getGuid(), esClient);
        if (familyId == null) {
            LOG.error("Exclude participant with GUID = '{}' from the export batch: "
                    + "Failed to get family ID for the participant because dsm.familyId is null", user.getGuid());
        }
    }
}
```
In order to get an error result I replaced in `CustomExporter.getFamilyId()` `dsm.familyId` with non-existing field `dsm.familyId1` (for testing period only).
As a result we get from ElasticSearch a response having `source` = an empty map (i.e. it is not null).
Therefore `source.get("dsm")` will be null in case if `familyId` not exist in `dsm`.
**The suggested fix is**: to check the `source.get("dsm")` and exclude a user from exporting instead of throwing an exception (in order to continue export process).
The information about a skipped user is in the alerts slack channel (but may be better to add a special DB table where to add skipped users?).

