### PR TITLE
DDP-7581 - fixing export bug with nested composite questions

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
@@ -3,11 +3,13 @@ package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
 
 /** handles questions with lists of lists for answers */
 public class CompositeValueProvider extends TextValueProvider {
     protected Collection<?> mapToCollection(Object o) {
-        //
         if (o != null && o instanceof Collection) {
             List<Object> allValues = new ArrayList<>();
             // flatten any nested lists
@@ -18,7 +20,8 @@ public class CompositeValueProvider extends TextValueProvider {
                     allValues.add(item);
                 }
             }
-            return allValues;
+            // replace any nulls with empty string
+            return allValues.stream().map(val -> val == null ? StringUtils.EMPTY : val).collect(Collectors.toList());
         } else {
             return super.mapToCollection(o);
         }

--- a/pepper-apis/dsm-core/src/main/resources/liquibase/DDP-7581-assigning-pt-export-role
+++ b/pepper-apis/dsm-core/src/main/resources/liquibase/DDP-7581-assigning-pt-export-role
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+
+    <changeSet author="dbush" id="DDP-7581-assigning-pt-export-role">
+        <insert tableName="access_user_role_group ">
+            <column name="name" value="pt_list_export"/>
+        </insert>
+        <sql>
+           INSERT INTO access_user_role_group (user_id, role_id, group_id)
+           SELECT user_id, (SELECT role_id from access_role where name = 'pt_list_export'), group_id
+                           from access_user_role_group WHERE role_id = (SELECT role_id from access_role where name = 'pt_list_view');
+        </sql>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This fixes a bug in export's handling of nested nulls within composite questions.  

This also adds a migration for assigning the pt_list_export role to all users who have the pt_list_view role.

I tested the SQL query against the development database, but would appreciate extra eyes on it since I haven't dealt muhc with this user schema