### PR TITLE
DecimalDef class implements serializable interface

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/types/DecimalDef.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/definition/types/DecimalDef.java
@@ -4,12 +4,13 @@ import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
 @Value
 @AllArgsConstructor
-public class DecimalDef implements Comparable<DecimalDef> {
+public class DecimalDef implements Comparable<DecimalDef>, Serializable {
     @SerializedName("value")
     BigInteger value;
 


### PR DESCRIPTION
DecimalDef class now implements serializable since otherwise its instance can't be put to the cache