### PR TITLE
Updates to the Decimal schemas [DDP-7460]

### DIFF
--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -416,17 +416,9 @@ Answer.Decimal:
       required:
         - type
         - value
-        - scale
       properties:
         value:
-          type: integer
-          format: int64
-          nullable: true
-        scale:
-          type: integer
-          description: the number of digits allowed to the right of the decimal point.
-          minimum: 0
-          default: 0
+          $ref: '#/DecimalNumber'
 Answer.Picklist:
   allOf:
     - $ref: '#/Answer'

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -11,6 +11,21 @@ ActivityInstanceStatusType:
     - COMPLETE
     - CREATED
     - IN_PROGRESS
+DecimalNumber:
+  type: object
+  description: |
+    A representation of a BigDecimal number. The represented number is equal to `value * 10 ^ scale`.
+  required:
+    - scale
+    - value
+  properties:
+    scale:
+      type: integer
+      format: int64
+    value:
+      description: the unscaled value 
+      type: integer
+      format: int64
 FormType:
   title: FormType
   type: string

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -2016,6 +2016,7 @@ Validation:
       DATE_RANGE: '#/Validation.DateRange'
       DAY_REQUIRED: '#/Validation.DayRequired'
       INT_RANGE: '#/Validation.IntRange'
+      DECIMAL_RANGE: '#/Validation.DecimalRange'
       LENGTH: '#/Validation.Length'
       MONTH_REQUIRED: '#/Validation.MonthRequired'
       NUM_OPTIONS_SELECTED: '#/Validation.OptionsSelected'
@@ -2199,6 +2200,26 @@ Validation.IntRange:
           type: integer
           nullable: true
           description: the maximum acceptable number, inclusive
+Validation.DecimalRange:
+  allOf:
+    - $ref: '#/Validation'
+    - type: object
+      properties:
+        rule:
+          type: string
+          default: DECIMAL_RANGE
+          enum:
+            - DECIMAL_RANGE
+        min:
+          allOf:
+            - $ref: '#/DecimalNumber'
+            - description: the minimum acceptable number, inclusive
+              nullable: true
+        max:
+          allOf:
+            - $ref: '#/DecimalNumber'
+            - description: the maximum acceptable number, inclusive
+              nullable: true
 Validation.Unique:
   allOf:
     - $ref: '#/Validation'

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -401,18 +401,12 @@ Answer.Decimal:
       required:
         - type
         - value
-        - precision
         - scale
       properties:
         value:
           type: integer
           format: int64
           nullable: true
-        precision:
-          type: integer
-          description: the total number of digits allowed in the number, including digits on both sides of the decimal point
-          minimum: 0
-          default: 0
         scale:
           type: integer
           description: the number of digits allowed to the right of the decimal point.
@@ -618,11 +612,6 @@ AnswerSubmission.Decimal:
           type: integer
           format: int64
           nullable: true
-        precision:
-          type: integer
-          description: the total number of digits allowed in the number, including digits on both sides of the decimal point
-          minimum: 0
-          default: 0
         scale:
           type: integer
           description: the number of digits allowed to the right of the decimal point.


### PR DESCRIPTION
DDP-7460

## Context

This PR addresses several issues identified with the Decimal API schema additions
* Adds a DecimalNumber type
* Adds a DecimalRange validation
* Removes the `precision` property from the Decimal Answer object schemas

## How do we demo these changes?

* Check out the associated branch
* `cd` into `pepper-apis/docs/specification`
* Run `npm run start` and follow the instructions to view the generated documentation locally

## Testing

- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!

