### PR TITLE
[DDP-8533] fixed typo

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/lms/snippets/consent-minors-section1-benefits.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/snippets/consent-minors-section1-benefits.conf
@@ -38,7 +38,7 @@
           {
             "language": "en",
             "text": """Results from the sequencing of your child’s non-tumor (germline) DNA from Invitae may include
-              details that inform cancer risk for your child and your family. You will be offered genetic counselling to
+              details that inform cancer risk for your child and your family. You will be offered genetic counseling to
               help ensure you understand the germline genetic results."""
           }
         ]


### PR DESCRIPTION
https://broadinstitute.atlassian.net/jira/software/c/projects/DDP/boards/836?modal=detail&selectedIssue=DDP-8533&assignee=627ecf988dd5f30068573750
1. In LMS consent-assent section there was an typo
2. Changed typo counselling to counseling.

