### PR TITLE
DDP-7707: Extend BOOLEAN question that can be rendered as a checkbox

### DIFF
--- a/pepper-apis/docs/specification/package-lock.json
+++ b/pepper-apis/docs/specification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.27-370-ge7f3453f7",
+  "version": "1.27.370",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pepper-api-spec",
-      "version": "1.27-370-ge7f3453f7",
+      "version": "1.27.370",
       "dependencies": {
         "@redocly/openapi-cli": "v1.0.0-beta.79",
         "redoc": "2.0.0-rc.59",

--- a/pepper-apis/docs/specification/package-lock.json
+++ b/pepper-apis/docs/specification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.27.370",
+  "version": "1.27.0-370",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pepper-api-spec",
-      "version": "1.27.370",
+      "version": "1.27.0-370",
       "dependencies": {
         "@redocly/openapi-cli": "v1.0.0-beta.79",
         "redoc": "2.0.0-rc.59",

--- a/pepper-apis/docs/specification/package-lock.json
+++ b/pepper-apis/docs/specification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.25.0-71",
+  "version": "1.27-370-ge7f3453f7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pepper-api-spec",
-      "version": "1.25.0-71",
+      "version": "1.27-370-ge7f3453f7",
       "dependencies": {
         "@redocly/openapi-cli": "v1.0.0-beta.79",
         "redoc": "2.0.0-rc.59",

--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.27.370",
+  "version": "1.27.0-370",
   "private": true,
   "description": "",
   "dependencies": {

--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.27-370-ge7f3453f7",
+  "version": "1.27.370",
   "private": true,
   "description": "",
   "dependencies": {

--- a/pepper-apis/docs/specification/package.json
+++ b/pepper-apis/docs/specification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pepper-api-spec",
-  "version": "1.25.0-71",
+  "version": "1.27-370-ge7f3453f7",
   "private": true,
   "description": "",
   "dependencies": {

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1642,10 +1642,10 @@ Question.Boolean:
           - CHECKBOX
           - RADIO_BUTTONS
       trueContent:
-        type: string | null (for CHECKBOX renderMode)
+        type: string
         example: 'Yes'
       falseContent:
-        type: string | null (for CHECKBOX renderMode)
+        type: string
         example: 'NO'
       answers:
         type: array

--- a/pepper-apis/docs/specification/src/components/schemas.yml
+++ b/pepper-apis/docs/specification/src/components/schemas.yml
@@ -1628,17 +1628,24 @@ Question.Boolean:
       - answers
       - trueContent
       - falseContent
+      - renderMode
     properties:
       questionType:
         type: string
         default: BOOLEAN
         enum:
           - BOOLEAN
-      trueContent:
+      renderMode:
         type: string
+        default: RADIO_BUTTONS
+        enum:
+          - CHECKBOX
+          - RADIO_BUTTONS
+      trueContent:
+        type: string | null (for CHECKBOX renderMode)
         example: 'Yes'
       falseContent:
-        type: string
+        type: string | null (for CHECKBOX renderMode)
         example: 'NO'
       answers:
         type: array

--- a/pepper-apis/docs/specification/src/pepper.yml
+++ b/pepper-apis/docs/specification/src/pepper.yml
@@ -6,7 +6,7 @@ servers:
     description: Production server (uses real data)
 info:
   description: 'Pepper API specification'
-  version: 'v1.25-46-gcd81179ef'
+  version: 'v1.27-370-ge7f3453f7'
   title: Pepper
   contact:
     email: info@datadonationplatform.org


### PR DESCRIPTION
## Context

This PR updates the API specification to extend API definitions for the Boolean question. It can have 2 render modes now: **RADIO_BUTTONS** (current one) and **CHECKBOX** (new one).

## Release

- [x] These changes require no special release procedures--just code!


