### PR TITLE
DDP-7386. Hot fix

### DIFF
--- a/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/template/Template.java
+++ b/pepper-apis/src/main/java/org/broadinstitute/ddp/model/activity/definition/template/Template.java
@@ -19,7 +19,6 @@ public class Template {
 
     public static final String VELOCITY_VAR_PREFIX = "$";
 
-    @NotNull
     @SerializedName("templateType")
     private TemplateType templateType;
 
@@ -67,7 +66,7 @@ public class Template {
     }
 
     public TemplateType getTemplateType() {
-        return templateType;
+        return templateType != null ? templateType : TemplateType.TEXT;
     }
 
     public void setTemplateType(TemplateType templateType) {


### PR DESCRIPTION
Hotfix made to the changes recently merged.
According to @evgeniipr, it is possible not to set the template type if it is text. But it turns it's not. Since new templates don't have field template type if it is set to text, we need to provide the correct template type value.