### PR TITLE
DDP-7619: adding information to ES needed for PE-CGS and mr tab bug

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -279,6 +279,7 @@ public class KitRequestShipping extends KitRequest {
     private Boolean careEvolve;
     @ColumnName(DBConstants.UPLOAD_REASON)
     private String uploadReason;
+    @ColumnName(DBConstants.DDP_INSTANCE_ID)
     private long ddpInstanceId;
 
     public KitRequestShipping() {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -279,6 +279,7 @@ public class KitRequestShipping extends KitRequest {
     private Boolean careEvolve;
     @ColumnName(DBConstants.UPLOAD_REASON)
     private String uploadReason;
+    private long ddpInstanceId;
 
     public KitRequestShipping() {
     }
@@ -882,6 +883,7 @@ public class KitRequestShipping extends KitRequest {
             kitRequestShipping.setExternalOrderNumber(externalOrderNumber);
             kitRequestShipping.setCreatedBy(createdBy);
             kitRequestShipping.setUploadReason(uploadReason);
+            kitRequestShipping.setDdpInstanceId(ddpInstance.getDdpInstanceIdAsInt());
 
             DDPInstanceDto ddpInstanceDto =
                     new DDPInstanceDao().getDDPInstanceByInstanceId(Integer.valueOf(ddpInstance.getDdpInstanceId())).orElseThrow();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -236,6 +236,7 @@ public class MedicalRecord {
             primaryKey = DBConstants.MEDICAL_RECORD_ID, columnPrefix = "")
     @ColumnName(DBConstants.PATHOLOGY_PRESENT)
     private String pathologyPresent;
+    @ColumnName(DBConstants.DDP_INSTANCE_ID)
     private long ddpInstanceId;
 
     public MedicalRecord(long medicalRecordId, long institutionId, String ddpInstitutionId, String type) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -254,7 +254,8 @@ public class MedicalRecord {
                          String mrReceived, String mrDocument, String mrDocumentFileNames, boolean mrProblem, String mrProblemText,
                          boolean unableObtain, boolean duplicate, boolean international, boolean crRequired, String pathologyPresent,
                          String mrNotes, boolean reviewMedicalRecord, FollowUp[] followUps, boolean followUpRequired,
-                         String followupRequiredText, String additionalValuesJson, String unableObtainText, String ddpParticipantId) {
+                         String followupRequiredText, String additionalValuesJson, String unableObtainText, String ddpParticipantId,
+                         long ddpInstanceId) {
         this.medicalRecordId = medicalRecordId;
         this.institutionId = institutionId;
         this.ddpInstitutionId = ddpInstitutionId;
@@ -290,6 +291,7 @@ public class MedicalRecord {
         this.additionalValuesJson = additionalValuesJson;
         this.unableObtainText = unableObtainText;
         this.ddpParticipantId = ddpParticipantId;
+        this.ddpInstanceId = ddpInstanceId;
     }
 
     public static MedicalRecord getMedicalRecord(@NonNull ResultSet rs) throws SQLException {
@@ -308,7 +310,7 @@ public class MedicalRecord {
                 new Gson().fromJson(rs.getString(DBConstants.FOLLOW_UP_REQUESTS), FollowUp[].class),
                 rs.getBoolean(DBConstants.FOLLOWUP_REQUIRED), rs.getString(DBConstants.FOLLOWUP_REQUIRED_TEXT),
                 rs.getString(DBConstants.ADDITIONAL_VALUES_JSON), rs.getString(DBConstants.MR_UNABLE_OBTAIN_TEXT),
-                rs.getString(DBConstants.DDP_PARTICIPANT_ID));
+                rs.getString(DBConstants.DDP_PARTICIPANT_ID), rs.getLong(DBConstants.DDP_INSTANCE_ID));
         return medicalRecord;
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -236,6 +236,7 @@ public class MedicalRecord {
             primaryKey = DBConstants.MEDICAL_RECORD_ID, columnPrefix = "")
     @ColumnName(DBConstants.PATHOLOGY_PRESENT)
     private String pathologyPresent;
+    private long ddpInstanceId;
 
     public MedicalRecord(long medicalRecordId, long institutionId, String ddpInstitutionId, String type) {
         this.medicalRecordId = medicalRecordId;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -40,8 +40,8 @@ import org.slf4j.LoggerFactory;
 public class OncHistoryDetail {
 
     public static final String SQL_SELECT_ONC_HISTORY_DETAIL =
-            "SELECT p.ddp_participant_id, p.participant_id, oD.onc_history_detail_id, oD.request, oD.deleted, oD.fax_sent, "
-                    + "oD.tissue_received, oD.medical_record_id, oD.date_px, oD.type_px, "
+            "SELECT p.ddp_participant_id, p.ddp_instance_id, p.participant_id, oD.onc_history_detail_id, oD.request, oD.deleted, "
+                    + "oD.fax_sent, oD.tissue_received, oD.medical_record_id, oD.date_px, oD.type_px, "
                     + "oD.location_px, oD.histology, oD.accession_number, oD.facility, oD.phone, oD.fax, oD.notes, "
                     + "oD.additional_values_json, oD.request, oD.fax_sent, oD.fax_sent_by, oD.fax_confirmed, oD.fax_sent_2, "
                     + "oD.fax_sent_2_by, oD.fax_confirmed_2, oD.fax_sent_3, "
@@ -51,7 +51,7 @@ public class OncHistoryDetail {
                     + "collaborator_sample_id, block_sent, scrolls_received, sk_id, sm_id, "
                     + "sent_gp, first_sm_id, additional_tissue_value_json, expected_return, return_date, return_fedex_id, "
                     + "shl_work_number, tumor_percentage, tissue_sequence, "
-                    + " scrolls_count, uss_count, h_e_count, blocks_count, sm.sm_id_value, sm.sm_id_type_id, sm.sm_id_pk, sm.deleted, "
+                    + "scrolls_count, uss_count, h_e_count, blocks_count, sm.sm_id_value, sm.sm_id_type_id, sm.sm_id_pk, sm.deleted, "
                     + "sm.tissue_id, smt.sm_id_type FROM ddp_onc_history_detail oD "
                     + "LEFT JOIN ddp_medical_record m on (oD.medical_record_id = m.medical_record_id "
                     + "AND NOT oD.deleted <=> 1 AND NOT m.deleted <=> 1) "
@@ -238,7 +238,8 @@ public class OncHistoryDetail {
                             String request, String faxSent, String faxSentBy, String faxConfirmed, String faxSent2, String faxSent2By,
                             String faxConfirmed2, String faxSent3, String faxSent3By, String faxConfirmed3, String tissueReceived,
                             String gender, String additionalValuesJson, List<Tissue> tissues, String tissueProblemOption,
-                            String destructionPolicy, boolean unableObtainTissue, String participantId, String ddpParticipantId) {
+                            String destructionPolicy, boolean unableObtainTissue, String participantId, String ddpParticipantId,
+                            long ddpInstanceId) {
         this.oncHistoryDetailId = oncHistoryDetailId;
         this.medicalRecordId = medicalRecordId;
         this.datePx = datePx;
@@ -269,6 +270,7 @@ public class OncHistoryDetail {
         this.unableObtainTissue = unableObtainTissue;
         this.participantId = participantId;
         this.ddpParticipantId = ddpParticipantId;
+        this.ddpInstanceId = ddpInstanceId;
     }
 
     public static OncHistoryDetail getOncHistoryDetail(@NonNull ResultSet rs) throws SQLException {
@@ -294,7 +296,7 @@ public class OncHistoryDetail {
                         DBConstants.DDP_ONC_HISTORY_DETAIL_ALIAS + DBConstants.ALIAS_DELIMITER + DBConstants.ADDITIONAL_VALUES_JSON),
                         tissues, rs.getString(DBConstants.TISSUE_PROBLEM_OPTION), rs.getString(DBConstants.DESTRUCTION_POLICY),
                         rs.getBoolean(DBConstants.UNABLE_OBTAIN_TISSUE), rs.getString(DBConstants.PARTICIPANT_ID),
-                        rs.getString(DBConstants.DDP_PARTICIPANT_ID));
+                        rs.getString(DBConstants.DDP_PARTICIPANT_ID), rs.getLong(DBConstants.DDP_INSTANCE_ID));
         return oncHistoryDetail;
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -192,6 +192,7 @@ public class OncHistoryDetail {
     private String participantId;
     private String ddpParticipantId;
     private List<Tissue> tissues;
+    private long ddpInstanceId;
 
     public OncHistoryDetail() {
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -192,6 +192,7 @@ public class OncHistoryDetail {
     private String participantId;
     private String ddpParticipantId;
     private List<Tissue> tissues;
+    @ColumnName(DBConstants.DDP_INSTANCE_ID)
     private long ddpInstanceId;
 
     public OncHistoryDetail() {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/TissueList.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/TissueList.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 public class TissueList {
     public static final Logger logger = LoggerFactory.getLogger(TissueList.class);
     public static final String SQL_SELECT_ALL_ONC_HISTORY_TISSUE_FOR_REALM =
-            "SELECT p.ddp_participant_id, p.participant_id, p.assignee_id_tissue,"
+            "SELECT p.ddp_participant_id, p.ddp_instance_id, p.participant_id, p.assignee_id_tissue,"
                     + "oD.onc_history_detail_id, oD.request, oD.deleted, oD.fax_sent, oD.tissue_received, oD.medical_record_id, "
                     + "oD.date_px, oD.type_px, "
                     + "oD.location_px, oD.histology, oD.accession_number, oD.facility, oD.phone, oD.fax, oD.notes, "

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
@@ -30,7 +30,7 @@ public class BaseCollectionMigratorTest {
     private List mockOncHistoryDetail() {
         OncHistoryDetail oncHistoryDetail =
                 new OncHistoryDetail(23, 0, null, null, null, null, null, null, null, null, null, null, null, null, null,
-                        null, null, null, null, null, null, null, null, null, mockTissues(), null, null, false, null, null);
+                        null, null, null, null, null, null, null, null, null, mockTissues(), null, null, false, null, null, 0);
         return Collections.singletonList(oncHistoryDetail);
     }
 


### PR DESCRIPTION
to fix the mr tab DSM needs the ddpInstitutionId (GUID) in the mr object in ES as well. Frontend needs to get info like type and pt entered info (address) from participant.data.medicalProviders and only relation to do so is the guid of the institution

for PE-CGS DSM needs to have the institutionID in teh mr/oncHistory/sample objects in ES as well