### PR TITLE
DDP-8413: don't throw if name and project is not set

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -83,12 +83,16 @@ public class ConfigManager {
 
         final var projectName = getProperty(GOOGLE_SECRET_PROJECT);
         if (projectName == null) {
-            throw new DDPException(GOOGLE_SECRET_PROJECT + " property is not set");
+            log.error(GOOGLE_SECRET_PROJECT + " property is not set");
         }
 
         final var secretName = getProperty(GOOGLE_SECRET_NAME);
         if (secretName == null) {
-            throw new DDPException(GOOGLE_SECRET_NAME + " property is not set");
+            log.error(GOOGLE_SECRET_NAME + " property is not set");
+        }
+
+        if (projectName == null && secretName == null) {
+            return ConfigFactory.parseFile(TYPESAFE_CONFIG_FILE);
         }
 
         final var secretVersion = getProperty(GOOGLE_SECRET_VERSION, "latest");


### PR DESCRIPTION
DSM is using that as well but doesn't have project and secret in the config