### PR TITLE
DDP-7581 -  export module fixes

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/ModuleExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/ModuleExportConfig.java
@@ -12,6 +12,7 @@ import org.broadinstitute.dsm.model.elastic.sort.Alias;
 @Getter
 public class ModuleExportConfig {
     private final String name;
+    private final String tableAlias;
     private final Alias filterKey;
     private final List<FilterExportConfig> questions = new ArrayList<>();
     private boolean isActivity = false;
@@ -20,6 +21,7 @@ public class ModuleExportConfig {
 
     public ModuleExportConfig(ParticipantColumn participantColumn) {
         filterKey = Alias.of(participantColumn);
+        tableAlias = participantColumn.getTableAlias();
         if (Alias.ACTIVITIES.equals(filterKey)) {
             this.isActivity = true;
             this.name = participantColumn.getTableAlias();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -274,8 +274,7 @@ public class TabularParticipantParser {
                                                                  boolean onlyMostRecent) {
         if (moduleConfig.isActivity()) {
             return getActivityCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);
-        } else if (moduleConfig.getFilterKey().isJson() && moduleConfig.getName()
-                .equals(ESObjectConstants.PARTICIPANT_DATA_DATA)) {
+        } else if (moduleConfig.getFilterKey().isJson() && moduleConfig.getName().startsWith(ESObjectConstants.DSM_PARTICIPANT_DATA)) {
             return getNestedJsonCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);
         } else {
             return getOtherCompletions(esDataAsMap, moduleConfig, subParticipant, onlyMostRecent);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -68,11 +68,14 @@ public class TabularParticipantParser {
         for (Filter filter : filters) {
             try {
                 ParticipantColumn participantColumn = filter.getParticipantColumn();
-                ModuleExportConfig moduleExport = exportInfoMap.get(participantColumn.getTableAlias());
+                // 'Modules' are combinations of tableAlias + object -- it's a discrete set of data
+                // within the ES data for a participant
+                String moduleConfigKey = participantColumn.getTableAlias() + participantColumn.getObject();
+                ModuleExportConfig moduleExport = exportInfoMap.get(moduleConfigKey);
                 if (moduleExport == null) {
                     moduleExport = new ModuleExportConfig(participantColumn);
                     configs.add(moduleExport);
-                    exportInfoMap.put(participantColumn.getTableAlias(), moduleExport);
+                    exportInfoMap.put(moduleConfigKey, moduleExport);
                 }
                 boolean splitChoicesIntoColumns = false;
                 List<Map<String, Object>> options = null;
@@ -125,11 +128,7 @@ public class TabularParticipantParser {
     public List<Map<String, String>> parse(List<ModuleExportConfig> moduleConfigs, List<ParticipantWrapperDto> participantDtos) {
         List<Map<String, String>> allParticipantMaps = new ArrayList<>(participantDtos.size());
         for (ParticipantWrapperDto participant : participantDtos) {
-            try {
-                allParticipantMaps.addAll(generateParticipantTabularMaps(moduleConfigs, participant));
-            } catch (Exception e) {
-                logger.info("Error mapping participant: " + participant.getEsData().getParticipantId(), e);
-            }
+            allParticipantMaps.addAll(generateParticipantTabularMaps(moduleConfigs, participant));
         }
         return allParticipantMaps;
     }
@@ -181,48 +180,37 @@ public class TabularParticipantParser {
     private void addModuleDataToParticipantMap(ModuleExportConfig moduleConfig, Map<String, String> participantMap,
                                                Map<String, Object> esModuleMap, int moduleRepeatNum) {
         for (FilterExportConfig filterConfig : moduleConfig.getQuestions()) {
+            TextValueProvider valueProvider =
+                    valueProviderFactory.getValueProvider(filterConfig.getColumn().getName(), filterConfig.getType());
 
-            try {
-                TextValueProvider valueProvider =
-                        valueProviderFactory.getValueProvider(filterConfig.getColumn().getName(), filterConfig.getType());
+            Collection<String> formattedValues = valueProvider.getFormattedValues(filterConfig, esModuleMap);
 
-                Collection<String> formattedValues = valueProvider.getFormattedValues(filterConfig, esModuleMap);
+            if (filterConfig.isSplitOptionsIntoColumns()) {
+                for (int optIndex = 0; optIndex < filterConfig.getOptions().size(); optIndex++) {
+                    Map<String, Object> opt = filterConfig.getOptions().get(optIndex);
 
-                if (filterConfig.isSplitOptionsIntoColumns()) {
-                    for (int optIndex = 0; optIndex < filterConfig.getOptions().size(); optIndex++) {
-                        Map<String, Object> opt = filterConfig.getOptions().get(optIndex);
-
-                        String colName = TabularParticipantExporter.getColumnName(
-                                filterConfig,
-                                moduleRepeatNum + 1,
-                                1,
-                                opt
-                        );
-
-                        String exportValue = formattedValues.contains(opt.get(ESObjectConstants.OPTION_STABLE_ID)) ?
-                                COLUMN_SELECTED : COLUMN_UNSELECTED;
-                        participantMap.put(colName, exportValue);
-                    }
-
-                } else {
                     String colName = TabularParticipantExporter.getColumnName(
                             filterConfig,
                             moduleRepeatNum + 1,
                             1,
-                            null);
-                    String exportValue = formattedValues.stream().collect(Collectors.joining(", "));
-                    participantMap.put(colName, exportValue);
+                            opt
+                    );
 
+                    String exportValue = formattedValues.contains(opt.get(ESObjectConstants.OPTION_STABLE_ID)) ?
+                            COLUMN_SELECTED : COLUMN_UNSELECTED;
+                    participantMap.put(colName, exportValue);
                 }
-            } catch (Exception e) {
+
+            } else {
                 String colName = TabularParticipantExporter.getColumnName(
                         filterConfig,
                         moduleRepeatNum + 1,
                         1,
                         null);
-                logger.error("Failed to write column: " + colName, e);
-            }
+                String exportValue = formattedValues.stream().collect(Collectors.joining(", "));
+                participantMap.put(colName, exportValue);
 
+            }
         }
     }
 
@@ -237,7 +225,9 @@ public class TabularParticipantParser {
         List<Map<String, Object>> participantDataList = (List<Map<String, Object>>) ((Map<String, Object>) esDataAsMap
                 .get(ESObjectConstants.DSM)).get(ESObjectConstants.PARTICIPANT_DATA);
         List<Map<String, Object>> subParticipants = participantDataList.stream()
-                .filter(item -> WorkflowAndFamilyIdExporter.RGP_PARTICIPANTS.equals(item.get(ESObjectConstants.FIELD_TYPE_ID)))
+                // do a case insensitive comparison as some data has "rgp_PARTICIPANTS" as fieldIds
+                .filter(item -> WorkflowAndFamilyIdExporter.RGP_PARTICIPANTS
+                        .equalsIgnoreCase((String) item.get(ESObjectConstants.FIELD_TYPE_ID)))
                 .collect(Collectors.toList());
         if (subParticipants.size() > 0) {
             return subParticipants;
@@ -316,7 +306,10 @@ public class TabularParticipantParser {
         // get the module name from the first question -- this assumes all questions
         // in the module get stored in the same object.
         String objectName = moduleConfig.getQuestions().get(0).getColumn().getObject();
-
+        if (objectName == null) {
+            // this handles some derived RGP columns like "#FIRSTNAME #LASTNAME.." that do not need to be exported
+            return Collections.singletonList(Collections.emptyMap());
+        }
         // figure out whether we're dealing with subparticipants (RGP) or just data
         if (objectName != null && objectName.startsWith("RGP") && objectName.endsWith("GROUP")) {
             if (subParticipant != null && subParticipant.get(DATA_AS_MAP) != null) {
@@ -344,7 +337,18 @@ public class TabularParticipantParser {
                                                                  Map<String, Object> subParticipant,
                                                                  boolean onlyMostRecen) {
         // this module is based off the root of the map, like 'dsm' or 'invitations'
-        Object rootObject = esDataAsMap.get(moduleConfig.getFilterKey().getValue());
+        String mapPath = moduleConfig.getFilterKey().getValue();
+        Object rootObject = esDataAsMap.get(mapPath);
+        if (rootObject == null && mapPath.contains(".")) {
+            // we need to traverse a nested path like "dsm.participant"
+            String[] pathSegments = mapPath.split("\\.");
+            rootObject = esDataAsMap;
+            for(String segment : pathSegments) {
+                if (rootObject != null && rootObject instanceof Map) {
+                    rootObject = ((Map<String, Object>) rootObject).get(segment);
+                }
+            }
+        }
         if (rootObject instanceof List) {
             // it's a list, like 'invitations'
             return (List<Map<String, Object>>) rootObject;
@@ -352,6 +356,8 @@ public class TabularParticipantParser {
             // it's a Map, like 'dsm'
             return Collections.singletonList((Map<String, Object>) rootObject);
         }
+
+        // we are either pulling data from the root "data" level, or
         // we don't know what the module/question will be getting at, so return the entire map
         // in case the question config has the logic to handle it.
         return Collections.singletonList(esDataAsMap);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** handles questions with lists of lists for answers */
+public class CompositeValueProvider extends TextValueProvider {
+    protected Collection<?> mapToCollection(Object o) {
+        //
+        if (o != null && o instanceof Collection) {
+            List<Object> allValues = new ArrayList<>();
+            // flatten any nested lists
+            for (Object item : ((Collection<?>) o)) {
+                if (item instanceof Collection) {
+                    allValues.addAll((Collection) item);
+                } else {
+                    allValues.add(item);
+                }
+            }
+            return allValues;
+        } else {
+            return super.mapToCollection(o);
+        }
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
@@ -15,7 +15,7 @@ public class ValueProviderFactory {
             QuestionType.CHECKBOX, booleanValueProvider,
             QuestionType.NUMBER, defaultValueProvider,
             QuestionType.BOOLEAN, booleanValueProvider,
-            QuestionType.COMPOSITE, defaultValueProvider,
+            QuestionType.COMPOSITE, new CompositeValueProvider(),
             QuestionType.AGREEMENT, booleanValueProvider,
             QuestionType.MATRIX, defaultValueProvider,
             QuestionType.DATE, new DateValueProvider(),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -82,7 +82,7 @@ public class ESObjectConstants {
     public static final String ONC_HISTORY_DETAIL = "oncHistoryDetail";
     public static final String ONC_HISTORY = "oncHistory";
     public static final String PARTICIPANT_DATA = "participantData";
-    public static final String PARTICIPANT_DATA_DATA = "dsm.participantData.data";
+    public static final String DSM_PARTICIPANT_DATA = "dsm.participantData";
     public static final String PARTICIPANT_RECORD = "participantRecord";
     public static final String PARTICIPANT = "participant";
     public static final String DYNAMIC_FIELDS = "dynamicFields";


### PR DESCRIPTION
This fixes a variety of export issues, including:

-  "dsm.participant" fields, such as the "Participant notes" field in Pancan
- nulls in ActivityStatus columns for participants who had a populated address
- removing brackets from the rendering of compound questions
- handling RGP subparticipants with differently cased fieldTypeIds
- Handling derived RGP columns that do not need specific export.
- Removes row-by-row error handling to ensure the export is never incomplete 
- handles nested json columns that do not necessarily have dsm.participantData.data as their name



