### PR TITLE
DDP-8666: `null` payload in messages to malware scanner

### DIFF
--- a/cloud-functions/cf-file-scanner/init-bucket-event.sh
+++ b/cloud-functions/cf-file-scanner/init-bucket-event.sh
@@ -15,7 +15,8 @@ BUCKET="$2"
 TOPIC="$3"
 
 gsutil notification create \
-  -f none -e OBJECT_FINALIZE \
+  -f json \
+  -e OBJECT_FINALIZE \
   -t "projects/$PROJECT_ID/topics/$TOPIC" \
   "gs://$BUCKET"
 


### PR DESCRIPTION
DDP-8666

This PR updates the init script for the malware scanner bucket events to specify a `json` payload instead of `none`. The `none` payload setting was resulting in `NullPointerExceptions` when attempting to deserialize Google Bucket notifications on file upload, and was primarily visible in the `broad-ddp-test` environment.

## Notes
This configuration value is not visible in the UI or cli interfaces to Google Cloud. The other environments should have the bucket notifications removed and reconfigured if the `cf-file-scanner` service in those environments is throwing `NullPointerExceptions` at `com.google.cloud.functions.invoker.AutoValue_Event.<init>`.

