### PR TITLE
[SB] Updates to questions requiring decimal input

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
@@ -473,7 +473,7 @@
             include required("../../snippets/decimal-question.conf"),
             "stableId": "Q2_CMR_HEIGHT_CM",
             "hideNumber": true,
-            "scale": 1
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q2_cmr_height_cm_prompt",
               "templateType": "HTML",
@@ -589,7 +589,7 @@
             include required("../../snippets/decimal-question.conf"),
             "stableId": "Q4_CMR_WEIGHT_KG",
             "hideNumber": true,
-            "scale": 1
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q4_cmr_weight_kg_prompt",
               "templateType": "HTML",
@@ -1376,7 +1376,7 @@
             include required("../../snippets/decimal-question.conf"),
             "stableId": "Q18_CMR_DIASTOLIC_VOLUME",
             "hideNumber": true,
-            "scale": 1
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q18_cmr_diastolic_volume_prompt",
               "templateType": "HTML",

--- a/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
@@ -518,11 +518,11 @@
                 "ruleType": "DECIMAL_RANGE",
                 "min": {
                   "value": 60,
-                  "scale": 1
+                  "scale": 0
                 },
                 "max": {
                   "value": 215,
-                  "scale": 1
+                  "scale": 0
                 },
                 "hintTemplate": {
                   "templateType": "TEXT",
@@ -634,11 +634,11 @@
                 "ruleType": "DECIMAL_RANGE",
                 "min": {
                   "value": 6,
-                  "scale": 1
+                  "scale": 0
                 },
                 "max": {
                   "value": 250,
-                  "scale": 1
+                  "scale": 0
                 },
                 "hintTemplate": {
                   "templateType": "TEXT",

--- a/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/activities/cmri.conf
@@ -470,9 +470,10 @@
         // Height: (cm)
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q2_CMR_HEIGHT_CM",
             "hideNumber": true,
+            "scale": 1
             "promptTemplate": {
               "templateText": "$q2_cmr_height_cm_prompt",
               "templateType": "HTML",
@@ -514,9 +515,15 @@
                 }
               },
               {
-                "ruleType": "INT_RANGE",
-                "min": 60,
-                "max": 215,
+                "ruleType": "DECIMAL_RANGE",
+                "min": {
+                  "value": 60,
+                  "scale": 1
+                },
+                "max": {
+                  "value": 215,
+                  "scale": 1
+                },
                 "hintTemplate": {
                   "templateType": "TEXT",
                   "templateText": "$q2_cmr_height_cm_int_range_hint",
@@ -579,9 +586,10 @@
         // Weight: (kg)
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q4_CMR_WEIGHT_KG",
             "hideNumber": true,
+            "scale": 1
             "promptTemplate": {
               "templateText": "$q4_cmr_weight_kg_prompt",
               "templateType": "HTML",
@@ -623,9 +631,15 @@
                 }
               },
               {
-                "ruleType": "INT_RANGE",
-                "min": 6,
-                "max": 250,
+                "ruleType": "DECIMAL_RANGE",
+                "min": {
+                  "value": 6,
+                  "scale": 1
+                },
+                "max": {
+                  "value": 250,
+                  "scale": 1
+                },
                 "hintTemplate": {
                   "templateType": "TEXT",
                   "templateText": "$q4_cmr_weight_kg_int_range_hint",
@@ -922,9 +936,10 @@
         // RV End Diastolic Volume in mL:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q9_CMR_DIASTOLIC_VOLUME",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q9_cmr_diastolic_volume_prompt",
               "templateType": "HTML",
@@ -964,9 +979,10 @@
         // RV End Diastolic Volume in mL/m2:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q10_CMR_DIASTOLIC_VOLUME_MLM2",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q10_cmr_diastolic_volume_mlm2_prompt",
               "templateType": "HTML",
@@ -1044,8 +1060,9 @@
         // RV End Systolic Volume in mL:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q12_CMR_SYSTOLIC_VOLUME",
+            "scale": 1,
             "hideNumber": true,
             "promptTemplate": {
               "templateText": "$q12_cmr_systolic_volume_prompt",
@@ -1086,9 +1103,10 @@
         // RV End Systolic Volume in mL/m2:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q13_CMR_SYSTOLIC_VOLUME_MLM2",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q13_cmr_systolic_volume_mlm2_prompt",
               "templateType": "HTML",
@@ -1355,9 +1373,10 @@
         // LV End Diastolic Volume in mL:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q18_CMR_DIASTOLIC_VOLUME",
             "hideNumber": true,
+            "scale": 1
             "promptTemplate": {
               "templateText": "$q18_cmr_diastolic_volume_prompt",
               "templateType": "HTML",
@@ -1397,9 +1416,10 @@
         // LV End Diastolic Volume in mL/m2:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q19_CMR_DIASTOLIC_VOLUME_MLM2",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q19_cmr_diastolic_volume_mlm2_prompt",
               "templateType": "HTML",
@@ -1477,9 +1497,10 @@
         // LV End Systolic Volume in mL:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q21_CMR_SYSTOLIC_VOLUME",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q21_cmr_systolic_volume_prompt",
               "templateType": "HTML",
@@ -1519,9 +1540,10 @@
         // LV End Systolic Volume in mL/m2:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q22_CMR_SYSTOLIC_VOLUME_MLM2",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q22_cmr_systolic_volume_mlm2_prompt",
               "templateType": "HTML",
@@ -1899,9 +1921,10 @@
         // Forward Flow in L/min:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q28_CMR_FORWARD_FLOW_IN_LMIN",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q28_cmr_forward_flow_in_lmin_prompt",
               "templateType": "HTML",
@@ -1941,9 +1964,10 @@
         // Forward Flow in mL/beat:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q29_CMR_FORWARD_FLOW_IN_MLBEAT",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q29_cmr_forward_flow_in_mlbeat_prompt",
               "templateType": "HTML",
@@ -2021,9 +2045,10 @@
         // Net Flow in L/min:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q31_CMR_NET_FLOW_IN_LMIN",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q31_cmr_net_flow_in_lmin_prompt",
               "templateType": "HTML",
@@ -2063,9 +2088,10 @@
         // Net Flow in mL/beat:
         {
           "question": {
-            include required("../../snippets/numeric-question.conf"),
+            include required("../../snippets/decimal-question.conf"),
             "stableId": "Q32_CMR_NET_FLOW_IN_MLBEAT",
             "hideNumber": true,
+            "scale": 1,
             "promptTemplate": {
               "templateText": "$q32_cmr_net_flow_in_mlbeat_prompt",
               "templateType": "HTML",


### PR DESCRIPTION
## Context

In the period since the `cMRI` activity was written, support for DECIMAL-type questions has been added to the Pepper platform. This PR updates questions in the `cMRI` study definition marked as "Numeric, allows decimals" in the study design spec to use the `DECIMAL` question type. If a `scale` was not defined for the question type, a `scale` of `1` was used (allowing a single decimal place).

## How do we demo these changes?
These changes should be visible in the Pepper UI once the deployed study has been updated.

## Testing
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release
- [x] These changes require no special release procedures--just code!

