### PR TITLE
Get remote picklist suggestions/options fix

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
@@ -131,10 +131,8 @@ public class GetOptionsForActivityInstanceQuestionRoute implements Route {
         List<PicklistOption> optionMatches = options.stream().filter(option -> option.getOptionLabel().toUpperCase()
                 .contains(autoCompleteQuery.toUpperCase())).collect(Collectors.toList());
 
-        //include options with allowDetails=true if no matches
-        if (optionMatches.isEmpty()) {
-            optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed()).collect(Collectors.toList()));
-        }
+        //include options with allowDetails=true if not already included
+        optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed() && !optionMatches.contains(option)).collect(Collectors.toList()));
 
         // now sort the matches in a way that puts left-most matches near the top, favoring word start matches
         // apply limit and return results

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
@@ -131,8 +131,10 @@ public class GetOptionsForActivityInstanceQuestionRoute implements Route {
         List<PicklistOption> optionMatches = options.stream().filter(option -> option.getOptionLabel().toUpperCase()
                 .contains(autoCompleteQuery.toUpperCase())).collect(Collectors.toList());
 
-        //include options with allowDetails = true
-        optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed()).collect(Collectors.toList()));
+        //include options with allowDetails=true if no matches
+        if (optionMatches.isEmpty()) {
+            optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed()).collect(Collectors.toList()));
+        }
 
         // now sort the matches in a way that puts left-most matches near the top, favoring word start matches
         // apply limit and return results

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetOptionsForActivityInstanceQuestionRoute.java
@@ -132,7 +132,8 @@ public class GetOptionsForActivityInstanceQuestionRoute implements Route {
                 .contains(autoCompleteQuery.toUpperCase())).collect(Collectors.toList());
 
         //include options with allowDetails=true if not already included
-        optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed() && !optionMatches.contains(option)).collect(Collectors.toList()));
+        optionMatches.addAll(options.stream().filter(option -> option.isDetailsAllowed() && !optionMatches.contains(option))
+                .collect(Collectors.toList()));
 
         // now sort the matches in a way that puts left-most matches near the top, favoring word start matches
         // apply limit and return results


### PR DESCRIPTION
Running into edge case where user enters text from Picklist options  with "allowDetails=true" , these "allowDetails=true" picklist options are duplicated in the response.

Include options with allowDetails=true only if option is NOT already included in the response options list