### PR TITLE
PS: DDP-8730 - Add patch Singular to use ddp.firstCompletedDate wherever ddp.date is used

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateActivitiesToUseDateFirstCompleted.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularUpdateActivitiesToUseDateFirstCompleted.java
@@ -1,0 +1,62 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.jdbi.v3.core.Handle;
+
+@Slf4j
+public class SingularUpdateActivitiesToUseDateFirstCompleted implements CustomTask {
+    private static final String STUDY_GUID = "singular";
+    private static final String EXISTING_DATE_TEMPLATE_PATTERN = "%$ddp.date%";
+    private static final String DATA_FILE = "patches/newFirstCreatedAtDateTemplateString.conf";
+
+    private static final int EXPECTED_NUM_ROWS_TO_BE_MODIFIED = 12;
+    private static final String QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE = "UPDATE template t"
+            + " JOIN block_content bc ON bc.body_template_id=t.template_id"
+            + " JOIN form_section__block fsb ON fsb.block_id=bc.block_id"
+            + " JOIN form_section fs ON fsb.form_section_id=fs.form_section_id"
+            + " JOIN form_activity__form_section fafs ON fs.form_section_id=fafs.form_section_id"
+            + " JOIN form_activity fa ON fafs.form_activity_id = fa.study_activity_id"
+            + " JOIN study_activity sa ON fa.study_activity_id = sa.study_activity_id"
+            + " JOIN umbrella_study us ON sa.study_id=us.umbrella_study_id"
+            + " SET t.template_text=?"
+            + " WHERE"
+            + " us.guid = ?"
+            + " AND t.template_text LIKE ?";
+
+
+    private Config dataCfg;
+
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        File file = cfgPath.getParent().resolve(DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+
+        dataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+    }
+
+    @Override
+    public void run(Handle handle) {
+        String newSubstitutionValue = dataCfg.getString("templateText");
+        if (StringUtils.isNotBlank(newSubstitutionValue)) {
+            int rowsModified = handle.execute(QUESTION_TEMPLATE_VARIABLE_SUBSTITUTION_VALUE, newSubstitutionValue,
+                    STUDY_GUID, EXISTING_DATE_TEMPLATE_PATTERN);
+            log.info("Modified number of rows: {}", rowsModified);
+            if (rowsModified != EXPECTED_NUM_ROWS_TO_BE_MODIFIED) {
+                throw new DDPException("Was expecting exactly: " + EXPECTED_NUM_ROWS_TO_BE_MODIFIED + " Rolling back");
+            }
+        } else {
+            throw new DDPException("Could not find the template text in configuration file");
+        }
+
+    }
+}

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/newFirstCreatedAtDateTemplateString.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/newFirstCreatedAtDateTemplateString.conf
@@ -1,0 +1,3 @@
+{
+  templateText="""<p class="paragraph">$ddp.firstCompletedDate("MM / dd / yyyy", $ddp.date("MM / dd / yyyy"))</p>"""
+}


### PR DESCRIPTION
Code is pretty simple: look for all the places where we use ddp.date in template_text and put in a new Velocity html template fragment that includes the new ddp.firstCompletedDate

If you do the following query:
```sql
SELECT template_text 
FROM
    study_activity sa
        JOIN
    umbrella_study us ON sa.study_id = us.umbrella_study_id
        JOIN
    form_activity fa ON fa.study_activity_id = sa.study_activity_id
        JOIN
    form_activity__form_section fafs ON fafs.form_activity_id = fa.study_activity_id
        JOIN
    form_section fs ON fs.form_section_id = fafs.form_section_id
        JOIN
    form_section__block fsb ON fsb.form_section_id = fs.form_section_id
        JOIN
    block_content bc ON fsb.block_id = bc.block_id
        JOIN
    template t ON bc.body_template_id = t.template_id
WHERE
    us.guid = 'singular'
AND t.template_text LIKE '%$ddp.date%'
```

You get following results:
<img width="340" alt="Screen Shot 2022-09-12 at 11 39 52 PM" src="https://user-images.githubusercontent.com/29984380/189802526-0cbf8d40-f4eb-4f78-9908-01e57b076529.png">

Following command also renders the same thing, which gives me more assurance that this is correct:
```bash
find pepper-apis/studybuilder-cli/studies/singular -name "*.conf" | grep -v newFirstCreatedAt | xargs grep -Eh '\$ddp\.date'
```
```
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
            <p class="paragraph">$ddp.date("MM / dd / yyyy")</p>
```

Tested locally by:
- updating the Singular study configuration to what is currently in v1.32 (original ps-init-version plus patches in v1.32), 
- signed up locally, created a few activities, completing some but not all
- applied patch in this PR
- set the created_at and first_completed_at times in all activity instances in Singular back 24 hours
- set every revision start_date and revision end_date back 24 hours (if instances are older than the revision timestamp, nothing works)
- built and ran backend using DDP-8730
Below is screenshot of user consent that I had created earlier, but had set the timestamps back
Note that while it is 9/12 today it show 9/11
I created new activites and they display todays date as expected.
<img width="480" alt="Screen Shot 2022-09-12 at 11 11 20 PM" src="https://user-images.githubusercontent.com/29984380/189804070-5aae786f-2aa3-4b3c-aa87-a5aa31a7ba33.png">

