### PR TITLE
DDP-7185 . Always include options with allowDetails=true

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
@@ -131,6 +131,9 @@ public class GetOptionsForActivityInstanceQuestionRoute implements Route {
         List<PicklistOption> optionMatches = options.stream().filter(option -> option.getOptionLabel().toUpperCase()
                 .contains(autoCompleteQuery.toUpperCase())).collect(Collectors.toList());
 
+        //include options with allowDetails = true
+        optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed()).collect(Collectors.toList()));
+
         // now sort the matches in a way that puts left-most matches near the top, favoring word start matches
         // apply limit and return results
         var suggestionComparator = new StringSuggestionTypeaheadComparator(autoCompleteQuery);

--- a/study-builder/studies/basil/snippets/question-rx-list.conf
+++ b/study-builder/studies/basil/snippets/question-rx-list.conf
@@ -92,6 +92,36 @@
           }
         ]
       }
+    },
+    {
+    "stableId": OTHER,
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "RX_OTHER",
+        "variables": [
+          {
+            "name": "RX_OTHER",
+            "translations": [
+              { "language": "en", "text": "RX Other" },
+              { "language": "es", "text": "[es] RX Other" },
+            ]
+          }
+        ]
+      }
+      "allowDetails": true,
+      "detailLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$details",
+        "variables": [
+          {
+            "name": "details",
+            "translations": [
+              { "language": "en", "text": "details" },
+              { "language": "es", "text": "[es] details" },
+            ]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
As part of DDP-7185 REMOTE_AUTOCOMPLETE picklist options:
If user enters some label/text that doesn't match any PL option labels, if there is a Picklist option with allowDetails=true, client need to select that option and send the entered text/label in details.

For ex:
Picklist list options are apple and orange and
the user enters “banana”, client need to send back to the server the stableId an answer with the stableId of the option that has “allowDetails=true” and “banana” as details.

For client/angular to know if there is a picklist option with allowDetails=true, backend need to include allowDetails=true option(s) . Usually study PL question conf will have one. 
Either restrict to one during study init OR client can always pick first one if more than one exists.

This PR has change to include  picklist option with allowDetails=true while returning selected matches.