### PR TITLE
DDP-8746 . update osteo patch 

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/osteo/OsteoMRDeleteIncomplete.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/osteo/OsteoMRDeleteIncomplete.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 public class OsteoMRDeleteIncomplete implements CustomTask {
-    private static final List<String> ACTIVITY_CODES = List.of("RELEASE_SELF", "RELEASE_MINOR");
+    private static final List<String> ACTIVITY_CODES = List.of("RELEASE_SELF", "RELEASE_MINOR", "ABOUTYOU", "ABOUTCHILD");
 
     private Config studyCfg;
     private StudyDto studyDto;

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -506,7 +506,7 @@
       },
       "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() ||
        (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].isStatus("CREATED", "IN_PROGRESS")) ||
-       (user.studies["CMI-OSTEO"].forms["RELEASE"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE"].isStatus("CREATED", "IN_PROGRESS"))""",
+       (user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 6
@@ -521,14 +521,67 @@
       },
       "action": {
         "type": "ACTIVITY_INSTANCE_CREATION",
-        "activityCode": "ABOUTCHILD"
+        "activityCode": "ABOUTYOU"
       },
       "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() ||
-       (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].isStatus("CREATED", "IN_PROGRESS")) ||
+       (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].isStatus("CREATED", "IN_PROGRESS")) ||
        (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 7
+    },
+
+    ##CONSENT_ASSENT to ABOUTYOU if RELEASE_MINOR is submitted.. handle osteo2 edge case
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ASSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUTYOU"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].isStatus("CREATED", "IN_PROGRESS")) ||
+       (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 8
+    },
+
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ADDENDUM_PEDIATRIC",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUTYOU"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 9
+    },
+
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ADDENDUM",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUTYOU"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("CREATED", "IN_PROGRESS"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 10
     },
 
     ## RELEASE TO ABOUT YOU

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -511,6 +511,22 @@
       "dispatchToHousekeeping": false,
       "order": 6
     },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUT_YOU_ACTIVITY"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].isStatus("CREATED", "IN_PROGRESS")""",
+      "preconditionExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() && user.studies["CMI-OSTEO"].forms["ABOUTYOU"].isStatus("COMPLETE"))"""
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 7
+    },
 
     ##PARENTAL_CONSENT to ABOUTYOU if RELEASE_MINOR is submitted.. handle osteo2 edge case
     {
@@ -530,6 +546,22 @@
       "dispatchToHousekeeping": false,
       "order": 7
     },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "PARENTAL_CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUT_YOU_ACTIVITY"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].isStatus("CREATED", "IN_PROGRESS")""",
+      "preconditionExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() && user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].isStatus("COMPLETE"))"""
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 8
+    },
 
     ##CONSENT_ASSENT to ABOUTYOU if RELEASE_MINOR is submitted.. handle osteo2 edge case
     {
@@ -547,9 +579,27 @@
        (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 8
+      "order": 6
     },
 
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ASSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUT_YOU_ACTIVITY"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM_PEDIATRIC"].isStatus("CREATED", "IN_PROGRESS")""",
+      "preconditionExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() && user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].isStatus("COMPLETE"))"""
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 7
+    },
+
+    ##PEDIATRIC ADDENDUM to ABOUTYOU V1->V2
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -564,9 +614,25 @@
        (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 9
+      "order": 5
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ADDENDUM_PEDIATRIC",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUT_YOU_ACTIVITY"
+      },
+      "preconditionExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() && user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].isStatus("COMPLETE"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 6
     },
 
+    ##ADDENDUM to ABOUTYOU V1->V2
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -581,7 +647,22 @@
        (user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 10
+      "order": 6
+    },
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT_ADDENDUM",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUT_YOU_ACTIVITY"
+      },
+      "preconditionExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() && user.studies["CMI-OSTEO"].forms["ABOUTYOU"].isStatus("COMPLETE"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 7
     },
 
     ## RELEASE TO ABOUT YOU

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -505,10 +505,11 @@
         "activityCode": "ABOUTYOU"
       },
       "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].isStatus("CREATED", "IN_PROGRESS")) ||
        (user.studies["CMI-OSTEO"].forms["RELEASE"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 4
+      "order": 6
     },
 
     ##PARENTAL_CONSENT to ABOUTYOU if RELEASE_MINOR is submitted.. handle osteo2 edge case
@@ -523,10 +524,11 @@
         "activityCode": "ABOUTCHILD"
       },
       "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].isStatus("CREATED", "IN_PROGRESS")) ||
        (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 5
+      "order": 7
     },
 
     ## RELEASE TO ABOUT YOU

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -123,9 +123,7 @@
           (!user.studies["CMI-OSTEO"].isGovernedParticipant() &&
               user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
               !( user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("CA")
-              || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("NY")) &&
-              !( user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA")
-              || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY"))
+              || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_STATE"].answers.hasOption("NY"))
           )
         )
         && user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_TISSUE"].answers.hasTrue()

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -493,6 +493,42 @@
       "dispatchToHousekeeping": false,
       "order": 1
     },
+    ##CONSENT to ABOUTYOU if RELEASE is submitted.. handle osteo2 edge case
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUTYOU"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["RELEASE"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE"].isStatus("CREATED", "IN_PROGRESS"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 4
+    },
+
+    ##PARENTAL_CONSENT to ABOUTYOU if RELEASE_MINOR is submitted.. handle osteo2 edge case
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "PARENTAL_CONSENT",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "ABOUTCHILD"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["ABOUTCHILD"].hasInstance() ||
+       (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].hasInstance() && user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("CREATED", "IN_PROGRESS"))""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 5
+    },
+
     ## RELEASE TO ABOUT YOU
     {
       "trigger": {

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-workflows.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-workflows.conf
@@ -174,6 +174,51 @@
     {
       "from": {
         "type": "ACTIVITY"
+        "activityCode": "CONSENT",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "CONSENT_ADDENDUM",
+          "expression": """user.studies["CMI-OSTEO"].forms["CONSENT_ADDENDUM"].hasInstance()"""
+        },
+        {
+          "type": "ACTIVITY",
+          "activityCode": "RELEASE_SELF",
+          "expression": """user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUTYOU",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUT_YOU_ACTIVITY",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUT_YOU_ACTIVITY"].hasInstance()"""
+        }
+      ]
+    },
+
+    {
+      "from": {
+        "type": "ACTIVITY"
         "activityCode": "CONSENT_ASSENT",
       },
       "to": [
@@ -210,6 +255,32 @@
     {
       "from": {
         "type": "ACTIVITY"
+        "activityCode": "PARENTAL_CONSENT",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUTYOU",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "PARENTAL_CONSENT",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUT_YOU_ACTIVITY",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUT_YOU_ACTIVITY"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
         "activityCode": "CONSENT_ADDENDUM_PEDIATRIC",
       },
       "to": [
@@ -220,6 +291,32 @@
          }
       ]
     },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT_ADDENDUM_PEDIATRIC",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUTYOU",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT_ADDENDUM_PEDIATRIC",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUT_YOU_ACTIVITY",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUT_YOU_ACTIVITY"].hasInstance()"""
+        }
+      ]
+    }
     {
       "from": {
         "type": "ACTIVITY"
@@ -237,6 +334,32 @@
         }
       ]
     },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT_ADDENDUM",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUTYOU",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].hasInstance()"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY"
+        "activityCode": "CONSENT_ADDENDUM",
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUT_YOU_ACTIVITY",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUT_YOU_ACTIVITY"].hasInstance()"""
+        }
+      ]
+    }
     {
       "from": {
         "type": "ACTIVITY",
@@ -291,6 +414,33 @@
         }
       ]
     },
+    {
+      "from": {
+        "type": "ACTIVITY",
+        "activityCode": "CONSENT_ASSENT"
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUTYOU",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUTYOU"].isStatus("CREATED", "IN_PROGRESS")"""
+        }
+      ]
+    },
+    {
+      "from": {
+        "type": "ACTIVITY",
+        "activityCode": "CONSENT_ASSENT"
+      },
+      "to": [
+        {
+          "type": "ACTIVITY",
+          "activityCode": "ABOUT_YOU_ACTIVITY",
+          "expression": """user.studies["CMI-OSTEO"].forms["ABOUT_YOU_ACTIVITY"].isStatus("CREATED", "IN_PROGRESS")"""
+        }
+      ]
+    },
+
     {
       "from": {
         "type": "ACTIVITY",


### PR DESCRIPTION
update osteo patch to cleanup incomplete ABOUTYOU/ABOUTCHILD
Just added new activity codes to existing activity codes

Added new events to create ABOUTYOU/ABOUTCHILD on re-consent submission to handle ABOUTYOU edge case

NOTE: 
Patch is targeted for prod. Executing the patch against current Dev/Test/Staging will cleanup even new OSTEO2 users activity instances if in created or in-progress state. 
"RELEASE_SELF", "RELEASE_MINOR", "ABOUTYOU", "ABOUTCHILD"

limitation:
The approach works only in scenarios where release is not yet submitted . 
we might need to manually create ABOUTYOU instance for users who already submitted release.
Manually run sql to find these ptps and manually create ABOUTYOU instances
OR add a event to create ABOUTYOU if not exists on re-consent (went with adding new events approach)



If  we want to run in Dev/Test/Staging, might need to alter queries to look for users / activity-instances created from some old date.

QA: Tested in Dev and Test by commenting out actual delete and verifying that right activity-instances are pulled.
Crosse checked using this SQL too
select
u.guid,
u.hruid,
inst.activity_instance_guid,inst.activity_instance_id,
st.activity_instance_status_type_code
from
study_activity a,
activity_instance inst,
activity_instance_status stat,
activity_instance_status_type st,
user u
where
u.user_id = inst.participant_id
and
st.activity_instance_status_type_id = stat.activity_instance_status_type_id
and
stat.activity_instance_id = inst.activity_instance_id
and
inst.study_activity_id = a.study_activity_id
and
a.study_activity_id in (17387,17388)
and
stat.updated_at = (select max(stat2.updated_at) from activity_instance_status stat2 where stat2.activity_instance_id = stat.activity_instance_id)
and
st.activity_instance_status_type_code != 'COMPLETE';
