### PR TITLE
[DSM] DDP-7188: workflow status

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
@@ -45,11 +45,11 @@ public class WorkflowStatusUpdate {
         Optional<FieldSettingsDto> fieldSetting =
                 fieldSettingsDao.getFieldSettingByColumnNameAndInstanceId(Integer.parseInt(instance.getDdpInstanceId()), workflow);
         if (fieldSetting.isEmpty()) {
-            logger.warn("Wrong workflow name");
+            logger.warn("Wrong workflow name " + workflow);
         } else {
             FieldSettingsDto setting = fieldSetting.get();
             boolean isOldParticipant = participantDatas.stream()
-                    .anyMatch(participantDataDto -> participantDataDto.getFieldTypeId().equals(setting.getFieldType())
+                    .anyMatch(participantDataDto -> participantDataDto.getFieldTypeId().get().equals(setting.getFieldType())
                             || participantDataDto.getFieldTypeId().orElse("").contains(FamilyMemberConstants.PARTICIPANTS));
             if (isOldParticipant) {
                 participantDatas.forEach(participantDataDto -> {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
@@ -16,6 +16,7 @@ import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.settings.FieldSettingsDto;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
+import org.broadinstitute.dsm.route.EditParticipantPublisherRoute;
 import org.broadinstitute.dsm.util.DBTestUtil;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -88,6 +89,21 @@ public class UpdateWorkflowStatusTest {
         }
         userDao.delete(userDto.getId());
         ddpInstanceDao.delete(ddpInstanceDto.getDdpInstanceId());
+    }
+
+    @Test
+    public void testUpdateCustomWorkflow() {
+        String messageData = "{\"participantGuid\":\"RBMJW6ZIXVXBMXUX6M3Q\",\"instanceName\":\"RGP\",\"data\":{\"workflow\":\"MEMBER_TYPE\",\"status\":\"COMPLETED\"}}";
+        JsonObject messageJsonObject = new Gson().fromJson(messageData, JsonObject.class);
+        String dataString = messageJsonObject.get("data").getAsJsonObject().toString();
+        Map<String, String> attributeMap = EditParticipantPublisherRoute.getStringStringMap("TEST", messageJsonObject);
+        WorkflowStatusUpdate.updateCustomWorkflow(attributeMap, dataString);
+        String data = participantDataDao.get(participantDataId).orElseThrow().getData().orElse("");
+        JsonObject dataJsonObject = gson.fromJson(data, JsonObject.class);
+        //checking that value was updated
+        Assert.assertEquals("COMPLETED", dataJsonObject.get("MEMBER_TYPE").getAsString());
+        //checking that updated value did not remove other fields
+        Assert.assertEquals("REGISTERED", dataJsonObject.get("REGISTRATION_STATUS").getAsString());
     }
 
     @Test


### PR DESCRIPTION
fix for AT. Currently when a pt changes workflow fields in the DSS site that should get added to DSM, DSM will add a new row in ddp_participant_data instead of updating the existing one