### PR TITLE
Brugada DDP-8192 Fix PI

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/brugada/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/brugada/i18n/en.conf
@@ -336,7 +336,7 @@
       "li4": "I may cancel this authorization at any time by submitting a written request to the study staff, except if Link My Heart has already relied upon it (for example, once information is released, it will not be retrieved)."
       "li5": "I understand that access to my medical records may include access to my previous genetic testing results."
       "li6": "My questions about this authorization form have been answered."
-      "li7": "I have already read and signed the informed consent document for this study, which describes the use of my personal health information, and hereby grant permission to Steven A. Lubitz, MD, MPH, and/or members of the study team to examine copies of my medical records pertaining to my Brugada syndrome diagnosis and other related conditions. I acknowledge that I can access a copy of this completed form on my dashboard on the study website at brugada.linkmyheart.org."
+      "li7": "I have already read and signed the informed consent document for this study, which describes the use of my personal health information, and hereby grant permission to Patrick Ellinor, MD, PhD, and/or members of the study team to examine copies of my medical records pertaining to my Brugada syndrome diagnosis and other related conditions. I acknowledge that I can access a copy of this completed form on my dashboard on the study website at brugada.linkmyheart.org."
     },
     "questions": {
       "address": {

--- a/pepper-apis/studybuilder-cli/studies/brugada/substitutions.conf
+++ b/pepper-apis/studybuilder-cli/studies/brugada/substitutions.conf
@@ -17,4 +17,5 @@
       "picklist-question-dk-ns-option": { include required("snippets/picklist-question-dk-ns-option.conf") },
       "picklist-question-relatives": { include required("snippets/picklist-question-relatives.conf") }
     }
+  "studyEmail": "info@linkmyheart.org"
 }


### PR DESCRIPTION
Will fix wrong PI name in medical release form
Had to modify studyEmail for command line to execute
Following command line is needed:
java -Dconfig.file=./output-config/ap
plication.conf -jar ./target/StudyBuilder.jar  --vars ./output-config/vars.conf --substitutions ./studies/brugada/substitutions.conf ./studies/brugada/study.conf --run-task UpdateActivityTemplatesInPlace -- "MEDICAL_RECORD_RELEASE"

