### PR TITLE
Increase logging when SendGrid fails to fetch a template version

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -760,7 +760,31 @@ public class Housekeeping {
                                                         + " is not in the pepper database");
                                             }
 
-                                            new EmailNotificationHandler(sendGridProvider.get(notificationMessage.getApiKey()),
+                                            var sendGridKey = notificationMessage.getApiKey();
+
+                                            /*
+                                                SendGrid keys are in the format:
+                                                SG.<key-id>.<key>
+                                                The <key-id> part is not considered secret, and
+                                                can be used to refer to the key directly (SendGrid's
+                                                APIs allow for this as well)
+                                            */
+                                            var keyParts = sendGridKey.split("\\.");
+
+                                            /*
+                                            Be a little careful here. If the key doesn't match
+                                                the exact format we're looking for, note that there's
+                                                an issue with the format, and don't log anything else.
+                                            This is to avoid a situation where the format changes and
+                                                we accidentally write the entire key to the log.
+                                            */
+                                            if (keyParts.length == 3 && keyParts[0].equals("SG")) {
+                                                log.info("creating EmailNotificationHandler using SendGrid key id {}", keyParts[1]);
+                                            } else {
+                                                log.warn("SendGrid API key is in an unexpected format.");
+                                            }
+
+                                            new EmailNotificationHandler(sendGridProvider.get(sendGridKey),
                                                     pdfService, pdfBucketService, pdfGenerationService)
                                                     .handleMessage(notificationMessage);
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/SendGridClient.java
@@ -217,7 +217,7 @@ public class SendGridClient {
      * @param templateId the template id
      * @return result with active version id, id can be null if no active ones
      */
-    public ApiResult<String, Void> getTemplateActiveVersionId(String templateId) {
+    public ApiResult<String, String> getTemplateActiveVersionId(String templateId) {
         Request request = new Request();
         request.setMethod(Method.GET);
         request.setEndpoint(PATH_TEMPLATES + "/" + templateId);
@@ -225,7 +225,7 @@ public class SendGridClient {
             Response response = sendGrid.api(request);
             int statusCode = response.getStatusCode();
             if (statusCode != 200) {
-                return ApiResult.err(statusCode, null);
+                return ApiResult.err(statusCode, response.getBody());
             }
 
             Template template = gson.fromJson(response.getBody(), Template.class);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/handler/EmailNotificationHandler.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/handler/EmailNotificationHandler.java
@@ -131,7 +131,8 @@ public class EmailNotificationHandler implements HousekeepingMessageHandler<Noti
 
         var versionResult = sendGrid.getTemplateActiveVersionId(templateId);
         if (versionResult.hasThrown() || versionResult.getStatusCode() != 200) {
-            String msg = "Error looking up version of template " + templateId;
+            String msg = String.format("[%s] error looking up version of template '%s': %s",
+                    versionResult.getStatusCode(), templateId, versionResult.getError());
             if (versionResult.hasThrown()) {
                 throw new MessageHandlingException(msg, versionResult.getThrown(), true);
             } else {


### PR DESCRIPTION
## Context

Adds more logging to where Housekeeping calls Sendgrid to try and aid in debugging any issues in deployed versions.

* Logs the identifier of the API key used when instantiating the EmailNotificationHandler
* Includes the response body from SendGrid in the ApiResult on failure
