### PR TITLE
[DSM] DDP-8664 removing the check for iss claim

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -195,7 +195,6 @@ public class DSMServer {
     private static final String API_ROOT = "/ddp/";
     private static final String UI_ROOT = "/ui/";
     public static final String SIGNER = "org.broadinstitute.kdux";
-    public static final String BSP_SIGNER = "https://dsm-dev.datadonationplatform.org/ddp/";
     private static final String[] CORS_HTTP_METHODS = new String[] {"GET", "PUT", "POST", "OPTIONS", "PATCH"};
     private static final String[] CORS_HTTP_HEADERS =
             new String[] {"Content-Type", "Authorization", "X-Requested-With", "Content-Length", "Accept", "Origin", ""};
@@ -544,7 +543,7 @@ public class DSMServer {
 
         //  capture basic route info for logging
         //        before("*", new LoggingFilter(auth0Domain, auth0claimNameSpace));
-        before(API_ROOT + "*", new LoggingFilter(auth0Domain, auth0claimNameSpace, bspSecret, BSP_SIGNER, bspSecretEncoded));
+        before(API_ROOT + "*", new LoggingFilter(auth0Domain, auth0claimNameSpace, bspSecret, null, bspSecretEncoded));
         before(UI_ROOT + "*", new LoggingFilter(auth0Domain, auth0claimNameSpace, null, null, false));
         before(INFO_ROOT + "*", new LoggingFilter(auth0Domain, auth0claimNameSpace, ddpSecret, SIGNER, ddpSecretEncoded));
         before(appRoute + "*", new LoggingFilter(auth0Domain, auth0claimNameSpace, ddpSecret, SIGNER, ddpSecretEncoded));


### PR DESCRIPTION
without this fix BSP will have problem receiving kit. 
To test: try receiving a kit with a token generated by BPS Secret and HMAC256 algorithm. The token can also be printed using the `printTestTokens()` unit test. Then make a call to `ddp/Kits/:label` with the kit mf barcode as label