### PR TITLE
DDP-8539: Identifiers for existing Expressions in Block DTOs

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/ComponentDao.java
@@ -204,8 +204,10 @@ public interface ComponentDao extends SqlObject {
             blockDef.setComponentRevisionId(componentDto.getRevisionId());
             blockDef.setBlockId(blockDto.getId());
             blockDef.setBlockGuid(blockDto.getGuid());
-            blockDef.setShownExpr(blockDto.getShownExpr());
-            blockDef.setEnabledExpr(blockDto.getEnabledExpr());
+            blockDef.setShownExprId(blockDto.getShownExpression().getId());
+            blockDef.setShownExpr(blockDto.getShownExpression().getText());
+            blockDef.setEnabledExprId(blockDto.getEnabledExpression().getId());
+            blockDef.setEnabledExpr(blockDto.getEnabledExpression().getText());
 
             blockDefs.put(blockDto.getId(), blockDef);
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.broadinstitute.ddp.db.dto.FormBlockDto;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.broadinstitute.ddp.db.dto.FormBlockDto;
 import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
@@ -23,33 +24,13 @@ public interface JdbiBlockNesting extends SqlObject {
 
     @UseStringTemplateSqlLocator
     @SqlQuery("queryOrderedNestedFormBlockDtosByBlockIdAndInstanceGuid")
-    @RegisterRowMapper(FormBlockDto.FormBlockDtoMapper.class)
+    @RegisterConstructorMapper(FormBlockDto.class)
     List<FormBlockDto> findOrderedNestedFormBlockDtos(@Bind("blockId") long blockId, @Bind("instanceGuid") String instanceGuid);
 
-    @SqlQuery("select null as form_section_id, bn.parent_block_id,"
-            + "       bt.block_type_code, nested.block_id, nested.block_guid,"
-            + "       e.expression_text as shown_expression_text,"
-            + "       ee.expression_text as enabled_expression_text"
-            + "  from block_nesting as bn"
-            + "  join block as nested on nested.block_id = bn.nested_block_id"
-            + "  join block_type as bt on bt.block_type_id = nested.block_type_id"
-            + "  join revision as rev on rev.revision_id = bn.revision_id"
-            + "  left join block__expression as be on be.block_id = nested.block_id"
-            + "  left join expression as e on e.expression_id = be.expression_id"
-            + "  left join revision as be_rev on be_rev.revision_id = be.revision_id"
-            + "  left join block_enabled_expression as bee on bee.block_id = nested.block_id"
-            + "  left join expression as ee on ee.expression_id = bee.expression_id"
-            + "  left join revision as bee_rev on bee_rev.revision_id = bee.revision_id"
-            + " where bn.parent_block_id in (<blockIds>)"
-            + "   and rev.start_date <= :timestamp"
-            + "   and (rev.end_date is null or :timestamp < rev.end_date)"
-            + "   and (be.block__expression_id is null or "
-            + "       (be_rev.start_date <= :timestamp and (be_rev.end_date is null or :timestamp < be_rev.end_date)))"
-            + "   and (bee.block_enabled_expression_id is null or "
-            + "       (bee_rev.start_date <= :timestamp and (bee_rev.end_date is null or :timestamp < bee_rev.end_date)))"
-            + " order by bn.parent_block_id asc, bn.display_order asc")
-    @RegisterRowMapper(FormBlockDto.FormBlockDtoMapper.class)
+    @UseStringTemplateSqlLocator
+    @SqlQuery("queryOrderedNestedDtosByParentIdsAndTimestamp")
+    @RegisterConstructorMapper(FormBlockDto.class)
     List<FormBlockDto> findOrderedNestedDtosByParentIdsAndTimestamp(
-            @BindList(value = "blockIds", onEmpty = EmptyHandling.NULL) Iterable<Long> parentBlockIds,
+            @BindList(value = "blockIds", onEmpty = EmptyHandling.NULL_VALUE) Iterable<Long> parentBlockIds,
             @Bind("timestamp") long timestamp);
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockTabular.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockTabular.java
@@ -61,8 +61,13 @@ public interface JdbiBlockTabular extends SqlObject {
     @RegisterConstructorMapper(BlockTabularHeaderDto.class)
     List<BlockTabularHeaderDto> findHeadersByBlockIdAndTimestamp(@Bind("blockId") long blockId, @Bind("timestamp") long timestamp);
 
-    @SqlQuery("SELECT btq.*, bt.block_id, bq.block_id as question_block_id, b.block_guid, "
-            + "     e2.expression_text as 'enabled_expr', e1.expression_text as 'shown_expr'"
+    @SqlQuery("SELECT btq.*, bt.block_id, bq.block_id as question_block_id, b.block_guid,"
+            + "     e2.expression_id AS en_expr_expression_id,"
+            + "     e2.expression_text AS en_expr_expression_text,"
+            + "     e2.expression_guid AS en_expr_expression_guid,"
+            + "     e1.expression_id AS sh_expr_expression_id,"
+            + "     e1.expression_text AS sh_expr_expression_text,"
+            + "     e1.expression_guid AS sh_expr_expression_guid,"
             + "  FROM block_tabular_question as btq"
             + "  JOIN block_tabular as bt ON bt.block_tabular_id = btq.block_tabular_id"
             + "  JOIN question as q ON q.question_id = btq.question_id"
@@ -79,6 +84,6 @@ public interface JdbiBlockTabular extends SqlObject {
             + " order by bq.block_id")
     @RegisterConstructorMapper(BlockTabularQuestionDto.class)
     List<BlockTabularQuestionDto> findQuestionsByBlockIdsAndTimestamp(
-            @BindList(value = "blockIds", onEmpty = BindList.EmptyHandling.NULL) Iterable<Long> blockIds,
+            @BindList(value = "blockIds", onEmpty = BindList.EmptyHandling.NULL_VALUE) Iterable<Long> blockIds,
             @Bind("timestamp") long timestamp);
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockTabular.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiBlockTabular.java
@@ -67,7 +67,7 @@ public interface JdbiBlockTabular extends SqlObject {
             + "     e2.expression_guid AS en_expr_expression_guid,"
             + "     e1.expression_id AS sh_expr_expression_id,"
             + "     e1.expression_text AS sh_expr_expression_text,"
-            + "     e1.expression_guid AS sh_expr_expression_guid,"
+            + "     e1.expression_guid AS sh_expr_expression_guid"
             + "  FROM block_tabular_question as btq"
             + "  JOIN block_tabular as bt ON bt.block_tabular_id = btq.block_tabular_id"
             + "  JOIN question as q ON q.question_id = btq.question_id"

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiExpression.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiExpression.java
@@ -9,6 +9,7 @@ import org.broadinstitute.ddp.model.pex.Expression;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -36,6 +37,9 @@ public interface JdbiExpression extends SqlObject {
 
     @SqlUpdate("update expression set expression_text = :text where expression_id = :expressionId")
     int updateById(@Bind("expressionId") long expressionId, @Bind("text") String text);
+
+    @SqlUpdate("UPDATE expression SET expression_guid = :guid, expression_text = :text WHERE expression_id = :id")
+    int update(@BindBean Expression expression);
 
     @SqlUpdate("delete from expression where expression_id = :expressionId")
     int deleteById(long expressionId);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiFormSectionBlock.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiFormSectionBlock.java
@@ -1,14 +1,11 @@
 package org.broadinstitute.ddp.db.dao;
 
-import org.broadinstitute.ddp.constants.SqlConstants;
 import org.broadinstitute.ddp.db.dto.FormBlockDto;
 import org.broadinstitute.ddp.db.dto.SectionBlockMembershipDto;
 import org.broadinstitute.ddp.model.activity.instance.ActivityInstance;
 import org.broadinstitute.ddp.service.actvityinstancebuilder.ActivityInstanceFromDefinitionBuilder;
-import org.jdbi.v3.core.statement.Query;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
-import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling;
@@ -17,13 +14,13 @@ import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-import org.jdbi.v3.stringtemplate4.StringTemplateSqlLocator;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateSqlLocator;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.Collections;
 
 public interface JdbiFormSectionBlock extends SqlObject {
@@ -59,7 +56,13 @@ public interface JdbiFormSectionBlock extends SqlObject {
             + " where form_section__block_id = :id")
     int[] bulkUpdateRevisionIdsByIds(@Bind("id") List<Long> membershipIds,
                                      @Bind("revisionId") long[] revisionIds);
-
+    
+    @UseStringTemplateSqlLocator
+    @SqlQuery("queryOrderedFormBlockDtosBySectionIdsAndInstanceGuid")
+    @RegisterConstructorMapper(value = FormBlockDto.class)
+    List<FormBlockDto> findOrderedFormBlocksForSectionsAndInstance(
+                @BindList(value = "sectionIds", onEmpty = EmptyHandling.NULL_VALUE) List<Long> sectionIds,
+                @Bind("instanceGuid") String instanceGuid);
 
     /**
      * Query for all the block data for given section ids, ordered by their display order.
@@ -72,24 +75,8 @@ public interface JdbiFormSectionBlock extends SqlObject {
      *    {@link ActivityInstanceFromDefinitionBuilder} was implemented
      */
     default Map<Long, List<FormBlockDto>> findOrderedFormBlockDtosForSections(List<Long> sectionIds, String instanceGuid) {
-        String query = StringTemplateSqlLocator
-                .findStringTemplate(JdbiFormSectionBlock.class, "queryOrderedFormBlockDtosBySectionIdsAndInstanceGuid")
-                .render();
-        Query stmt = getHandle().createQuery(query);
-        if (sectionIds == null || sectionIds.isEmpty()) {
-            stmt.define("sectionIds", "null");
-        } else {
-            stmt.bindList("sectionIds", sectionIds);
-        }
-        return stmt.bind("instanceGuid", instanceGuid)
-                .registerRowMapper(FormBlockDto.class, new FormBlockDto.FormBlockDtoMapper())
-                .reduceRows(new HashMap<>(), (accumulator, row) -> {
-                    long key = row.getColumn(SqlConstants.FormSectionTable.ID, Long.class);
-                    List<FormBlockDto> blocks = accumulator.computeIfAbsent(key, k -> new ArrayList<>());
-                    FormBlockDto current = row.getRow(FormBlockDto.class);
-                    blocks.add(current);
-                    return accumulator;
-                });
+        return findOrderedFormBlocksForSectionsAndInstance(sectionIds, instanceGuid).stream()
+                .collect(Collectors.groupingBy(FormBlockDto::getSectionId));
     }
 
     /**
@@ -104,30 +91,11 @@ public interface JdbiFormSectionBlock extends SqlObject {
                 .getOrDefault(sectionId, new ArrayList<>());
     }
 
-    @SqlQuery("select fsb.form_section_id, null as parent_block_id,"
-            + "       bt.block_type_code, b.block_id, b.block_guid,"
-            + "       e.expression_text as shown_expression_text,"
-            + "       ee.expression_text as enabled_expression_text"
-            + "  from form_section__block as fsb"
-            + "  join revision as rev on rev.revision_id = fsb.revision_id"
-            + "  join block as b on b.block_id = fsb.block_id"
-            + "  join block_type as bt on bt.block_type_id = b.block_type_id"
-            + "  left join block__expression as be on be.block_id = b.block_id"
-            + "  left join expression as e on e.expression_id = be.expression_id"
-            + "  left join revision as be_rev on be_rev.revision_id = be.revision_id"
-            + "  left join block_enabled_expression as bee on bee.block_id = b.block_id"
-            + "  left join expression as ee on ee.expression_id = bee.expression_id"
-            + "  left join revision as bee_rev on bee_rev.revision_id = bee.revision_id"
-            + " where fsb.form_section_id in (<sectionIds>)"
-            + "   and rev.start_date <= :timestamp"
-            + "   and (rev.end_date is null or :timestamp < rev.end_date)"
-            + "   and (be.block__expression_id is null or "
-            + "       (be_rev.start_date <= :timestamp and (be_rev.end_date is null or :timestamp < be_rev.end_date)))"
-            + "   and (bee.block_enabled_expression_id is null or "
-            + "       (bee_rev.start_date <= :timestamp and (bee_rev.end_date is null or :timestamp < bee_rev.end_date)))"
-            + " order by fsb.form_section_id asc, fsb.display_order asc")
-    @RegisterRowMapper(FormBlockDto.FormBlockDtoMapper.class)
+    
+    @UseStringTemplateSqlLocator
+    @SqlQuery("queryOrderedFormBlockDtosBySectionIdsAndTimestamp")
+    @RegisterConstructorMapper(value = FormBlockDto.class)
     List<FormBlockDto> findOrderedFormBlockDtosBySectionIdsAndTimestamp(
-            @BindList(value = "sectionIds", onEmpty = EmptyHandling.NULL) Iterable<Long> sectionIds,
+            @BindList(value = "sectionIds", onEmpty = EmptyHandling.NULL_VALUE) Iterable<Long> sectionIds,
             @Bind("timestamp") long timestamp);
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/QuestionDao.java
@@ -1843,8 +1843,10 @@ public interface QuestionDao extends SqlObject {
             var blockDef = new QuestionBlockDef(questionDef);
             blockDef.setBlockId(blockDto.getId());
             blockDef.setBlockGuid(blockDto.getGuid());
-            blockDef.setShownExpr(blockDto.getShownExpr());
-            blockDef.setEnabledExpr(blockDto.getEnabledExpr());
+            blockDef.setShownExprId(blockDto.getShownExpression().getId());
+            blockDef.setShownExpr(blockDto.getShownExpression().getText());
+            blockDef.setEnabledExprId(blockDto.getEnabledExpression().getId());
+            blockDef.setEnabledExpr(blockDto.getEnabledExpression().getText());
             blockDefs.put(blockDto.getId(), blockDef);
         }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/SectionBlockDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/SectionBlockDao.java
@@ -774,8 +774,10 @@ public interface SectionBlockDao extends SqlObject {
             blockDef.getNested().addAll(nestedDefs);
             blockDef.setBlockId(blockDto.getId());
             blockDef.setBlockGuid(blockDto.getGuid());
-            blockDef.setShownExpr(blockDto.getShownExpr());
-            blockDef.setEnabledExpr(blockDto.getEnabledExpr());
+            blockDef.setShownExprId(blockDto.getShownExpression().getId());
+            blockDef.setShownExpr(blockDto.getShownExpression().getText());
+            blockDef.setEnabledExprId(blockDto.getEnabledExpression().getId());
+            blockDef.setEnabledExpr(blockDto.getEnabledExpression().getText());
 
             blockDefs.put(blockDto.getId(), blockDef);
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/BlockTabularQuestionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/BlockTabularQuestionDto.java
@@ -32,17 +32,11 @@ public class BlockTabularQuestionDto {
     @ColumnName("block_guid")
     String blockGuid;
 
-    @ColumnName("shown_expr")
-    String shownExpr;
-
     @Nested("sh_expr")
     Expression shownExpression;
 
     @Nested("en_expr")
     Expression enabledExpression;
-
-    @ColumnName("enabled_expr")
-    String enabledExpr;
 
     public String getShownExpr() {
         return shownExpression.getText();

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/BlockTabularQuestionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/BlockTabularQuestionDto.java
@@ -2,6 +2,9 @@ package org.broadinstitute.ddp.db.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Value;
+
+import org.broadinstitute.ddp.model.pex.Expression;
+import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
@@ -32,7 +35,21 @@ public class BlockTabularQuestionDto {
     @ColumnName("shown_expr")
     String shownExpr;
 
+    @Nested("sh_expr")
+    Expression shownExpression;
+
+    @Nested("en_expr")
+    Expression enabledExpression;
+
     @ColumnName("enabled_expr")
     String enabledExpr;
+
+    public String getShownExpr() {
+        return shownExpression.getText();
+    }
+
+    public String getEnabledExpr() {
+        return enabledExpression.getText();
+    }
 
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/FormBlockDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/FormBlockDto.java
@@ -2,26 +2,34 @@ package org.broadinstitute.ddp.db.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Value;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-
-import org.broadinstitute.ddp.constants.SqlConstants;
 
 import org.broadinstitute.ddp.model.activity.types.BlockType;
-import org.jdbi.v3.core.mapper.RowMapper;
-import org.jdbi.v3.core.statement.StatementContext;
+import org.broadinstitute.ddp.model.pex.Expression;
+import org.jdbi.v3.core.mapper.Nested;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 /**
  * A wrapper data object around a block and its optional conditional expression.
  */
 @Value
-@AllArgsConstructor
+@AllArgsConstructor(onConstructor = @__({@JdbiConstructor}))
 public class FormBlockDto {
+
+    @ColumnName("section_id")
     Long sectionId;
+
+    @ColumnName("parent_block_id")
     Long parentBlockId;
+
+    @Nested("block_meta")
     BlockDto blockDto;
-    String shownExpr;
-    String enabledExpr;
+
+    @Nested("sh_expr")
+    Expression shownExpression;
+
+    @Nested("en_expr")
+    Expression enabledExpression;
 
     public BlockType getType() {
         return blockDto.getType();
@@ -35,18 +43,12 @@ public class FormBlockDto {
         return blockDto.getGuid();
     }
 
-    public static class FormBlockDtoMapper implements RowMapper<FormBlockDto> {
-        @Override
-        public FormBlockDto map(ResultSet rs, StatementContext ctx) throws SQLException {
-            return new FormBlockDto(
-                    rs.getLong("form_section_id"),
-                    rs.getLong("parent_block_id"),
-                    new BlockDto(
-                            BlockType.valueOf(rs.getString(SqlConstants.BlockTypeTable.CODE)),
-                            rs.getLong(SqlConstants.BlockTable.ID),
-                            rs.getString(SqlConstants.BlockTable.GUID)),
-                    rs.getString("shown_expression_text"),
-                    rs.getString("enabled_expression_text"));
-        }
+    public String getShownExpr() {
+        return shownExpression.getText();
     }
+
+    public String getEnabledExpr() {
+        return enabledExpression.getText();
+    }
+
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/pex/Expression.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/pex/Expression.java
@@ -9,7 +9,7 @@ import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 @AllArgsConstructor(onConstructor = @__(@JdbiConstructor))
 public class Expression {
     @ColumnName("expression_id")
-    long id;
+    Long id;
 
     @ColumnName("expression_guid")
     String guid;
@@ -18,6 +18,6 @@ public class Expression {
     String text;
 
     public Expression(final String text) {
-        this(0, null, text);
+        this(null, null, text);
     }
 }

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiBlockNesting.sql.stg
@@ -1,30 +1,72 @@
 group JdbiBlockNesting;
 
 queryOrderedNestedFormBlockDtosByBlockIdAndInstanceGuid() ::= <<
-select null as form_section_id,
-       bn.parent_block_id,
-       bt.block_type_code,
-       nested.block_id,
-       nested.block_guid,
-       ev.expression_text as shown_expression_text,
-       ee.expression_text as enabled_expression_text
-  from block_nesting bn
-  join block as nested on nested.block_id = bn.nested_block_id
-  join block_type as bt on bt.block_type_id = nested.block_type_id
-  join revision as rev on rev.revision_id = bn.revision_id
-  left join block__expression as bve on bve.block_id = nested.block_id
-  left join expression as ev on ev.expression_id = bve.expression_id
-  left join revision as bve_rev on bve_rev.revision_id = bve.revision_id
-  left join block_enabled_expression as bee on bee.block_id = nested.block_id
-  left join expression as ee on ee.expression_id = bee.expression_id
-  left join revision as bee_rev on bee_rev.revision_id = bee.revision_id
-  join activity_instance as ai on ai.activity_instance_guid = :instanceGuid
- where bn.parent_block_id = :blockId
-   and rev.start_date \<= ai.created_at
-   and (rev.end_date is null or ai.created_at \< rev.end_date)
-   and (bve.block__expression_id is null or
-       (bve_rev.start_date \<= ai.created_at and (bve_rev.end_date is null or ai.created_at \< bve_rev.end_date)))
-   and (bee.block_enabled_expression_id is null or
-       (bee_rev.start_date \<= ai.created_at and (bee_rev.end_date is null or ai.created_at \< bee_rev.end_date)))
- order by bn.display_order asc
+SELECT
+    null AS section_id,
+    bn.parent_block_id AS parent_block_id,
+    bt.block_type_code AS block_meta_block_type_code,
+    nested.block_id AS block_meta_block_id,
+    nested.block_guid AS block_meta_block_guid,
+    ev.expression_id AS sh_expr_expression_id,
+    ev.expression_guid AS sh_expr_expression_guid,
+    ev.expression_text AS sh_expr_expression_text,
+    ee.expression_id AS en_expr_expression_id,
+    ee.expression_guid AS en_expr_expression_guid,
+    ee.expression_text AS en_expr_expression_text
+FROM block_nesting AS bn
+    JOIN block AS nested ON nested.block_id = bn.nested_block_id
+    JOIN block_type AS bt ON bt.block_type_id = nested.block_type_id
+    JOIN revision AS rev ON rev.revision_id = bn.revision_id
+    LEFT JOIN block__expression AS bev ON bev.block_id = nested.block_id
+    LEFT JOIN expression AS ev ON ev.expression_id = bev.expression_id
+    LEFT JOIN revision AS bev_rev ON bev_rev.revision_id = bev.revision_id
+    LEFT JOIN block_enabled_expression AS bee ON bee.block_id = nested.block_id
+    LEFT JOIN expression AS ee ON ee.expression_id = bee.expression_id
+    LEFT JOIN revision AS bee_rev ON bee_rev.revision_id = bee.revision_id
+    JOIN activity_instance AS ai ON ai.activity_instance_guid = :instanceGuid
+WHERE bn.parent_block_id = :blockId
+    AND rev.start_date \<= ai.created_at
+    AND (rev.end_date IS null OR ai.created_at \< rev.end_date)
+    AND (bev.block__expression_id IS null
+        OR (bev_rev.start_date \<= ai.created_at
+            AND (bev_rev.end_date IS null OR ai.created_at \< bev_rev.end_date)))
+    AND (bee.block_enabled_expression_id IS null
+        OR (bee_rev.start_date \<= ai.created_at
+            AND (bee_rev.end_date IS null OR ai.created_at \< bee_rev.end_date)))
+ORDER BY bn.display_order asc
+>>
+
+queryOrderedNestedDtosByParentIdsAndTimestamp(blockIds) ::= <<
+SELECT
+    null AS section_id,
+    bn.parent_block_id AS parent_block_id,
+    bt.block_type_code AS block_meta_block_type_code,
+    nested.block_id AS block_meta_block_id,
+    nested.block_guid AS block_meta_block_guid,
+    ev.expression_id AS sh_expr_expression_id,
+    ev.expression_guid AS sh_expr_expression_guid,
+    ev.expression_text AS sh_expr_expression_text,
+    ee.expression_id AS en_expr_expression_id,
+    ee.expression_guid AS en_expr_expression_guid,
+    ee.expression_text AS en_expr_expression_text
+FROM block_nesting AS bn
+    JOIN block AS nested ON nested.block_id = bn.nested_block_id
+    JOIN block_type AS bt ON bt.block_type_id = nested.block_type_id
+    JOIN revision AS rev ON rev.revision_id = bn.revision_id
+    LEFT JOIN block__expression AS bev ON bev.block_id = nested.block_id
+    LEFT JOIN expression AS ev ON ev.expression_id = bev.expression_id
+    LEFT JOIN revision AS bev_rev ON bev_rev.revision_id = bev.revision_id
+    LEFT JOIN block_enabled_expression AS bee ON bee.block_id = nested.block_id
+    LEFT JOIN expression AS ee ON ee.expression_id = bee.expression_id
+    LEFT JOIN revision AS bee_rev ON bee_rev.revision_id = bee.revision_id
+WHERE bn.parent_block_id in (<blockIds>)
+    AND rev.start_date \<= :timestamp
+    AND (rev.end_date IS null OR :timestamp \< rev.end_date)
+    AND (bev.block__expression_id IS null
+        OR (bev_rev.start_date \<= :timestamp
+            AND (bev_rev.end_date IS null OR :timestamp \< bev_rev.end_date)))
+    AND (bee.block_enabled_expression_id IS null
+        OR (bee_rev.start_date \<= :timestamp
+            AND (bee_rev.end_date IS null OR :timestamp \< bee_rev.end_date)))
+ORDER BY bn.parent_block_id asc, bn.display_order asc
 >>

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiFormSectionBlock.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiFormSectionBlock.sql.stg
@@ -1,30 +1,72 @@
 group JdbiFormSectionBlock;
 
-queryOrderedFormBlockDtosBySectionIdsAndInstanceGuid() ::= <<
-select fsb.form_section_id,
-       null as parent_block_id,
-       bt.block_type_code,
-       b.block_id,
-       b.block_guid,
-       ev.expression_text as shown_expression_text,
-       ee.expression_text as enabled_expression_text
-  from form_section__block as fsb
-  join revision as rev on rev.revision_id = fsb.revision_id
-  join block as b on b.block_id = fsb.block_id
-  join block_type as bt on bt.block_type_id = b.block_type_id
-  left join block__expression as bve on bve.block_id = b.block_id
-  left join expression as ev on ev.expression_id = bve.expression_id
-  left join revision as bve_rev on bve_rev.revision_id = bve.revision_id
-  left join block_enabled_expression as bee on bee.block_id = b.block_id
-  left join expression as ee on ee.expression_id = bee.expression_id
-  left join revision as bee_rev on bee_rev.revision_id = bee.revision_id
-  join activity_instance as ai on ai.activity_instance_guid = :instanceGuid
- where fsb.form_section_id in (\<sectionIds>)
-   and rev.start_date \<= ai.created_at
-   and (rev.end_date is null or ai.created_at \< rev.end_date)
-   and (bve.block__expression_id is null or
-       (bve_rev.start_date \<= ai.created_at and (bve_rev.end_date is null or ai.created_at \< bve_rev.end_date)))
-   and (bee.block_enabled_expression_id is null or
-       (bee_rev.start_date \<= ai.created_at and (bee_rev.end_date is null or ai.created_at \< bee_rev.end_date)))
- order by fsb.form_section_id asc, fsb.display_order asc
+queryOrderedFormBlockDtosBySectionIdsAndInstanceGuid(sectionIds) ::= <<
+SELECT
+    fsb.form_section_id AS section_id,
+    null AS parent_block_id,
+    bt.block_type_code AS block_meta_block_type_code,
+    b.block_id AS block_meta_block_id,
+    b.block_guid AS block_meta_block_guid,
+    ev.expression_id AS sh_expr_expression_id,
+    ev.expression_guid AS sh_expr_expression_guid,
+    ev.expression_text AS sh_expr_expression_text,
+    ee.expression_id AS en_expr_expression_id,
+    ee.expression_guid AS en_expr_expression_guid,
+    ee.expression_text AS en_expr_expression_text
+FROM form_section__block AS fsb
+    JOIN revision AS rev ON rev.revision_id = fsb.revision_id
+    JOIN block AS b ON b.block_id = fsb.block_id
+    JOIN block_type AS bt ON bt.block_type_id = b.block_type_id
+    LEFT JOIN block__expression AS bev ON bev.block_id = b.block_id
+    LEFT JOIN expression AS ev ON ev.expression_id = bev.expression_id
+    LEFT JOIN revision AS bev_rev ON bev_rev.revision_id = bev.revision_id
+    LEFT JOIN block_enabled_expression AS bee ON bee.block_id = b.block_id
+    LEFT JOIN expression AS ee ON ee.expression_id = bee.expression_id
+    LEFT JOIN revision AS bee_rev ON bee_rev.revision_id = bee.revision_id
+    JOIN activity_instance AS ai ON ai.activity_instance_guid = :instanceGuid
+WHERE fsb.form_section_id in (<sectionIds>)
+   AND rev.start_date \<= ai.created_at
+   AND (rev.end_date IS null OR ai.created_at \< rev.end_date)
+   AND (bev.block__expression_id IS null
+        OR (bev_rev.start_date \<= ai.created_at 
+            AND (bev_rev.end_date IS null OR ai.created_at \< bev_rev.end_date)))
+   AND (bee.block_enabled_expression_id IS null
+        OR (bee_rev.start_date \<= ai.created_at
+            AND (bee_rev.end_date IS null OR ai.created_at \< bee_rev.end_date)))
+ORDER BY fsb.form_section_id asc, fsb.display_order asc
+>>
+
+queryOrderedFormBlockDtosBySectionIdsAndTimestamp(sectionIds) ::= <<
+SELECT
+    fsb.form_section_id AS section_id,
+    null AS parent_block_id,
+    bt.block_type_code AS block_meta_block_type_code,
+    b.block_id AS block_meta_block_id,
+    b.block_guid AS block_meta_block_guid,
+    ev.expression_id AS sh_expr_expression_id,
+    ev.expression_guid AS sh_expr_expression_guid,
+    ev.expression_text AS sh_expr_expression_text,
+    ee.expression_id AS en_expr_expression_id,
+    ee.expression_guid AS en_expr_expression_guid,
+    ee.expression_text AS en_expr_expression_text
+FROM form_section__block AS fsb
+    JOIN revision AS rev ON rev.revision_id = fsb.revision_id
+    JOIN block AS b ON b.block_id = fsb.block_id
+    JOIN block_type AS bt ON bt.block_type_id = b.block_type_id
+    LEFT JOIN block__expression AS bev ON bev.block_id = b.block_id
+    LEFT JOIN expression AS ev ON ev.expression_id = bev.expression_id
+    LEFT JOIN revision AS bev_rev ON bev_rev.revision_id = bev.revision_id
+    LEFT JOIN block_enabled_expression AS bee ON bee.block_id = b.block_id
+    LEFT JOIN expression AS ee ON ee.expression_id = bee.expression_id
+    LEFT JOIN revision AS bee_rev ON bee_rev.revision_id = bee.revision_id
+WHERE fsb.form_section_id IN (<sectionIds>)
+    AND rev.start_date \<= :timestamp
+    AND (rev.end_date IS null OR :timestamp \< rev.end_date)
+    AND (bev.block__expression_id IS null
+        OR (bev_rev.start_date \<= :timestamp
+            AND (bev_rev.end_date IS null OR :timestamp \< bev_rev.end_date)))
+    AND (bee.block_enabled_expression_id IS null
+        OR (bee_rev.start_date \<= :timestamp
+            AND (bee_rev.end_date IS null OR :timestamp \< bee_rev.end_date)))
+ORDER BY fsb.form_section_id asc, fsb.display_order asc
 >>


### PR DESCRIPTION
DDP-8539

## Context

This PR exposes the complete expression objects used in the various Block types.

* Fixes a bug where a pre-existing and valid id is being used for all newly instantiated Expression objects using the `Expression(String)` constructor.
* Updates SQL statements to include the ID and GUID of the `shown` and `enabled` PEX expressions associated with a block
* Exposes nested Expression objects on Block DTOs.
* Updates necessary methods to pass this information forward to the various `Def` classes.
