### PR TITLE
DDP-8504: GAE uses `config_file` for the config path

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -38,8 +38,8 @@ public class ConfigManager {
 
     static {
         // For benefit of GAE. Does not like command line options with "=" characters and env variables with "."
-        final var configFileName = Optional.ofNullable(System.getenv(TYPESAFE_CONFIG_SYSTEM_VAR))
-                .map(value -> value.replace('.', '_'))
+        final var gaeConfigPropertyName = TYPESAFE_CONFIG_SYSTEM_VAR.replace('.', '_');
+        final var configFileName = Optional.ofNullable(System.getenv(gaeConfigPropertyName))
                 .orElse(System.getProperty(TYPESAFE_CONFIG_SYSTEM_VAR));
 
         TYPESAFE_CONFIG_FILE = Optional.ofNullable(configFileName).map(File::new).orElse(null);


### PR DESCRIPTION
## Context
DDP-8504

This fixes a bug introduced in #2088. 

The GAE deployment is attempting to check the environment for the key `config.file` instead of `config_file`. GAE does not support `.` characters in environment variable names, and this led to the configuration file not being found on launch.

## Testing
This change can be tested by launching DSS as normal, but omitting the `-Dconfig.file` property. Instead, the environment variable `config_file` should be used to pass the path to the configuration file to the application.

On the current [develop](https://github.com/broadinstitute/ddp-study-server/commit/f385d037536df220a6531fc01dd3148bd945d5fc), passing the configuration file using an environment variable named`config_file` should result in an error loading the configuration.

After this fix is applied, DSS should be able to load a configuration file if the path is passed using an environment variable named `config_file`