### PR TITLE
DDP-8587: checkAnswer NPE if no answer is selected

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/RenderValueProvider.java
@@ -215,13 +215,20 @@ public class RenderValueProvider {
     }
 
     /**
-     * checkAnswer
-     *
-     * @param questionStableId the question stable id
-     * @param optionStableId    the option stable Id
-     * @param stringIfMatches    string if question is answered with option stable Id
-     * @param stringOtherwise    string if question is not answered with option stable Id
-     * @return string stringIfMatches or stringOtherwise
+     * Returns a string value depending on whether a specified PICKLIST question's option
+     * is selected or not.
+     * 
+     * <p>If {@link useDefaultsForDdpMethods} is true, this method will always return
+     * a value of the form "stringIfMatches/stringOtherwise".
+     * 
+     * <p>If an activity does not have a response,
+     * or the question does not have an associated answer, a match will be assumed,
+     * and the `stringIfMatches` value will be returned.
+     * @param questionStableId  the stable id of the PICKLIST question
+     * @param optionStableId    the stable id of the option to check
+     * @param stringIfMatches    string to return if the option is selected, or there is no answer
+     * @param stringOtherwise    string to return if the option is not selected
+     * @return the string value based on the option's selected state
      */
     public String checkAnswer(String questionStableId, String optionStableId,
                               String stringIfMatches, String stringOtherwise) {
@@ -230,11 +237,8 @@ public class RenderValueProvider {
             return String.format("%s/%s", stringIfMatches, stringOtherwise);
         }
 
-        // Defaulting to `true` if the activity or question does not
-        // have a response or answer (respectively). This behavior is currently
-        // expected and relied upon in some templates (a notable example being
-        // in the About Me/About My Child activity names in Singular)
-        //
+        // Defaulting to `true` is intentional- a null response or answer
+        // is assumed to be "selected"
         // (bskinner 2022.08.25)
         var optionIsSelected = true;
 


### PR DESCRIPTION
DDP-8587

## Context

This PR fixes a bug in the `RenderValueProvider.checkAnswer(String,String,String,String)` method (used by the `$ddp.checkAnswer` macro) where a `NullPointerException` would be thrown in the event that an answer for the checked Stable ID was not present in the `FormResponse` context.

Existing behavior was to consider the option as selected, and return the `stringIfMatches` value, if there was no response recorded for the activity (`formResponse == null`). This existing behavior has been extended to also apply to the previously undefined case of a missing answer.

## Testing
See [DDP-8587](https://broadinstitute.atlassian.net/browse/DDP-8587) for reproduction instructions.

## Additional Notes
The below is the appearance of the activity names on the Singular Dashboard after the fix. The value of the titles are controlled by checking which option is selected in the `PATIENT_SURVEY_WHO_ENROLLING_HIDDEN` question (the `en` template is given below)
```
 "name": "About $ddp.checkAnswer(\"ABOUT_PATIENT_WHO_ENROLLING_HIDDEN\",\"CHILD\", \"My Child\", \"Me\")",
```
![Screen Shot 2022-08-25 at 16 34 16](https://user-images.githubusercontent.com/274456/186764608-22a70a9e-6386-4bca-bd67-9de59a63250f.png)