### PR TITLE
DDP-7306. Decimal question extended with scale

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiDecimalQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiDecimalQuestion.java
@@ -4,13 +4,11 @@ import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
-import java.math.BigInteger;
-
 public interface JdbiDecimalQuestion extends SqlObject {
 
     @SqlUpdate("insert into decimal_question (question_id, placeholder_template_id, scale)"
             + " values (:questionId, :placeholderTemplateId, :scale)")
     int insert(@Bind("questionId") long questionId,
                @Bind("placeholderTemplateId") Long placeholderTemplateId,
-               @Bind("scale") BigInteger scale);
+               @Bind("scale") Integer scale);
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiDecimalQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiDecimalQuestion.java
@@ -4,10 +4,13 @@ import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import java.math.BigInteger;
+
 public interface JdbiDecimalQuestion extends SqlObject {
 
-    @SqlUpdate("insert into decimal_question (question_id, placeholder_template_id)"
-            + " values (:questionId, :placeholderTemplateId)")
+    @SqlUpdate("insert into decimal_question (question_id, placeholder_template_id, scale)"
+            + " values (:questionId, :placeholderTemplateId, :scale)")
     int insert(@Bind("questionId") long questionId,
-               @Bind("placeholderTemplateId") Long placeholderTemplateId);
+               @Bind("placeholderTemplateId") Long placeholderTemplateId,
+               @Bind("scale") BigInteger scale);
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
@@ -879,7 +879,8 @@ public interface QuestionDao extends SqlObject {
                 dto.getAdditionalInfoHeaderTemplateId(),
                 dto.getAdditionalInfoFooterTemplateId(),
                 answers,
-                rules);
+                rules,
+                dto.getScale());
     }
 
     /**
@@ -1380,7 +1381,7 @@ public interface QuestionDao extends SqlObject {
             placeholderTemplateId = templateDao.insertTemplate(questionDef.getPlaceholderTemplate(), revisionId);
         }
 
-        int numInserted = getJdbiDecimalQuestion().insert(questionDef.getQuestionId(), placeholderTemplateId);
+        int numInserted = getJdbiDecimalQuestion().insert(questionDef.getQuestionId(), placeholderTemplateId, questionDef.getScale());
         if (numInserted != 1) {
             throw new DaoException("Inserted " + numInserted + " for decimal question " + questionDef.getStableId());
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/DecimalQuestionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/DecimalQuestionDto.java
@@ -5,20 +5,28 @@ import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.util.Set;
 
 public final class DecimalQuestionDto extends QuestionDto implements Serializable {
     private final Long placeholderTemplateId;
+    private final BigInteger scale;
 
     @JdbiConstructor
     public DecimalQuestionDto(@Nested QuestionDto questionDto,
-                              @ColumnName("placeholder_template_id") Long placeholderTemplateId) {
+                              @ColumnName("placeholder_template_id") Long placeholderTemplateId,
+                              @ColumnName("scale") BigInteger scale) {
         super(questionDto);
         this.placeholderTemplateId = placeholderTemplateId;
+        this.scale = scale;
     }
 
     public Long getPlaceholderTemplateId() {
         return placeholderTemplateId;
+    }
+
+    public BigInteger getScale() {
+        return scale;
     }
 
     @Override

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/DecimalQuestionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/DecimalQuestionDto.java
@@ -5,17 +5,16 @@ import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 import java.io.Serializable;
-import java.math.BigInteger;
 import java.util.Set;
 
 public final class DecimalQuestionDto extends QuestionDto implements Serializable {
     private final Long placeholderTemplateId;
-    private final BigInteger scale;
+    private final Integer scale;
 
     @JdbiConstructor
     public DecimalQuestionDto(@Nested QuestionDto questionDto,
                               @ColumnName("placeholder_template_id") Long placeholderTemplateId,
-                              @ColumnName("scale") BigInteger scale) {
+                              @ColumnName("scale") Integer scale) {
         super(questionDto);
         this.placeholderTemplateId = placeholderTemplateId;
         this.scale = scale;
@@ -25,7 +24,7 @@ public final class DecimalQuestionDto extends QuestionDto implements Serializabl
         return placeholderTemplateId;
     }
 
-    public BigInteger getScale() {
+    public Integer getScale() {
         return scale;
     }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/DecimalQuestionDef.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/DecimalQuestionDef.java
@@ -6,12 +6,16 @@ import org.broadinstitute.ddp.model.activity.definition.validation.RuleDef;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
 import javax.validation.Valid;
+import java.math.BigInteger;
 import java.util.List;
 
 public final class DecimalQuestionDef extends QuestionDef {
     @Valid
     @SerializedName("placeholderTemplate")
     private Template placeholderTemplate;
+
+    @SerializedName("scale")
+    private BigInteger scale;
 
     public static Builder builder() {
         return new Builder();
@@ -26,18 +30,24 @@ public final class DecimalQuestionDef extends QuestionDef {
     public DecimalQuestionDef(String stableId, Template promptTemplate, Template placeholderTemplate,
                               boolean isRestricted, boolean hideNumber, boolean writeOnce,
                               Template additionalInfoHeaderTemplate, Template additionalInfoFooterTemplate,
-                              List<RuleDef> validations) {
+                              List<RuleDef> validations, BigInteger scale) {
         super(QuestionType.DECIMAL, stableId, isRestricted, promptTemplate,
                 additionalInfoHeaderTemplate, additionalInfoFooterTemplate, validations, hideNumber, writeOnce);
         this.placeholderTemplate = placeholderTemplate;
+        this.scale = scale;
     }
 
     public Template getPlaceholderTemplate() {
         return placeholderTemplate;
     }
 
+    public BigInteger getScale() {
+        return scale;
+    }
+
     public static final class Builder extends AbstractQuestionBuilder<Builder> {
         private Template placeholderTemplate;
+        private BigInteger scale;
 
         private Builder() {
             // Use static factories.
@@ -53,6 +63,11 @@ public final class DecimalQuestionDef extends QuestionDef {
             return self();
         }
 
+        public Builder setScale(BigInteger scale) {
+            this.scale = scale;
+            return self();
+        }
+
         public DecimalQuestionDef build() {
             DecimalQuestionDef question = new DecimalQuestionDef(
                     stableId,
@@ -63,7 +78,8 @@ public final class DecimalQuestionDef extends QuestionDef {
                     writeOnce,
                     getAdditionalInfoHeader(),
                     getAdditionalInfoFooter(),
-                    validations);
+                    validations,
+                    scale);
             configure(question);
             return question;
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/DecimalQuestionDef.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/DecimalQuestionDef.java
@@ -6,7 +6,6 @@ import org.broadinstitute.ddp.model.activity.definition.validation.RuleDef;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
 import javax.validation.Valid;
-import java.math.BigInteger;
 import java.util.List;
 
 public final class DecimalQuestionDef extends QuestionDef {
@@ -15,7 +14,7 @@ public final class DecimalQuestionDef extends QuestionDef {
     private Template placeholderTemplate;
 
     @SerializedName("scale")
-    private BigInteger scale;
+    private Integer scale;
 
     public static Builder builder() {
         return new Builder();
@@ -30,7 +29,7 @@ public final class DecimalQuestionDef extends QuestionDef {
     public DecimalQuestionDef(String stableId, Template promptTemplate, Template placeholderTemplate,
                               boolean isRestricted, boolean hideNumber, boolean writeOnce,
                               Template additionalInfoHeaderTemplate, Template additionalInfoFooterTemplate,
-                              List<RuleDef> validations, BigInteger scale) {
+                              List<RuleDef> validations, Integer scale) {
         super(QuestionType.DECIMAL, stableId, isRestricted, promptTemplate,
                 additionalInfoHeaderTemplate, additionalInfoFooterTemplate, validations, hideNumber, writeOnce);
         this.placeholderTemplate = placeholderTemplate;
@@ -41,13 +40,13 @@ public final class DecimalQuestionDef extends QuestionDef {
         return placeholderTemplate;
     }
 
-    public BigInteger getScale() {
+    public Integer getScale() {
         return scale;
     }
 
     public static final class Builder extends AbstractQuestionBuilder<Builder> {
         private Template placeholderTemplate;
-        private BigInteger scale;
+        private Integer scale;
 
         private Builder() {
             // Use static factories.
@@ -63,7 +62,7 @@ public final class DecimalQuestionDef extends QuestionDef {
             return self();
         }
 
-        public Builder setScale(BigInteger scale) {
+        public Builder setScale(Integer scale) {
             this.scale = scale;
             return self();
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/DecimalQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/DecimalQuestion.java
@@ -7,7 +7,6 @@ import org.broadinstitute.ddp.model.activity.instance.answer.DecimalAnswer;
 import org.broadinstitute.ddp.model.activity.instance.validation.Rule;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -17,14 +16,14 @@ public final class DecimalQuestion extends Question<DecimalAnswer> {
     private String placeholderText;
 
     @SerializedName("scale")
-    private BigInteger scale;
+    private Integer scale;
 
     private transient Long placeholderTemplateId;
 
     public DecimalQuestion(String stableId, long promptTemplateId, Long placeholderTemplateId,
                            boolean isRestricted, boolean isDeprecated, Boolean readonly, Long tooltipTemplateId,
                            Long additionalInfoHeaderTemplateId, Long additionalInfoFooterTemplateId,
-                           List<DecimalAnswer> answers, List<Rule<DecimalAnswer>> validations, BigInteger scale) {
+                           List<DecimalAnswer> answers, List<Rule<DecimalAnswer>> validations, Integer scale) {
         super(QuestionType.DECIMAL, stableId, promptTemplateId, isRestricted, isDeprecated, readonly, tooltipTemplateId,
                 additionalInfoHeaderTemplateId, additionalInfoFooterTemplateId, answers, validations);
         this.placeholderTemplateId = placeholderTemplateId;
@@ -35,7 +34,7 @@ public final class DecimalQuestion extends Question<DecimalAnswer> {
         return placeholderTemplateId;
     }
 
-    public BigInteger getScale() {
+    public Integer getScale() {
         return scale;
     }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/DecimalQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/instance/question/DecimalQuestion.java
@@ -7,6 +7,7 @@ import org.broadinstitute.ddp.model.activity.instance.answer.DecimalAnswer;
 import org.broadinstitute.ddp.model.activity.instance.validation.Rule;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -15,19 +16,27 @@ public final class DecimalQuestion extends Question<DecimalAnswer> {
     @SerializedName("placeholderText")
     private String placeholderText;
 
+    @SerializedName("scale")
+    private BigInteger scale;
+
     private transient Long placeholderTemplateId;
 
     public DecimalQuestion(String stableId, long promptTemplateId, Long placeholderTemplateId,
                            boolean isRestricted, boolean isDeprecated, Boolean readonly, Long tooltipTemplateId,
                            Long additionalInfoHeaderTemplateId, Long additionalInfoFooterTemplateId,
-                           List<DecimalAnswer> answers, List<Rule<DecimalAnswer>> validations) {
+                           List<DecimalAnswer> answers, List<Rule<DecimalAnswer>> validations, BigInteger scale) {
         super(QuestionType.DECIMAL, stableId, promptTemplateId, isRestricted, isDeprecated, readonly, tooltipTemplateId,
                 additionalInfoHeaderTemplateId, additionalInfoFooterTemplateId, answers, validations);
         this.placeholderTemplateId = placeholderTemplateId;
+        this.scale = scale;
     }
 
     public Long getPlaceholderTemplateId() {
         return placeholderTemplateId;
+    }
+
+    public BigInteger getScale() {
+        return scale;
     }
 
     @Override

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
@@ -226,7 +226,8 @@ public class QuestionCreatorHelper {
                 ctx.getAIBuilderFactory().getTemplateRenderHelper().addTemplate(
                         ctx, questionDef.getAdditionalInfoFooterTemplate()),
                 questionCreator.getAnswers(ctx, questionDef.getStableId()),
-                questionCreator.getValidationRules(ctx, questionDef)
+                questionCreator.getValidationRules(ctx, questionDef),
+                questionDef.getScale()
         );
     }
 

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestion.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestion.sql.stg
@@ -68,6 +68,8 @@ select qt.question_type_code as question_type,
          dq.placeholder_template_id, nq.placeholder_template_id, dcq.placeholder_template_id, tq.placeholder_template_id
        ) as placeholder_template_id,
 
+       dcq.scale,
+
        bq.true_template_id,
        bq.false_template_id,
 

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/activity/instance/validation/DecimalRangeRuleTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/activity/instance/validation/DecimalRangeRuleTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,7 +25,7 @@ public class DecimalRangeRuleTest {
 
     @BeforeClass
     public static void setup() {
-        unused = new DecimalQuestion("sid", 1L, 2L, false, false, false, null, null, null, List.of(), List.of());
+        unused = new DecimalQuestion("sid", 1L, 2L, false, false, false, null, null, null, List.of(), List.of(), BigInteger.ZERO);
     }
 
     @Test

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/activity/instance/validation/DecimalRangeRuleTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/activity/instance/validation/DecimalRangeRuleTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +24,7 @@ public class DecimalRangeRuleTest {
 
     @BeforeClass
     public static void setup() {
-        unused = new DecimalQuestion("sid", 1L, 2L, false, false, false, null, null, null, List.of(), List.of(), BigInteger.ZERO);
+        unused = new DecimalQuestion("sid", 1L, 2L, false, false, false, null, null, null, List.of(), List.of(), 0);
     }
 
     @Test

--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -292,4 +292,5 @@
     <include file="db-changes/schema/add_new_event_type_DDP-7415.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/DDP-7182-add-unique-value-validation-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7306-decimal-question.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-7306-decimal-question-scale.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7306-decimal-question-scale.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7306-decimal-question-scale.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="Dmitrii Eliseev" id="20220214-add-scale-to-decimal-question">
+        <renameColumn tableName="decimal_question"
+                      oldColumnName="fractional_digits"
+                      newColumnName="scale"
+                      columnDataType="bigint" />
+        <addDefaultValue tableName="decimal_question"
+                         columnName="scale"
+                         defaultValue="0"/>
+    </changeSet>
+</databaseChangeLog>

--- a/study-builder/studies/basil/numeric-activity.conf
+++ b/study-builder/studies/basil/numeric-activity.conf
@@ -45,6 +45,7 @@
           "question": {
             include required("../snippets/decimal-question.conf"),
             "stableId": ${id.q.num_dec_range_1},
+            "scale": 2,
             "promptTemplate": {
               "templateType": "HTML",
               "templateText": "$decimal.dec_range_1_prompt",


### PR DESCRIPTION
I hope this is the last PR from the series of DECIMAL PRs.

This PR contains the change to the decimal question table and corresponding classes. The field scale is now in use. It could be set on the definition of the study, imported to the database, and provided to the front-end side to render and restrict the numbers properly.