### PR TITLE
DDP-8428: File upload fix

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -98,9 +98,10 @@ public class FileScanResultReceiver implements MessageReceiver {
         }
     }
 
-    private String parseFileUploadGuid(String fileName) {
+    private String parseFileUploadGuid(String blobName) {
         // For authorized uploads, the base file name should start with the upload guid.
-        return Path.of(fileName).getFileName().toString().substring(0, fileName.indexOf("_"));
+        final var fileName = Path.of(blobName).getFileName().toString();
+        return fileName.substring(0, fileName.indexOf("_"));
     }
 
     private boolean handleFileScanResult(Handle handle, Blob blob, FileScanResult scanResult, Instant scannedAt) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -99,6 +99,11 @@ public class FileScanResultReceiver implements MessageReceiver {
     }
 
     private String parseFileUploadGuid(String blobName) {
+        if (!blobName.contains("_")) {
+            log.error("The blob name {} doesn't have any underscores in it. It must have at least one", blobName);
+            return null;
+        }
+
         // For authorized uploads, the base file name should start with the upload guid.
         final var fileName = Path.of(blobName).getFileName().toString();
         return fileName.substring(0, fileName.indexOf("_"));

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -14,6 +14,7 @@ import org.broadinstitute.ddp.client.GoogleBucketClient;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.DataExportDao;
 import org.broadinstitute.ddp.db.dao.FileUploadDao;
+import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.broadinstitute.ddp.model.files.FileUpload;
 import org.jdbi.v3.core.Handle;
@@ -103,7 +104,7 @@ public class FileScanResultReceiver implements MessageReceiver {
         final var fileName = Path.of(blobName).getFileName().toString();
         if (!fileName.contains("_")) {
             log.error("The blob name {} doesn't have any underscores in it. It must have at least one", blobName);
-            return null;
+            throw new DDPException(String.format("The blob name %s doesn't have any underscores in it. It must have at least one", blobName));
         }
 
         return fileName.substring(0, fileName.indexOf("_"));

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -99,13 +99,13 @@ public class FileScanResultReceiver implements MessageReceiver {
     }
 
     private String parseFileUploadGuid(String blobName) {
-        if (!blobName.contains("_")) {
+        // For authorized uploads, the base file name should start with the upload guid.
+        final var fileName = Path.of(blobName).getFileName().toString();
+        if (!fileName.contains("_")) {
             log.error("The blob name {} doesn't have any underscores in it. It must have at least one", blobName);
             return null;
         }
 
-        // For authorized uploads, the base file name should start with the upload guid.
-        final var fileName = Path.of(blobName).getFileName().toString();
         return fileName.substring(0, fileName.indexOf("_"));
     }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/FileScanResultReceiver.java
@@ -104,7 +104,8 @@ public class FileScanResultReceiver implements MessageReceiver {
         final var fileName = Path.of(blobName).getFileName().toString();
         if (!fileName.contains("_")) {
             log.error("The blob name {} doesn't have any underscores in it. It must have at least one", blobName);
-            throw new DDPException(String.format("The blob name %s doesn't have any underscores in it. It must have at least one", blobName));
+            throw new DDPException(String.format("The blob name %s doesn't have any underscores in it. It must have at least one",
+                    blobName));
         }
 
         return fileName.substring(0, fileName.indexOf("_"));

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
@@ -31,6 +31,7 @@ import org.broadinstitute.ddp.util.ActivityInstanceUtil;
 import org.broadinstitute.ddp.util.QuestionUtil;
 import org.broadinstitute.ddp.util.ResponseUtil;
 import org.broadinstitute.ddp.util.RouteUtil;
+import org.broadinstitute.ddp.util.GuidUtils;
 import org.broadinstitute.ddp.util.ValidatedJsonInputRoute;
 import spark.Request;
 import spark.Response;
@@ -111,13 +112,16 @@ public class CreateUserActivityUploadRoute extends ValidatedJsonInputRoute<Creat
             User operatorUser = handle.attach(UserDao.class).findUserByGuid(operatorGuid)
                     .orElseThrow(() -> new DDPException("Could not find operator with guid " + operatorGuid));
 
+            final var fileGuid = GuidUtils.randomFileUploadGuid();
+
             return service.authorizeUpload(
                     handle,
                     instanceDto.getStudyId(),
                     operatorUser.getId(),
                     instanceDto.getParticipantId(),
                     fileQuestionDef,
-                    getBlobPath(payload, userGuid, studyGuid, instanceDto.getActivityCode()),
+                    fileGuid,
+                    getBlobPath(payload, userGuid, studyGuid, fileGuid, instanceDto.getActivityCode()),
                     payload.getMimeType(),
                     payload.getFileName(),
                     payload.getFileSize(),
@@ -143,9 +147,10 @@ public class CreateUserActivityUploadRoute extends ValidatedJsonInputRoute<Creat
         return new CreateUserActivityUploadResponse(upload.getGuid(), result.getSignedUrl().toString());
     }
 
-    private String getBlobPath(CreateUserActivityUploadPayload payload, String userGuid, String studyGuid, String activityCode) {
-        return String.format("%s/%s_%s_%s_%d_%s",
-                studyGuid, activityCode, userGuid, getCurrentTimestamp(), System.nanoTime(), payload.getFileName());
+    private String getBlobPath(CreateUserActivityUploadPayload payload, String userGuid, String studyGuid,
+                               String fileGuid, String activityCode) {
+        return String.format("%s/%s_%s_%s_%s_%d_%s",
+                studyGuid, fileGuid, activityCode, userGuid, getCurrentTimestamp(), System.nanoTime(), payload.getFileName());
     }
 
     private long bytesToMbs(long maxFileSize) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/CreateUserActivityUploadRoute.java
@@ -149,8 +149,8 @@ public class CreateUserActivityUploadRoute extends ValidatedJsonInputRoute<Creat
 
     private String getBlobPath(CreateUserActivityUploadPayload payload, String userGuid, String studyGuid,
                                String fileGuid, String activityCode) {
-        return String.format("%s/%s_%s_%s_%s_%d_%s",
-                studyGuid, fileGuid, activityCode, userGuid, getCurrentTimestamp(), System.nanoTime(), payload.getFileName());
+        return String.format("%s/%s_%s_%s_%s_%s",
+                studyGuid, fileGuid, activityCode, userGuid, getCurrentTimestamp(), payload.getFileName());
     }
 
     private long bytesToMbs(long maxFileSize) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/FileUploadService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/FileUploadService.java
@@ -35,7 +35,6 @@ import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.broadinstitute.ddp.model.files.FileUpload;
 import org.broadinstitute.ddp.util.ConfigUtil;
 import org.broadinstitute.ddp.util.GoogleCredentialUtil;
-import org.broadinstitute.ddp.util.GuidUtils;
 import org.jdbi.v3.core.Handle;
 
 @Slf4j
@@ -139,7 +138,7 @@ public class FileUploadService {
      * @return authorization result
      */
     public AuthorizeResult authorizeUpload(Handle handle, long studyId, long operatorUserId, long participantUserId,
-                                           FileUploadSettings fileUploadSettings,
+                                           FileUploadSettings fileUploadSettings, String fileGuid,
                                            String blobPath, String mimeType,
                                            String fileName, long fileSize, boolean resumable) {
         if (fileSize > fileUploadSettings.getMaxFileSize()) {
@@ -155,7 +154,7 @@ public class FileUploadService {
         HttpMethod method = resumable ? HttpMethod.POST : HttpMethod.PUT;
 
         FileUpload upload = handle.attach(FileUploadDao.class).createAuthorized(
-                GuidUtils.randomFileUploadGuid(), studyId, operatorUserId, participantUserId,
+                fileGuid, studyId, operatorUserId, participantUserId,
                 blobPath, mimeType, fileName, fileSize);
         Map<String, String> headers = Map.of("Content-Type", mimeType);
         URL signedURL = storageClient.generateSignedUrl(

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/event/FileScanResultReceiverTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/event/FileScanResultReceiverTest.java
@@ -42,18 +42,18 @@ public class FileScanResultReceiverTest {
         var mockExportDao = mock(DataExportDao.class);
         var mockBlob = mock(Blob.class);
         var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
-        var upload = new FileUpload(1L, "guid", 1L, 1L, 1L, "blob", "mime", "name",
+        var upload = new FileUpload(1L, "guid", 1L, 1L, 1L, "guid_filename", "mime", "name",
                 123L, true, now, null, null, null);
         var msg = PubsubMessage.newBuilder()
                 .setMessageId("foo")
                 .putAttributes(ATTR_BUCKET_ID, "uploads")
-                .putAttributes(ATTR_OBJECT_ID, "foo/bar/guid")
+                .putAttributes(ATTR_OBJECT_ID, "foo/bar/guid_filename")
                 .putAttributes(ATTR_SCAN_RESULT, FileScanResult.CLEAN.name())
                 .build();
 
         // Setup behavior.
         doReturn(true).when(mockBlob).exists();
-        doReturn("foo/bar/guid").when(mockBlob).getName();
+        doReturn("foo/bar/guid_filename").when(mockBlob).getName();
         doReturn(now.toEpochMilli()).when(mockBlob).getCreateTime();
         doReturn(mockBlob).when(mockStorage).getBlob(any(), any());
         doReturn(mockFileDao).when(mockHandle).attach(FileUploadDao.class);
@@ -68,8 +68,8 @@ public class FileScanResultReceiverTest {
         receiverSpy.receiveMessage(msg, mockReply);
 
         // Do asserts.
-        verify(mockStorage).getBlob("uploads", "foo/bar/guid");
-        verify(mockStorage).moveBlob(any(), eq("scanned"), eq("foo/bar/guid"));
+        verify(mockStorage).getBlob("uploads", "foo/bar/guid_filename");
+        verify(mockStorage).moveBlob(any(), eq("scanned"), eq("foo/bar/guid_filename"));
         verify(mockFileDao).findAndLockByGuid("guid");
         verify(mockExportDao, times(1)).queueDataSync(1L, 1L);
         verify(mockReply, times(1)).ack();

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/service/FileUploadServiceTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/service/FileUploadServiceTest.java
@@ -33,6 +33,7 @@ import org.broadinstitute.ddp.interfaces.FileUploadSettings;
 import org.broadinstitute.ddp.model.files.FileScanResult;
 import org.broadinstitute.ddp.model.files.FileUpload;
 import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.ddp.util.GuidUtils;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.jdbi.v3.core.Handle;
 import org.junit.BeforeClass;
@@ -57,7 +58,7 @@ public class FileUploadServiceTest extends TxnAwareBaseTest {
         long fileSize = 50000;
         var service = FileUploadService.fromConfig(ConfigManager.getInstance().getConfig());
         var result = TransactionWrapper.withTxn(handle -> service
-                .authorizeUpload(handle, studyId, userId, userId, createFileUploadSettings(fileSize),
+                .authorizeUpload(handle, studyId, userId, userId, createFileUploadSettings(fileSize), GuidUtils.randomFileUploadGuid(),
                         "prefix/filename.pdf", "application/pdf", "filename.pdf", 50000, false));
 
         var guid = result.getFileUpload().getGuid();
@@ -86,7 +87,8 @@ public class FileUploadServiceTest extends TxnAwareBaseTest {
         doReturn(dummyUrl).when(mockClient).generateSignedUrl(any(), eq("uploads"), startsWith("prefix/"),
                 anyLong(), any(), eq(expectedMethod), argThat(map -> expectedMime.equals(map.get("Content-Type"))));
 
-        var result = service.authorizeUpload(mockHandle, 1L, 1L, 1L, createFileUploadSettings(123), "prefix/file", null, "file", 123, true);
+        var result = service.authorizeUpload(mockHandle, 1L, 1L, 1L, createFileUploadSettings(123),
+                GuidUtils.randomFileUploadGuid(), "prefix/file", null, "file", 123, true);
 
         assertNotNull(result);
         assertNotSame(result.getAuthorizeResultType(), FILE_SIZE_EXCEEDS_MAXIMUM);
@@ -103,7 +105,8 @@ public class FileUploadServiceTest extends TxnAwareBaseTest {
     @Test
     public void testAuthorizeUpload_exceededSize() {
         var service = new FileUploadService(null, null, "uploads", "scanned", "quarantine", 5, 1L, null, 1);
-        var result = service.authorizeUpload(null, 1L, 1L, 1L, createFileUploadSettings(123), "prefix/file", "mime", "file", 1024, false);
+        var result = service.authorizeUpload(null, 1L, 1L, 1L, createFileUploadSettings(123),
+                GuidUtils.randomFileUploadGuid(), "prefix/file", "mime", "file", 1024, false);
         assertNotNull(result);
         assertSame("should hit size limit", result.getAuthorizeResultType(), FILE_SIZE_EXCEEDS_MAXIMUM);
         assertNull(result.getFileUpload());


### PR DESCRIPTION
Since the filename format has changed (previously was GUID and currently a combination of different values) the housekeeping tool needs to obtain GUID from it instead of just using it.