### PR TITLE
[DSS] DDP-8224: Get rid of units in composite titles

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/fon/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/fon/i18n/en.conf
@@ -6666,7 +6666,7 @@
       "prompt": "Volumes"
     },
     "q9_cact_diastolic_volume": {
-      "prompt": "RV End Diastolic Volume in mL:",
+      "prompt": "RV End Diastolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q10_cact_diastolic_volume_mlm2": {
@@ -6679,7 +6679,7 @@
       }
     },
     "q12_cact_systolic_volume": {
-      "prompt": "RV End Systolic Volume in mL:",
+      "prompt": "RV End Systolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q13_cact_systolic_volume_mlm2": {
@@ -6692,7 +6692,7 @@
       }
     },
     "q15_cact_rv_ejection_fraction": {
-      "prompt": "RV Ejection Fraction: (%)",
+      "prompt": "RV Ejection Fraction:",
       "pl_hold": "From 0 to 100",
       "required_hint": "Please answer this question *",
       "int_range_hint": "From 6 to 250"
@@ -6707,7 +6707,7 @@
       "valid_cardiac_output_cannot_tooltip": "A valid RV Cardiac Output cannot be calculated if RV End Diastolic Volume, RV End Systolic Volume, Heart Rate, and BSA have been left blank."
     },
     "q18_cact_diastolic_volume": {
-      "prompt": "LV End Diastolic Volume in mL:",
+      "prompt": "LV End Diastolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q19_cact_diastolic_volume_mlm2": {
@@ -6720,7 +6720,7 @@
       }
     },
     "q21_cact_systolic_volume": {
-      "prompt": "LV End Systolic Volume in mL:",
+      "prompt": "LV End Systolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q22_cact_systolic_volume_mlm2": {
@@ -6733,7 +6733,7 @@
       }
     },
     "q24_cact_lv_ejection_fraction": {
-      "prompt": "LV Ejection Fraction: (%)",
+      "prompt": "LV Ejection Fraction:",
       "pl_hold": "From 0 to 100",
       "required_hint": "Please answer this question *",
       "int_range_hint": "From 6 to 250"
@@ -6865,7 +6865,7 @@
       "required_hint": "Please answer this question *"
     },
     "q10_cmr_diastolic_volume_mlm2": {
-      "prompt": "RV End Diastolic Volume in mL/m2:",
+      "prompt": "RV End Diastolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q11_cmri": {
@@ -6874,7 +6874,7 @@
       }
     },
     "q12_cmr_systolic_volume": {
-      "prompt": "RV End Systolic Volume in mL:",
+      "prompt": "RV End Systolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q13_cmr_systolic_volume_mlm2": {
@@ -6887,7 +6887,7 @@
       }
     },
     "q15_cmr_rv_ejection_fraction": {
-      "prompt": "RV Ejection Fraction: (%)",
+      "prompt": "RV Ejection Fraction:",
       "pl_hold": "From 0 to 100",
       "required_hint": "Please answer this question *",
       "int_range_hint": "From 0 to 100"
@@ -6902,7 +6902,7 @@
       "valid_cardiac_output_cannot_tooltip": "A valid RV Cardiac Output cannot be calculated if RV End Diastolic Volume, RV End Systolic Volume, Heart Rate, and BSA have been left blank."
     },
     "q18_cmr_diastolic_volume": {
-      "prompt": "LV End Diastolic Volume in mL:",
+      "prompt": "LV End Diastolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q19_cmr_diastolic_volume_mlm2": {
@@ -6915,7 +6915,7 @@
       }
     },
     "q21_cmr_systolic_volume": {
-      "prompt": "LV End Systolic Volume in mL:",
+      "prompt": "LV End Systolic Volume:",
       "required_hint": "Please answer this question *"
     },
     "q22_cmr_systolic_volume_mlm2": {
@@ -6928,7 +6928,7 @@
       }
     },
     "q24_cmr_lv_ejection_fraction": {
-      "prompt": "LV Ejection Fraction: (%)",
+      "prompt": "LV Ejection Fraction:",
       "pl_hold": "From 0 to 100",
       "required_hint": "Please answer this question *",
       "int_range_hint": "From 0 to 100"


### PR DESCRIPTION
Since now the FON study has a tabular structure, the measurement units were moved to column headers. So question titles don't need to have units anymore.