### PR TITLE
DDP-7394-update-ddp-automation-to-latest-log4j-version

### DIFF
--- a/ddp-automation/pom.xml
+++ b/ddp-automation/pom.xml
@@ -85,6 +85,12 @@
           <version>1.0</version>
           <type>jar</type>
       </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.13-beta-3</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
 
@@ -93,7 +99,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
updating from log4j 2.16 to log4j 2.17 as requested

dependency tree can be seen as below:
```
mvn dependency:tree | grep log4j 
[INFO] |  |  \- org.slf4j:slf4j-log4j12:jar:2.0.0-alpha5:compile
[INFO] |  +- log4j:log4j:jar:1.2.16:compile
[INFO] |  |  |  +- org.apache.logging.log4j:log4j-api:jar:2.17.0:compile
```