### PR TITLE
DDP-8576: Picklist option exclusivity changes in PATIENT_SURVEY and ABOUT_HEALTHY

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
@@ -60,11 +60,12 @@ public interface JdbiPicklistOption extends SqlObject {
 
     @UseStringTemplateSqlLocator
     @SqlQuery("fetchOptionById")
+    @RegisterConstructorMapper(PicklistOptionDto.class)
     Optional<PicklistOptionDto> findById(@Bind("id") long id);
     
     @UseStringTemplateSqlLocator
     @SqlUpdate("updateOptionByDto")
-    int update(@BindBean("dto") PicklistOptionDto optionDto);
+    int update(@BindMethods("dto") PicklistOptionDto optionDto);
 
     /**
      * Get all picklist options for given picklist question that are/were active at creation time of given

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
@@ -8,6 +8,7 @@ import org.broadinstitute.ddp.db.dto.PicklistOptionDto;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
@@ -56,6 +57,14 @@ public interface JdbiPicklistOption extends SqlObject {
     long[] bulkInsertByDtos(@BindMethods("dto") List<PicklistOptionDto> optionDtos,
                             @Bind("picklistQuestionId") long picklistQuestionId,
                             @Bind("revisionId") long revisionId);
+
+    @UseStringTemplateSqlLocator
+    @SqlQuery("fetchOptionById")
+    Optional<PicklistOptionDto> findById(@Bind("id") long id);
+    
+    @UseStringTemplateSqlLocator
+    @SqlUpdate("updateOptionByDto")
+    int update(@BindBean("dto") PicklistOptionDto optionDto);
 
     /**
      * Get all picklist options for given picklist question that are/were active at creation time of given

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.java
@@ -8,7 +8,6 @@ import org.broadinstitute.ddp.db.dto.PicklistOptionDto;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/PicklistOptionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/PicklistOptionDto.java
@@ -20,45 +20,45 @@ public final class PicklistOptionDto implements Serializable {
     private final long id;
 
     @ColumnName("picklist_option_stable_id")
-    private final String stableId;
+    private String stableId;
 
     @Nullable
     @ColumnName("value")
-    private final String value;
+    private String value;
 
     @ColumnName("option_label_template_id")
-    private final long optionLabelTemplateId;
+    private long optionLabelTemplateId;
 
     @ColumnName("tooltip_template_id")
-    private final Long tooltipTemplateId;
+    private Long tooltipTemplateId;
 
     @ColumnName("detail_label_template_id")
-    private final Long detailLabelTemplateId;
+    private Long detailLabelTemplateId;
 
     @ColumnName("allow_details")
-    private final boolean allowDetails;
+    private boolean allowDetails;
 
     @ColumnName("is_exclusive")
-    private final boolean exclusive;
+    private boolean exclusive;
 
     @Accessors(fluent = true)
     @ColumnName("is_default")
-    private final boolean isDefault;
+    private boolean isDefault;
 
     @ColumnName("display_order")
     private int displayOrder;
 
     @ColumnName("revision_id")
-    private final long revisionId;
+    private long revisionId;
 
     @ColumnName("revision_start_timestamp")
-    private final Long revisionStartTimestamp;
+    private Long revisionStartTimestamp;
 
     @ColumnName("revision_end_timestamp")
-    private final Long revisionEndTimestamp;
+    private Long revisionEndTimestamp;
 
     @ColumnName("nested_options_template_id")
-    private final Long nestedOptionsTemplateId;
+    private Long nestedOptionsTemplateId;
 
     private final List<PicklistOptionDto> nestedOptions = new ArrayList<>();
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/PicklistOptionDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/PicklistOptionDto.java
@@ -1,17 +1,17 @@
 package org.broadinstitute.ddp.db.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.experimental.Accessors;
-import org.jdbi.v3.core.mapper.reflect.ColumnName;
-import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
-
-import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.experimental.Accessors;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
 @Data
 @AllArgsConstructor(onConstructor = @__(@JdbiConstructor))

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
@@ -15,16 +15,16 @@ insert into picklist_option (picklist_question_id, picklist_option_stable_id, to
        display_order, revision_id)
 values (:picklistQuestionId, :dto.getStableId, :dto.getTooltipTemplateId,
        :dto.getOptionLabelTemplateId, :dto.getDetailLabelTemplateId,
-       :dto.isAllowDetails, :dto.isExclusive, :dto.isDefault, :dto.getDisplayOrder, :revisionId)
+       :dto.isAllowDetails, :dto.exclusive, :dto.isDefault, :dto.getDisplayOrder, :revisionId)
 >>
 
 fetchOptionById() ::= <<
 SELECT  picklist_option_id,
         picklist_option_stable_id,
         value,
-        option_table_template_id,
+        option_label_template_id,
         tooltip_template_id,
-        default_label_template_id,
+        detail_label_template_id,
         allow_details,
         is_exclusive,
         is_default,
@@ -34,25 +34,30 @@ SELECT  picklist_option_id,
         revision.end_date AS revision_end_timestamp,
         nested_options_template_id
 FROM picklist_option
-    JOIN revision ON revision.revision_id = picklist_option.picklist_option_id
+    JOIN revision ON revision.revision_id = picklist_option.revision_id
 WHERE picklist_option.picklist_option_id = :id
 >>
 
+<!
+    The longer names here are due to the PicklistOptionDto
+    not being completely Java Bean compatible.
+    (bskinner - 2022.08.29)
+!>
 updateOptionByDto() ::= <<
 UPDATE `picklist_option`
-SET picklist_option_stable_id = :dto.stableId,
-    value = :dto.value,
-    option_label_template_id = :dto.optionLabelTemplateId,
-    tooltip_template_id = :dto.tooltipTemplateId,
-    detail_label_template_id = :dto.detailLabelTemplateId,
-    allow_details = :dto.allowDetails,
+SET picklist_option_stable_id = :dto.getStableId,
+    value = :dto.getValue,
+    option_label_template_id = :dto.getOptionLabelTemplateId,
+    tooltip_template_id = :dto.getTooltipTemplateId,
+    detail_label_template_id = :dto.getDetailLabelTemplateId,
+    allow_details = :dto.isAllowDetails,
     is_exclusive = :dto.isExclusive,
     is_default = :dto.isDefault,
-    display_order = :dto.displayOrder,
-    revision.revision_id = :dto.revisionId,
-    nested_options_template_id = :dto.nestedOptionsTemplateId
+    display_order = :dto.getDisplayOrder,
+    revision_id = :dto.getRevisionId,
+    nested_options_template_id = :dto.getNestedOptionsTemplateId
 WHERE
-    picklist_option_id = :dto.id
+    picklist_option_id = :dto.getId
 >>
 
 queryInfoByOptionStableIdAndRevision() ::= <<

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
@@ -12,10 +12,10 @@ values (:picklistQuestionId, :stableId, :tooltipTemplateId,
 insertOptionByDto() ::= <<
 insert into picklist_option (picklist_question_id, picklist_option_stable_id, tooltip_template_id,
        option_label_template_id, detail_label_template_id, allow_details, is_exclusive, is_default,
-       display_order, revision_id)
+       display_order, revision_id, value)
 values (:picklistQuestionId, :dto.getStableId, :dto.getTooltipTemplateId,
        :dto.getOptionLabelTemplateId, :dto.getDetailLabelTemplateId,
-       :dto.isAllowDetails, :dto.exclusive, :dto.isDefault, :dto.getDisplayOrder, :revisionId)
+       :dto.isAllowDetails, :dto.isExclusive, :dto.isDefault, :dto.getDisplayOrder, :revisionId, :dto.getValue)
 >>
 
 fetchOptionById() ::= <<
@@ -39,8 +39,8 @@ WHERE picklist_option.picklist_option_id = :id
 >>
 
 <!
-    The longer names here are due to the PicklistOptionDto
-    not being completely Java Bean compatible.
+    The lombok-generated method names used here are due to
+    the PicklistOptionDto not being Java Bean compatible.
     (bskinner - 2022.08.29)
 !>
 updateOptionByDto() ::= <<

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
@@ -38,11 +38,9 @@ FROM picklist_option
 WHERE picklist_option.picklist_option_id = :id
 >>
 
-<!
-    The lombok-generated method names used here are due to
-    the PicklistOptionDto not being Java Bean compatible.
-    (bskinner - 2022.08.29)
-!>
+// The lombok-generated method names used here are due to
+// the PicklistOptionDto not being Java Bean compatible.
+// (bskinner - 2022.08.29)
 updateOptionByDto() ::= <<
 UPDATE `picklist_option`
 SET picklist_option_stable_id = :dto.getStableId,

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiPicklistOption.sql.stg
@@ -18,6 +18,43 @@ values (:picklistQuestionId, :dto.getStableId, :dto.getTooltipTemplateId,
        :dto.isAllowDetails, :dto.isExclusive, :dto.isDefault, :dto.getDisplayOrder, :revisionId)
 >>
 
+fetchOptionById() ::= <<
+SELECT  picklist_option_id,
+        picklist_option_stable_id,
+        value,
+        option_table_template_id,
+        tooltip_template_id,
+        default_label_template_id,
+        allow_details,
+        is_exclusive,
+        is_default,
+        display_order,
+        revision.revision_id AS revision_id,
+        revision.start_date AS revision_start_timestamp,
+        revision.end_date AS revision_end_timestamp,
+        nested_options_template_id
+FROM picklist_option
+    JOIN revision ON revision.revision_id = picklist_option.picklist_option_id
+WHERE picklist_option.picklist_option_id = :id
+>>
+
+updateOptionByDto() ::= <<
+UPDATE `picklist_option`
+SET picklist_option_stable_id = :dto.stableId,
+    value = :dto.value,
+    option_label_template_id = :dto.optionLabelTemplateId,
+    tooltip_template_id = :dto.tooltipTemplateId,
+    detail_label_template_id = :dto.detailLabelTemplateId,
+    allow_details = :dto.allowDetails,
+    is_exclusive = :dto.isExclusive,
+    is_default = :dto.isDefault,
+    display_order = :dto.displayOrder,
+    revision.revision_id = :dto.revisionId,
+    nested_options_template_id = :dto.nestedOptionsTemplateId
+WHERE
+    picklist_option_id = :dto.id
+>>
+
 queryInfoByOptionStableIdAndRevision() ::= <<
 select
     po.picklist_option_id,

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAboutHealthySelectLogic.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAboutHealthySelectLogic.java
@@ -1,8 +1,26 @@
 package org.broadinstitute.ddp.studybuilder.task;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.db.dao.FormActivityDao;
+import org.broadinstitute.ddp.db.dao.JdbiActivity;
+import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistQuestionDef;
+import org.broadinstitute.ddp.model.activity.types.ActivityType;
+import org.broadinstitute.ddp.model.activity.types.QuestionType;
 import org.jdbi.v3.core.Handle;
 
 /**
@@ -12,19 +30,168 @@ import org.jdbi.v3.core.Handle;
  * 
  * See https://broadinstitute.atlassian.net/browse/DDP-8576
  */
+@Slf4j
 public class SingularAboutHealthySelectLogic implements CustomTask {
+    private static final String PATCH_PATH = "patches";
     private static final String PATCH_CONF_NAME = "SingularAboutHealthySelectLogic.conf";
+    private static final String CONFIG_STUDY_GUID = "study.guid";
+
+    private static class Keys {
+        private static class ChangeSet {
+            private static final String AUTHOR = "author";
+            private static final String DESCRIPTION = "description";
+            private static final String STUDY = "study";
+            private static final String CONTENT = "content";
+        }
+
+        private static class ChangeContent {
+            private static final String ACTIVITY = "activity";
+            private static final String VERSION_TAG = "versionTag";
+            private static final String STABLE_ID = "stableId";
+            private static final String OPTION_ID = "optionId";
+            private static final String EXCLUSIVE = "exclusive";
+        }
+    }
+
+    private Config studyConfig;
+    private Config patchConfig;
+
+    private JdbiUmbrellaStudy studySql;
+    private JdbiActivity activitySql;
+    private JdbiActivityVersion activityVersionSql;
+    private FormActivityDao activityDao;
 
     @Override
-    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
-        // TODO Auto-generated method stub
-        
+    public void init(Path configPath, Config studyConfig, Config varsConfig) {
+        var studyRoot = configPath.getParent();
+        var patchConfPath = Paths.get(PATCH_PATH, PATCH_CONF_NAME);
+        var patchPath = studyRoot.resolve(patchConfPath);
+
+        final Config patchConfig;
+        try {
+            patchConfig = ConfigFactory.parseFile(patchPath.toFile()).resolveWith(varsConfig);
+        } catch (ConfigException configException) {
+            var message = String.format("failed to load patch data file expected at '%s'", patchPath);
+            throw new DDPException(message, configException);
+        }
+
+        var studyGuid = studyConfig.getString(CONFIG_STUDY_GUID);
+        var targetStudy = patchConfig.getString(Keys.ChangeSet.STUDY);
+        if (!targetStudy.equals(studyGuid)) {
+            throw new DDPException(String.format("Patch %s targets study '%s', but is being run against '%s'",
+                    this.getClass().getSimpleName(),
+                    targetStudy,
+                    studyGuid));
+        }
+
+        this.patchConfig = patchConfig;
+        this.studyConfig = studyConfig;
     }
 
     @Override
     public void run(Handle handle) {
-        // TODO Auto-generated method stub
-        
+        var taskName = this.getClass().getSimpleName();
+        log.info("TASK:: {}", taskName);
+
+        daoSetup(handle);
+
+        final var studyGuid = studyConfig.getString(Keys.ChangeSet.STUDY);
+        final var studyDto = Optional.ofNullable(studySql.findByStudyGuid(studyGuid)).orElseThrow(() -> {
+            return new DDPException(String.format("failed to locate the study '%s'", studyGuid));
+        });
+
+        patchConfig.getConfigList(Keys.ChangeSet.CONTENT).stream()
+                .forEach((config) -> {
+                    final var activityCode = config.getString(Keys.ChangeContent.ACTIVITY);
+                    final var versionTag = config.getString(Keys.ChangeContent.VERSION_TAG);
+
+                    final var activityDef = getActivityDef(studyDto, activityCode, versionTag);
+                    final var picklistDef = getPicklistDef(activityDef, patchConfig.getString(Keys.ChangeContent.STABLE_ID));
+
+                    var optionId = patchConfig.getString(Keys.ChangeContent.OPTION_ID);
+                    var optionDef = picklistDef.getAllPicklistOptions().stream()
+                            .filter((option) -> StringUtils.equals(optionId, option.getStableId()))
+                            .findFirst()
+                            .orElseThrow(() -> {
+                                return new DDPException();
+                            });
+
+                    var newValue = patchConfig.getBoolean(Keys.ChangeContent.EXCLUSIVE);
+
+                    if (optionDef.isExclusive() != newValue) {
+                        log.info("setting isExclusive:{} for [activity:{},question:{},option:{}]",
+                            newValue,
+                            activityCode,
+                            picklistDef.getStableId(),
+                            optionId);
+                        optionDef = optionDef.toBuilder().isExclusive(newValue).build();
+
+                    }
+                });
+
+        daoTearDown();
+    }
+
+    private void daoSetup(Handle handle) {
+        this.studySql = handle.attach(JdbiUmbrellaStudy.class);
+        this.activitySql = handle.attach(JdbiActivity.class);
+        this.activityVersionSql = handle.attach(JdbiActivityVersion.class);
+        this.activityDao = handle.attach(FormActivityDao.class);
+    }
+
+    private void daoTearDown() {
+        this.studySql = null;
+        this.activitySql = null;
+        this.activityVersionSql = null;
+        this.activityDao = null;
+    }
+
+    private FormActivityDef getActivityDef(StudyDto study, String activityCode, String versionTag) {
+        final var studyGuid = study.getGuid();
+        final var studyId = study.getId();
+
+        final var activity = activitySql.findActivityByStudyGuidAndCode(studyGuid, activityCode)
+        .orElseThrow(() -> {
+            return new DDPException(String.format("failed to locate the activity '%s' in study '%s'",
+                    activityCode,
+                    studyGuid));
+        });
+
+        final var activityVersion = activityVersionSql.findByActivityCodeAndVersionTag(studyId, activityCode, versionTag)
+                .orElseThrow(() -> {
+                    var message = String.format("failed to locate the version tag '%s' for the activity '%s' in study '%s'",
+                        versionTag,
+                        activityCode,
+                        studyGuid);
+                    return new DDPException(message);
+                });
+
+        return Optional.ofNullable(activityDao.findDefByDtoAndVersion(activity, activityVersion)).stream()
+                    .filter((activityDef) -> activityDef.getActivityType() == ActivityType.FORMS)
+                    .map(FormActivityDef.class::cast)
+                    .findFirst()
+                    .orElseThrow(() -> {
+                        final var message = String.format("Unable to find the activity [%s:s] with code '%s' in study %s]",
+                                activityCode,
+                                versionTag,
+                                ActivityType.FORMS,
+                                studyGuid);
+                        throw new DDPException(message);
+                    });
+    }
+
+    private PicklistQuestionDef getPicklistDef(final FormActivityDef activityDef, final String stableId) {
+        return Optional.ofNullable(activityDef.getQuestionByStableId(stableId)).stream()
+                .filter((questionDef) -> questionDef.getQuestionType() == QuestionType.PICKLIST)
+                .map(PicklistQuestionDef.class::cast)
+                .findFirst()
+                .orElseThrow(() -> {
+                    final var message = String.format("Unable to find a question with stable id '%s' and type '%s' in activity %s]",
+                            stableId,
+                            QuestionType.PICKLIST,
+                            activityDef.getActivityCode());
+                    throw new DDPException(message);
+                });
     }
     
 }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAboutHealthySelectLogic.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAboutHealthySelectLogic.java
@@ -1,0 +1,30 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+
+import com.typesafe.config.Config;
+import org.jdbi.v3.core.Handle;
+
+/**
+ * Task for updating the IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS (PATIENT_SURVEY)
+ * and IF_YOU_HAVE_HAD_ARRHYTHMIA (ABOUT_HEALTHY) questions to mark the DO_NOT_REQUIRE
+ * and DID_NOT_REQUIRED options (respectively) as exclusive.
+ * 
+ * See https://broadinstitute.atlassian.net/browse/DDP-8576
+ */
+public class SingularAboutHealthySelectLogic implements CustomTask {
+    private static final String PATCH_CONF_NAME = "SingularAboutHealthySelectLogic.conf";
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    public void run(Handle handle) {
+        // TODO Auto-generated method stub
+        
+    }
+    
+}

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularMakeNoMedicalTreatmentOptionExclusive.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularMakeNoMedicalTreatmentOptionExclusive.java
@@ -31,7 +31,7 @@ import org.jdbi.v3.core.Handle;
  * <p>See https://broadinstitute.atlassian.net/browse/DDP-8576
  */
 @Slf4j
-public class SingularAboutHealthySelectLogic implements CustomTask {
+public class SingularMakeNoMedicalTreatmentOptionExclusive implements CustomTask {
     private static final String PATCH_PATH = "patches";
     private static final String PATCH_CONF_NAME = "ddp-8576-select-logic.conf";
     private static final String CONFIG_STUDY_GUID = "study.guid";

--- a/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
@@ -4,6 +4,6 @@
     "SingularUpdates",
     "SingularAboutHealthyPexTask",
     "SingularUpdateConsentCopyEvents",
-    "SingularAboutHealthySelectLogic"
+    "SingularMakeNoMedicalTreatmentOptionExclusive"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
@@ -3,6 +3,7 @@
     "SingularPatientSurveyUpdate",
     "SingularUpdates",
     "SingularAboutHealthyPexTask",
-    "SingularUpdateConsentCopyEvents"
+    "SingularUpdateConsentCopyEvents",
+    "SingularAboutHealthySelectLogic"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
@@ -8,16 +8,14 @@
       versionTag = "v1"
       stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS"
       optionId = "DO_NOT_REQUIRE"
-      expectedExclusive = false
-      updatedExclusive = true
+      exclusive = true
     },
     {
       activity = "ABOUT_HEALTHY"
       versionTag = "v1"
       stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA"
       optionId = "DID_NOT_REQUIRED"
-      expectedExclusive = false
-      updatedExclusive = true
+      exclusive = true
     }
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
@@ -1,18 +1,19 @@
 {
   author = "bskinner"
   description = "Updates exclusivity flags for options of questions IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS and IF_YOU_HAVE_HAD_ARRHYTHMIA."
-  versionTag = "v1"
   study = "singular"
   content = [
     {
-      activityCode = "PATIENT_SURVEY"
+      activity = "PATIENT_SURVEY"
+      versionTag = "v1"
       stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS"
       optionId = "DO_NOT_REQUIRE"
       expectedExclusive = false
       updatedExclusive = true
     },
     {
-      activityCode = "ABOUT_HEALTHY"
+      activity = "ABOUT_HEALTHY"
+      versionTag = "v1"
       stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA"
       optionId = "DID_NOT_REQUIRED"
       expectedExclusive = false

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8576-select-logic.conf
@@ -1,0 +1,22 @@
+{
+  author = "bskinner"
+  description = "Updates exclusivity flags for options of questions IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS and IF_YOU_HAVE_HAD_ARRHYTHMIA."
+  versionTag = "v1"
+  study = "singular"
+  content = [
+    {
+      activityCode = "PATIENT_SURVEY"
+      stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS"
+      optionId = "DO_NOT_REQUIRE"
+      expectedExclusive = false
+      updatedExclusive = true
+    },
+    {
+      activityCode = "ABOUT_HEALTHY"
+      stableId = "IF_YOU_HAVE_HAD_ARRHYTHMIA"
+      optionId = "DID_NOT_REQUIRED"
+      expectedExclusive = false
+      updatedExclusive = true
+    }
+  ]
+}


### PR DESCRIPTION
DDP-8576

## Context

This PR adds a patch with 2 changes to existing questions in the `PATIENT_SURVEY` and `ABOUT_HEALTHY` surveys. The changes are as below:
|Survey|Question|Option|Notes|
|:----:|:-:|:-:|:-:|
|ABOUT_HEALTHY|IF_YOU_HAVE_HAD_ARRHYTHMIA|DID_NOT_REQUIRED|Set option to be `exclusive`|
|PATIENT_SURVEY|IF_YOU_HAVE_HAD_ARRHYTHMIA_COMPLICATIONS|DO_NOT_REQUIRE|Set option to be `exclusive`|

This change does not require that a new revision be created for these modifications.

## Applying the changes
The changes in this PR can be applied using the `--run-task` or `--patch` options to `studybuilder-cli` (replacing `path/to/my/application.conf` with the path to your actual configuration)
```
java \
    -Dconfig.file=path/to/my/application.conf \
    -cp studybuilder-cli/target/StudyBuilder.jar \
    org.broadinstitute.ddp.studybuilder.StudyBuilderCli \
      --vars "studybuilder-cli/output-config/vars.conf" \
      --substitutions "studybuilder-cli/studies/singular/substitutions.conf" \
      --process-translations "PROCESS_IGNORE_TEMPLATES_WITH_TRANSLATIONS" \
      --translations-to-db-json \
      --run-task "SingularAboutHealthySelectLogic" \
      "studybuilder-cli/studies/singular/study.conf"
```