### PR TITLE
DDP-8413: DSM didn't go into parseConfig

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -92,7 +92,7 @@ public class ConfigManager {
         }
 
         if (projectName == null && secretName == null) {
-            return ConfigFactory.parseFile(TYPESAFE_CONFIG_FILE);
+            return null;
         }
 
         final var secretVersion = getProperty(GOOGLE_SECRET_VERSION, "latest");


### PR DESCRIPTION
DSM didn't use parseConfig