### PR TITLE
Removes assentDate and consentDate parameters from /users payload [DDP-8402]

### DIFF
--- a/pepper-apis/docs/specification/src/components/request-bodies.yml
+++ b/pepper-apis/docs/specification/src/components/request-bodies.yml
@@ -207,8 +207,6 @@ ParticipantCreateRequest:
           - firstName
           - lastName
           - birthDate
-          - informedConsentDate
-          - assentDate
         properties:
           email:
             type: string
@@ -227,12 +225,3 @@ ParticipantCreateRequest:
           birthDate:
             type: string
             format: iso8601-date
-          informedConsentDate:
-            type: string
-            format: iso8601-date
-            nullable: true
-          assentDate:
-            type: string
-            format: iso8601-date
-            nullable: true
-

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/json/users/requests/UserCreationPayload.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/json/users/requests/UserCreationPayload.java
@@ -6,7 +6,6 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Past;
-import javax.validation.constraints.PastOrPresent;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/json/users/requests/UserCreationPayload.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/json/users/requests/UserCreationPayload.java
@@ -40,15 +40,6 @@ public class UserCreationPayload {
     @SerializedName("birthDate")
     private LocalDate birthDate;
 
-    @NotNull
-    @PastOrPresent
-    @SerializedName("consentDate")
-    private LocalDate consentDate;
-
-    @PastOrPresent
-    @SerializedName("assentDate")
-    private LocalDate assentDate;
-
     @SerializedName("centerId")
     private String centerId;
 }


### PR DESCRIPTION
DDP-8402

## Context

The `assentDate` and `consentDate` were a FON-specific change. This PR removes these from the request payload as required parameters as we do not have a place for them in the current implementation.

This PR updates the API specification, and updates the Java payload with the necessary changes. No front-end changes are required as any additional properties in the payload will just be ignored.
