### PR TITLE
[DSS]Ensure needed sheetappend dependencies are installed for sheetappend

### DIFF
--- a/pepper-apis/build-utils/build-support-images/Dockerfile-build
+++ b/pepper-apis/build-utils/build-support-images/Dockerfile-build
@@ -56,6 +56,7 @@ RUN case "${TARGETARCH:-amd64}" in \
 WORKDIR /opt
 RUN apk --no-cache add npm subversion && \
     svn export https://github.com/broadinstitute/ddp-angular/trunk/build-utils \
+        && npm install ./build-utils/sheetappend \
         && npm install -g ./build-utils/sheetappend \
         && chmod 555 build-utils/reportdeploy.sh
 


### PR DESCRIPTION
Updated ticket with problem we just encountered.
https://broadinstitute.atlassian.net/browse/DDP-8126

For some reason, in previous build node dependencies were being included in installation the the sheetappend utility and they were not being installed in the new docker images.

