### PR TITLE
[DSS] Fix for NPE in DataExporter when processing FileAnswers

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -659,17 +659,16 @@ public interface AnswerDao extends SqlObject {
                             actInstanceGuid);
                     break;
                 case FILE:
-                    FileInfo info = null;
                     answer = container.computeIfAbsent(answerId, id ->
                             new FileAnswer(answerId, questionStableId, answerGuid, new ArrayList<>(), actInstanceGuid));
                     Long fileUploadId = view.getColumn("fa_upload_id", Long.class);
                     if (fileUploadId != null) {
-                        info = new FileInfo(fileUploadId,
+                        var info = new FileInfo(fileUploadId,
                                 view.getColumn("fa_upload_guid", String.class),
                                 view.getColumn("fa_file_name", String.class),
                                 view.getColumn("fa_file_size", Long.class));
+                        ((FileAnswer) answer).getValue().add(info);
                     }
-                    ((FileAnswer) answer).getValue().add(info);
                     break;
                 case NUMERIC:
                     answer = new NumericAnswer(answerId, questionStableId, answerGuid,


### PR DESCRIPTION
DDP-8034

## Context
Fixes a case where a `null` value could be inserted into a `FileAnswer`'s value list by `SimpleAnswerWithValueReducer` when the answer does not have an associated `file_upload_id`. This situation leads to a `NullPointerException` being thrown when `DataExporter.java:1055` attempts to invoke `FileInfo::getUploadId` on `null`.

The fix is to move the declaration of the local variable containing the reference to the `FileInfo` object, and the line which appends the value onto the `FileAnswer`'s value array into the scope of the `fileUploadId` null check.

## Release

- [x] These changes require no special release procedures--just code!

