### PR TITLE
[DSS] DDP-7630: composite dates mapping fix

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -359,7 +359,6 @@
                 "prion_medical_earliest_symptoms": {
                   "type": "text"
                 },
-
                 "selected": {
                   "type": "keyword"
                 },

--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -344,6 +344,22 @@
                     }
                   }
                 },
+                "LONGITUDINAL_VACCINE_RECEIVED_LIST": {
+                  "type": "text"
+                },
+                "LONGITUDINAL_BLOOD_TEST_LIST": {
+                  "type": "text"
+                },
+                "VIRAL_TEST_LIST": {
+                  "type": "text"
+                },
+                "BLOOD_TEST_LIST": {
+                  "type": "text"
+                },
+                "prion_medical_earliest_symptoms": {
+                  "type": "text"
+                },
+
                 "selected": {
                   "type": "keyword"
                 },


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-7630
Mapping changes to handle edge cases where dates are captured as non Date fields in a composite questions.
Explicitly called out in mapping to handle as text rather than dates while exporting in new style for dsm.

Tried to go through old alerts and studies to identify these possible questions but if any missed , need to add them later .