### PR TITLE
fon conf cleanup

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/fon/substitutions.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/substitutions.conf
@@ -32,11 +32,8 @@
     "is_age_of_majority": """((user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q13_PALE_PRIMARY_RESIDENTIAL_ADDRESS_ENROLLME"].isAnswered() && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q13_PALE_PRIMARY_RESIDENTIAL_ADDRESS_ENROLLME"].answers.hasAnyOption("AL_STATE", "NE_STATE", "NB_STATE", "NL_STATE", "NT_STATE", "NS_STATE", "NU_STATE", "YT_STATE") && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].isAnswered() && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].answers.ageAtLeast(19, YEARS)) || (user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q13_PALE_PRIMARY_RESIDENTIAL_ADDRESS_ENROLLME"].isAnswered() && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q13_PALE_PRIMARY_RESIDENTIAL_ADDRESS_ENROLLME"].answers.hasOption("PR_STATE") && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].isAnswered() && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].answers.ageAtLeast(21, YEARS)) || (user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q13_PALE_PRIMARY_RESIDENTIAL_ADDRESS_ENROLLME"].isAnswered() && user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].isAnswered()&& user.studies["fon"].forms["PATIENT_PROFILE"].questions["Q9_PALE_DATE_OF_BIRTH"].answers.ageAtLeast(18, YEARS)))""",
   }
   "_includes": {
-    question_medications = {include required("snippets/question-medications.conf")},
     composite-question = {include required("snippets/composite-question.conf")},
     question_fon_rx_list = {include required("snippets/question-medication-list.conf")}
-    question_medication_start_date = {include required("snippets/question-medication-start-date.conf")}
-    question_medication_stop_date = {include required("snippets/question-medication-stop-date.conf")}
   }
 
 }


### PR DESCRIPTION
cleanup some unwanted conf entries in substitutions

to redeploy:

java -Dconfig.file=./output-config/application.conf -cp ./target/StudyBuilder.jar org.broadinstitute.ddp.studybuilder.StudyBuilderCli --vars ./output-config/vars.conf --substitutions ./studies/fon/substitutions.conf ./studies/fon/study.conf --process-translations PROCESS_IGNORE_TEMPLATES_WITH_TRANSLATIONS --translations-to-db-json