### PR TITLE
DDP-8414 Fix Auth0 logo proportions

### DIFF
--- a/pepper-apis/studybuilder-cli/tenants/singular/pages/login.html
+++ b/pepper-apis/studybuilder-cli/tenants/singular/pages/login.html
@@ -736,7 +736,7 @@
 
       #ddp-header .auth0-lock-header-logo {
         max-width: 100%;
-        height: 60px;
+        height: 48px;
         margin-bottom: 10px;
       }
 

--- a/pepper-apis/studybuilder-cli/tenants/singular/pages/password_reset.html
+++ b/pepper-apis/studybuilder-cli/tenants/singular/pages/password_reset.html
@@ -236,7 +236,7 @@
 
       #ddp-header .auth0-lock-header-logo {
         max-width: 100%;
-        height: 60px;
+        height: 48px;
         margin-bottom: 10px;
       }
     </style>


### PR DESCRIPTION
Corrected Auth0 logo image proportions (according to [DDP-8414 comment](https://broadinstitute.atlassian.net/browse/DDP-8414?focusedCommentId=1336238)).

**_Before fix:_** 
![qq1](https://user-images.githubusercontent.com/7396837/186912220-479edb7a-efec-4b54-b5d3-56569349e6e6.png)


**_After fix:_** 

![qq2](https://user-images.githubusercontent.com/7396837/186912250-5b66d951-6eaa-41e4-b052-5d43f9854752.png)
