### PR TITLE
DDP-8193 FON config fix: Remove unneeded include in substitutions.conf

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/fon/substitutions.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/substitutions.conf
@@ -34,7 +34,6 @@
   "_includes": {
     composite-question = {include required("snippets/composite-question.conf")},
     question_fon_rx_list = {include required("snippets/question-medication-list.conf")}
-    question_enrollment_med_comps = {include required("snippets/question-enrollment-q23-med-comps.conf")}
 
   }
 


### PR DESCRIPTION
Removing unneeded include that breaks building fon study.
FON builds without error without line.