### PR TITLE
Remote autocomplete update

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/PicklistQuestionDef.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/question/PicklistQuestionDef.java
@@ -141,10 +141,6 @@ public final class PicklistQuestionDef extends QuestionDef {
         }
     }
 
-    public List<PicklistOptionDef> getPicklistOptionsIncludingRemoteAutoComplete() {
-        return picklistOptions;
-    }
-
     public List<PicklistOptionDef> getAllPicklistOptions() {
         Stream<PicklistOptionDef> nestedOptions =
                 picklistOptions.stream().flatMap(def -> def.getNestedOptions().stream());

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
@@ -19,6 +19,7 @@ import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestio
 import org.broadinstitute.ddp.model.activity.definition.question.MatrixQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.ActivityInstanceSelectQuestionDef;
+import org.broadinstitute.ddp.model.activity.instance.answer.Answer;
 import org.broadinstitute.ddp.model.activity.instance.answer.PicklistAnswer;
 import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
 import org.broadinstitute.ddp.model.activity.instance.question.AgreementQuestion;
@@ -257,9 +258,8 @@ public class QuestionCreatorHelper {
         List<PicklistOptionDef> options = questionDef.getLocalPicklistOptions();
         if (questionDef.getRenderMode() == PicklistRenderMode.REMOTE_AUTOCOMPLETE && !answers.isEmpty()) {
 
-            List<String> selectedOptsStableIds = answers.stream()
-                    .flatMap(answer -> answer.getValue().stream().map(SelectedPicklistOption::getStableId))
-                    .collect(Collectors.toList());
+            List<String> selectedOptsStableIds = answers.stream().map(Answer::getValue)
+                    .flatMap(opts -> opts.stream()).map(SelectedPicklistOption::getStableId).collect(Collectors.toList());
 
             options = questionDef.getPicklistOptions().stream()
                     .filter(optionDef -> selectedOptsStableIds.contains(optionDef.getStableId()))

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/QuestionCreatorHelper.java
@@ -4,6 +4,7 @@ import static org.broadinstitute.ddp.util.QuestionUtil.isReadOnly;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.broadinstitute.ddp.model.activity.definition.question.AgreementQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.BoolQuestionDef;
@@ -13,10 +14,13 @@ import org.broadinstitute.ddp.model.activity.definition.question.FileQuestionDef
 import org.broadinstitute.ddp.model.activity.definition.question.NumericQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.DecimalQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistGroupDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.MatrixQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
 import org.broadinstitute.ddp.model.activity.definition.question.ActivityInstanceSelectQuestionDef;
+import org.broadinstitute.ddp.model.activity.instance.answer.PicklistAnswer;
+import org.broadinstitute.ddp.model.activity.instance.answer.SelectedPicklistOption;
 import org.broadinstitute.ddp.model.activity.instance.question.AgreementQuestion;
 import org.broadinstitute.ddp.model.activity.instance.question.BoolQuestion;
 import org.broadinstitute.ddp.model.activity.instance.question.CompositeQuestion;
@@ -34,6 +38,7 @@ import org.broadinstitute.ddp.model.activity.instance.question.MatrixQuestion;
 import org.broadinstitute.ddp.model.activity.instance.question.MatrixRow;
 import org.broadinstitute.ddp.model.activity.instance.question.TextQuestion;
 import org.broadinstitute.ddp.model.activity.instance.question.ActivityInstanceSelectQuestion;
+import org.broadinstitute.ddp.model.activity.types.PicklistRenderMode;
 import org.broadinstitute.ddp.service.actvityinstancebuilder.context.AIBuilderContext;
 import org.broadinstitute.ddp.util.CollectionMiscUtil;
 
@@ -246,7 +251,22 @@ public class QuestionCreatorHelper {
                                     .createPicklistOption(ctx, picklistOptionDef, questionDef.getGroups())));
         }
 
-        List<PicklistOption> picklistOptions = CollectionMiscUtil.createListFromAnotherList(questionDef.getLocalPicklistOptions(),
+        //localPicklistOptions doesn't include RemotePicklistOptions
+        //include option defs of any already selected options (answers)
+        List<PicklistAnswer> answers = questionCreator.getAnswers(ctx, questionDef.getStableId());
+        List<PicklistOptionDef> options = questionDef.getLocalPicklistOptions();
+        if (questionDef.getRenderMode() == PicklistRenderMode.REMOTE_AUTOCOMPLETE && !answers.isEmpty()) {
+
+            List<String> selectedOptsStableIds = answers.stream()
+                    .flatMap(answer -> answer.getValue().stream().map(SelectedPicklistOption::getStableId))
+                    .collect(Collectors.toList());
+
+            options = questionDef.getPicklistOptions().stream()
+                    .filter(optionDef -> selectedOptsStableIds.contains(optionDef.getStableId()))
+                                    .collect(Collectors.toList());
+        }
+
+        List<PicklistOption> picklistOptions = CollectionMiscUtil.createListFromAnotherList(options,
                 (picklistOptionDef) ->
                         ctx.getAIBuilderFactory().getPicklistCreatorHelper()
                                 .createPicklistOption(ctx, picklistOptionDef, questionDef.getGroups()));


### PR DESCRIPTION
For REMOTE_AUTOCOMPLETE backend doesn't send picklist option defs as part of activity / activity_instance requests.
Angular needs a way to get the selected PL option def's (option lables) to display the selected answer(s).

Updated backend to include PL options defs of selected options  (from answer) during activity instance loading.
Angular need to look at the option stableID, get the option label from activity Def and display the answer.