### PR TITLE
[DSM] DDP-8656: fixing patch for fields that have a workflow action

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/ExistingRecordPatch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/ExistingRecordPatch.java
@@ -174,6 +174,9 @@ public class ExistingRecordPatch extends BasePatch {
         int startingSize = workflowsList.size();
         workflowsList.forEach(workflow -> {
             Map<String, String> workflowDataMap = (Map<String, String>) workflow.get(ESObjectConstants.DATA);
+            if (workflowDataMap == null || !workflowDataMap.containsKey(ESObjectConstants.SUBJECT_ID)) {
+                return;
+            }
             String collaboratorParticipantId = workflowDataMap.get(ESObjectConstants.SUBJECT_ID);
             if (Objects.isNull(collaboratorParticipantId)) {
                 return;


### PR DESCRIPTION
If a dynamic field has an action configured to write that value also under workflows in ES that failed because of missing SUBJECT_ID which is only present for RGP. Where the workflow field needs to get removed if the contact email of the family member is not equals the profile email