### PR TITLE
final scan feedback for pe-cgs

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDaoImpl.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDaoImpl.java
@@ -172,8 +172,10 @@ public class KitDaoImpl implements KitDao {
                             + kitRequestShipping.getDdpLabel() + " does not exist or already has a Kit Label");
                 } else {
                     logger.info("Updated kitRequests w/ ddp_label " + kitRequestShipping.getDdpLabel());
-                    dbVals.resultValue = new ScanError(kitRequestShipping.getBspCollaboratorParticipantId(),
-                            kitRequestShipping.getBspCollaboratorParticipantId());
+                    if (StringUtils.isNotBlank(kitRequestShipping.getBspCollaboratorParticipantId())) {
+                        dbVals.resultValue = new ScanError(kitRequestShipping.getBspCollaboratorParticipantId(),
+                                kitRequestShipping.getBspCollaboratorParticipantId());
+                    }
                 }
             } catch (Exception ex) {
                 dbVals.resultValue = new ScanError(kitRequestShipping.getDdpLabel(),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
@@ -42,7 +42,9 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
                 if (kitRequestShipping.hasTrackingScan()) {
                     if (StringUtils.isNotEmpty(kitRequestShipping.getKitLabel()) && kitLabel.equals(kitRequestShipping.getKitLabel())
                             || StringUtils.isEmpty(kitRequestShipping.getKitLabel())) {
-                        result = updateKitRequest(kitLabel, ddpLabel, kitRequestShipping.getBspCollaboratorParticipantId());
+                        result = updateKitRequest(kitLabel, ddpLabel,
+                                StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
+                                        kitRequestShipping.getBspCollaboratorParticipantId());
                         trigerEventsIfSuccessfulKitUpdate(result, ddpLabel, getKitRequestShipping(kitLabel, ddpLabel));
                         this.writeSampleSentToES(kitRequestShipping);
                     } else {
@@ -55,7 +57,9 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
             } else {
                 if (StringUtils.isNotEmpty(kitRequestShipping.getKitLabel()) && kitLabel.equals(kitRequestShipping.getKitLabel())
                         || StringUtils.isEmpty(kitRequestShipping.getKitLabel())) {
-                    result = updateKitRequest(kitLabel, ddpLabel, kitRequestShipping.getBspCollaboratorParticipantId());
+                    result = updateKitRequest(kitLabel, ddpLabel,
+                            StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
+                                    kitRequestShipping.getBspCollaboratorParticipantId());
                 } else {
                     result = Optional.of(
                             new ScanError(ddpLabel, "Kit Label " + kitLabel + " was scanned on Initial Scan page with another ShortID"));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
@@ -96,8 +96,7 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
     }
 
     private String getBspCollaboratorParticipantId(KitRequestShipping kitRequestShipping) {
-        return StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
-                kitRequestShipping.getBspCollaboratorParticipantId();
+        return StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null : kitRequestShipping.getBspCollaboratorParticipantId();
     }
 
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/kit/KitFinalScanUseCase.java
@@ -42,9 +42,7 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
                 if (kitRequestShipping.hasTrackingScan()) {
                     if (StringUtils.isNotEmpty(kitRequestShipping.getKitLabel()) && kitLabel.equals(kitRequestShipping.getKitLabel())
                             || StringUtils.isEmpty(kitRequestShipping.getKitLabel())) {
-                        result = updateKitRequest(kitLabel, ddpLabel,
-                                StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
-                                        kitRequestShipping.getBspCollaboratorParticipantId());
+                        result = updateKitRequest(kitLabel, ddpLabel, getBspCollaboratorParticipantId(kitRequestShipping));
                         trigerEventsIfSuccessfulKitUpdate(result, ddpLabel, getKitRequestShipping(kitLabel, ddpLabel));
                         this.writeSampleSentToES(kitRequestShipping);
                     } else {
@@ -57,9 +55,7 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
             } else {
                 if (StringUtils.isNotEmpty(kitRequestShipping.getKitLabel()) && kitLabel.equals(kitRequestShipping.getKitLabel())
                         || StringUtils.isEmpty(kitRequestShipping.getKitLabel())) {
-                    result = updateKitRequest(kitLabel, ddpLabel,
-                            StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
-                                    kitRequestShipping.getBspCollaboratorParticipantId());
+                    result = updateKitRequest(kitLabel, ddpLabel, getBspCollaboratorParticipantId(kitRequestShipping));
                 } else {
                     result = Optional.of(
                             new ScanError(ddpLabel, "Kit Label " + kitLabel + " was scanned on Initial Scan page with another ShortID"));
@@ -97,6 +93,11 @@ public class KitFinalScanUseCase extends KitFinalSentBaseUseCase {
 
     private boolean isSalivaKit(String ddpLabel) {
         return !kitDao.isBloodKit(ddpLabel);
+    }
+
+    private String getBspCollaboratorParticipantId(KitRequestShipping kitRequestShipping) {
+        return StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
+                kitRequestShipping.getBspCollaboratorParticipantId();
     }
 
 }


### PR DESCRIPTION
adding user feedback to final scan page so that study staff sees the hruid after the final scan was successful. 
only for pe-cgs because for other studies 
```
StringUtils.isEmpty(kitRequestShipping.getKitLabel()) ? null :
                                        kitRequestShipping.getBspCollaboratorParticipantId());
``` 
will be null