### PR TITLE
[DSM] DDP-8665 removing Singular default values

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/DefaultableMaker.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/DefaultableMaker.java
@@ -13,9 +13,6 @@ public class DefaultableMaker {
             case RGP:
                 defaultable = new RgpAutomaticProbandDataCreator();
                 break;
-            case SINGULAR:
-                defaultable = new SingularDefaultValues();
-                break;
             default:
                 break;
         }


### PR DESCRIPTION
Code was added to set the default ENROLLED value per DDP-8642. This PR is to stop that default value from being set 

To test: sign up a new participant in Singular dev. When it appears in DSM the Enrollment Status column should be empty