### PR TITLE
Enable Google Cloud Logging for Auth0 registration rule

### DIFF
--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -196,7 +196,7 @@ function (user, context, callback) {
             if (cloudLoggingEnabled) {
                 var severity = "INFO";
 
-                if ( !!pepper_params.mode ) {
+                if (pepper_params.mode) {
                     if ( (pepper_params.mode === 'signup') && (!pepper_params.tempUserGuid) ) {
                         severity = "ERROR";
                     }

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -194,7 +194,7 @@ function (user, context, callback) {
             }
 
             if (cloudLoggingEnabled) {
-                var severity = "DEBUG";
+                var severity = "INFO";
 
                 if ( !!pepper_params.mode ) {
                     if ( (pepper_params.mode === 'signup') && (!pepper_params.tempUserGuid) ) {

--- a/study-builder/tenants/register-user-in-pepper.js
+++ b/study-builder/tenants/register-user-in-pepper.js
@@ -1,4 +1,23 @@
 function (user, context, callback) {
+    const {Logging} = require('@google-cloud/logging');
+    const cloudLoggingEnabled = !!configuration.googleApplicationCredentials;
+    var cloudLog = null;
+
+    if (cloudLoggingEnabled) {
+        const cloudLogName = "_Default";
+        var applicationCredentials = JSON.parse(configuration.googleApplicationCredentials);
+
+        console.log("Successfully loaded googleApplicationCredentials. Google Cloud Logging to project " + applicationCredentials.project_id + " is enabled");
+
+        var cloudLoggingConfig = {
+            projectId: applicationCredentials.project_id,
+            credentials: applicationCredentials
+        };
+
+        var cloudLogging = new Logging(cloudLoggingConfig);
+        cloudLog = cloudLogging.log(cloudLogName);
+    }
+
     // Environment stabilization. This will save us a number of
     // overly complex if statements later
     context.clientMetadata = context.clientMetadata || {};
@@ -141,8 +160,6 @@ function (user, context, callback) {
             console.log('User timezone passed in (via body) = ' + pepper_params.timeZone);
         }
 
-        console.log(context);
-
         // This is the token renewal case. Let's avoid going through pepper registration
         if (context.request.query.renew_token_only) {
             context.idToken[pepperUserGuidClaim] = user.app_metadata.user_guid;
@@ -176,6 +193,28 @@ function (user, context, callback) {
                 console.log('User metadata has last name = ' + pepper_params.lastName);
             }
 
+            if (cloudLoggingEnabled) {
+                var severity = "DEBUG";
+
+                if ( !!pepper_params.mode ) {
+                    if ( (pepper_params.mode === 'signup') && (!pepper_params.tempUserGuid) ) {
+                        severity = "ERROR";
+                    }
+                }
+
+                var entry = cloudLog.entry({
+                    severity: severity,
+                    labels: {
+                        source: "auth0",
+                        mode: pepper_params.mode || "default"
+                    }
+                }, context);
+
+                cloudLog.write(entry);
+            } else {
+                console.log(context);
+            }
+            
             request.post({
                 url: configuration.pepperBaseUrl + '/pepper/v1/register',
                 json: pepper_params,


### PR DESCRIPTION
## Context

This PR enables the [@google-cloud/logging](https://www.npmjs.com/package/@google-cloud/logging) module in the Auth0 `Register User in Pepper` rule to try and cover a hole in our logging coverage. Entries logged to GCP will include a label named `source` with the value `auth0`, and will include the full context from the execution environment as the `jsonPayload`.

In order to enable this feature, the tenant must have a key named `googleApplicationCredentials` present in the global `configuration` object for the rules (this is managed from Auth0's `Rules` page). The value of the `googleApplicationCredentials` key should be a set of keys for a Google Service Account with the `Logs Writer` role.

## How do we demo these changes?

The changes are currently visible when using the `ddp-dev`. The log statements can be viewed using the [Auth0 Registration Rule](https://cloudlogging.app.goo.gl/r6KtjU1QAHXF19vM9) query.

## Testing

- [x] I have written zero automated tests but have poked around locally to verify proper functionality

## Release

The script update can be deployed using the normal deployment process with [auth0-deploy-cli](https://auth0.com/docs/deploy/deploy-cli-tool), but the addition configuration value must be manually added at this time.

