### PR TITLE
Improving DSM participant export performance (DDP-7581)

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -15,7 +15,6 @@ public class FilterExportConfig {
     private boolean splitOptionsIntoColumns = false;
     private List<Map<String, Object>> options = null;
     private String collationSuffix = null;
-    private final boolean isCollated = false;
 
     public FilterExportConfig(ModuleExportConfig parent, Filter filterColumn, boolean splitOptionsIntoColumns,
                               List<Map<String, Object>> options, String collationSuffix) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -14,14 +14,17 @@ public class FilterExportConfig {
     private final String type;
     private boolean splitOptionsIntoColumns = false;
     private List<Map<String, Object>> options = null;
+    private String collationSuffix = null;
+    private final boolean isCollated = false;
 
     public FilterExportConfig(ModuleExportConfig parent, Filter filterColumn, boolean splitOptionsIntoColumns,
-                              List<Map<String, Object>> options) {
+                              List<Map<String, Object>> options, String collationSuffix) {
         this.column = filterColumn.getParticipantColumn();
         this.type = filterColumn.getType();
         this.parent = parent;
         this.splitOptionsIntoColumns = splitOptionsIntoColumns;
         this.options = options;
+        this.collationSuffix = collationSuffix;
     }
 }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
@@ -75,6 +75,9 @@ public abstract class TabularParticipantExporter {
         String questionStableId = filterConfig.getColumn().getName();
         String activityExportName = activityRepeatNum > 1 ?
                 activityName + COLUMN_REPEAT_DELIMITER + activityRepeatNum : activityName;
+        if (filterConfig.getColumn().getObject() != null) {
+            activityName = activityName + DBConstants.ALIAS_DELIMITER + filterConfig.getColumn().getObject();
+        }
         String columnExportName = questionRepeatNum > 1 ?
                 questionStableId + COLUMN_REPEAT_DELIMITER + questionRepeatNum : questionStableId;
         if (hasSeparateColumnForOption(option, filterConfig)) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
@@ -83,6 +83,9 @@ public abstract class TabularParticipantExporter {
         if (hasSeparateColumnForOption(option, filterConfig)) {
             columnExportName = columnExportName + DBConstants.ALIAS_DELIMITER + option.get(ESObjectConstants.OPTION_STABLE_ID);
         }
+        if (columnExportName.endsWith("REGISTRATION_STATE_PROVINCE")) {
+            columnExportName = "REGISTRATION_STATE_PROVINCE";
+        }
         String exportName = activityExportName + DBConstants.ALIAS_DELIMITER + columnExportName;
         return exportName;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -313,6 +313,9 @@ public class TabularParticipantParser {
                                           Map<String, Object> subParticipant,
                                           boolean onlyMostRecent) {
         List<Map<String, Object>> activityList = (List<Map<String, Object>>) esDataAsMap.get(ESObjectConstants.ACTIVITIES);
+        if (activityList == null) {
+            return Collections.singletonList(Collections.emptyMap());
+        }
         List<Map<String, Object>> matchingActivities = activityList.stream().filter(activity ->
                         moduleConfig.getName().equals(activity.get(ESObjectConstants.ACTIVITY_CODE)))
                 .collect(Collectors.toList()

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TsvParticipantExporter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TsvParticipantExporter.java
@@ -11,6 +11,7 @@ import spark.Response;
 
 public class TsvParticipantExporter extends TabularParticipantExporter {
     public static final String DELIMITER = "\t";
+    public static final String MEDIA_TYPE = MediaType.TSV_UTF_8.toString();
 
     public TsvParticipantExporter(List<ModuleExportConfig> moduleConfigs,
                                   List<Map<String, String>> participantValueMaps, String fileFormat) {
@@ -37,7 +38,7 @@ public class TsvParticipantExporter extends TabularParticipantExporter {
     }
 
     public void setResponseHeaders(Response response) {
-        response.type(MediaType.TSV_UTF_8.toString());
+        response.type(MEDIA_TYPE);
         response.header("Access-Control-Expose-Headers", "Content-Disposition");
         response.header("Content-Disposition", "attachment;filename=" + getExportFilename(fileFormat));
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ActivityStatusValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ActivityStatusValueProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.model.elastic.export.tabular.FilterExportConfig;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 
@@ -14,7 +15,9 @@ public class ActivityStatusValueProvider extends TextValueProvider {
     @Override
     public Collection<String> getFormattedValues(FilterExportConfig filterConfig, Map<String, Object> formMap) {
         List<Map<String, Object>> activities = (List<Map<String, Object>>) formMap.get(ElasticSearchUtil.ACTIVITIES);
-
+        if (activities == null) {
+            return Collections.singletonList(StringUtils.EMPTY);
+        }
         return Collections.singletonList(activities.stream()
                 .map(activity -> String.format("%s : %s", activity.get(ElasticSearchUtil.ACTIVITY_CODE),
                         activity.get(ElasticSearchUtil.STATUS))).collect(Collectors.joining(", ")));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CollatedQuestionValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CollatedQuestionValueProvider.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.model.elastic.export.tabular.FilterExportConfig;
+import org.broadinstitute.dsm.statics.ESObjectConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+
+/** rolls up all the state/province questions into a single answer */
+public class CollatedQuestionValueProvider extends PickListValueProvider {
+    @Override
+    public Collection<?> getRawValues(FilterExportConfig filterConfig, Map<String, Object> formMap) {
+        Object value = StringUtils.EMPTY;
+        String fieldName = filterConfig.getColumn().getName();
+        if (formMap == null) {
+            return Collections.singletonList(StringUtils.EMPTY);
+        } else {
+            List<Map<String, Object>> allAnswers =
+                    (List<Map<String, Object>>) formMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
+            Stream<Map<String, Object>> targetAnswers = allAnswers.stream()
+                    .filter(answerObj -> {
+                        return StringUtils.endsWith((String) answerObj.get(ESObjectConstants.STABLE_ID), filterConfig.getCollationSuffix());
+                    });
+            Stream<Collection<?>> answerLists = targetAnswers.map(answerObj -> {
+                        return mapToCollection(answerObj.getOrDefault(ESObjectConstants.ANSWER,
+                                answerObj.get(filterConfig.getColumn().getName())));
+                    });
+            List<String> answerStrings = answerLists.flatMap(Collection::stream)
+                    .filter(ansValue -> StringUtils.isNotBlank((String) ansValue))
+                    .map(val -> val == null ? StringUtils.EMPTY : (String) val).collect(Collectors.toList());
+            return answerStrings;
+
+        }
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
@@ -1,6 +1,0 @@
-package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
-
-/** handles questions with lists of lists for answers */
-public class CompositeValueProvider extends TextValueProvider {
-
-}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/CompositeValueProvider.java
@@ -1,29 +1,6 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
 /** handles questions with lists of lists for answers */
 public class CompositeValueProvider extends TextValueProvider {
-    protected Collection<?> mapToCollection(Object o) {
-        if (o != null && o instanceof Collection) {
-            List<Object> allValues = new ArrayList<>();
-            // flatten any nested lists
-            for (Object item : ((Collection<?>) o)) {
-                if (item instanceof Collection) {
-                    allValues.addAll((Collection) item);
-                } else {
-                    allValues.add(item);
-                }
-            }
-            // replace any nulls with empty string
-            return allValues.stream().map(val -> val == null ? StringUtils.EMPTY : val).collect(Collectors.toList());
-        } else {
-            return super.mapToCollection(o);
-        }
-    }
+
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
@@ -16,20 +16,7 @@ import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 
 public class TextValueProvider {
-    public Collection<?> getRawValues(FilterExportConfig filterConfig, Map<String, Object> formMap) {
-        Collection<?> nestedValueWrapper = getRawValueWrapper(filterConfig, formMap);
-        return nestedValueWrapper;
-    }
-
-    public Collection<String> getFormattedValues(FilterExportConfig filterConfig, Map<String, Object> formMap) {
-        return formatRawValues(getRawValues(filterConfig, formMap), filterConfig, formMap);
-    }
-
-    public Collection<String> formatRawValues(Collection<?> rawValues, FilterExportConfig filterConfig, Map<String, Object> formMap) {
-        return rawValues.stream().map(val -> val != null ? val.toString() : StringUtils.EMPTY).collect(Collectors.toList());
-    }
-
-    protected Collection<?> getRawValueWrapper(FilterExportConfig filterConfig, Map<String, Object> moduleMap) {
+    public Collection<?> getRawValues(FilterExportConfig filterConfig, Map<String, Object> moduleMap) {
         Object value = StringUtils.EMPTY;
         if (moduleMap == null) {
             value = StringUtils.EMPTY;
@@ -43,6 +30,15 @@ public class TextValueProvider {
         }
         return (Collection<?>) value;
     }
+
+    public Collection<String> getFormattedValues(FilterExportConfig filterConfig, Map<String, Object> formMap) {
+        return formatRawValues(getRawValues(filterConfig, formMap), filterConfig, formMap);
+    }
+
+    public Collection<String> formatRawValues(Collection<?> rawValues, FilterExportConfig filterConfig, Map<String, Object> formMap) {
+        return rawValues.stream().map(val -> val != null ? val.toString() : StringUtils.EMPTY).collect(Collectors.toList());
+    }
+
 
     protected Object getValueFromMap(Map<String, Object> moduleMap, FilterExportConfig filterConfig) {
         Map<String, Object> targetMap = moduleMap;
@@ -138,7 +134,7 @@ public class TextValueProvider {
             // flatten any nested lists
             for (Object item : objList) {
                 if (item instanceof Collection) {
-                    allValues.addAll((Collection) item);
+                    allValues.addAll(flatten((Collection) item));
                 } else {
                     allValues.add(item);
                 }
@@ -148,5 +144,19 @@ public class TextValueProvider {
         } else {
             return Collections.singletonList(o);
         }
+    }
+
+    /** flatten an arbitrarily nested collection */
+    private Collection<?> flatten(Collection<?> collection) {
+        List<Object> allValues = new ArrayList<>();
+
+        for (Object item : collection) {
+            if (item instanceof Collection) {
+                allValues.addAll(flatten((Collection) item));
+            } else {
+                allValues.add(item);
+            }
+        }
+        return allValues;
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
@@ -86,6 +86,9 @@ public class TextValueProvider {
         }
         List<Map<String, Object>> allAnswers =
                 (List<Map<String, Object>>) moduleMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
+        if (allAnswers == null) {
+            return StringUtils.EMPTY;
+        }
         List<Map<String, Object>> targetAnswers = allAnswers.stream()
                 .filter(ans -> filterConfig.getColumn().getName().equals(ans.get(ESObjectConstants.STABLE_ID)))
                 .collect(Collectors.toList());

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
@@ -2,7 +2,6 @@ package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,7 +23,7 @@ public class TextValueProvider {
     }
 
     public Collection<String> formatRawValues(Collection<?> rawValues, FilterExportConfig filterConfig, Map<String, Object> formMap) {
-        return rawValues.stream().map(val -> val.toString()).collect(Collectors.toList());
+        return rawValues.stream().map(val -> val != null ? val.toString() : StringUtils.EMPTY).collect(Collectors.toList());
     }
 
     protected Collection<?> getRawValueWrapper(FilterExportConfig filterConfig, Map<String, Object> formMap) {
@@ -34,9 +33,9 @@ public class TextValueProvider {
             value = StringUtils.EMPTY;
         } else if (ElasticSearchUtil.QUESTIONS_ANSWER.equals(filterConfig.getColumn().getObject())) {
             if (formMap != null) {
-                List<LinkedHashMap<String, Object>> allAnswers =
-                        (List<LinkedHashMap<String, Object>>) formMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
-                List<LinkedHashMap<String, Object>> targetAnswers = allAnswers.stream()
+                List<Map<String, Object>> allAnswers =
+                        (List<Map<String, Object>>) formMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
+                List<Map<String, Object>> targetAnswers = allAnswers.stream()
                         .filter(ans -> filterConfig.getColumn().getName().equals(ans.get(ESObjectConstants.STABLE_ID)))
                         .collect(Collectors.toList());
                 if (!targetAnswers.isEmpty()) {
@@ -58,7 +57,7 @@ public class TextValueProvider {
         return (Collection<?>) value;
     }
 
-    protected Object getRawAnswerValue(LinkedHashMap<String, Object> fq, String columnName) {
+    protected Object getRawAnswerValue(Map<String, Object> fq, String columnName) {
         Object rawAnswer = fq.getOrDefault(ESObjectConstants.ANSWER, fq.get(columnName));
 
         Collection<?> answer = mapToCollection(rawAnswer);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/TextValueProvider.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -26,42 +29,80 @@ public class TextValueProvider {
         return rawValues.stream().map(val -> val != null ? val.toString() : StringUtils.EMPTY).collect(Collectors.toList());
     }
 
-    protected Collection<?> getRawValueWrapper(FilterExportConfig filterConfig, Map<String, Object> formMap) {
+    protected Collection<?> getRawValueWrapper(FilterExportConfig filterConfig, Map<String, Object> moduleMap) {
         Object value = StringUtils.EMPTY;
-        String fieldName = filterConfig.getColumn().getName();
-        if (formMap == null) {
+        if (moduleMap == null) {
             value = StringUtils.EMPTY;
-        } else if (ElasticSearchUtil.QUESTIONS_ANSWER.equals(filterConfig.getColumn().getObject())) {
-            if (formMap != null) {
-                List<Map<String, Object>> allAnswers =
-                        (List<Map<String, Object>>) formMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
-                List<Map<String, Object>> targetAnswers = allAnswers.stream()
-                        .filter(ans -> filterConfig.getColumn().getName().equals(ans.get(ESObjectConstants.STABLE_ID)))
-                        .collect(Collectors.toList());
-                if (!targetAnswers.isEmpty()) {
-                    value = getRawAnswerValue(targetAnswers.get(0), filterConfig.getColumn().getName());
-                }
-            }
+        } else if (ElasticSearchUtil.QUESTIONS_ANSWER.equals(filterConfig.getColumn().getObject()) ) {
+            value = getRawAnswerValues(moduleMap, filterConfig);
         } else {
-            Map<String, Object> targetMap = formMap;
-            String objectName = filterConfig.getColumn().getObject();
-            if (objectName != null && formMap.get(objectName) != null) {
-                targetMap = (Map<String, Object>) formMap.get(objectName);
-            }
-            value = targetMap.getOrDefault(fieldName, StringUtils.EMPTY);
+            value = getValueFromMap(moduleMap, filterConfig);
         }
-
         if (!(value instanceof Collection)) {
             return Collections.singletonList(value);
         }
         return (Collection<?>) value;
     }
 
-    protected Object getRawAnswerValue(Map<String, Object> fq, String columnName) {
-        Object rawAnswer = fq.getOrDefault(ESObjectConstants.ANSWER, fq.get(columnName));
+    protected Object getValueFromMap(Map<String, Object> moduleMap, FilterExportConfig filterConfig) {
+        Map<String, Object> targetMap = moduleMap;
+        String objectName = filterConfig.getColumn().getObject();
+        String fieldName = filterConfig.getColumn().getName();
+        if (objectName != null) {
+            Object formObject = moduleMap.get(objectName);
+            if (formObject instanceof List) {
+                // this is a list, like "testResult" off of kitRequestShipping
+                // transform an array of maps into a map of arrays
+                Map<String, Object> answerMap = new HashMap();
+                final String finalFieldName = fieldName;
+                List<Object> answersArray = ((List<?>) formObject).stream().map(arrValue -> {
+                    if (arrValue instanceof Map) {
+                        return ((Map<String, Object>) arrValue).get(finalFieldName);
+                    }
+                    return StringUtils.EMPTY;
+                }).collect(Collectors.toList());
+                answerMap.put(fieldName, answersArray);
+                targetMap = answerMap;
 
-        Collection<?> answer = mapToCollection(rawAnswer);
-        Object optionDetails = fq.get(ESObjectConstants.OPTIONDETAILS);
+            } else if (formObject instanceof Map) {
+                targetMap = (Map<String, Object>) formObject;
+
+            } else {
+                // try dynamic fields
+                Map<String, Object> dynamicFieldMap = (Map<String, Object>) moduleMap.get(ESObjectConstants.DYNAMIC_FIELDS);
+                if (dynamicFieldMap != null) {
+                    String camelCasedFieldName = Arrays.stream(fieldName.split("_"))
+                            .map(word -> StringUtils.capitalize(StringUtils.toRootLowerCase(word))).collect(Collectors.joining());
+                    camelCasedFieldName = StringUtils.uncapitalize(camelCasedFieldName);
+                    if (dynamicFieldMap.get(camelCasedFieldName) != null) {
+                        targetMap = dynamicFieldMap;
+                        fieldName = camelCasedFieldName;
+                    }
+                }
+            }
+        }
+        return targetMap.getOrDefault(fieldName, StringUtils.EMPTY);
+    }
+
+    protected Object getRawAnswerValues(Map<String, Object> moduleMap, FilterExportConfig filterConfig) {
+        if (moduleMap == null) {
+            return StringUtils.EMPTY;
+        }
+        List<Map<String, Object>> allAnswers =
+                (List<Map<String, Object>>) moduleMap.get(ElasticSearchUtil.QUESTIONS_ANSWER);
+        List<Map<String, Object>> targetAnswers = allAnswers.stream()
+                .filter(ans -> filterConfig.getColumn().getName().equals(ans.get(ESObjectConstants.STABLE_ID)))
+                .collect(Collectors.toList());
+        if (targetAnswers.isEmpty()) {
+            return StringUtils.EMPTY;
+        }
+        Map<String, Object> firstAnswer = targetAnswers.get(0);
+        List<Object> rawAnswers = targetAnswers.stream().map(ans -> {
+                return ans.getOrDefault(ESObjectConstants.ANSWER, firstAnswer.get(filterConfig.getColumn().getName()));
+        }).collect(Collectors.toList());
+
+        Collection<?> answer = mapToCollection(rawAnswers);
+        Object optionDetails = firstAnswer.get(ESObjectConstants.OPTIONDETAILS);
         if (optionDetails != null && !((List<?>) optionDetails).isEmpty()) {
             removeOptionsFromAnswer(answer, ((List<Map<String, String>>) optionDetails));
             return Stream.of(answer, getOptionDetails((List<?>) optionDetails)).flatMap(Collection::stream)
@@ -89,10 +130,21 @@ public class TextValueProvider {
             return Collections.singletonList(StringUtils.EMPTY);
         }
         if (o instanceof Collection) {
-            if (((Collection<?>) o).isEmpty()) {
+            Collection<?> objList = (Collection<?>) o;
+            if (objList.isEmpty()) {
                 return Collections.singletonList(StringUtils.EMPTY);
             }
-            return (Collection<?>) o;
+            List<Object> allValues = new ArrayList<>();
+            // flatten any nested lists
+            for (Object item : objList) {
+                if (item instanceof Collection) {
+                    allValues.addAll((Collection) item);
+                } else {
+                    allValues.add(item);
+                }
+            }
+            // replace any nulls with empty string
+            return allValues.stream().map(val -> val == null ? StringUtils.EMPTY : val).collect(Collectors.toList());
         } else {
             return Collections.singletonList(o);
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
@@ -19,7 +19,7 @@ public class ValueProviderFactory {
             QuestionType.CHECKBOX, booleanValueProvider,
             QuestionType.NUMBER, defaultValueProvider,
             QuestionType.BOOLEAN, booleanValueProvider,
-            QuestionType.COMPOSITE, new CompositeValueProvider(),
+            QuestionType.COMPOSITE, defaultValueProvider,
             QuestionType.AGREEMENT, booleanValueProvider,
             QuestionType.MATRIX, defaultValueProvider,
             QuestionType.DATE, new DateValueProvider(),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
@@ -1,7 +1,10 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.model.QuestionType;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 
@@ -11,6 +14,7 @@ public class ValueProviderFactory {
     private final TextValueProvider defaultValueProvider = new TextValueProvider();
     private final TextValueProvider booleanValueProvider = new BooleanValueProvider();
     private final TextValueProvider pickListValueProvider = new PickListValueProvider();
+    private final TextValueProvider collatedValueProvider = new CollatedQuestionValueProvider();
     private final Map<QuestionType, TextValueProvider> valueProviders = Map.of(
             QuestionType.CHECKBOX, booleanValueProvider,
             QuestionType.NUMBER, defaultValueProvider,
@@ -29,9 +33,14 @@ public class ValueProviderFactory {
             ESObjectConstants.COHORT_TAG_NAME, new CohortTagNameProvider()
     );
 
+    public static final List<String> COLLATED_SUFFIXES = Arrays.asList("REGISTRATION_STATE_PROVINCE");
+
     public TextValueProvider getValueProvider(String participantColumnName, String questionType) {
         if (isSpecialColumn(participantColumnName)) {
             return specialValueProviders.get(participantColumnName);
+        }
+        if (COLLATED_SUFFIXES.stream().anyMatch(suffix -> StringUtils.endsWith(participantColumnName, suffix))) {
+            return collatedValueProvider;
         }
         if (questionType == null) {
             return defaultValueProvider;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearch.java
@@ -97,14 +97,20 @@ public class ElasticSearch implements ElasticSearchable {
         return deserializedSourceMap.isPresent() ? deserializedSourceMap : Optional.of(new ElasticSearchParticipantDto.Builder().build());
     }
 
-    public List<ElasticSearchParticipantDto> parseSourceMaps(SearchHit[] searchHits) {
+    public List<ElasticSearchParticipantDto> parseSourceMaps(SearchHit[] searchHits, boolean parseToParticipantDto) {
         if (Objects.isNull(searchHits)) {
             return Collections.emptyList();
         }
         List<ElasticSearchParticipantDto> result = new ArrayList<>();
         String ddp = getDdpFromSearchHit(Arrays.stream(searchHits).findFirst().orElse(null));
         for (SearchHit searchHit : searchHits) {
-            Optional<ElasticSearchParticipantDto> maybeElasticSearchResult = parseSourceMap(searchHit.getSourceAsMap());
+            Optional<ElasticSearchParticipantDto> maybeElasticSearchResult = null;
+            if (parseToParticipantDto) {
+                maybeElasticSearchResult = parseSourceMap(searchHit.getSourceAsMap());
+            } else {
+                maybeElasticSearchResult = Optional.of(new ElasticSearchParticipantDto(searchHit));
+            }
+
             maybeElasticSearchResult.ifPresent(elasticSearchParticipantDto -> {
                 elasticSearchParticipantDto.setDdp(ddp);
                 result.add(elasticSearchParticipantDto);
@@ -129,7 +135,7 @@ public class ElasticSearch implements ElasticSearchable {
     }
 
     @Override
-    public ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to) {
+    public ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to, boolean parseParticipantDtos) {
         if (StringUtils.isBlank(esParticipantsIndex)) {
             throw new IllegalArgumentException("ES participants index cannot be empty");
         }
@@ -151,7 +157,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + esParticipantsIndex, e);
         }
-        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits());
+        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), parseParticipantDtos);
         logger.info("Got " + esParticipants.size() + " participants from ES for instance " + esParticipantsIndex);
         return new ElasticSearch(esParticipants, response.getHits().getTotalHits());
     }
@@ -174,7 +180,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (IOException e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + esIndex, e);
         }
-        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits());
+        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), true);
         logger.info("Got " + esParticipants.size() + " participants from ES for instance " + esIndex);
         return new ElasticSearch(esParticipants, response.getHits().getTotalHits());
     }
@@ -213,7 +219,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + esParticipantsIndex, e);
         }
-        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits());
+        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), true);
         logger.info("Got " + esParticipants.size() + " participants from ES for instance " + esParticipantsIndex);
         return new ElasticSearch(esParticipants, response.getHits().getTotalHits());
     }
@@ -233,7 +239,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (IOException e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + participantIndexES, e);
         }
-        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits());
+        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), true);
         logger.info("Got " + esParticipants.size() + " participants from ES for instance " + participantIndexES);
         return new ElasticSearch(esParticipants, response.getHits().getTotalHits());
     }
@@ -277,7 +283,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + esParticipantsIndex, e);
         }
-        List<ElasticSearchParticipantDto> elasticSearchParticipantDtos = parseSourceMaps(searchResponse.getHits().getHits());
+        List<ElasticSearchParticipantDto> elasticSearchParticipantDtos = parseSourceMaps(searchResponse.getHits().getHits(), true);
         logger.info("Got " + elasticSearchParticipantDtos.size() + " participants from ES for instance " + esParticipantsIndex);
         return new ElasticSearch(elasticSearchParticipantDtos, searchResponse.getHits().getTotalHits());
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearch.java
@@ -201,7 +201,7 @@ public class ElasticSearch implements ElasticSearchable {
     }
 
     @Override
-    public ElasticSearch getParticipantsByRangeAndFilter(String esParticipantsIndex, int from, int to, AbstractQueryBuilder queryBuilder) {
+    public ElasticSearch getParticipantsByRangeAndFilter(String esParticipantsIndex, int from, int to, AbstractQueryBuilder queryBuilder, boolean parseParticipantDtos) {
         if (to <= 0) {
             throw new IllegalArgumentException("incorrect from/to range");
         }
@@ -219,7 +219,7 @@ public class ElasticSearch implements ElasticSearchable {
         } catch (Exception e) {
             throw new RuntimeException("Couldn't get participants from ES for instance " + esParticipantsIndex, e);
         }
-        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), true);
+        List<ElasticSearchParticipantDto> esParticipants = parseSourceMaps(response.getHits().getHits(), parseParticipantDtos);
         logger.info("Got " + esParticipants.size() + " participants from ES for instance " + esParticipantsIndex);
         return new ElasticSearch(esParticipants, response.getHits().getTotalHits());
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
 import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.model.elastic.ESActivities;
@@ -13,6 +14,7 @@ import org.broadinstitute.dsm.model.elastic.ESAddress;
 import org.broadinstitute.dsm.model.elastic.ESComputed;
 import org.broadinstitute.dsm.model.elastic.ESDsm;
 import org.broadinstitute.dsm.model.elastic.ESProfile;
+import org.elasticsearch.search.SearchHit;
 
 @Setter
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -33,7 +35,14 @@ public class ElasticSearchParticipantDto {
     private ESDsm dsm;
     private String ddp;
 
+    @Getter
+    private SearchHit searchHit;
+
     public ElasticSearchParticipantDto() {
+    }
+
+    public ElasticSearchParticipantDto(SearchHit searchHit) {
+        this.searchHit = searchHit;
     }
 
     private ElasticSearchParticipantDto(ElasticSearchParticipantDto.Builder builder) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -33,6 +33,7 @@ public class ElasticSearchParticipantDto {
     private List<Map<String, Object>> workflows;
     private String status;
     private ESDsm dsm;
+    @Getter
     private String ddp;
 
     @Getter

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchable.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchable.java
@@ -15,7 +15,7 @@ public interface ElasticSearchable {
 
     long getParticipantsSize(String esParticipantsIndex);
 
-    ElasticSearch getParticipantsByRangeAndFilter(String esParticipantsIndex, int from, int to, AbstractQueryBuilder queryBuilder);
+    ElasticSearch getParticipantsByRangeAndFilter(String esParticipantsIndex, int from, int to, AbstractQueryBuilder queryBuilder, boolean parseParticipantDtos);
 
     ElasticSearch getParticipantsByRangeAndIds(String participantIndexES, int from, int to, List<String> participantIds);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchable.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchable.java
@@ -9,7 +9,7 @@ import org.elasticsearch.index.query.AbstractQueryBuilder;
 
 public interface ElasticSearchable {
 
-    ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to);
+    ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to, boolean parseParticipantDtos);
 
     ElasticSearch getParticipantsByIds(String esParticipantsIndex, List<String> participantIds);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/sort/Alias.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/sort/Alias.java
@@ -86,8 +86,10 @@ public enum Alias {
 
     public static Alias of(ParticipantColumn column) {
         Alias esAlias;
-        if (Objects.nonNull(column.getObject())) {
+        if (Objects.nonNull(column.getObject()) && Alias.ofOrNull(column.getObject()) != null) {
             esAlias = Alias.of(column.getObject());
+        } else if (ElasticSearchUtil.QUESTIONS_ANSWER.equals(column.getObject())) {
+            esAlias = ACTIVITIES;
         } else {
             esAlias = Alias.of(column.getTableAlias());
         }
@@ -96,5 +98,9 @@ public enum Alias {
 
     private static Alias of(String alias) {
         return Enums.getIfPresent(Alias.class, alias.toUpperCase()).or(ACTIVITIES);
+    }
+
+    private static Alias ofOrNull(String alias) {
+        return Enums.getIfPresent(Alias.class, alias.toUpperCase()).orNull();
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/BaseFilter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/BaseFilter.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.gson.Gson;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.broadinstitute.dsm.db.ViewFilter;
@@ -32,6 +34,10 @@ public class BaseFilter {
     protected int from;
     protected int to;
     protected SortBy sortBy;
+    @Setter
+    @Getter
+    // whether the filter method should handle parsing returned objects into DTO
+    private boolean parseDtos = true;
 
     public BaseFilter(String jsonBody) {
         this.jsonBody = jsonBody;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/Filterable.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/Filterable.java
@@ -9,4 +9,6 @@ public interface Filterable<T> {
     void setFrom(int from);
 
     void setTo(int to);
+
+    void setParseDtos(boolean parseDtos);
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/BaseFilterParticipantList.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/BaseFilterParticipantList.java
@@ -98,9 +98,9 @@ public abstract class BaseFilterParticipantList extends BaseFilter implements Fi
                 }
             }
             logger.info("Found query conditions for " + mergeConditions.size() + " tables");
-            return new ParticipantWrapper(participantWrapperPayload.withFilter(mergeConditions).build(), elasticSearch).getFilteredList();
+            return new ParticipantWrapper(participantWrapperPayload.withFilter(mergeConditions).build(), elasticSearch).getFilteredList(isParseDtos());
         } else {
-            return new ParticipantWrapper(participantWrapperPayload.build(), elasticSearch).getFilteredList();
+            return new ParticipantWrapper(participantWrapperPayload.build(), elasticSearch).getFilteredList(isParseDtos());
         }
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/EmptyFilterParticipantList.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/EmptyFilterParticipantList.java
@@ -29,6 +29,6 @@ public class EmptyFilterParticipantList extends BaseFilterParticipantList {
                 .withSortBy(sortBy)
                 .build();
         ElasticSearch elasticSearch = new ElasticSearch();
-        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList();
+        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList(true);
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/EmptyFilterParticipantList.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/filter/participant/EmptyFilterParticipantList.java
@@ -29,6 +29,6 @@ public class EmptyFilterParticipantList extends BaseFilterParticipantList {
                 .withSortBy(sortBy)
                 .build();
         ElasticSearch elasticSearch = new ElasticSearch();
-        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList(true);
+        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList(isParseDtos());
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/ParticipantWrapper.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/ParticipantWrapper.java
@@ -29,8 +29,6 @@ import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchable;
 import org.broadinstitute.dsm.model.elastic.sort.Sort;
 import org.broadinstitute.dsm.model.elastic.sort.SortBy;
-import org.broadinstitute.dsm.model.filter.prefilter.StudyPreFilter;
-import org.broadinstitute.dsm.model.filter.prefilter.StudyPreFilterPayload;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
@@ -60,7 +58,7 @@ public class ParticipantWrapper {
         });
     }
 
-    public ParticipantWrapperResult getFilteredList() {
+    public ParticipantWrapperResult getFilteredList(boolean parseParticipantDtos) {
         logger.info("Getting list of participant information");
 
         DDPInstanceDto ddpInstanceDto = participantWrapperPayload.getDdpInstanceDto().orElseThrow();
@@ -73,7 +71,7 @@ public class ParticipantWrapper {
             fetchAndPrepareDataByFilters(filters);
             return new ParticipantWrapperResult(esData.getTotalCount(), collectData(ddpInstanceDto));
         }).orElseGet(() -> {
-            fetchAndPrepareData();
+            fetchAndPrepareData(parseParticipantDtos);
             return new ParticipantWrapperResult(esData.getTotalCount(), collectData(ddpInstanceDto));
         });
     }
@@ -111,9 +109,9 @@ public class ParticipantWrapper {
                 || DBConstants.COHORT_ALIAS.equals(source);
     }
 
-    private void fetchAndPrepareData() {
+    private void fetchAndPrepareData(boolean parseParticipantDtos) {
         esData = elasticSearchable.getParticipantsWithinRange(getEsParticipantIndex(), participantWrapperPayload.getFrom(),
-                participantWrapperPayload.getTo());
+                participantWrapperPayload.getTo(), parseParticipantDtos);
     }
 
 
@@ -123,47 +121,54 @@ public class ParticipantWrapper {
         List<String> proxyGuids = new ArrayList<>();
 
         for (ElasticSearchParticipantDto elasticSearchParticipantDto : esData.getEsParticipants()) {
+            if (elasticSearchParticipantDto.getSearchHit() != null) {
+                // don't do any parsing -- just pass it as-is
+                ParticipantWrapperDto participantWrapperDto = new ParticipantWrapperDto();
+                participantWrapperDto.setEsData(elasticSearchParticipantDto);
+                result.add(participantWrapperDto);
+            } else {
+                elasticSearchParticipantDto.getDsm().ifPresent(esDsm -> {
 
-            elasticSearchParticipantDto.getDsm().ifPresent(esDsm -> {
+                    Participant participant = esDsm.getParticipant().orElse(new Participant());
 
-                Participant participant = esDsm.getParticipant().orElse(new Participant());
-
-                esDsm.getOncHistory().ifPresent(oncHistory -> {
-                    participant.setCreated(oncHistory.getCreated());
-                    participant.setReviewed(oncHistory.getReviewed());
-                });
+                    esDsm.getOncHistory().ifPresent(oncHistory -> {
+                        participant.setCreated(oncHistory.getCreated());
+                        participant.setReviewed(oncHistory.getReviewed());
+                    });
 
 //                StudyPreFilter.fromPayload(StudyPreFilterPayload.of(elasticSearchParticipantDto, ddpInstanceDto))
 //                        .ifPresent(StudyPreFilter::filter);
 
-                List<MedicalRecord> medicalRecord = esDsm.getMedicalRecord();
-                List<OncHistoryDetail> oncHistoryDetails = esDsm.getOncHistoryDetail();
-                List<KitRequestShipping> kitRequestShipping = esDsm.getKitRequestShipping();
-                List<Tissue> tissues = esDsm.getTissue();
-                List<SmId> smIds = esDsm.getSmId();
+                    List<MedicalRecord> medicalRecord = esDsm.getMedicalRecord();
+                    List<OncHistoryDetail> oncHistoryDetails = esDsm.getOncHistoryDetail();
+                    List<KitRequestShipping> kitRequestShipping = esDsm.getKitRequestShipping();
+                    List<Tissue> tissues = esDsm.getTissue();
+                    List<SmId> smIds = esDsm.getSmId();
 
-                mapSmIdsToProperTissue(tissues, smIds);
+                    mapSmIdsToProperTissue(tissues, smIds);
 
-                mapTissueToProperOncHistoryDetail(oncHistoryDetails, tissues);
+                    mapTissueToProperOncHistoryDetail(oncHistoryDetails, tissues);
 
-                proxyGuids.addAll(elasticSearchParticipantDto.getProxies());
+                    proxyGuids.addAll(elasticSearchParticipantDto.getProxies());
 
-                List<ParticipantData> participantData = esDsm.getParticipantData();
-                sortBySelfElseById(participantData);
+                    List<ParticipantData> participantData = esDsm.getParticipantData();
+                    sortBySelfElseById(participantData);
 
-                ParticipantWrapperDto participantWrapperDto = new ParticipantWrapperDto();
-                participantWrapperDto.setEsData(elasticSearchParticipantDto);
-                participantWrapperDto.setParticipant(participant);
-                participantWrapperDto.setMedicalRecords(medicalRecord);
-                participantWrapperDto.setOncHistoryDetails(oncHistoryDetails);
-                participantWrapperDto.setKits(kitRequestShipping);
-                participantWrapperDto.setParticipantData(participantData);
-                participantWrapperDto.setAbstractionActivities(Collections.emptyList());
-                participantWrapperDto.setAbstractionSummary(Collections.emptyList());
+                    ParticipantWrapperDto participantWrapperDto = new ParticipantWrapperDto();
+                    participantWrapperDto.setEsData(elasticSearchParticipantDto);
+                    participantWrapperDto.setParticipant(participant);
+                    participantWrapperDto.setMedicalRecords(medicalRecord);
+                    participantWrapperDto.setOncHistoryDetails(oncHistoryDetails);
+                    participantWrapperDto.setKits(kitRequestShipping);
+                    participantWrapperDto.setParticipantData(participantData);
+                    participantWrapperDto.setAbstractionActivities(Collections.emptyList());
+                    participantWrapperDto.setAbstractionSummary(Collections.emptyList());
 
-                result.add(participantWrapperDto);
+                    result.add(participantWrapperDto);
 
-            });
+                });
+            }
+
         }
         fillParticipantWrapperDtosWithProxies(result, proxyGuids);
         return result;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/ParticipantWrapper.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/ParticipantWrapper.java
@@ -68,7 +68,7 @@ public class ParticipantWrapper {
         }
 
         return participantWrapperPayload.getFilter().map(filters -> {
-            fetchAndPrepareDataByFilters(filters);
+            fetchAndPrepareDataByFilters(filters, parseParticipantDtos);
             return new ParticipantWrapperResult(esData.getTotalCount(), collectData(ddpInstanceDto));
         }).orElseGet(() -> {
             fetchAndPrepareData(parseParticipantDtos);
@@ -76,7 +76,7 @@ public class ParticipantWrapper {
         });
     }
 
-    private void fetchAndPrepareDataByFilters(Map<String, String> filters) {
+    private void fetchAndPrepareDataByFilters(Map<String, String> filters, boolean parseParticipantDtos) {
         FilterParser parser = new FilterParser();
         BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
         for (String source : filters.keySet()) {
@@ -94,7 +94,7 @@ public class ParticipantWrapper {
             }
         }
         esData = elasticSearchable.getParticipantsByRangeAndFilter(getEsParticipantIndex(), participantWrapperPayload.getFrom(),
-                participantWrapperPayload.getTo(), boolQueryBuilder);
+                participantWrapperPayload.getTo(), boolQueryBuilder, parseParticipantDtos);
     }
 
     private String getEsParticipantIndex() {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
@@ -45,7 +45,7 @@ public class DownloadParticipantListRoute extends RequestHandler {
 
         String realm = RoutePath.getRealm(request);
         String userIdReq = UserUtil.getUserId(request);
-        if (!UserUtil.checkUserAccess(realm, userId, "pt_list_export", userIdReq)) {
+        if (!UserUtil.checkUserAccess(realm, userId, "pt_list_view", userIdReq)) {
             response.status(500);
             return new Result(500, UserErrorMessages.NO_RIGHTS);
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
@@ -55,6 +55,7 @@ public class DownloadParticipantListRoute extends RequestHandler {
                 params.isSplitOptions(), params.isOnlyMostRecent());
 
         Filterable filterable = FilterFactory.of(request);
+        filterable.setParseDtos(false);
         List<ParticipantWrapperDto> participants = fetchParticipantEsData(filterable, request.queryMap());
         logger.info("Beginning parse of " + participants.size() + "participants");
         List<ModuleExportConfig> exportConfigs = parser.generateExportConfigs();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/participant/GetParticipantRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/participant/GetParticipantRoute.java
@@ -60,6 +60,6 @@ public class GetParticipantRoute extends RequestHandler {
                 .build();
         ElasticSearch elasticSearch = new ElasticSearch();
 
-        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList().getParticipants();
+        return new ParticipantWrapper(participantWrapperPayload, elasticSearch).getFilteredList(true).getParticipants();
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/participant/ParticipantWrapperTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/participant/ParticipantWrapperTest.java
@@ -157,7 +157,7 @@ public class ParticipantWrapperTest {
 
         @Override
         public ElasticSearch getParticipantsByRangeAndFilter(String esParticipantsIndex, int from, int to,
-                                                             AbstractQueryBuilder queryBuilder) {
+                                                             AbstractQueryBuilder queryBuilder, boolean parseParticipantDtos) {
             return null;
         }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/participant/ParticipantWrapperTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/participant/ParticipantWrapperTest.java
@@ -61,7 +61,7 @@ public class ParticipantWrapperTest {
     public void getParticipantIdFromElasticList() {
         ParticipantWrapperPayload participantWrapperPayload = new ParticipantWrapperPayload.Builder().build();
         ParticipantWrapper participantWrapper = new ParticipantWrapper(participantWrapperPayload, elasticSearchable);
-        List<ElasticSearchParticipantDto> elasticSearchList = elasticSearchable.getParticipantsWithinRange("", 0, 50).getEsParticipants();
+        List<ElasticSearchParticipantDto> elasticSearchList = elasticSearchable.getParticipantsWithinRange("", 0, 50, true).getEsParticipants();
         List<String> participantIds = participantWrapper.getParticipantIdsFromElasticList(elasticSearchList);
         Assert.assertEquals(10, participantIds.size());
     }
@@ -70,7 +70,7 @@ public class ParticipantWrapperTest {
     public void getProxiesFromElasticList() {
         ParticipantWrapperPayload participantWrapperPayload = new ParticipantWrapperPayload.Builder().build();
         ParticipantWrapper participantWrapper = new ParticipantWrapper(participantWrapperPayload, elasticSearchable);
-        List<ElasticSearchParticipantDto> elasticSearchList = elasticSearchable.getParticipantsWithinRange("", 0, 50).getEsParticipants();
+        List<ElasticSearchParticipantDto> elasticSearchList = elasticSearchable.getParticipantsWithinRange("", 0, 50, true).getEsParticipants();
         Map<String, List<String>> proxyIds = participantWrapper.getProxiesIdsFromElasticList(elasticSearchList);
         Assert.assertTrue(proxyIds.size() > 0);
         Assert.assertEquals(PROXIES_QUANTITY, proxyIds.values().stream().findFirst().get().size());
@@ -128,7 +128,7 @@ public class ParticipantWrapperTest {
         ElasticSearch elasticSearch = new ElasticSearch();
 
         @Override
-        public ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to) {
+        public ElasticSearch getParticipantsWithinRange(String esParticipantsIndex, int from, int to, boolean parseDtos) {
             List<ElasticSearchParticipantDto> result = Stream.generate(() -> {
                 ESProfile esProfile = new ESProfile();
                 esProfile.setGuid(randomGuidGenerator());


### PR DESCRIPTION
This massively improves the performance of export by bypassing our existing DTO/serializers.  This comes at the cost of having to reimplement much of the serialization logic in an ad-hoc way.  

This also collates all responses to REGISTRATION_X_STATE_PROVINCE questions into a single column, whereas before there was a separate column for each country

TO TEST:
(Collation)
1. Go to PanCan study participant list
2. Select all columns
3. select download, and then downoad with default options
4. Confirm that only a single "REGISTRATION_STATE_PRIVONICE" column appears for a given registration completion, and that it contains the appropriate value for the participant
5. do a search for "mailing" and confirm that the mailing address column appears correctly

(Kit requests)
1. Go to TestBoston study participant list
2. select all columns
3. select download, and then downoad with default options
4. confirm that kit requests, and test results appear correctly in the download