### PR TITLE
DDP-8628: supporting human-readable export format

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/QuestionType.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/QuestionType.java
@@ -9,6 +9,7 @@ public enum QuestionType {
     MATRIX("MATRIX"),
     DATE("DATE"),
     OPTIONS("OPTIONS"),
+    PICKLIST("PICKLIST"),
     TEXT("TEXT"),
     JSON_ARRAY("JSON_ARRAY"),
     RADIO("RADIO");

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -21,6 +21,7 @@ public class FilterExportConfig {
     private final ModuleExportConfig parent;
     private final String type;
     private boolean splitOptionsIntoColumns = false;
+    private boolean stableIdsForOptions = true;
     private Set<String> optionIdsWithDetails = new HashSet<String>();
     private String collationSuffix = null;
     private Map<String, Object> questionDef = null;
@@ -33,12 +34,13 @@ public class FilterExportConfig {
     private boolean allowMultiple = false;
     private String questionType = null;
 
-    public FilterExportConfig(ModuleExportConfig parent, Filter filterColumn, boolean splitOptionsIntoColumns,
+    public FilterExportConfig(ModuleExportConfig parent, Filter filterColumn, boolean splitOptionsIntoColumns, boolean stableIdsForOptions,
                               String collationSuffix, Map<String, Object> questionDef, int questionIndex) {
         this.column = filterColumn.getParticipantColumn();
         this.type = filterColumn.getType();
         this.parent = parent;
         this.splitOptionsIntoColumns = splitOptionsIntoColumns;
+        this.stableIdsForOptions = stableIdsForOptions;
         this.collationSuffix = collationSuffix;
         this.questionIndex = questionIndex;
         this.questionDef = questionDef;
@@ -80,7 +82,7 @@ public class FilterExportConfig {
 
         this.questionDef = childQuestion;
         this.options = getOptionsForQuestion(childQuestion, optionIdsWithDetails);
-
+        this.stableIdsForOptions = parent.isStableIdsForOptions();
     }
 
     public boolean isAllowMultiple(Map<String, Object> questionDef) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -45,7 +45,7 @@ public class FilterExportConfig {
         this.allowMultiple = isAllowMultiple(questionDef);
         this.questionType = this.type;
         if (this.questionDef != null) {
-            this.options = getOptionsForQuestion(questionDef);
+            this.options = getOptionsForQuestion(questionDef, optionIdsWithDetails);
             this.questionType = (String) questionDef.get(ESObjectConstants.QUESTION_TYPE);
         }
         List<Map<String, Object>> childQuestions = getChildQuestions();
@@ -79,7 +79,7 @@ public class FilterExportConfig {
         this.column.setDisplay(childDisplayText);
 
         this.questionDef = childQuestion;
-        this.options = getOptionsForQuestion(childQuestion);
+        this.options = getOptionsForQuestion(childQuestion, optionIdsWithDetails);
 
     }
 
@@ -101,7 +101,7 @@ public class FilterExportConfig {
         return optionIdsWithDetails.size() > 0;
     }
 
-    private List<Map<String, Object>> getOptionsForQuestion(Map<String, Object> questionDef) {
+    private List<Map<String, Object>> getOptionsForQuestion(Map<String, Object> questionDef, Set<String> optionIdsWithDetails) {
         List<Map<String, Object>> options = (List<Map<String, Object>>) questionDef.get(ESObjectConstants.OPTIONS);
         if (questionDef.containsKey(ESObjectConstants.OPTION_GROUPS)) {
             Object groups = questionDef.get(ESObjectConstants.OPTION_GROUPS);
@@ -113,6 +113,8 @@ public class FilterExportConfig {
                 }
             }
         }
+        options.stream().filter(opt -> (boolean) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_ALLOWED, false))
+                .forEach(opt -> optionIdsWithDetails.add((String) opt.get(ESObjectConstants.OPTION_STABLE_ID)));
         return options;
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/FilterExportConfig.java
@@ -113,8 +113,11 @@ public class FilterExportConfig {
                 }
             }
         }
-        options.stream().filter(opt -> (boolean) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_ALLOWED, false))
-                .forEach(opt -> optionIdsWithDetails.add((String) opt.get(ESObjectConstants.OPTION_STABLE_ID)));
+        if (options instanceof List) {
+            options.stream().filter(opt -> (boolean) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_ALLOWED, false))
+                    .forEach(opt -> optionIdsWithDetails.add((String) opt.get(ESObjectConstants.OPTION_STABLE_ID)));
+        }
+
         return options;
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
@@ -1,16 +1,17 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular;
 
+import org.broadinstitute.dsm.model.elastic.export.tabular.renderer.ValueProviderFactory;
+import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.statics.ESObjectConstants;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import org.broadinstitute.dsm.model.elastic.export.tabular.renderer.ValueProviderFactory;
-import org.broadinstitute.dsm.statics.DBConstants;
-import org.broadinstitute.dsm.statics.ESObjectConstants;
 
 /** base class for taking a String=>String map of participant data and writing out a tabular file
  * It is designed to work with the outputs from TabularParticipantParser
@@ -208,7 +209,7 @@ public abstract class TabularParticipantExporter {
         } else {
             colFunc.apply(filterConfig, activityRepeatNum, questionRepeatNum, null, null, parentConfig);
             if (filterConfig.hasAnyOptionDetails()) {
-                colFunc.apply(filterConfig, activityRepeatNum, questionRepeatNum, null, "DETAIL", parentConfig);
+            colFunc.apply(filterConfig, activityRepeatNum, questionRepeatNum, Collections.EMPTY_MAP, "DETAIL", parentConfig);
             }
         }
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantExporter.java
@@ -64,7 +64,7 @@ public abstract class TabularParticipantExporter {
 
     protected static String getColumnDisplayText(FilterExportConfig filterConfig, Map<String, Object> opt, String detailName) {
         if (detailName != null) {
-            return "additional detail";
+            return (String) opt.getOrDefault(ESObjectConstants.OPTION_DETAILS_TEXT, "additional details");
         } else if (opt != null) {
             return (String) opt.get(ESObjectConstants.OPTION_TEXT);
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -13,7 +13,13 @@ import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.stream.Collectors;
 
 /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParser.java
@@ -1,14 +1,5 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.export.WorkflowAndFamilyIdExporter;
@@ -21,6 +12,9 @@ import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Parses a list of ParticipantDtos from elasticSearch into a map of column names to string values.
@@ -37,16 +31,16 @@ public class TabularParticipantParser {
     private static final String COLUMN_UNSELECTED = "0";
     private final List<Filter> filters;
     private final DDPInstance ddpInstance;
-    private final boolean splitOptions;
+    private final boolean humanReadable;
     private final boolean onlyMostRecent;
     private final List<String> nestedArrayObjects = Arrays.asList(ESObjectConstants.KIT_TEST_RESULT);
     private  Map<String, Map<String, Object>> activityDefs;
 
-    public TabularParticipantParser(List<Filter> filters, DDPInstance ddpInstance, boolean splitOptions, boolean onlyMostRecent,
+    public TabularParticipantParser(List<Filter> filters, DDPInstance ddpInstance, boolean humanReadable, boolean onlyMostRecent,
                                     Map<String, Map<String, Object>> activityDefs) {
         this.filters = filters;
         this.ddpInstance = ddpInstance;
-        this.splitOptions = splitOptions;
+        this.humanReadable = humanReadable;
         this.onlyMostRecent = onlyMostRecent;
         if (activityDefs == null) {
             activityDefs = ElasticSearchUtil.getActivityDefinitions(ddpInstance);
@@ -94,7 +88,7 @@ public class TabularParticipantParser {
                 if (ESObjectConstants.OPTIONS_TYPE.equals(filter.getType())) {
                     if (questionDef != null) {
                         // create a column for each option if it's a multiselect
-                        splitChoicesIntoColumns = splitOptions
+                        splitChoicesIntoColumns = !humanReadable
                                 && ESObjectConstants.MULTIPLE.equals(questionDef.get(ESObjectConstants.SELECT_MODE));
                     }
                 }
@@ -106,7 +100,7 @@ public class TabularParticipantParser {
                         .findFirst()
                         .orElse(null);
 
-                FilterExportConfig colConfig = new FilterExportConfig(moduleExport, filter, splitChoicesIntoColumns,
+                FilterExportConfig colConfig = new FilterExportConfig(moduleExport, filter, splitChoicesIntoColumns, !humanReadable,
                         collationSuffix, questionDef, questionIndex);
                 if (collationSuffix != null) {
                     if (collationColumnMap.containsKey(collationSuffix)) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/PickListValueProvider.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/PickListValueProvider.java
@@ -1,19 +1,19 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.model.elastic.export.tabular.FilterExportConfig;
+import org.broadinstitute.dsm.statics.ESObjectConstants;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsm.model.elastic.export.tabular.FilterExportConfig;
-import org.broadinstitute.dsm.statics.ESObjectConstants;
-
 public class PickListValueProvider extends TextValueProvider {
     @Override
     public List<String> formatRawValues(List<?> rawValues, FilterExportConfig filterConfig, Map<String, Object> formMap) {
-        if (filterConfig.getOptions() == null || filterConfig.isSplitOptionsIntoColumns()) {
-            // return the defaults (stableId), so they can be matched for the multicolumn format
+        if (filterConfig.getOptions() == null || filterConfig.isSplitOptionsIntoColumns() || filterConfig.isStableIdsForOptions() ) {
+            // return the text as-is (which are stableIds), so they can be matched for the multicolumn format or rendered directly
             return super.formatRawValues(rawValues, filterConfig, formMap);
         }
         // attempt to return the user-visible text, rather than the stableId

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/tabular/renderer/ValueProviderFactory.java
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsm.model.elastic.export.tabular.renderer;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.model.QuestionType;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 public class ValueProviderFactory {
     private static final String AMBULATION = "AMBULATION";
@@ -24,6 +24,7 @@ public class ValueProviderFactory {
             Map.entry(QuestionType.MATRIX, defaultValueProvider),
             Map.entry(QuestionType.DATE, new DateValueProvider()),
             Map.entry(QuestionType.OPTIONS, pickListValueProvider),
+            Map.entry(QuestionType.PICKLIST, pickListValueProvider),
             Map.entry(QuestionType.JSON_ARRAY, defaultValueProvider),
             Map.entry(QuestionType.RADIO, pickListValueProvider)
     );

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/DownloadParticipantListParams.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/DownloadParticipantListParams.java
@@ -1,17 +1,17 @@
 package org.broadinstitute.dsm.model.participant;
 
-import java.util.Arrays;
-import java.util.List;
-
 import lombok.Getter;
 import lombok.Setter;
 import spark.QueryParamsMap;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Getter
 @Setter
 public class DownloadParticipantListParams {
     public static final List<String> allowedFileFormats = Arrays.asList("tsv", "xlsx");
-    private boolean splitOptions = true;
+    private boolean humanReadable = true;
     private boolean onlyMostRecent = false;
     private String fileFormat = "tsv";
 
@@ -22,8 +22,8 @@ public class DownloadParticipantListParams {
                 fileFormat = fileFormatParam;
             }
         }
-        if (paramMap.hasKey("splitOptions")) {
-            splitOptions = Boolean.valueOf(paramMap.get("splitOptions").value());
+        if (paramMap.hasKey("humanReadable")) {
+            humanReadable = Boolean.valueOf(paramMap.get("humanReadable").value());
         }
         if (paramMap.hasKey("onlyMostRecent")) {
             onlyMostRecent = Boolean.valueOf(paramMap.get("onlyMostRecent").value());

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/DownloadParticipantListRoute.java
@@ -1,15 +1,5 @@
 package org.broadinstitute.dsm.route;
 
-import static org.broadinstitute.dsm.util.ElasticSearchUtil.DEFAULT_FROM;
-import static org.broadinstitute.dsm.util.ElasticSearchUtil.MAX_RESULT_SIZE;
-
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
 import com.google.common.net.MediaType;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.model.elastic.export.tabular.DataDictionaryExporter;
@@ -35,6 +25,15 @@ import spark.QueryParamsMap;
 import spark.Request;
 import spark.Response;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.broadinstitute.dsm.util.ElasticSearchUtil.DEFAULT_FROM;
+import static org.broadinstitute.dsm.util.ElasticSearchUtil.MAX_RESULT_SIZE;
+
 public class DownloadParticipantListRoute extends RequestHandler {
 
     private static final Logger logger = LoggerFactory.getLogger(DownloadParticipantListRoute.class);
@@ -58,7 +57,7 @@ public class DownloadParticipantListRoute extends RequestHandler {
         DDPInstance instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.MEDICAL_RECORD_ACTIVATED);
 
         TabularParticipantParser parser = new TabularParticipantParser(payload.getColumnNames(), instance,
-                params.isSplitOptions(), params.isOnlyMostRecent(), null);
+                params.isHumanReadable(), params.isOnlyMostRecent(), null);
         setResponseHeaders(response, realm + "_export.zip");
 
         Filterable filterable = FilterFactory.of(request);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ESObjectConstants.java
@@ -100,6 +100,8 @@ public class ESObjectConstants {
     public static final String OPTIONDETAILS = "optionDetails";
     public static final String OPTION_TEXT = "optionText";
     public static final String OPTION_STABLE_ID = "optionStableId";
+    public static final String OPTION_DETAILS_ALLOWED = "isDetailsAllowed";
+    public static final String OPTION_DETAILS_TEXT = "detailsText";
     public static final String OPTION = "option";
     public static final String OPTIONS = "options";
     public static final String ALLOW_MULTIPLE = "allowMultiple";

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParserTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParserTest.java
@@ -29,6 +29,9 @@ public class TabularParticipantParserTest {
             "r", null, "ADDITIONALVALUE", "Patient notes");
     private static final Filter PROXY_EMAIL_FILTER = buildFilter("email", "proxy", null, "TEXT", "Email");
 
+    private static final Filter ALLERGIES_FILTER = buildFilter("ALLERGY_DESCRIPTION",
+            "MEDICAL_HISTORY", "questionsAnswers", "TEXT", "describe any allergies");
+
     @Test
     public void testBasicConfigGeneration() throws IOException {
         Assert.assertNotEquals(2, 1);
@@ -60,6 +63,15 @@ public class TabularParticipantParserTest {
     }
 
     @Test
+    public void testTextQuestionParsing() throws IOException {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(ALLERGIES_FILTER), null,
+                true, true, SIMPLE_HISTORY_DEF);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(SIMPLE_PARTICIPANT));
+        assertEquals("text values not rendered correctly", "minor pollen allergy", participantValueMaps.get(0).get("MEDICAL_HISTORY.ALLERGY_DESCRIPTION"));
+    }
+
+    @Test
     public void testSingleSelectParsing() throws IOException {
         TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(INCONTINENCE_FILTER), null,
                 true, true, ATCP_ACTIVITY_DEFS);
@@ -79,7 +91,7 @@ public class TabularParticipantParserTest {
         assertEquals("Mutliselect value not rendered", "0", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN"));
 
         assertEquals("option details not rendered", "71", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES_DETAIL"));
-        assertEquals("option details not rendered", null, pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN_DETAIL"));
+        assertEquals("option details not rendered", "", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN_DETAIL"));
     }
 
     @Test
@@ -142,6 +154,7 @@ public class TabularParticipantParserTest {
                 "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES",
                 "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES_DETAIL",
                 "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN",
+                "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN_DETAIL",
                 "MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME",
                 "MEDICAL_HISTORY.MEDICATION_CATEGORY.BEGAN_TAKING_AT_AGE",
                 "MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME_2",
@@ -153,8 +166,9 @@ public class TabularParticipantParserTest {
                 "First Name",
                 "describe incontinence",
                 "eye",
-                "additional detail",
+                "age of onset",
                 "skin",
+                "age of onset",
                 "MEDICATION_NAME",
                 "BEGAN_TAKING_AT_AGE",
                 "MEDICATION_NAME",
@@ -168,6 +182,7 @@ public class TabularParticipantParserTest {
                 "1",
                 "71",
                 "0",
+                "",
                 "med1",
                 "39",
                 "med2",
@@ -183,7 +198,38 @@ public class TabularParticipantParserTest {
         return filter;
     }
 
+    private static final Map<String, Map<String, Object>> SIMPLE_HISTORY_DEF = Map.of(
+            "MEDICAL_HISTORY_V1", Map.of(
+                    "activityCode", "MEDICAL_HISTORY",
+                    "questions", Arrays.asList(
+                            new HashMap(Map.of(
+                                    "stableId", "ALLERGY_DESCRIPTION",
+                                    "questionType", "TEXT",
+                                    "questionText", "Describe any allergies"
+                            ))
+                    )
+            )
+    );
 
+    private static final Map<String, Object> SIMPLE_PARTICIPANT = Map.of(
+            "ddp", "basic",
+            "profile", Map.of(
+                    "firstName", "Simple",
+                    "lastName", "Person",
+                    "hruid", "PKSSSS"
+            ),
+            "activities", Arrays.asList(
+                    Map.of(
+                            "activityCode", "MEDICAL_HISTORY",
+                            "questionsAnswers", Arrays.asList(
+                                    Map.of(
+                                            "stableId", "ALLERGY_DESCRIPTION",
+                                            "answer", "minor pollen allergy"
+                                    )
+                            )
+                    )
+            )
+    );
 
     private static final Map<String, Object> ATCP_MEDICAL_HISTORY_DEF = Map.of(
             "activityCode", "MEDICAL_HISTORY",
@@ -208,9 +254,13 @@ public class TabularParticipantParserTest {
                             "questionText", "Telangiectasia (choose all that apply)",
                             "options", Arrays.asList(
                                     Map.of("optionStableId", "TELANGIECTASIA_EYES",
-                                            "optionText", "eye"),
+                                            "optionText", "eye",
+                                            "isDetailsAllowed", true,
+                                            "detailsText", "age of onset"),
                                     Map.of("optionStableId", "TELANGIECTASIA_SKIN",
-                                            "optionText", "skin")
+                                            "optionText", "skin",
+                                            "isDetailsAllowed", true,
+                                            "detailsText", "age of onset")
                             )
 
                     )),
@@ -267,11 +317,16 @@ public class TabularParticipantParserTest {
                                                     Arrays.asList("med1", "39"),
                                                     Arrays.asList("med2", "18")
                                             )
+                                    ),
+                                    Map.of(
+                                            "stableId", "ALLERGY_DESCRIPTION",
+                                            "answer", "minor pollen allergy"
                                     )
                             )
                     )
             )
     );
+
 
     private static final Map<String, Object> TEST_SINGULAR_PARTICIPANT = Map.of(
             "ddp", "atcp",

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParserTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/tabular/TabularParticipantParserTest.java
@@ -5,6 +5,7 @@ import org.broadinstitute.dsm.model.ParticipantColumn;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -16,12 +17,17 @@ public class TabularParticipantParserTest {
     private static final Filter DDP_FILTER = buildFilter("ddp", "data", null, "TEXT", "DDP");
     private static final Filter HRUID_FILTER = buildFilter("hruid", "data", "profile", "TEXT", "Short ID");
     private static final Filter FIRST_NAME_FILTER= buildFilter("firstName", "data", "profile", "TEXT", "First Name");
+    private static final Filter EMAIL_FILTER= buildFilter("email", "data", "profile", "TEXT", "Email");
     private static final Filter INCONTINENCE_FILTER = buildFilter("INCONTINENCE",
             "MEDICAL_HISTORY", "questionsAnswers", "OPTIONS", "describe incontinence");
     private static final Filter TELANGIECTASIA_FILTER = buildFilter("TELANGIECTASIA",
             "MEDICAL_HISTORY", "questionsAnswers", "OPTIONS", "Telangiectasia: choose all that apply");
     private static final Filter MEDICATION_CATEGORY_FILTER = buildFilter("MEDICATION_CATEGORY",
             "MEDICAL_HISTORY", "questionsAnswers", "COMPOSITE", "MEDICATION_CATEGORY");
+
+    private static final Filter SINGULAR_NOTES_FILTER = buildFilter("singularNotes",
+            "r", null, "ADDITIONALVALUE", "Patient notes");
+    private static final Filter PROXY_EMAIL_FILTER = buildFilter("email", "proxy", null, "TEXT", "Email");
 
     @Test
     public void testBasicConfigGeneration() throws IOException {
@@ -40,6 +46,133 @@ public class TabularParticipantParserTest {
                 .collect(Collectors.toList());
         Assert.assertEquals("questions should be in order of appearance in activity def.",
                 Arrays.asList("INCONTINENCE", "TELANGIECTASIA", "MEDICATION_CATEGORY"), historyQuestionIds);
+    }
+
+    @Test
+    public void testDdpParsing() {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(DDP_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_ATCP_PARTICIPANT));
+        // should be sorted into two modules -- data and profile
+        assertEquals("correct number of participants not extracted", 1, participantValueMaps.size());
+        assertEquals("DDP instance name not parsed", "atcp", participantValueMaps.get(0).get("DATA.DDP"));
+    }
+
+    @Test
+    public void testSingleSelectParsing() throws IOException {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(INCONTINENCE_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_ATCP_PARTICIPANT));
+        assertEquals("single select value not correct", "Occasional (up to two times per week)", participantValueMaps.get(0).get("MEDICAL_HISTORY.INCONTINENCE"));
+    }
+
+    @Test
+    public void testMultiselectParsing() {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(TELANGIECTASIA_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_ATCP_PARTICIPANT));
+        Map<String, String> pMap = participantValueMaps.get(0);
+        assertEquals("Mutliselect value not rendered", "1", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES"));
+        assertEquals("Mutliselect value not rendered", "0", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN"));
+
+        assertEquals("option details not rendered", "71", pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES_DETAIL"));
+        assertEquals("option details not rendered", null, pMap.get("MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN_DETAIL"));
+    }
+
+    @Test
+    public void testCompositeParsing() {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(MEDICATION_CATEGORY_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_ATCP_PARTICIPANT));
+        Map<String, String> pMap = participantValueMaps.get(0);
+        assertEquals("Composite value not rendered", "med1", pMap.get("MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME"));
+        assertEquals("Composite value not rendered", "39", pMap.get("MEDICAL_HISTORY.MEDICATION_CATEGORY.BEGAN_TAKING_AT_AGE"));
+
+        assertEquals("Composite value not rendered", "med2", pMap.get("MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME_2"));
+        assertEquals("Composite value not rendered", "18", pMap.get("MEDICAL_HISTORY.MEDICATION_CATEGORY.BEGAN_TAKING_AT_AGE_2"));
+    }
+
+    @Test
+    public void testProxyParsing() {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(PROXY_EMAIL_FILTER, EMAIL_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_SINGULAR_PARTICIPANT));
+        Map<String, String> pMap = participantValueMaps.get(0);
+        assertEquals("proxy email not rendered", "iamaproxy@gmail.com", pMap.get("PROFILE.PROXY.EMAIL"));
+        assertEquals("email not rendered", "participantEmail@gmail.com", pMap.get("PROFILE.EMAIL"));
+    }
+
+    @Test
+    public void testDsmDynamicValuesParsing() {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(SINGULAR_NOTES_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+        List<ModuleExportConfig> moduleConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(moduleConfigs, Collections.singletonList(TEST_SINGULAR_PARTICIPANT));
+        Map<String, String> pMap = participantValueMaps.get(0);
+        assertEquals("dynamic field not rendered", "admin entered notes", pMap.get("DSM.PARTICIPANT.RECORD.SINGULARNOTES"));
+    }
+
+    @Test
+    public void testExport() throws IOException {
+        TabularParticipantParser parser = new TabularParticipantParser(Arrays.asList(DDP_FILTER, HRUID_FILTER, FIRST_NAME_FILTER,
+                MEDICATION_CATEGORY_FILTER, INCONTINENCE_FILTER, TELANGIECTASIA_FILTER), null,
+                true, true, ATCP_ACTIVITY_DEFS);
+
+        List<ModuleExportConfig> exportConfigs = parser.generateExportConfigs();
+        List<Map<String, String>> participantValueMaps = parser.parse(exportConfigs, Collections.singletonList(TEST_ATCP_PARTICIPANT));
+
+        TabularParticipantExporter participantExporter = TabularParticipantExporter.getExporter(exportConfigs,
+                participantValueMaps, ".tsv");
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        participantExporter.export(os);
+        String exportText = os.toString("UTF-8");
+
+        String[] rows = exportText.split("\n");
+        assertEquals(3, rows.length);
+        String[] firstRowVals = rows[2].split("\t");
+        List<String> expectedHeaders = Arrays.asList("DATA.DDP",
+                "PROFILE.HRUID",
+                "PROFILE.FIRSTNAME",
+                "MEDICAL_HISTORY.INCONTINENCE",
+                "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES",
+                "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_EYES_DETAIL",
+                "MEDICAL_HISTORY.TELANGIECTASIA.TELANGIECTASIA_SKIN",
+                "MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME",
+                "MEDICAL_HISTORY.MEDICATION_CATEGORY.BEGAN_TAKING_AT_AGE",
+                "MEDICAL_HISTORY.MEDICATION_CATEGORY.MEDICATION_NAME_2",
+                "MEDICAL_HISTORY.MEDICATION_CATEGORY.BEGAN_TAKING_AT_AGE_2");
+        assertEquals(expectedHeaders, Arrays.asList(rows[0].split(TsvParticipantExporter.DELIMITER)));
+
+        List<String> expectedSubeaders = Arrays.asList("DDP",
+                "Short ID",
+                "First Name",
+                "describe incontinence",
+                "eye",
+                "additional detail",
+                "skin",
+                "MEDICATION_NAME",
+                "BEGAN_TAKING_AT_AGE",
+                "MEDICATION_NAME",
+                "BEGAN_TAKING_AT_AGE");
+        assertEquals(expectedSubeaders, Arrays.asList(rows[1].split(TsvParticipantExporter.DELIMITER)));
+
+        List<String> expectedValues = Arrays.asList("atcp",
+                "PKG8PA",
+                "Tester",
+                "Occasional (up to two times per week)",
+                "1",
+                "71",
+                "0",
+                "med1",
+                "39",
+                "med2",
+                "18");
+        assertEquals(expectedValues, Arrays.asList(rows[2].split(TsvParticipantExporter.DELIMITER)));
     }
 
     private static Filter buildFilter(String colName, String tableAlias, String objectName, String type, String display) {
@@ -62,7 +195,7 @@ public class TabularParticipantParserTest {
                             "questionText", "Please describe $ddp.participantFirstName()'s incontinence",
                             "options", Arrays.asList(
                                     Map.of("optionStableId", "INCONTINENCE_OCCASIONAL",
-                                    "optionText", "Occasional (up to two times per week)"),
+                                            "optionText", "Occasional (up to two times per week)"),
                                     Map.of("optionStableId", "FREQUENT",
                                             "optionText", "Frequent (more than two times per week)")
                             )
@@ -78,7 +211,7 @@ public class TabularParticipantParserTest {
                                             "optionText", "eye"),
                                     Map.of("optionStableId", "TELANGIECTASIA_SKIN",
                                             "optionText", "skin")
-                                    )
+                            )
 
                     )),
                     new HashMap(Map.of(
@@ -103,6 +236,68 @@ public class TabularParticipantParserTest {
             "MEDICAL_HISTORY_V1", ATCP_MEDICAL_HISTORY_DEF
     );
 
+    private static final Map<String, Object> TEST_ATCP_PARTICIPANT = Map.of(
+            "ddp", "atcp",
+            "profile", Map.of(
+                    "firstName", "Tester",
+                    "lastName", "atStudy",
+                    "hruid", "PKG8PA"
+            ),
+            "activities", Arrays.asList(
+                    Map.of(
+                            "activityCode", "MEDICAL_HISTORY",
+                            "questionsAnswers", Arrays.asList(
+                                    Map.of(
+                                            "stableId", "INCONTINENCE",
+                                            "answer", Arrays.asList("INCONTINENCE_OCCASIONAL")
+                                    ),
+                                    Map.of(
+                                            "stableId", "TELANGIECTASIA",
+                                            "answer", Arrays.asList("TELANGIECTASIA_EYES"),
+                                            "optionDetails", Arrays.asList(
+                                                    Map.of(
+                                                            "details", "71",
+                                                            "option", "TELANGIECTASIA_EYES"
+                                                    )
+                                            )
+                                    ),
+                                    Map.of(
+                                            "stableId", "MEDICATION_CATEGORY",
+                                            "answer", Arrays.asList(
+                                                    Arrays.asList("med1", "39"),
+                                                    Arrays.asList("med2", "18")
+                                            )
+                                    )
+                            )
+                    )
+            )
+    );
 
+    private static final Map<String, Object> TEST_SINGULAR_PARTICIPANT = Map.of(
+            "ddp", "atcp",
+            "profile", Map.of(
+                    "firstName", "Tester",
+                    "lastName", "atStudy",
+                    "hruid", "PKG8PS",
+                    "email", "participantEmail@gmail.com"
+            ),
+            "dsm", Map.of(
+                    "participant", Map.of(
+                            "dynamicFields", Map.of(
+                                    "singularNotes", "admin entered notes",
+                                    "singularEnrollmentStatus", "NOT_ENROLLED"
+                            )
+                    )
+            ),
+            "proxyData", Arrays.asList(
+                    Map.of(
+                            "ddp", "singular",
+                            "profile", Map.of(
+                                    "firstName", "Proxier",
+                                    "email", "iamaproxy@gmail.com"
+                            )
+                    )
+            )
+    );
 }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/collectors/PicklistQuestionFormatStrategy.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/collectors/PicklistQuestionFormatStrategy.java
@@ -60,9 +60,7 @@ public class PicklistQuestionFormatStrategy implements ResponseFormatStrategy<Pi
             String groupTxt = HtmlConverter.getPlainText(group.getNameTemplate().renderWithDefaultValues("en"));
             List<Object> options = new ArrayList<>();
             for (PicklistOptionDef optionDef : group.getOptions()) {
-                Map<String, String> stableIdTxt = new HashMap<>();
-                stableIdTxt.put("optionStableId", optionDef.getStableId());
-                stableIdTxt.put("optionText", HtmlConverter.getPlainText(optionDef.getOptionLabelTemplate().renderWithDefaultValues("en")));
+                Map<String, Object> stableIdTxt = makeOptionDefMap(optionDef);
                 options.add(stableIdTxt);
             }
             groupDef.put("groupStableId", groupStableId);
@@ -74,9 +72,7 @@ public class PicklistQuestionFormatStrategy implements ResponseFormatStrategy<Pi
 
         List<Object> options = new ArrayList<>();
         for (PicklistOptionDef optionDef : definition.getPicklistOptions()) {
-            Map<String, Object> stableIdTxt = new HashMap<>();
-            stableIdTxt.put("optionStableId", optionDef.getStableId());
-            stableIdTxt.put("optionText", HtmlConverter.getPlainText(optionDef.getOptionLabelTemplate().renderWithDefaultValues("en")));
+            Map<String, Object> stableIdTxt = makeOptionDefMap(optionDef);
 
             //add nested options
             if (CollectionUtils.isNotEmpty(optionDef.getNestedOptions())) {
@@ -86,10 +82,7 @@ public class PicklistQuestionFormatStrategy implements ResponseFormatStrategy<Pi
                 }
                 List<Object> nestedOptions = new ArrayList<>();
                 for (PicklistOptionDef suboptionDef : optionDef.getNestedOptions()) {
-                    Map<String, String> suboptStableIdTxt = new HashMap<>();
-                    suboptStableIdTxt.put("optionStableId", suboptionDef.getStableId());
-                    suboptStableIdTxt.put("optionText",
-                            HtmlConverter.getPlainText(suboptionDef.getOptionLabelTemplate().renderWithDefaultValues("en")));
+                    Map<String, Object> suboptStableIdTxt = makeOptionDefMap(suboptionDef);
                     nestedOptions.add(suboptStableIdTxt);
                 }
                 stableIdTxt.put("nestedOptions", nestedOptions);
@@ -98,6 +91,17 @@ public class PicklistQuestionFormatStrategy implements ResponseFormatStrategy<Pi
         }
         props.put("options", options);
         return props;
+    }
+
+    private Map<String, Object> makeOptionDefMap(PicklistOptionDef optionDef) {
+        Map<String, Object> stableIdTxt = new HashMap<>();
+        stableIdTxt.put("optionStableId", optionDef.getStableId());
+        stableIdTxt.put("optionText", HtmlConverter.getPlainText(optionDef.getOptionLabelTemplate().renderWithDefaultValues("en")));
+        if (optionDef.isDetailsAllowed()) {
+            stableIdTxt.put("isDetailsAllowed", optionDef.isDetailsAllowed());
+            stableIdTxt.put("detailsText", HtmlConverter.getPlainText(optionDef.getDetailLabelTemplate().renderWithDefaultValues("en")));
+        }
+        return stableIdTxt;
     }
 
     @Override

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/export/collectors/PicklistQuestionFormatStrategyTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/export/collectors/PicklistQuestionFormatStrategyTest.java
@@ -105,6 +105,28 @@ public class PicklistQuestionFormatStrategyTest {
         assertEquals("This is op1 details, with lots of stuff.", actual.get("sid_op1_DETAILS"));
     }
 
+    @Test
+    public void questionDefExport() {
+        PicklistQuestionDef def = PicklistQuestionDef.buildMultiSelect(PicklistRenderMode.LIST, "sid", Template.text(""))
+                .addOption(new PicklistOptionDef("op1", Template.text("has"), Template.text("details 1")))
+                .addOption(new PicklistOptionDef("op2", Template.text("no details")))
+                .addOption(new PicklistOptionDef("op3", Template.text("has"), Template.text("details 2")))
+                .build();
+
+        Map<String, Object> defExport = fmt.questionDef(def);
+        assertEquals(Map.of(
+                "isDetailsAllowed", true,
+                "detailsText", "details 1",
+                "optionText", "has",
+                "optionStableId", "op1"),
+                ((List) defExport.get("options")).get(0));
+
+        assertEquals(Map.of(
+                        "optionText", "no details",
+                        "optionStableId", "op2"),
+                ((List) defExport.get("options")).get(1));
+    }
+
     private PicklistQuestionDef buildQuestion() {
         return PicklistQuestionDef.buildMultiSelect(PicklistRenderMode.LIST, "sid", Template.text(""))
                 .addOption(new PicklistOptionDef("op1", Template.text("has"), Template.text("details")))


### PR DESCRIPTION
We would like to give the users an explicit choice between human readable and analysis friendly formatting.  This adds a single new variable "humanReadable" which consolidates a choice between splitting multiselect questions into multiple columns, and rendering option stable ids vs. the display text.  This also merges some bugfixes and test improvements from develop

This is paired with  https://github.com/broadinstitute/ddp-angular/pull/1658

TO TEST:
1. open the participant list for the AT study
2. customize view to include the Medical History "telangiectasia" question
3. export the participant list, selecting "analysis-friendly" 
4. confirm the telangiectasia responses are split into 4 columns - 1 each for eyes and skin, and 1 for each of the supporting details
5. export the participant list again, selecting "human-readable"
6. confirm the telangiectasia responses are shown in two columns -- one showing the main responses as dispaly text, and the other showing the consolidated details 