### PR TITLE
DDP-8353: fast fix triggering followup surveys

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/ParticipantSurveyStatusResponse.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/ParticipantSurveyStatusResponse.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import lombok.Data;
 import lombok.NonNull;
-import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.exception.FileColumnMissing;
 import org.broadinstitute.dsm.exception.UploadLineException;
 import org.broadinstitute.dsm.util.SystemUtil;
@@ -22,10 +21,6 @@ public class ParticipantSurveyStatusResponse {
     private static final Logger logger = LoggerFactory.getLogger(ParticipantSurveyStatusResponse.class);
 
     private static final String DDP_PARTICIPANT_ID = "participantId";
-    private static final String SHORT_ID = "shortId";
-    private static final String FIRST_NAME = "firstName";
-    private static final String LAST_NAME = "lastName";
-    private static final String EMAIL = "email";
 
     private final ParticipantSurveyInfo surveyInfo;
     private String reason;
@@ -36,14 +31,14 @@ public class ParticipantSurveyStatusResponse {
         this.surveyInfo = surveyInfo;
     }
 
-    public static List<ParticipantSurveyUploadObject> isFileValid(@NonNull DDPInstance instance, @NonNull String fileContent) {
+    public static List<ParticipantSurveyUploadObject> isFileValid(@NonNull String fileContent) {
         if (fileContent != null) {
             String linebreak = SystemUtil.lineBreak(fileContent);
             String[] rows = fileContent.split(linebreak);
             if (rows.length > 1) {
                 String firstRow = rows[0];
                 List<String> fieldNames = new ArrayList<>(Arrays.asList(firstRow.trim().split(SystemUtil.SEPARATOR)));
-                String missingFieldName = fieldNameMissing(instance, fieldNames);
+                String missingFieldName = fieldNameMissing(fieldNames);
                 if (missingFieldName == null) {
                     List<ParticipantSurveyUploadObject> uploadObjects = new ArrayList<>();
                     for (int rowIndex = 1; rowIndex < rows.length; rowIndex++) {
@@ -54,13 +49,7 @@ public class ParticipantSurveyStatusResponse {
                                 obj.put(fieldNames.get(columnIndex), row[columnIndex]);
                             }
                             try {
-                                ParticipantSurveyUploadObject object;
-                                if (instance.isHasRole()) {
-                                    object = new ParticipantSurveyUploadObject(obj.get(SHORT_ID),
-                                            obj.get(FIRST_NAME), obj.get(LAST_NAME), obj.get(EMAIL));
-                                } else {
-                                    object = new ParticipantSurveyUploadObject(obj.get(DDP_PARTICIPANT_ID));
-                                }
+                                ParticipantSurveyUploadObject object = new ParticipantSurveyUploadObject(obj.get(DDP_PARTICIPANT_ID));
                                 if (object != null) {
                                     uploadObjects.add(object);
                                 }
@@ -81,24 +70,9 @@ public class ParticipantSurveyStatusResponse {
         return null;
     }
 
-    private static String fieldNameMissing(@NonNull DDPInstance instance, @NonNull List<String> fieldName) {
-        if (instance.isHasRole()) {
-            if (!fieldName.contains(SHORT_ID)) {
-                return SHORT_ID;
-            }
-            if (!fieldName.contains(FIRST_NAME)) {
-                return FIRST_NAME;
-            }
-            if (!fieldName.contains(LAST_NAME)) {
-                return LAST_NAME;
-            }
-            if (!fieldName.contains(EMAIL)) {
-                return EMAIL;
-            }
-        } else {
-            if (!fieldName.contains(DDP_PARTICIPANT_ID)) {
-                return DDP_PARTICIPANT_ID;
-            }
+    private static String fieldNameMissing(@NonNull List<String> fieldName) {
+        if (!fieldName.contains(DDP_PARTICIPANT_ID)) {
+            return DDP_PARTICIPANT_ID;
         }
         return null;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/TriggerSurveyRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/TriggerSurveyRoute.java
@@ -105,7 +105,7 @@ public class TriggerSurveyRoute extends RequestHandler {
             DDPInstance instance;
             if (queryParams.value(RoutePath.REALM) != null) {
                 realm = queryParams.get(RoutePath.REALM).value();
-                instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.SURVEY_STATUS_ENDPOINTS);
+                instance = DDPInstance.getDDPInstance(realm);
             } else {
                 throw new RuntimeException("No realm query param was sent");
             }
@@ -140,7 +140,6 @@ public class TriggerSurveyRoute extends RequestHandler {
                     List<ParticipantSurveyInfo> surveyInfos = null;
                     String comment = null;
                     Long surveyTriggerId = null;
-                    if (instance.isHasRole()) {
                         if (queryParams.value("comment") != null) {
                             comment = queryParams.get("comment").value();
                         } else {
@@ -148,7 +147,6 @@ public class TriggerSurveyRoute extends RequestHandler {
                         }
                         surveyInfos = DDPRequestUtil.getFollowupSurveysStatus(instance, surveyName);
                         surveyTriggerId = addTriggerCommentIntoDB(userIdRequest, comment, currentTime);
-                    }
                     if (isFileUpload || triggerAgain) {
                         List<ParticipantSurveyUploadObject> participantList = null;
                         if (triggerAgain) { //already participants and no file
@@ -158,7 +156,7 @@ public class TriggerSurveyRoute extends RequestHandler {
                             if (isFileUpload) {
                                 HttpServletRequest rawRequest = request.raw();
                                 String content = SystemUtil.getBody(rawRequest);
-                                participantList = ParticipantSurveyStatusResponse.isFileValid(instance, content);
+                                participantList = ParticipantSurveyStatusResponse.isFileValid(content);
                             }
                         }
                         logger.info(participantList.size() + " Participants were uploaded to trigger surveys");
@@ -166,7 +164,7 @@ public class TriggerSurveyRoute extends RequestHandler {
                         List<ParticipantSurveyUploadObject> alreadyUploaded = new ArrayList<>();
                         for (ParticipantSurveyUploadObject participant : participantList) {
                             if (triggerAgain) {
-                                if (!triggerSurvey(instance, participant, surveyTriggerId, surveyName, instance.isHasRole())) {
+                                if (!triggerSurvey(instance, participant, surveyTriggerId, surveyName)) {
                                     failed.add(participant);
                                 }
                             } else {
@@ -180,7 +178,7 @@ public class TriggerSurveyRoute extends RequestHandler {
                                     }
                                 }
                                 if (!alreadyTriggered) {
-                                    if (!triggerSurvey(instance, participant, surveyTriggerId, surveyName, instance.isHasRole())) {
+                                    if (!triggerSurvey(instance, participant, surveyTriggerId, surveyName)) {
                                         failed.add(participant);
                                     }
                                 } else {
@@ -259,13 +257,8 @@ public class TriggerSurveyRoute extends RequestHandler {
     }
 
     private boolean triggerSurvey(@NonNull DDPInstance instance, @NonNull ParticipantSurveyUploadObject participant, Long surveyTriggerId,
-                                  @NonNull String surveyName, boolean hasSurveyStatusEndpoint) {
-        SimpleFollowUpSurvey survey = null;
-        if (hasSurveyStatusEndpoint) {
-            survey = new SimpleFollowUpSurvey(participant.getDDPParticipantID(), surveyTriggerId);
-        } else {
-            survey = new SimpleFollowUpSurvey(participant.getDDPParticipantID());
-        }
+                                  @NonNull String surveyName) {
+        SimpleFollowUpSurvey survey = new SimpleFollowUpSurvey(participant.getDDPParticipantID(), surveyTriggerId);
         try {
             if (DDPRequestUtil.triggerFollowupSurvey(instance, survey, surveyName).getCode() != 200) {
                 return false;


### PR DESCRIPTION
removed left over code from old mbc version of how files should look when triggering followup surveys.
all studies have now a DSS version so only participantId is needed for triggering the surveys
Code was looking for shortID|firstName|lastName|email


![Screen Shot 2022-07-22 at 10 55 42 AM](https://user-images.githubusercontent.com/20780088/180466681-0c0e114d-939f-466d-89fa-fdebc493d456.png)
1) go to Miscellaneous > Follow-Up Survey
2) select a followup survey
3) select a previous created file or use this example file for dev pancan
[dev-pancan-followup1.txt](https://github.com/broadinstitute/ddp-study-server/files/9168798/dev-pancan-followup1.txt)
4) enter a reason
5) click 'Create Survey'
after triggering and reloading of the page (no auto reload)
you should see the triggered surveys in the list
![Screen Shot 2022-07-22 at 10 56 49 AM](https://user-images.githubusercontent.com/20780088/180467198-935031b0-2033-4304-a2b6-1b4047fde760.png)

