### PR TITLE
[DSS] DDP-8082: auth0_domain column removed

### DIFF
--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -306,4 +306,5 @@
     <include file="db-changes/seed/DDP-7709-add-boolean-render-mode-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7709-add-boolean-render-mode.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8012.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/DDP-8000.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-8000.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/schema/DDP-8000.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="DROP_AUTH0_DOMAIN_COLUMN_AGAIN" author="Dmitrii">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <columnExists tableName="client" columnName="auth0_domain" />
+        </preConditions>
+
+        <dropColumn tableName="client" columnName="auth0_domain"/>
+    </changeSet>
+</databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/tenant-migration.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/tenant-migration.xml
@@ -3,12 +3,18 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+        https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <changeSet id="DDP-2606-backfill-auth0-tenant" author="andrew">
+    <changeSet id="DROP_AUTH0_DOMAIN_COLUMN" author="Dmitrii">
+        <preConditions onError="MARK_RAN" onFail="MARK_RAN">
+            <columnExists tableName="client" columnName="auth0_domain" />
+        </preConditions>
 
         <dropNotNullConstraint tableName="client" columnName="auth0_domain" columnDataType="varchar(255)"/>
+        <dropColumn tableName="client" columnName="auth0_domain"/>
+    </changeSet>
 
+    <changeSet id="DDP-2606-backfill-auth0-tenant" author="andrew">
         <sql>
             update umbrella_study s set s.auth0_tenant_id = (select auth0_tenant_id from auth0_tenant order by auth0_tenant_id asc limit 1)
             where s.auth0_tenant_id is null
@@ -23,8 +29,6 @@
             update user set auth0_tenant_id = (select auth0_tenant_id from auth0_tenant order by auth0_tenant_id asc limit 1)
             where auth0_tenant_id is null
         </sql>
-
-        <dropColumn tableName="client" columnName="auth0_domain"/>
 
         <addNotNullConstraint tableName="client" columnName="auth0_tenant_id" columnDataType="bigint"/>
 


### PR DESCRIPTION
```
12:40:26.325   C: S: [main] INFO  liquibase.changelog.ChangeSet ChangeSet db-changes/schema/DDP-8000.xml::DROP_AUTH0_DOMAIN_COLUMN_AGAIN::Dmitrii ran successfully in 34ms

...

12:40:27.401   C: S: [main] INFO  liquibase.changelog.ChangeSet Marking ChangeSet: db-changes/tenant-migration.xml::DROP_AUTH0_DOMAIN_COLUMN::Dmitrii ran despite precondition failure due to onFail='MARK_RAN': 
          db-changes/tenant-migration.xml : Column pepperlocal.client.auth0_domain does not exist
```