### PR TITLE
DDP-8050: changing variables to not being capitalized

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/mercury/ActionRequestMessage.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/mercury/ActionRequestMessage.java
@@ -10,10 +10,10 @@ public class ActionRequestMessage {
     }
 
     class ActionRequest {
-        @SerializedName("Action")
+        @SerializedName("action")
         String action = "CheckStatus";
 
-        @SerializedName("OrderID")
+        @SerializedName("orderID")
         String orderId;
 
         public ActionRequest(String orderId) {


### PR DESCRIPTION
in specification doc the variables where capital but should be lowercase 