### PR TITLE
DDP-8706: Introduce dynamic check for AOM when enrolling myself

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8554-self-validation.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8554-self-validation.conf
@@ -26,7 +26,7 @@
           }
         ]
       },
-      "stableIds": ["CONSENT_SELF_DATE_OF_BIRTH"],
+      "stableIds": ["CONSENT_SELF_DATE_OF_BIRTH", "PREQUAL_COUNTRY", "PREQUAL_STATE", "PREQUAL_PROVINCE"],
       "precondition": """
                       user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].isAnswered()
                       &&
@@ -50,42 +50,52 @@
                       """,
       "expression": """
                     ( 
-                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
                       && 
                       (
-                        ( user.studies["singular"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("AL")
-                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 19
+                        ( 
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          && 
+                          user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(19, YEARS)
                         ) 
                         || 
                         (
-                          !user.studies["singular"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("AL")
-                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                          !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          && 
+                          user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                         )
                       )
                     ) 
                     || 
                     (
-                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("CA")
-                      && (
-                        ( user.studies["singular"].forms["PREQUAL"].questions["SELF_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
-                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 19
-                        ) || (
-                          user.studies["singular"].forms["PREQUAL"].questions["SELF_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
-                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                      && 
+                      (
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                          && 
+                          user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(19, YEARS)
+                        ) 
+                        || 
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                          && 
+                          user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                         )
                       )
-                    ) || (
-                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("PR")
-                      && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 21
-                    ) || (
-                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
-                      && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                    ) 
+                    || 
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("PR")
+                      && 
+                      user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(21, YEARS)
+                    ) 
+                    || 
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+                      && 
+                      user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                     )
-                  
-      
-      
-      
-                    user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                     """
     }
   ]

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8554-self-validation.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8554-self-validation.conf
@@ -28,9 +28,63 @@
       },
       "stableIds": ["CONSENT_SELF_DATE_OF_BIRTH"],
       "precondition": """
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].isAnswered()
+                      &&
+                      (
+                        !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("US", "CA")
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].isAnswered()
+                        )
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].isAnswered()
+                        )
+                      )      
+                      &&
                       user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].isAnswered()
                       """,
       "expression": """
+                    ( 
+                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+                      && 
+                      (
+                        ( user.studies["singular"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("AL")
+                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 19
+                        ) 
+                        || 
+                        (
+                          !user.studies["singular"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("AL")
+                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                        )
+                      )
+                    ) 
+                    || 
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("CA")
+                      && (
+                        ( user.studies["singular"].forms["PREQUAL"].questions["SELF_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 19
+                        ) || (
+                          user.studies["singular"].forms["PREQUAL"].questions["SELF_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                          && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                        )
+                      )
+                    ) || (
+                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("PR")
+                      && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 21
+                    ) || (
+                      user.studies["singular"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+                      && user.studies["singular"].forms["PREQUAL"].questions["SELF_CURRENT_AGE"].answers.value() < 18
+                    )
+                  
+      
+      
+      
                     user.studies["singular"].forms["CONSENT_SELF"].questions["CONSENT_SELF_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                     """
     }

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8705-medical-release-dob-validations.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8705-medical-release-dob-validations.conf
@@ -25,16 +25,80 @@
           }
         ]
       },
-      "stableIds": ["MRR_DATE_OF_BIRTH", "MRR_WHO_ENROLLING_COPY"],
+      "stableIds": ["MRR_DATE_OF_BIRTH", "MRR_WHO_ENROLLING_COPY", "PREQUAL_COUNTRY", "PREQUAL_STATE", "PREQUAL_PROVINCE"],
       "precondition": """
                       user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
                       &&
                       user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("MYSELF")
                       &&
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].isAnswered()
+                      &&
+                      (
+                        !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("US", "CA")
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].isAnswered()
+                        )
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].isAnswered()
+                        )
+                      )
+                      &&
                       user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].isAnswered()
                       """,
       "expression": """
-                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
+                      &&
+                      (
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(19, YEARS)
+                        )
+                        ||
+                        (
+                          !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
+                        )
+                      )
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                      &&
+                      (
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(19, YEARS)
+                        )
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
+                        )
+                      )
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("PR")
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(21, YEARS)
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
+                    )
                     """
     },
 

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8705-medical-release-dob-validations.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/ddp-8705-medical-release-dob-validations.conf
@@ -269,6 +269,281 @@
                     &&
                     user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DATE_OF_BIRTH"].answers.ageLessThan(18, YEARS)
                     """
+    },
+    
+    ######################################################
+    # Following are validations for the 2nd DOB question #
+    ######################################################
+
+    # When using the Enroll Myself flow, if a user enters an age at or above the AOM for their region in
+    # the pre-qual but enters a date of birth that equates to <AOM for their region in the adult self consent,
+    # an error message should appear under the consent DOB field.
+    # Formally: MRR.DOB < 18
+    {
+      "messageTemplate": {
+        "templateType": "HTML",
+        "templateText": "$singular_consent_self_validation",
+        "variables": [
+          {
+            "name": "singular_consent_self_validation",
+            "translations": [
+              {
+                "language": "en",
+                "text": """Please check the date of birth you have entered. If the date is correct, then you are
+                               younger than the age required by local law to self-enroll in this study. However, you
+                               may ask your parent or guardian to enroll you in the study. If you think there is a
+                               mistake, please reach out to us at (650) 561-6750 or
+                               <a href="mailto:contact@projectsingular.org">contact@projectsingular.org</a>.
+                            """
+              }
+            ]
+          }
+        ]
+      },
+      "stableIds": ["MRR_DOB", "MRR_WHO_ENROLLING_COPY", "PREQUAL_COUNTRY", "PREQUAL_STATE", "PREQUAL_PROVINCE"],
+      "precondition": """
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("MYSELF")
+                      &&
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].isAnswered()
+                      &&
+                      (
+                        !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("US", "CA")
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].isAnswered()
+                        )
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                          &&
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].isAnswered()
+                        )
+                      )
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].isAnswered()
+                      """,
+      "expression": """
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("US")
+                      &&
+                      (
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(19, YEARS)
+                        )
+                        ||
+                        (
+                          !user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_STATE"].answers.hasOption("AL")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(18, YEARS)
+                        )
+                      )
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("CA")
+                      &&
+                      (
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("BC", "NB", "NL", "NT", "NS", "NU", "YT")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(19, YEARS)
+                        )
+                        ||
+                        (
+                          user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_PROVINCE"].answers.hasAnyOption("AB", "MB", "ON", "PE", "QC", "SK")
+                          &&
+                          user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(18, YEARS)
+                        )
+                      )
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasOption("PR")
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(21, YEARS)
+                    )
+                    ||
+                    (
+                      user.studies["singular"].forms["PREQUAL"].questions["PREQUAL_COUNTRY"].answers.hasAnyOption("GU", "VI", "MP", "AS")
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(18, YEARS)
+                    )
+                    """
+    },
+
+    # When using the Enroll Child flow, if a user enters an age between >=7 years and AOM for their region
+    # and answers NO to cognitive-impairment in the pre-qual but enters a date of birth that equates to <7 years
+    # in the child consent, an error message should appear under the consent DOB field
+    # Formally: ENROLLING_CHILD.AGE >= 7 && !ADD_PARTICIPANT_INCAPACITATED && MRR.AGE < 7
+    {
+      "messageTemplate": {
+        "templateType": "HTML",
+        "templateText": "$singular_consent_parental_validation_case1",
+        "variables": [
+          {
+            "name": "singular_consent_parental_validation_case1",
+            "translations": [
+              {
+                "language": "en",
+                "text": """Please check the date of birth you entered for your child. If the date is correct,
+                               then your child does not need to give their own assent to participate in the study.
+                               In that case, please return to the dashboard and click "Enroll my child" to begin a
+                               new enrollment for your child, or contact us for help at (650) 561-6750 or
+                               <a href="mailto:contact@projectsingular.org">contact@projectsingular.org</a>.
+                            """
+              }
+            ]
+          }
+        ]
+      },
+      "stableIds": ["MRR_DOB", "MRR_WHO_ENROLLING_COPY", "CONSENT_PARENTAL_CHILD_DATE_OF_BIRTH", "ENROLLING_CHILD_AGE, ADD_PARTICIPANT_INCAPACITATED"],
+      "precondition": """
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("CHILD")
+                      &&
+                      user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ENROLLING_CHILD_AGE"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_INCAPACITATED"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].isAnswered()
+                      """,
+      "expression": """
+                    user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ENROLLING_CHILD_AGE"].answers.value() >= 7
+                    &&
+                    user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_INCAPACITATED"].answers.hasFalse()
+                    &&
+                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(7, YEARS)
+                    """
+    },
+
+    # When using the Enroll Child flow, if a user enters an age between >=7 and AOM for their region and
+    # answers NO to cognitive-impairment in the pre-qual but enters a date of birth that equates to >=AOM
+    # in the child consent, an error message should appear under the consent DOB field.
+    # Formally: ENROLLING_CHILD.AGE < 7 && MRR.AGE >= 7 && MRR.AGE < 18
+    {
+      "messageTemplate": {
+        "templateType": "HTML",
+        "templateText": "$singular_consent_parental_validation_case2",
+        "variables": [
+          {
+            "name": "singular_consent_parental_validation_case2",
+            "translations": [
+              {
+                "language": "en",
+                "text": """Please check the date of birth you entered for your child. If the date is correct, then
+                               along with your consent, your child must give their own assent to participate in the study.
+                               In that case, please return to the dashboard and click "Enroll my child" to begin a new
+                               enrollment for your child, or contact us for help at (650) 561-6750 or
+                               <a href="mailto:contact@projectsingular.org">contact@projectsingular.org</a>.
+                            """
+              }
+            ]
+          }
+        ]
+      },
+      "stableIds": ["MRR_DOB", "MRR_WHO_ENROLLING_COPY", "CONSENT_PARENTAL_CHILD_DATE_OF_BIRTH", "ENROLLING_CHILD_AGE"],
+      "precondition": """
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("CHILD")
+                      &&
+                      user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ENROLLING_CHILD_AGE"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].isAnswered()
+                      """,
+      "expression": """
+                    user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ENROLLING_CHILD_AGE"].answers.value() < 7
+                    &&
+                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageAtLeast(7, YEARS)
+                    &&
+                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(18, YEARS)
+                    """
+    },
+
+    # When using the Enroll Child flow, if a user enters an age between >=7 and AOM for their region and
+    # answers NO to cognitive-impairment in the pre-qual but enters a date of birth that equates to >=AOM
+    # in the child consent, an error message should appear under the consent DOB field
+    # Formally: MRR.AGE >= 18
+    {
+      "messageTemplate": {
+        "templateType": "HTML",
+        "templateText": "$singular_consent_parental_validation_case1",
+        "variables": [
+          {
+            "name": "singular_consent_parental_validation_case1",
+            "translations": [
+              {
+                "language": "en",
+                "text": """Please check the date of birth you have entered. If the date is correct, your child has
+                           reached the age of majority and must register and enroll themself. If you think there is
+                           a mistake, please reach out to us at (650) 561-6750 or
+                           <a href="mailto:contact@projectsingular.org">contact@projectsingular.org</a>.
+                        """
+              }
+            ]
+          }
+        ]
+      },
+      "stableIds": ["MRR_DOB", "MRR_WHO_ENROLLING_COPY", "CONSENT_PARENTAL_CHILD_DATE_OF_BIRTH"],
+      "precondition": """
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("CHILD")
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].isAnswered()
+                      """,
+      "expression": """
+                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageAtLeast(18, YEARS)
+                    """
+    },
+
+    # When using the Enroll My Adult Dependent flow, if a user enters an age at or above the AOM for their region in
+    # the pre-qual but enters a date of birth that equates to <AOM for their region in the adult dependent consent,
+    # an error message should appear under the consent DOB field.
+    # Formally: ENROLLING_DEPENDENT.AGE >= 18 && MRR.AGE < 18
+    {
+      "messageTemplate": {
+        "templateType": "HTML",
+        "templateText": "$singular_consent_dependent_validation",
+        "variables": [
+          {
+            "name": "singular_consent_dependent_validation",
+            "translations": [
+              {
+                "language": "en",
+                "text": """Please check the date of birth you have entered. If the date is correct, then your dependent
+                           is younger than the age required by local law to self-enroll in this study. In that case,
+                           please return to the dashboard and click "Enroll my child" to begin a new enrollment for
+                           your dependent, or contact us for help at (650) 561-6750 or
+                           <a href="mailto:contact@projectsingular.org">contact@projectsingular.org</a>.
+                        """
+              }
+            ]
+          }
+        ]
+      },
+      "stableIds": ["MRR_DOB", "MRR_WHO_ENROLLING_COPY", "ENROLLING_DEPENDENT_AGE"],
+      "precondition": """
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_WHO_ENROLLING_COPY"].answers.hasOption("DEPENDENT")
+                      &&
+                      user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].isAnswered()
+                      &&
+                      user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].isAnswered()
+                      """,
+      "expression": """
+                    user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ENROLLING_DEPENDENT_AGE"].answers.value() >= 18
+                    &&
+                    user.studies["singular"].forms["MEDICAL_RECORD_RELEASE"].questions["MRR_DOB"].answers.ageLessThan(18, YEARS)
+                    """
     }
   ]
 }


### PR DESCRIPTION
**Consent form: Canada, British Columbia (AOM = 19)**
<img width="1021" alt="Снимок экрана 2022-09-08 в 17 19 39" src="https://user-images.githubusercontent.com/759263/189162431-30f74af5-8937-46df-ad3f-912e17525b5e.png">

**Medical Record Release Form: Canada, British Columbia (AOM = 19)**
<img width="1003" alt="Снимок экрана 2022-09-08 в 17 29 02" src="https://user-images.githubusercontent.com/759263/189163261-5ffee84f-9f56-4822-bd1c-7188665c5665.png">

**Consent form: Canada, Alberta (AOM = 18)**
<img width="1155" alt="Снимок экрана 2022-09-08 в 17 32 28" src="https://user-images.githubusercontent.com/759263/189163947-2efd0495-33b5-42bd-9266-3ebe25eb7f29.png">

**Medical Record Release Form: Canada, Alberta (AOM = 18)**
<img width="1107" alt="Снимок экрана 2022-09-08 в 17 33 40" src="https://user-images.githubusercontent.com/759263/189164238-d8754ff0-196f-4caf-be10-448d7a2349ee.png">

**Medical Record Release Form: Canada, Alberta (AOM = 18); 2nd DOB**
<img width="1162" alt="Снимок экрана 2022-09-08 в 17 43 09" src="https://user-images.githubusercontent.com/759263/189166195-f56c4e41-1d4f-497f-b46a-3340139e4f1e.png">
