### PR TITLE
DDP-7824 . Mapping fixes to handle dates in composite questions

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -344,6 +344,30 @@
                     }
                   }
                 },
+                "LONGITUDINAL_VACCINE_RECEIVED_LIST": {
+                  "type": "text"
+                },
+                "LONGITUDINAL_VACCINE_STUDY_LIST": {
+                  "type": "text"
+                },
+                "LONGITUDINAL_BLOOD_TEST_LIST": {
+                  "type": "text"
+                },
+                "VIRAL_TEST_LIST": {
+                  "type": "text"
+                },
+                "BLOOD_TEST_LIST": {
+                  "type": "text"
+                },
+                "prion_medical_earliest_symptoms": {
+                  "type": "text"
+                },
+                "prion_medical_diagnosis_date": {
+                  "type": "text"
+                },
+                "ESTIMATED_DATE": {
+                  "type": "text"
+                },
                 "selected": {
                   "type": "keyword"
                 },


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-7824
Mapping changes to handle dates in composite questions that are not captured as dates while exporting in new style needed for DSM.
Explicitly call out these edge cases in mapping to export as text 
tested and looks good