### PR TITLE
DDP-8659. Update Adult Dependent enrollment

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateDependentEnrollment.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateDependentEnrollment.java
@@ -48,20 +48,23 @@ public class SingularUpdateDependentEnrollment implements CustomTask {
         long validationId = helper.getValidationId("ENROLLING_DEPENDENT_AGE", "INT_RANGE", studyDto.getId());
         int rowCount = helper.updateValidation(validationId);
         DBUtils.checkUpdate(1, rowCount);
-        rowCount = helper.updateValidation(validationId);
+        rowCount = helper.updateIntRangeValidation(validationId, 18);
         DBUtils.checkUpdate(1, rowCount);
 
         //update Question expression
         long expressionId = helper.getExpressionId("ADD_PARTICIPANT_INCAPACITATED_DEPENDENT", studyDto.getId());
         //update expression
-        String expressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].isAnswered() \n"
-                + " && user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].answers.value() >= 18";
+        String expressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"] "
+                + ".questions[\"ENROLLING_DEPENDENT_AGE\"].isAnswered() \n"
+                + " && user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"]"
+                + ".answers.value() >= 18";
         rowCount = helper.updateExpression(expressionId, expressionText);
         DBUtils.checkUpdate(1, rowCount);
 
         //update activity validation
         long activityValidationId = helper.getActivityValidationId("ADD_PARTICIPANT_DEPENDENT", studyDto.getId());
-        String activityExpressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].answers.value() >= 18";
+        String activityExpressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"]"
+                + ".questions[\"ENROLLING_DEPENDENT_AGE\"].answers.value() >= 18";
         rowCount = helper.updateActivityValidation(activityValidationId, activityExpressionText);
         DBUtils.checkUpdate(1, rowCount);
 
@@ -81,7 +84,8 @@ public class SingularUpdateDependentEnrollment implements CustomTask {
                 + "                and qsc.stable_id = :stableId \n"
                 + "                and vt.validation_type_code = :validationType \n"
                 + "                and qsc.umbrella_study_id = :studyId ")
-        long getValidationId(@Bind("stableId") String stableId, @Bind("validationType") String validationType, @Bind("studyId") long studyId);
+        long getValidationId(@Bind("stableId") String stableId, @Bind("validationType") String validationType,
+                             @Bind("studyId") long studyId);
 
         @SqlUpdate("update validation set allow_save = true where validation_id = :validationId")
         int updateValidation(@Bind("validationId") long validationId);
@@ -90,7 +94,8 @@ public class SingularUpdateDependentEnrollment implements CustomTask {
         int updateIntRangeValidation(@Bind("validationId") long validationId, @Bind("min") int min);
 
 
-        @SqlQuery("select e.expression_id from block__expression be, expression e, block__question bq, question q, question_stable_code qsc \n"
+        @SqlQuery("select e.expression_id from block__expression be, expression e, block__question bq, "
+                + " question q, question_stable_code qsc \n"
                 + "                where be.expression_id = e.expression_id \n"
                 + "                and bq.block_id = be.block_id \n"
                 + "                and q.question_id = bq.question_id \n"
@@ -104,8 +109,8 @@ public class SingularUpdateDependentEnrollment implements CustomTask {
 
 
         @SqlQuery("select av.activity_validation_id from activity_validation av, study_activity sa \n"
-                +" where sa.study_activity_id = av.study_activity_id \n"
-                +" and sa.study_activity_code = :activityCode \n"
+                + " where sa.study_activity_id = av.study_activity_id \n"
+                + " and sa.study_activity_code = :activityCode \n"
                 + " and av.precondition_text like '%ADD_PARTICIPANT_INCAPACITATED_DEPENDENT%' \n"
                 + " and sa.study_id = :studyId")
         long getActivityValidationId(@Bind("activityCode") String activityCode, @Bind("studyId") long studyId);

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateDependentEnrollment.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateDependentEnrollment.java
@@ -1,0 +1,136 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.CopyConfigurationDao;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.JdbiUser;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.db.dto.UserDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.activity.types.InstanceStatusType;
+import org.broadinstitute.ddp.model.copy.CopyAnswerLocation;
+import org.broadinstitute.ddp.model.copy.CopyConfiguration;
+import org.broadinstitute.ddp.model.event.ActivityStatusChangeTrigger;
+import org.broadinstitute.ddp.model.event.CopyAnswerEventAction;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.studybuilder.EventBuilder;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Task to fix for Singular Consent copy events to handle parent/self name overriding.
+ */
+@Slf4j
+public class SingularUpdateDependentEnrollment implements CustomTask {
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+
+    private Handle handle;
+    private StudyDto studyDto;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+    }
+
+    @Override
+    public void run(Handle handle) {
+        this.studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyCfg.getString("study.guid"));
+        this.handle = handle;
+
+        updateAdultDependentEnrollment();
+    }
+
+    private void updateAdultDependentEnrollment() {
+        //update Question allow_save
+        //update Question validation INT_RANGE
+        var helper = handle.attach(SingularUpdateDependentEnrollment.SqlHelper.class);
+        long validationId = helper.getValidationId("ENROLLING_DEPENDENT_AGE", "INT_RANGE", studyDto.getId());
+        int rowCount = helper.updateValidation(validationId);
+        DBUtils.checkUpdate(1, rowCount);
+        rowCount = helper.updateValidation(validationId);
+        DBUtils.checkUpdate(1, rowCount);
+
+        //update Question expression
+        long expressionId = helper.getExpressionId("ADD_PARTICIPANT_INCAPACITATED_DEPENDENT", studyDto.getId());
+        //update expression
+        String expressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].isAnswered()\n" +
+                " && user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].answers.value() >= 18";
+        rowCount = helper.updateExpression(expressionId, expressionText);
+        DBUtils.checkUpdate(1, rowCount);
+
+        //update activity validation
+        long activityValidationId = helper.getActivityValidationId("ADD_PARTICIPANT_DEPENDENT", studyDto.getId());
+        String activityExpressionText = "user.studies[\"singular\"].forms[\"ADD_PARTICIPANT_DEPENDENT\"].questions[\"ENROLLING_DEPENDENT_AGE\"].answers.value() >= 18";
+        rowCount = helper.updateActivityValidation(activityValidationId, activityExpressionText);
+        DBUtils.checkUpdate(1, rowCount);
+
+        log.info("completed ADD_PARTICIPANT_DEPENDENT updates");
+    }
+
+
+    private interface SqlHelper extends SqlObject {
+
+        @SqlQuery("select v.validation_id from validation v, validation_type vt , int_range_validation irv, \n" +
+                "                question q, question_stable_code qsc, question__validation qv\n" +
+                "                where v.validation_type_id = vt.validation_type_id\n" +
+                "                and irv.validation_id = v.validation_id\n" +
+                "                and qv.validation_id = v.validation_id\n" +
+                "                and qv.question_id = q.question_id\n" +
+                "                and qsc.question_stable_code_id = q.question_stable_code_id\n" +
+                "                and qsc.stable_id = :stableId \n" +
+                "                and vt.validation_type_code = :validationType\n" +
+                "                and qsc.umbrella_study_id = :studyId")
+        long getValidationId(@Bind("stableId") String stableId, @Bind("validationType") String validationType, @Bind("studyId") long studyId);
+
+        @SqlUpdate("update validation set allow_save = true where validation_id = :validationId")
+        int updateValidation(@Bind("validationId") long validationId);
+
+        @SqlUpdate("update int_range_validation set min = :min where validation_id = :validationId")
+        int updateIntRangeValidation(@Bind("validationId") long validationId, @Bind("min") int min);
+
+
+        @SqlQuery("select e.expression_id from block__expression be, expression e, block__question bq, question q, question_stable_code qsc\n" +
+                "                where be.expression_id = e.expression_id\n" +
+                "                and bq.block_id = be.block_id\n" +
+                "                and q.question_id = bq.question_id\n" +
+                "                and qsc.question_stable_code_id = q.question_stable_code_id\n" +
+                "                and qsc.stable_id = :stableId\n" +
+                "                and qsc.umbrella_study_id = :studyId")
+        long getExpressionId(@Bind("stableId") String stableId, @Bind("studyId") long studyId);
+
+        @SqlUpdate("update expression set expression_text = :expressionText where expression_id = :expressionId")
+        int updateExpression(@Bind("expressionId") long expressionId, @Bind("expressionText") String expressionText);
+
+
+        @SqlQuery("select av.activity_validation_id from activity_validation av, study_activity sa\n" +
+                "where sa.study_activity_id = av.study_activity_id\n" +
+                "and sa.study_activity_code = :activityCode \n" +
+                "and av.precondition_text like '%ADD_PARTICIPANT_INCAPACITATED_DEPENDENT%'\n" +
+                "and sa.study_id = :studyId")
+        long getActivityValidationId(@Bind("activityCode") String activityCode, @Bind("studyId") long studyId);
+
+        @SqlUpdate("update activity_validation set expression_text = :expressionText where activity_validation_id = :validationId")
+        int updateActivityValidation(@Bind("validationId") long validationId,  @Bind("expressionText") String expressionText);
+
+    }
+}

--- a/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
@@ -298,7 +298,7 @@
               },
               {
                 "ruleType": "INT_RANGE",
-                "min": 0,
+                "min": 18,
                 "max": 120,
                 "hintTemplate": {
                   "templateType": "TEXT",
@@ -321,7 +321,7 @@
           "blockType": "QUESTION",
           "shownExpr": """
             user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].isAnswered()
-            && user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].answers.value() >= 7
+            && user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].answers.value() >= 18
           """,
           "question": {
             include required("../../snippets/bool-question-yes-no.conf"),

--- a/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
@@ -328,8 +328,8 @@
 
     "enrolling_dependent_age": {
       "prompt": "How old is your dependent? *",
-      "placeholder": "Enter age",
-      "range_hint": "Please enter an age between 0 and 100",
+      "placeholder": "Enter valid adult age [18 or above]",
+      "range_hint": "Please enter an age 18 or above",
       "required_hint": "Please enter your dependent's age",
       "restriction_hint": "Your dependent has reached the age of majority and must register and enroll themself"
     },

--- a/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
@@ -5,6 +5,7 @@
     "SingularAboutHealthyPexTask",
     "SingularUpdateConsentCopyEvents",
     "SingularMakeNoMedicalTreatmentOptionExclusive",
-    "SingularMedicalReleaseV2"
+    "SingularMedicalReleaseV2",
+    "SingularUpdateDependentEnrollment"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patch-log.conf
@@ -3,6 +3,8 @@
     "SingularPatientSurveyUpdate",
     "SingularUpdates",
     "SingularAboutHealthyPexTask",
-    "SingularUpdateConsentCopyEvents"
+    "SingularEmailEventUpdates",
+    "SingularUpdateConsentCopyEvents",
+    "SingularUpdateDependentEnrollment"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/singular/study-activities.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/study-activities.conf
@@ -178,7 +178,7 @@
             && user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_INCAPACITATED_DEPENDENT"].isAnswered()
             && user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_INCAPACITATED_DEPENDENT"].answers.hasFalse()
           """,
-          "expression": ${_pex.age_of_majority.dependent},
+          "expression": "user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].answers.value() >= 18",
           "messageTemplate": {
             "templateType": "HTML",
             "templateText": "$add_participant_enrolling_dependent_age_restriction_hint",


### PR DESCRIPTION
look at https://broadinstitute.atlassian.net/browse/DDP-8659
Main goal: Restrict enrolling child participant using "Enroll My Adult Dependent" tab.

Update question: ENROLLING_DEPENDENT_AGE INT_RANGE validation
Update Question: ADD_PARTICIPANT_INCAPACITATED_DEPENDENT shown expression
Update Question : ADD_PARTICIPANT_INCAPACITATED_DEPENDENT validation's expression
Removed AOM rules check depending on operator (proxy) and check is just if user is 18+
Operator can register adult dependent if dependent age is 18+ and "INCAPACITATED". 

study conf files are updated to keep in sync with patch updates

Changes need two tasks to be executed
--run-task SingularUpdateDependentEnrollment
--run-task UpdateActivityTemplatesInPlace or UpdateTemplatesInPlace for activity ADD_PARTICIPANT_DEPENDENT
Tested locally.