### PR TITLE
Newer versions of vault use the `secret` keyword [DDP-8364]

### DIFF
--- a/elasticsearch/config/users.json.ctmpl
+++ b/elasticsearch/config/users.json.ctmpl
@@ -1,6 +1,6 @@
 {{with $environment := env "ENVIRONMENT"}}
 {{with $version := env "VERSION"}}
-{{with $response := vault (printf "secret/pepper/%s/%s/elasticsearch" $environment $version)}}
+{{with $response := secret (printf "secret/pepper/%s/%s/elasticsearch" $environment $version)}}
 {{with $conf := $response.Data}}
 
 {


### PR DESCRIPTION
DDP-8364

## Context

This PR is intended to fix a template change that was missed after the upgrade to Consul-template & Vault in the Docker toolbox image. In newer versions of consul-template, the keyword use to access a value in value given a path was changed from `vault` to `secret`.

## Testing
* Run the following command in the `ddp-study-server/elasticsearch` directory
    ```
    $ ./render.sh v1 dev
    ```
* _The command should successfully render the elasticsearch ACLs from vault_

