### PR TITLE
DDP7707 Boolean question liquibase  fix

### DIFF
--- a/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7709-add-boolean-render-mode.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7709-add-boolean-render-mode.xml
@@ -5,10 +5,10 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="bskinner" id="add-boolean-render-mode">
-        <addColumn tableName="boolean_question">
+        <update tableName="boolean_question">
             <column name="boolean_render_mode_id" type="bigint" valueComputed="(select boolean_render_mode_id from boolean_render_mode where boolean_render_mode_code = 'RADIO_BUTTONS')">
                 <constraints nullable="false" references="boolean_render_mode(boolean_render_mode_id)" foreignKeyName="boolean_question_boolean_render_mode_fk"/>
             </column>
-        </addColumn>
+        </update>
     </changeSet>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7709-add-boolean-render-mode.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-7709-add-boolean-render-mode.xml
@@ -5,10 +5,16 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
     <changeSet author="bskinner" id="add-boolean-render-mode">
-        <update tableName="boolean_question">
-            <column name="boolean_render_mode_id" type="bigint" valueComputed="(select boolean_render_mode_id from boolean_render_mode where boolean_render_mode_code = 'RADIO_BUTTONS')">
-                <constraints nullable="false" references="boolean_render_mode(boolean_render_mode_id)" foreignKeyName="boolean_question_boolean_render_mode_fk"/>
+        <addColumn tableName="boolean_question">
+            <column name="boolean_render_mode_id" type="bigint">
+                <constraints references="boolean_render_mode(boolean_render_mode_id)" foreignKeyName="boolean_question_boolean_render_mode_fk"/>
             </column>
+        </addColumn>
+
+        <update tableName="boolean_question">
+            <column name="boolean_render_mode_id" type="bigint" valueComputed="(select boolean_render_mode_id from boolean_render_mode where boolean_render_mode_code = 'RADIO_BUTTONS')"/>
         </update>
+
+        <addNotNullConstraint tableName="boolean_question" columnName="boolean_render_mode_id" columnDataType="bigint"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Separated out liquibase sql
to add column, update and add not null constraint.
tested in local and looks ok. 

To avoid:
08:19:43.508   C: S: [main] ERROR liquibase.changelog.ChangeSet Change Set db-changes/schema/DDP-7709-add-boolean-render-mode.xml::add-boolean-render-mode::bskinner failed.  Error: Cannot add or update a child row: a foreign key constraint fails (`pepperdev`.`#sql-8_cd490`, CONSTRAINT `boolean_question_boolean_render_mode_fk` FOREIGN KEY (`boolean_render_mode_id`) REFERENCES `boolean_render_mode` (`boolean_render_mode_id`)) [Failed SQL: ALTER TABLE pepperdev.boolean_question ADD CONSTRAINT boolean_question_boolean_render_mode_fk FOREIGN KEY (boolean_render_mode_id) REFERENCES pepperdev.boolean_render_mode (boolean_render_mode_id)]