### PR TITLE
comparison validation fix

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestion.java
@@ -78,6 +78,13 @@ public interface JdbiQuestion extends SqlObject {
             @Bind("questionStableId") String questionStableId);
 
     @UseStringTemplateSqlLocator
+    @SqlQuery("queryLatestDtoByStudyGuidAndQuestionStableId")
+    @RegisterConstructorMapper(QuestionDto.class)
+    Optional<QuestionDto> findLatestDtoByStudyGuidAndQuestionStableId(
+            @Bind("studyGuid") String studyGuid,
+            @Bind("questionStableId") String questionStableId);
+
+    @UseStringTemplateSqlLocator
     @SqlQuery("queryQuestionsByStudyGuid")
     @RegisterConstructorMapper(QuestionDto.class)
     List<QuestionDto> findByStudyGuid(@Bind("studyGuid") String studyGuid);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiQuestionCached.java
@@ -74,6 +74,11 @@ public class JdbiQuestionCached extends SQLObjectWrapper<JdbiQuestion> implement
     }
 
     @Override
+    public Optional<QuestionDto> findLatestDtoByStudyGuidAndQuestionStableId(String studyGuid, String questionStableId) {
+        return delegate.findLatestDtoByStudyGuidAndQuestionStableId(studyGuid, questionStableId);
+    }
+
+    @Override
     public List<QuestionDto> findByStudyGuid(String studyGuid) {
         return delegate.findByStudyGuid(studyGuid);
     }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/ValidationRuleCreator.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/ValidationRuleCreator.java
@@ -9,6 +9,7 @@ import org.broadinstitute.ddp.db.ActivityDefStore;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.QuestionDao;
 import org.broadinstitute.ddp.db.dao.ValidationDao;
+import org.broadinstitute.ddp.db.dto.QuestionDto;
 import org.broadinstitute.ddp.model.activity.definition.types.DecimalDef;
 import org.broadinstitute.ddp.model.activity.definition.validation.AgeRangeRuleDef;
 import org.broadinstitute.ddp.model.activity.definition.validation.CompleteRuleDef;
@@ -207,6 +208,12 @@ public class ValidationRuleCreator {
     }
 
     private ComparisonRule createComparisonRule(AIBuilderContext ctx, ComparisonRuleDef ruleDef) {
+        QuestionDto questionDto = TransactionWrapper.withTxn(handle -> handle.attach(QuestionDao.class).getJdbiQuestion()
+                .findLatestDtoByStudyGuidAndQuestionStableId(ctx.getStudyGuid(), ruleDef.getValueStableId())
+                .orElseThrow(() -> new RuntimeException(
+                        String.format("Can't find question by stable ID: %s & Study GUID: %s",
+                                ruleDef.getValueStableId(), ctx.getStudyGuid()))));
+
         return ComparisonRule.builder()
                 .id(ruleDef.getRuleId())
                 .type(ruleDef.getRuleType())
@@ -215,11 +222,7 @@ public class ValidationRuleCreator {
                 .allowSave(ruleDef.getAllowSave())
                 .comparisonType(ruleDef.getComparison())
                 .referenceQuestionStableId(ruleDef.getValueStableId())
-                .referenceQuestionId(TransactionWrapper.withTxn(handle -> handle.attach(QuestionDao.class).getJdbiQuestion()
-                                .findIdByStableIdAndInstanceGuid(ruleDef.getValueStableId(), ctx.getInstanceGuid())
-                                .orElseThrow(() -> new RuntimeException(
-                                        String.format("Can't find question by stable ID: %s & instance GUID: %s",
-                                                ruleDef.getValueStableId(), ctx.getInstanceGuid())))))
+                .referenceQuestionId(questionDto.getId())
                 .build();
     }
 

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestion.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestion.sql.stg
@@ -29,6 +29,14 @@ where qsc.umbrella_study_id = :studyId
   and rev.end_date is null
 >>
 
+queryLatestDtoByStudyGuidAndQuestionStableId() ::= <<
+<all_questions_select()>
+join umbrella_study us on us.umbrella_study_id = qsc.umbrella_study_id
+where us.guid = :studyGuid
+  and qsc.stable_id = :questionStableId
+  and rev.end_date is null
+>>
+
 queryQuestionsByStudyGuid() ::= <<
 <all_questions_select()>
 join umbrella_study us on us.umbrella_study_id = qsc.umbrella_study_id

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestionValidation.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiQuestionValidation.sql.stg
@@ -31,7 +31,8 @@ select q.question_id,
   left join num_options_selected_validation as nosv on nosv.validation_id = v.validation_id
   left join regex_validation as rv on rv.validation_id = v.validation_id
   left join comparison_validation as cmpv on cmpv.validation_id = v.validation_id
-  left join question_stable_code as rqsc on cmpv.reference_question_id = rqsc.question_stable_code_id
+  left join question as rq on cmpv.reference_question_id = rq.question_id
+  left join question_stable_code as rqsc on rq.question_stable_code_id = rqsc.question_stable_code_id
 >>
 
 getAllActiveValidations() ::= <<


### PR DESCRIPTION
fix for https://broadinstitute.slack.com/archives/GC80PJLTZ/p1651797690687739
Basil bug with comparison rule/validation

1. SQL fix 
2. As per Basil configuration:
Question in LOVED_ONE activity is referring to (comparing to) question in another activity NUMERIC_ACTIVITY
Code in ValidationRuleCreator.createComparisonRule is looking for question with referring stableID in same activity instance (LOVED_ONE) and hence not able to find the question.
ValidationRuleCreator.createComparisonRule should be updated to lookup referred question  probably by stableId, user and study and NOT activityInstance
