### PR TITLE
DSS DDP-8129 use newer circle ci images

### DIFF
--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -51,8 +51,8 @@ executors:
       - image: broadinstitute/study-server-build:java-2022-06-01A
       # start pubsub emulator
       - image: broadinstitute/study-server-build:pubsub-1
-      - image: cimg/redis:4-alpine
-      - image: cimg/mysql:5.7-ram
+      - image: cimg/redis:5.0
+      - image: cimg/mysql:5.7
         environment: &DB_VARS
           MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: test_db

--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -51,8 +51,8 @@ executors:
       - image: broadinstitute/study-server-build:java-2022-06-01A
       # start pubsub emulator
       - image: broadinstitute/study-server-build:pubsub-1
-      - image: circleci/redis:4-alpine
-      - image: circleci/mysql:5.7-ram
+      - image: cimg/redis:4-alpine
+      - image: cimg/mysql:5.7-ram
         environment: &DB_VARS
           MYSQL_ROOT_PASSWORD: rootpw
           MYSQL_DATABASE: test_db


### PR DESCRIPTION
As ticket indicates, just using newer non-deprecated versions of CircleCi convenience images. We use a Redis and a MySQL image while running our tests.