### PR TITLE
[DDP-8534] fix the ordering for consent-addendum

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/lms/snippets/somatic-consent-addendum-documentation.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/snippets/somatic-consent-addendum-documentation.conf
@@ -8,7 +8,7 @@
         "translations": [
           {
             "language": "en",
-            "text": "Q. Documentation of Consent"
+            "text": " Documentation of Consent"
           }
         ]
       }


### PR DESCRIPTION
https://broadinstitute.atlassian.net/jira/software/c/projects/DDP/boards/836?modal=detail&selectedIssue=DDP-8534

1. Typo in Somatic-consent-addendum as Q is added manually in ordering
2. Removed Q.

