### PR TITLE
fixing export of nested json data columns

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -274,8 +274,7 @@ public class TabularParticipantParser {
                                                                  boolean onlyMostRecent) {
         if (moduleConfig.isActivity()) {
             return getActivityCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);
-        } else if (moduleConfig.getFilterKey().isJson() && moduleConfig.getName()
-                .equals(ESObjectConstants.PARTICIPANT_DATA_DATA)) {
+        } else if (moduleConfig.getFilterKey().isJson() && moduleConfig.getName().startsWith(ESObjectConstants.DSM_PARTICIPANT_DATA)) {
             return getNestedJsonCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);
         } else {
             return getOtherCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -82,7 +82,7 @@ public class ESObjectConstants {
     public static final String ONC_HISTORY_DETAIL = "oncHistoryDetail";
     public static final String ONC_HISTORY = "oncHistory";
     public static final String PARTICIPANT_DATA = "participantData";
-    public static final String PARTICIPANT_DATA_DATA = "dsm.participantData.data";
+    public static final String DSM_PARTICIPANT_DATA = "dsm.participantData";
     public static final String PARTICIPANT_RECORD = "participantRecord";
     public static final String PARTICIPANT = "participant";
     public static final String DYNAMIC_FIELDS = "dynamicFields";


### PR DESCRIPTION
This fixes export of data nested in the dsm -> participantData -> data elastic search object.  

TO TEST:
 1. go to RGP study
 2. select a family id (e.g. 2104) to export
 3. confirm export includes subparticipants along with proband