### PR TITLE
DDP-7866: fixing edge case around text question handling (DSM)

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -113,8 +113,11 @@ public class FilterExportConfig {
                 }
             }
         }
-        options.stream().filter(opt -> (boolean) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_ALLOWED, false))
-                .forEach(opt -> optionIdsWithDetails.add((String) opt.get(ESObjectConstants.OPTION_STABLE_ID)));
+        if (options instanceof List) {
+            options.stream().filter(opt -> (boolean) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_ALLOWED, false))
+                    .forEach(opt -> optionIdsWithDetails.add((String) opt.get(ESObjectConstants.OPTION_STABLE_ID)));
+        }
+
         return options;
     }
 


### PR DESCRIPTION
## Context

This fixes a bug Kiara identified where for some questions, if options were not specified in the question definition, the export would fail with a NPE. 

TO TEST:
1. open DSM, on the PanCan study, go to participant list
2. export using the default options
3. confirm the export completes successfully
