### PR TITLE
DDP-8504: Return null if a config is not found

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -90,11 +90,11 @@ public class ConfigManager {
         }
 
         if (configCloud.isEmpty() && configLocal.isEmpty()) {
-            log.error("no configuration was specified. Use properties '{}' to use a local file or '{}' and '{}' to use a cloud secret",
+            log.info("no configuration was specified, an empty configuration will be used. " +
+                    "Use properties '{}' to use a local file or '{}' and '{}' to use a cloud secret",
                     TYPESAFE_CONFIG_SYSTEM_VAR,
                     GOOGLE_SECRET_PROJECT,
                     GOOGLE_SECRET_NAME);
-            throw new DDPException("no configuration was specified.");
         }
 
         return configLocal.withFallback(configCloud).resolve();

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -95,6 +95,7 @@ public class ConfigManager {
                     TYPESAFE_CONFIG_SYSTEM_VAR,
                     GOOGLE_SECRET_PROJECT,
                     GOOGLE_SECRET_NAME);
+            return null;
         }
 
         return configLocal.withFallback(configCloud).resolve();

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -90,8 +90,8 @@ public class ConfigManager {
         }
 
         if (configCloud.isEmpty() && configLocal.isEmpty()) {
-            log.info("no configuration was specified, an empty configuration will be used. " +
-                    "Use properties '{}' to use a local file or '{}' and '{}' to use a cloud secret",
+            log.info("no configuration was specified, an empty configuration will be used. "
+                    + "Use properties '{}' to use a local file or '{}' and '{}' to use a cloud secret",
                     TYPESAFE_CONFIG_SYSTEM_VAR,
                     GOOGLE_SECRET_PROJECT,
                     GOOGLE_SECRET_NAME);


### PR DESCRIPTION
## Context

Failure to load a configuration file should return a null, not throw an error.

The ConfigManager class is shared by DSM and, by default, DSM uses a different location for the default configuration file. The result is that even if no config is loaded here, DSM may still have a valid configuration. Shared parts of the code rely on `getConfig()` returning `null` when running in DSM so an empty config is not a valid option.
