### PR TITLE
DDP-7393-update-pepper-apis-to-latest-log4j-version

### DIFF
--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -531,7 +531,7 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.16.0</version>
+                <version>2.17.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
updating from log4j 2.16 to log4j 2.17 as requested

see dependency tree below (search for log4j)

```
mvn dependency:tree
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< org.broadinstitute.ddp:pepper-apis >-----------------
[INFO] Building pepper-apis 1.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ pepper-apis ---
[INFO] org.broadinstitute.ddp:pepper-apis:jar:1.0
[INFO] +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- org.apache.commons:commons-csv:jar:1.5:compile
[INFO] +- com.google.guava:guava:jar:27.0-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:2.5.2:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.2.0:compile
[INFO] |  +- com.google.j2objc:j2objc-annotations:jar:1.1:compile
[INFO] |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17:compile
[INFO] +- com.aventrix.jnanoid:jnanoid:jar:2.0.0:compile
[INFO] +- com.google.cloud:google-cloud-pubsub:jar:1.50.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core:jar:1.94.8:compile
[INFO] |  +- com.google.cloud:google-cloud-core-grpc:jar:1.94.8:compile
[INFO] |  +- com.google.api.grpc:proto-google-cloud-pubsub-v1:jar:1.94.3:compile
[INFO] |  +- com.google.api.grpc:grpc-google-cloud-pubsub-v1:jar:1.94.3:compile
[INFO] |  +- io.grpc:grpc-netty-shaded:jar:1.37.0:compile
[INFO] |  +- io.grpc:grpc-stub:jar:1.37.0:compile
[INFO] |  +- io.grpc:grpc-auth:jar:1.37.0:compile
[INFO] |  \- com.google.auto.value:auto-value:jar:1.4:compile
[INFO] +- com.brsanthu:google-analytics-java:jar:2.0.0:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.25:compile
[INFO] |  \- org.slf4j:jcl-over-slf4j:jar:1.7.25:compile
[INFO] +- ch.qos.logback:logback-core:jar:1.2.3:compile
[INFO] +- ch.qos.logback:logback-classic:jar:1.2.3:compile
[INFO] +- com.typesafe:config:jar:1.4.1:compile
[INFO] +- org.zeroturnaround:zt-exec:jar:1.10:compile
[INFO] |  \- commons-io:commons-io:jar:1.4:compile
[INFO] +- com.sendgrid:sendgrid-java:jar:4.7.1:compile
[INFO] |  +- com.sendgrid:java-http-client:jar:4.3.6:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.11.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.11.0:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.10.4:compile
[INFO] |  \- org.bouncycastle:bcprov-jdk15on:jar:1.67:compile
[INFO] +- org.apache.httpcomponents:fluent-hc:jar:4.5.1:compile
[INFO] |  \- commons-logging:commons-logging:jar:1.2:compile
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.1:compile
[INFO] |  \- org.apache.httpcomponents:httpcore:jar:4.4.3:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.11:compile
[INFO] +- commons-codec:commons-codec:jar:1.12:compile
[INFO] +- commons-cli:commons-cli:jar:1.4:compile
[INFO] +- com.sparkjava:spark-core:jar:2.8.0:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.12.v20180830:compile
[INFO] |  |  \- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.12.v20180830:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-xml:jar:9.4.12.v20180830:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-servlet:jar:9.4.12.v20180830:compile
[INFO] |  |     \- org.eclipse.jetty:jetty-security:jar:9.4.12.v20180830:compile
[INFO] |  +- org.eclipse.jetty.websocket:websocket-server:jar:9.4.12.v20180830:compile
[INFO] |  |  +- org.eclipse.jetty.websocket:websocket-common:jar:9.4.12.v20180830:compile
[INFO] |  |  \- org.eclipse.jetty.websocket:websocket-client:jar:9.4.12.v20180830:compile
[INFO] |  |     \- org.eclipse.jetty:jetty-client:jar:9.4.12.v20180830:compile
[INFO] |  \- org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.12.v20180830:compile
[INFO] |     \- org.eclipse.jetty.websocket:websocket-api:jar:9.4.12.v20180830:compile
[INFO] +- com.zaxxer:HikariCP:jar:3.4.2:compile
[INFO] +- org.liquibase:liquibase-core:jar:3.6.3:compile
[INFO] +- mysql:mysql-connector-java:jar:8.0.18:compile
[INFO] |  \- com.google.protobuf:protobuf-java:jar:3.15.8:compile
[INFO] +- com.google.cloud.sql:mysql-socket-factory-connector-j-8:jar:1.0.15:compile
[INFO] |  +- com.google.cloud.sql:jdbc-socket-factory-core:jar:1.0.15:compile
[INFO] |  +- com.github.jnr:jnr-unixsocket:jar:0.23:compile
[INFO] |  |  +- com.github.jnr:jnr-ffi:jar:2.1.10:compile
[INFO] |  |  |  +- com.github.jnr:jffi:jar:1.2.19:compile
[INFO] |  |  |  +- com.github.jnr:jffi:jar:native:1.2.19:runtime
[INFO] |  |  |  +- org.ow2.asm:asm-commons:jar:7.1:compile
[INFO] |  |  |  +- com.github.jnr:jnr-a64asm:jar:1.0.0:compile
[INFO] |  |  |  \- com.github.jnr:jnr-x86asm:jar:1.0.2:compile
[INFO] |  |  +- com.github.jnr:jnr-constants:jar:0.9.12:compile
[INFO] |  |  +- com.github.jnr:jnr-enxio:jar:0.21:compile
[INFO] |  |  \- com.github.jnr:jnr-posix:jar:3.0.50:compile
[INFO] |  \- org.ow2.asm:asm-util:jar:7.1:compile
[INFO] |     +- org.ow2.asm:asm:jar:7.1:compile
[INFO] |     +- org.ow2.asm:asm-tree:jar:7.1:compile
[INFO] |     \- org.ow2.asm:asm-analysis:jar:7.1:compile
[INFO] +- org.jdbi:jdbi3-core:jar:3.1.1:compile
[INFO] |  +- org.antlr:antlr-runtime:jar:3.4:compile
[INFO] |  |  \- antlr:antlr:jar:2.7.7:compile
[INFO] |  \- net.jodah:expiringmap:jar:0.5.6:compile
[INFO] +- org.jdbi:jdbi3-sqlobject:jar:3.1.1:compile
[INFO] +- org.jdbi:jdbi3-stringtemplate4:jar:3.1.1:compile
[INFO] |  \- org.antlr:stringtemplate:jar:4.0.2:compile
[INFO] +- com.google.code.gson:gson:jar:2.5:compile
[INFO] +- com.google.maps:google-maps-services:jar:0.9.1:compile
[INFO] |  \- com.squareup.okhttp3:okhttp:jar:3.12.0:compile
[INFO] |     \- com.squareup.okio:okio:jar:1.15.0:compile
[INFO] +- com.google.openlocationcode:openlocationcode:jar:1.0.2:compile
[INFO] +- com.opencsv:opencsv:jar:4.4:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.3:compile
[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  \- org.apache.commons:commons-collections4:jar:4.2:compile
[INFO] +- org.bouncycastle:bcpkix-jdk15on:jar:1.60:compile
[INFO] +- com.auth0:auth0:jar:1.8.0:compile
[INFO] |  \- com.squareup.okhttp3:logging-interceptor:jar:3.9.1:compile
[INFO] +- com.auth0:java-jwt:jar:3.2.0:compile
[INFO] +- com.auth0:jwks-rsa:jar:0.2.0:compile
[INFO] +- org.apache.velocity:velocity:jar:1.7:compile
[INFO] |  \- commons-lang:commons-lang:jar:2.4:compile
[INFO] +- org.jsoup:jsoup:jar:1.11.3:compile
[INFO] +- org.antlr:antlr4-runtime:jar:4.7.1:compile
[INFO] +- com.google.api-client:google-api-client:jar:1.23.0:compile
[INFO] |  +- com.google.oauth-client:google-oauth-client:jar:1.23.0:compile
[INFO] |  \- com.google.http-client:google-http-client-jackson2:jar:1.39.2:compile
[INFO] +- com.google.cloud:google-cloud-storage:jar:1.69.0:compile
[INFO] |  +- com.google.cloud:google-cloud-core-http:jar:1.94.8:compile
[INFO] |  |  +- com.google.http-client:google-http-client-appengine:jar:1.39.2:compile
[INFO] |  |  \- com.google.api:gax-httpjson:jar:0.80.0:compile
[INFO] |  +- com.google.apis:google-api-services-storage:jar:v1-rev20181109-1.27.0:compile
[INFO] |  +- com.google.http-client:google-http-client-apache:jar:2.1.0:compile
[INFO] |  \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- org.projectlombok:lombok:jar:1.18.6:provided
[INFO] +- org.hibernate.validator:hibernate-validator:jar:6.0.7.Final:compile
[INFO] |  +- javax.validation:validation-api:jar:2.0.1.Final:compile
[INFO] |  +- org.jboss.logging:jboss-logging:jar:3.3.0.Final:compile
[INFO] |  \- com.fasterxml:classmate:jar:1.3.1:compile
[INFO] +- org.glassfish:javax.el:jar:3.0.1-b08:compile
[INFO] +- com.easypost:easypost-api-client:jar:3.4.0:compile
[INFO] +- io.rest-assured:rest-assured:jar:3.0.6:test
[INFO] |  +- org.codehaus.groovy:groovy:jar:2.4.12:test
[INFO] |  +- org.codehaus.groovy:groovy-xml:jar:2.4.12:test
[INFO] |  +- org.apache.httpcomponents:httpmime:jar:4.5.1:test
[INFO] |  +- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] |  +- org.hamcrest:hamcrest-library:jar:1.3:test
[INFO] |  +- org.ccil.cowan.tagsoup:tagsoup:jar:1.2.1:test
[INFO] |  +- io.rest-assured:json-path:jar:3.0.6:test
[INFO] |  |  +- org.codehaus.groovy:groovy-json:jar:2.4.12:test
[INFO] |  |  \- io.rest-assured:rest-assured-common:jar:3.0.6:test
[INFO] |  \- io.rest-assured:xml-path:jar:3.0.6:test
[INFO] |     \- javax.xml.bind:jaxb-api:jar:2.2.12:test
[INFO] +- org.reflections:reflections:jar:0.9.11:test
[INFO] |  \- org.javassist:javassist:jar:3.21.0-GA:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] +- org.mockito:mockito-core:jar:3.6.28:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.10.18:compile
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.10.18:test
[INFO] |  \- org.objenesis:objenesis:jar:3.1:compile
[INFO] +- org.mockito:mockito-inline:jar:3.6.28:test
[INFO] +- org.mock-server:mockserver-netty:jar:5.11.0:test
[INFO] |  +- org.mock-server:mockserver-client-java:jar:5.11.0:test
[INFO] |  +- org.mock-server:mockserver-core:jar:5.11.0:test
[INFO] |  |  +- com.lmax:disruptor:jar:3.4.2:test
[INFO] |  |  +- io.netty:netty-codec-socks:jar:4.1.50.Final:test
[INFO] |  |  +- io.netty:netty-handler-proxy:jar:4.1.50.Final:test
[INFO] |  |  +- com.jcraft:jzlib:jar:1.1.3:test
[INFO] |  |  +- org.apache.velocity:velocity-engine-scripting:jar:2.2:test
[INFO] |  |  +- org.apache.velocity:velocity-engine-core:jar:2.2:test
[INFO] |  |  +- net.javacrumbs.json-unit:json-unit-core:jar:2.14.0:test
[INFO] |  |  |  \- org.opentest4j:opentest4j:jar:1.1.1:test
[INFO] |  |  +- com.github.java-json-tools:json-schema-validator:jar:2.2.14:test
[INFO] |  |  |  +- com.github.java-json-tools:jackson-coreutils-equivalence:jar:1.0:test
[INFO] |  |  |  |  \- com.github.java-json-tools:jackson-coreutils:jar:2.0:test
[INFO] |  |  |  |     \- com.github.java-json-tools:msg-simple:jar:1.2:test
[INFO] |  |  |  |        \- com.github.java-json-tools:btf:jar:1.3:test
[INFO] |  |  |  +- com.github.java-json-tools:json-schema-core:jar:1.2.14:test
[INFO] |  |  |  |  +- com.github.java-json-tools:uri-template:jar:0.10:test
[INFO] |  |  |  |  \- org.mozilla:rhino:jar:1.7.7.2:test
[INFO] |  |  |  +- com.sun.mail:mailapi:jar:1.6.2:test
[INFO] |  |  |  +- com.googlecode.libphonenumber:libphonenumber:jar:8.11.1:test
[INFO] |  |  |  \- net.sf.jopt-simple:jopt-simple:jar:5.0.4:compile
[INFO] |  |  +- com.jayway.jsonpath:json-path:jar:2.4.0:test
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.3:test
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:1.2:test
[INFO] |  |  +- io.swagger.parser.v3:swagger-parser:jar:2.0.20:test
[INFO] |  |  |  +- io.swagger.parser.v3:swagger-parser-v2-converter:jar:2.0.20:test
[INFO] |  |  |  |  +- io.swagger:swagger-core:jar:1.6.1:test
[INFO] |  |  |  |  |  \- io.swagger:swagger-models:jar:1.6.1:test
[INFO] |  |  |  |  |     \- io.swagger:swagger-annotations:jar:1.6.1:test
[INFO] |  |  |  |  +- io.swagger:swagger-parser:jar:1.0.51:test
[INFO] |  |  |  |  +- io.swagger:swagger-compat-spec-parser:jar:1.0.51:test
[INFO] |  |  |  |  +- io.swagger.core.v3:swagger-models:jar:2.1.2:test
[INFO] |  |  |  |  \- io.swagger.parser.v3:swagger-parser-core:jar:2.0.20:test
[INFO] |  |  |  +- io.swagger.parser.v3:swagger-parser-v3:jar:2.0.20:test
[INFO] |  |  |  |  \- io.swagger.core.v3:swagger-core:jar:2.1.2:test
[INFO] |  |  |  |     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:test
[INFO] |  |  |  |     |  \- jakarta.activation:jakarta.activation-api:jar:1.2.1:test
[INFO] |  |  |  |     +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.10.1:test
[INFO] |  |  |  |     +- io.swagger.core.v3:swagger-annotations:jar:2.1.2:test
[INFO] |  |  |  |     \- jakarta.validation:jakarta.validation-api:jar:2.0.2:test
[INFO] |  |  |  \- org.slf4j:slf4j-ext:jar:1.7.30:test
[INFO] |  |  +- org.xmlunit:xmlunit-core:jar:2.7.0:test
[INFO] |  |  \- org.xmlunit:xmlunit-placeholders:jar:2.7.0:test
[INFO] |  +- io.netty:netty-buffer:jar:4.1.50.Final:compile
[INFO] |  +- io.netty:netty-codec:jar:4.1.50.Final:compile
[INFO] |  +- io.netty:netty-codec-http:jar:4.1.50.Final:test
[INFO] |  +- io.netty:netty-handler:jar:4.1.50.Final:compile
[INFO] |  |  \- io.netty:netty-resolver:jar:4.1.50.Final:compile
[INFO] |  \- io.netty:netty-transport:jar:4.1.50.Final:compile
[INFO] +- org.mock-server:mockserver-junit-rule:jar:5.11.0:test
[INFO] +- com.itextpdf:kernel:jar:7.1.4:compile
[INFO] +- com.itextpdf:io:jar:7.1.4:compile
[INFO] +- com.itextpdf:layout:jar:7.1.4:compile
[INFO] +- com.itextpdf:forms:jar:7.1.4:compile
[INFO] +- com.itextpdf:html2pdf:jar:2.0.2:compile
[INFO] +- com.itextpdf:font-asian:jar:7.1.4:compile
[INFO] +- com.itextpdf:itext-licensekey:jar:3.0.3:compile
[INFO] +- org.testcontainers:mysql:jar:1.12.3:test
[INFO] |  \- org.testcontainers:jdbc:jar:1.12.3:test
[INFO] |     \- org.testcontainers:database-commons:jar:1.12.3:test
[INFO] |        \- org.testcontainers:testcontainers:jar:1.12.3:test
[INFO] |           +- org.jetbrains:annotations:jar:17.0.0:test
[INFO] |           +- org.apache.commons:commons-compress:jar:1.19:test
[INFO] |           +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |           +- org.rnorth.visible-assertions:visible-assertions:jar:2.1.2:test
[INFO] |           +- org.rnorth:tcp-unix-socket-proxy:jar:1.0.2:test
[INFO] |           |  +- com.kohlschutter.junixsocket:junixsocket-native-common:jar:2.0.4:test
[INFO] |           |  |  \- org.scijava:native-lib-loader:jar:2.0.2:test
[INFO] |           |  \- com.kohlschutter.junixsocket:junixsocket-common:jar:2.0.4:test
[INFO] |           \- net.java.dev.jna:jna-platform:jar:5.4.0:test
[INFO] |              \- net.java.dev.jna:jna:jar:5.4.0:test
[INFO] +- org.elasticsearch.client:elasticsearch-rest-high-level-client:jar:6.8.2:compile
[INFO] |  +- org.elasticsearch:elasticsearch:jar:6.8.2:compile
[INFO] |  |  +- org.elasticsearch:elasticsearch-core:jar:6.8.2:compile
[INFO] |  |  +- org.elasticsearch:elasticsearch-secure-sm:jar:6.8.2:compile
[INFO] |  |  +- org.elasticsearch:elasticsearch-x-content:jar:6.8.2:compile
[INFO] |  |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:jar:2.8.11:compile
[INFO] |  |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.8.11:compile
[INFO] |  |  +- org.apache.lucene:lucene-core:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-analyzers-common:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-backward-codecs:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-grouping:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-highlighter:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-join:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-memory:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-misc:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-queries:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-queryparser:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-sandbox:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-spatial:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-spatial-extras:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-spatial3d:jar:7.7.0:compile
[INFO] |  |  +- org.apache.lucene:lucene-suggest:jar:7.7.0:compile
[INFO] |  |  +- org.elasticsearch:elasticsearch-cli:jar:6.8.2:compile
[INFO] |  |  +- com.carrotsearch:hppc:jar:0.7.1:compile
[INFO] |  |  +- joda-time:joda-time:jar:2.10.1:compile
[INFO] |  |  +- com.tdunning:t-digest:jar:3.2:compile
[INFO] |  |  +- org.hdrhistogram:HdrHistogram:jar:2.1.9:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.17.0:compile
[INFO] |  |  \- org.elasticsearch:jna:jar:4.5.1:compile
[INFO] |  +- org.elasticsearch.client:elasticsearch-rest-client:jar:6.8.2:compile
[INFO] |  |  +- org.apache.httpcomponents:httpasyncclient:jar:4.1.2:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore-nio:jar:4.4.5:compile
[INFO] |  +- org.elasticsearch.plugin:parent-join-client:jar:6.8.2:compile
[INFO] |  +- org.elasticsearch.plugin:aggs-matrix-stats-client:jar:6.8.2:compile
[INFO] |  +- org.elasticsearch.plugin:rank-eval-client:jar:6.8.2:compile
[INFO] |  \- org.elasticsearch.plugin:lang-mustache-client:jar:6.8.2:compile
[INFO] |     \- com.github.spullara.mustache.java:compiler:jar:0.9.3:compile
[INFO] +- org.quartz-scheduler:quartz:jar:2.3.2:compile
[INFO] |  \- com.mchange:mchange-commons-java:jar:0.2.15:compile
[INFO] +- com.google.cloud:google-cloud-monitoring:jar:1.59.0:compile
[INFO] |  \- com.google.api.grpc:proto-google-cloud-monitoring-v3:jar:2.2.1:compile
[INFO] +- com.google.apis:google-api-services-sqladmin:jar:v1beta4-rev69-1.25.0:compile
[INFO] +- org.eclipse.jetty:jetty-servlets:jar:9.4.28.v20200408:compile
[INFO] |  +- org.eclipse.jetty:jetty-continuation:jar:9.4.28.v20200408:compile
[INFO] |  +- org.eclipse.jetty:jetty-http:jar:9.4.28.v20200408:compile
[INFO] |  +- org.eclipse.jetty:jetty-util:jar:9.4.28.v20200408:compile
[INFO] |  \- org.eclipse.jetty:jetty-io:jar:9.4.28.v20200408:compile
[INFO] +- org.redisson:redisson:jar:3.13.4:compile
[INFO] |  +- io.netty:netty-resolver-dns:jar:4.1.51.Final:compile
[INFO] |  |  \- io.netty:netty-codec-dns:jar:4.1.51.Final:compile
[INFO] |  +- javax.cache:cache-api:jar:1.0.0:compile
[INFO] |  +- io.projectreactor:reactor-core:jar:3.3.9.RELEASE:compile
[INFO] |  |  \- org.reactivestreams:reactive-streams:jar:1.0.3:compile
[INFO] |  +- io.reactivex.rxjava2:rxjava:jar:2.2.19:compile
[INFO] |  +- org.jboss.marshalling:jboss-marshalling-river:jar:2.0.9.Final:compile
[INFO] |  |  \- org.jboss.marshalling:jboss-marshalling:jar:2.0.9.Final:compile
[INFO] |  +- org.yaml:snakeyaml:jar:1.26:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.11.1:compile
[INFO] |  \- org.jodd:jodd-bean:jar:5.1.6:compile
[INFO] |     \- org.jodd:jodd-core:jar:5.1.6:compile
[INFO] +- redis.clients:jedis:jar:3.3.0:compile
[INFO] |  \- org.apache.commons:commons-pool2:jar:2.6.2:compile
[INFO] +- io.netty:netty-common:jar:4.1.50.Final:compile
[INFO] +- de.ruedigermoeller:fst:jar:2.57:compile
[INFO] \- com.google.cloud:google-cloud-secretmanager:jar:1.5.1:compile
[INFO]    +- io.grpc:grpc-api:jar:1.37.0:compile
[INFO]    +- io.grpc:grpc-context:jar:1.37.0:compile
[INFO]    +- io.grpc:grpc-protobuf:jar:1.37.0:compile
[INFO]    +- io.grpc:grpc-protobuf-lite:jar:1.37.0:compile
[INFO]    +- com.google.api:api-common:jar:1.10.3:compile
[INFO]    +- com.google.auto.value:auto-value-annotations:jar:1.8.1:compile
[INFO]    +- com.google.api.grpc:proto-google-common-protos:jar:2.1.0:compile
[INFO]    +- com.google.api.grpc:proto-google-iam-v1:jar:1.0.12:compile
[INFO]    +- com.google.api.grpc:proto-google-cloud-secretmanager-v1:jar:1.5.1:compile
[INFO]    +- com.google.api.grpc:proto-google-cloud-secretmanager-v1beta1:jar:1.5.1:compile
[INFO]    +- org.checkerframework:checker-compat-qual:jar:2.5.5:compile
[INFO]    +- com.google.api:gax:jar:1.63.0:compile
[INFO]    +- com.google.auth:google-auth-library-oauth2-http:jar:0.25.5:compile
[INFO]    +- com.google.http-client:google-http-client:jar:1.39.2:compile
[INFO]    +- io.opencensus:opencensus-contrib-http-util:jar:0.28.0:compile
[INFO]    +- com.google.http-client:google-http-client-gson:jar:1.39.2:compile
[INFO]    +- io.opencensus:opencensus-api:jar:0.28.0:compile
[INFO]    +- com.google.api:gax-grpc:jar:1.63.0:compile
[INFO]    +- com.google.auth:google-auth-library-credentials:jar:0.25.5:compile
[INFO]    +- io.grpc:grpc-core:jar:1.37.0:compile
[INFO]    +- com.google.android:annotations:jar:4.1.1.4:runtime
[INFO]    +- io.perfmark:perfmark-api:jar:0.23.0:runtime
[INFO]    +- io.grpc:grpc-alts:jar:1.37.0:compile
[INFO]    +- io.grpc:grpc-grpclb:jar:1.37.0:compile
[INFO]    +- com.google.protobuf:protobuf-java-util:jar:3.15.8:compile
[INFO]    +- org.conscrypt:conscrypt-openjdk-uber:jar:2.5.1:compile
[INFO]    \- org.threeten:threetenbp:jar:1.5.1:compile
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  7.090 s
[INFO] Finished at: 2021-12-20T11:40:40-05:00
[INFO] ------------------------------------------------------------------------
```