### PR TITLE
DDP-8641 Patch for Singular Race Question Typo

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
@@ -16,21 +16,21 @@ public class SingularFixRaceQuestionTypo implements CustomTask {
     private static final String TEMPLATE_VARIABLE_NAME = "what_is_your_race_prompt_p1";
     private static final String QUESTION_STABLE_ID = "RACE";
     private static final String LANGUAGE_CODE_EN = "en";
-    private static final String QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE = "UPDATE " +
-            "  template_variable tv " +
-            "  join question q on q.question_prompt_template_id = tv.template_id natural " +
-            "  join question_stable_code qsc natural " +
-            "  join language_code lc " +
-            "  join study_activity sa on sa.study_activity_id = q.study_activity_id " +
-            "  join i18n_template_substitution its on its.template_variable_id = tv.template_variable_id " +
-            "  join umbrella_study us on us.umbrella_study_id = sa.study_id " +
-            "set " +
-            "  substitution_value = ?" +
-            "where " +
-            "  tv.variable_name = ? " +
-            "  AND qsc.stable_id = ? " +
-            "  AND lc.iso_language_code = ? " +
-            "  AND us.guid = ?;";
+    private static final String QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE = "UPDATE "
+            + "  template_variable tv "
+             + "  join question q on q.question_prompt_template_id = tv.template_id natural "
+             + "  join question_stable_code qsc natural "
+             + "  join language_code lc "
+             + "  join study_activity sa on sa.study_activity_id = q.study_activity_id "
+             + "  join i18n_template_substitution its on its.template_variable_id = tv.template_variable_id "
+             + "  join umbrella_study us on us.umbrella_study_id = sa.study_id "
+             + "set "
+             + "  substitution_value = ?"
+             + "where "
+             + "  tv.variable_name = ? "
+             + "  AND qsc.stable_id = ? "
+             + "  AND lc.iso_language_code = ? "
+             + "  AND us.guid = ?";
 
 
     private Config dataCfg;
@@ -52,7 +52,8 @@ public class SingularFixRaceQuestionTypo implements CustomTask {
     @Override
     public void run(Handle handle) {
         String newSubstitutionValue = dataCfg.getString("prompt");
-        int rowsModified = handle.execute(QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE, newSubstitutionValue, TEMPLATE_VARIABLE_NAME, QUESTION_STABLE_ID, LANGUAGE_CODE_EN, STUDY_GUID);
+        int rowsModified = handle.execute(QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE, newSubstitutionValue,
+                TEMPLATE_VARIABLE_NAME, QUESTION_STABLE_ID, LANGUAGE_CODE_EN, STUDY_GUID);
         log.info("Modified number of rows: {}", rowsModified);
     }
 }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
@@ -32,9 +32,9 @@ public class SingularFixRaceQuestionTypo implements CustomTask {
             "  AND lc.iso_language_code = ? " +
             "  AND us.guid = ?;";
 
-    
+
     private Config dataCfg;
-    
+
 
     @Override
     public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
@@ -49,12 +49,10 @@ public class SingularFixRaceQuestionTypo implements CustomTask {
         }
     }
 
-
     @Override
     public void run(Handle handle) {
         String newSubstitutionValue = dataCfg.getString("prompt");
         int rowsModified = handle.execute(QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE, newSubstitutionValue, TEMPLATE_VARIABLE_NAME, QUESTION_STABLE_ID, LANGUAGE_CODE_EN, STUDY_GUID);
-        System.out.println("Modified number of rows: " + rowsModified);
+        log.info("Modified number of rows: {}", rowsModified);
     }
-
 }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularFixRaceQuestionTypo.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.jdbi.v3.core.Handle;
+
+import java.io.File;
+import java.nio.file.Path;
+
+@Slf4j
+public class SingularFixRaceQuestionTypo implements CustomTask {
+    private static final String STUDY_GUID = "singular";
+    private static final String DATA_FILE = "patches/singular-race-question-prompt-fix.conf";
+    private static final String TEMPLATE_VARIABLE_NAME = "what_is_your_race_prompt_p1";
+    private static final String QUESTION_STABLE_ID = "RACE";
+    private static final String LANGUAGE_CODE_EN = "en";
+    private static final String QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE = "UPDATE " +
+            "  template_variable tv " +
+            "  join question q on q.question_prompt_template_id = tv.template_id natural " +
+            "  join question_stable_code qsc natural " +
+            "  join language_code lc " +
+            "  join study_activity sa on sa.study_activity_id = q.study_activity_id " +
+            "  join i18n_template_substitution its on its.template_variable_id = tv.template_variable_id " +
+            "  join umbrella_study us on us.umbrella_study_id = sa.study_id " +
+            "set " +
+            "  substitution_value = ?" +
+            "where " +
+            "  tv.variable_name = ? " +
+            "  AND qsc.stable_id = ? " +
+            "  AND lc.iso_language_code = ? " +
+            "  AND us.guid = ?;";
+
+    
+    private Config dataCfg;
+    
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        File file = cfgPath.getParent().resolve(DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        dataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+
+        if (!studyCfg.getString("study.guid").equals(STUDY_GUID)) {
+            throw new DDPException("This task is only for the " + STUDY_GUID + " study!");
+        }
+    }
+
+
+    @Override
+    public void run(Handle handle) {
+        String newSubstitutionValue = dataCfg.getString("prompt");
+        int rowsModified = handle.execute(QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE, newSubstitutionValue, TEMPLATE_VARIABLE_NAME, QUESTION_STABLE_ID, LANGUAGE_CODE_EN, STUDY_GUID);
+        System.out.println("Modified number of rows: " + rowsModified);
+    }
+
+}

--- a/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
@@ -1787,7 +1787,7 @@
         "prefer_not_to_answer": "$ddp.checkAnswer(\"PATIENT_SURVEY_WHO_ENROLLING_HIDDEN\",\"CHILD\", \"Prefer not to say\", \"Prefer not to answer\")"
       },
       "what_is_your_race": {
-        "prompt_p1": "What is $ddp.checkAnswer(\"PATIENT_SURVEY_WHO_ENROLLING_HIDDEN\",\"CHILD\", \"your child's?\", \"your\") race*",
+        "prompt_p1": "What is $ddp.checkAnswer(\"PATIENT_SURVEY_WHO_ENROLLING_HIDDEN\",\"CHILD\", \"your child's\", \"your\") race?*",
         "prompt_p2": "(We ask this question to help us learn about the unique characteristics of each person in our study which may help us to better understand genetics and/or risk.)",
         "required_hint": "Please choose an option",
         "white": "White",

--- a/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
@@ -4,5 +4,6 @@
     "SingularUpdates",
     "SingularAboutHealthyPexTask",
     "SingularUpdateConsentCopyEvents"
+    "SingularFixRaceQuestionTypo"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/singular-race-question-prompt-fix.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/singular-race-question-prompt-fix.conf
@@ -1,0 +1,3 @@
+{
+  "prompt": "What is $ddp.checkAnswer(\"PATIENT_SURVEY_WHO_ENROLLING_HIDDEN\",\"CHILD\", \"your child's\", \"your\") race?*"
+}


### PR DESCRIPTION
Just did a database update for this.
Put the expression in HOCON file instead of static variable in Java because I would have had to escape a lot of backslashes and would have gotten pretty ugly.
After applying patch, this is what race question looks like:

For child's survey:
![Screen Shot 2022-08-30 at 4 21 58 PM](https://user-images.githubusercontent.com/29984380/187537744-1d2f9415-6136-48fe-9f8e-479c4206e966.png)

For the survey for self-enrollment:
![Screen Shot 2022-08-30 at 4 23 59 PM](https://user-images.githubusercontent.com/29984380/187537825-7480cc42-1235-4e29-a77e-01df3f8ae197.png)
