### PR TITLE
Latest log4j fix

### DIFF
--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -531,7 +531,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.15.0</version>
+                <version>2.16.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixing log4j again. Going up to 2.16.0 now.
Checking dependencies after fix applied:

`mvn dependency:tree | grep log4j`                                                                       
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
