### PR TITLE
[DDP-8508] Track uploaded at date for file uploads

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
@@ -102,8 +102,7 @@ public class ConfigUtil {
      * Get sql from config file
      * @param queryName name of query
      * @return the SQL for query
-     * @deprecated
-     * please use JDBI and daos instead of looking up
+     * @deprecated please use JDBI and daos instead of looking up
      */
     @Deprecated
     public static String getSqlFromConfig(@NonNull String queryName) {
@@ -112,8 +111,7 @@ public class ConfigUtil {
 
     /**
      * Get sql from config file
-     * @deprecated
-     * please use JDBI and daos instead of looking up SQL snippets from config files
+     * @deprecated please use JDBI and daos instead of looking up SQL snippets from config files
      */
     @Deprecated
     public static String getSqlFromConfig(String sourceName, @NonNull String queryName) {

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.ddp.util;
 
 import java.time.Instant;
-import java.util.Optional;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigRenderOptions;
@@ -52,18 +51,6 @@ public class ConfigUtil {
      */
     public static String getStringOrElse(Config cfg, String key, String defaultValue) {
         return cfg.hasPath(key) ? cfg.getString(key) : defaultValue;
-    }
-
-    public static Optional<String> getString(Config cfg, String key) {
-        if (cfg.hasPathOrNull(key)) {
-            if (cfg.getIsNull(key)) {
-                return Optional.empty();
-            } else {
-                return Optional.of(cfg.getString(key));
-            }
-        } else {
-            return Optional.empty();
-        }
     }
 
     /**

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigUtil.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.util;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigRenderOptions;
@@ -51,6 +52,18 @@ public class ConfigUtil {
      */
     public static String getStringOrElse(Config cfg, String key, String defaultValue) {
         return cfg.hasPath(key) ? cfg.getString(key) : defaultValue;
+    }
+
+    public static Optional<String> getString(Config cfg, String key) {
+        if (cfg.hasPathOrNull(key)) {
+            if (cfg.getIsNull(key)) {
+                return Optional.empty();
+            } else {
+                return Optional.of(cfg.getString(key));
+            }
+        } else {
+            return Optional.empty();
+        }
     }
 
     /**

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.ddp.db.dao;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -175,6 +176,7 @@ public interface AnswerDao extends SqlObject {
         final var uploadedAt = getAnswerSql()
                 .findDtoById(answerId)
                 .map(AnswerDto::getLastUpdatedAt)
+                .map(timestamp -> Instant.ofEpochMilli((long)timestamp))
                 .orElse(Instant.now());
         final var fileUploadDao = getHandle().attach(FileUploadDao.class);
         fileUploadDao.findByIds(uploadIds.stream().mapToLong(id -> id).toArray())

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -165,6 +165,11 @@ public interface AnswerDao extends SqlObject {
             throw new DaoException(message);
         }
 
+        if (uploadIds.isEmpty()) {
+            // No file uploads specified- nothing more to do here.
+            return;
+        }
+
         /*
          * The answer dto needs to be pulled directly here as the `Answer` class does not
          *  include the lastUpdatedAt time. It could be added- the ideal spot would likely be
@@ -178,6 +183,7 @@ public interface AnswerDao extends SqlObject {
                 .map(timestamp -> Instant.ofEpochMilli((long)timestamp))
                 .orElse(Instant.now());
         final var fileUploadDao = getHandle().attach(FileUploadDao.class);
+
         fileUploadDao.findByIds(uploadIds.stream().mapToLong(id -> id).toArray())
                 .forEach(record -> {
                     fileUploadDao.updateStatus(record.getId(),

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -158,11 +158,10 @@ public interface AnswerDao extends SqlObject {
         final List<Long> uploadIds = answer.getValue().stream().map(FileInfo::getUploadId).collect(Collectors.toList());
         final int[] inserted = getAnswerSql().bulkInsertFileValue(answerId, uploadIds);
         if (inserted.length != uploadIds.size()) {
-            final var message = String.format("Failed to insert uploads ids for [answer:%s] (%s inserted, %s expected)",
+            throw new DaoException(String.format("Failed to insert uploads ids for [answer:%s] (%s inserted, %s expected)",
                     answerId,
                     inserted.length,
-                    uploadIds.size());
-            throw new DaoException(message);
+                    uploadIds.size()));
         }
 
         if (uploadIds.isEmpty()) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -481,7 +481,7 @@ public interface AnswerDao extends SqlObject {
             boolean isChildAnswer = view.getColumn("is_child_answer", Boolean.class);
             String actInstanceGuid = view.getColumn("activity_instance_guid", String.class);
 
-            Answer answer;
+            final Answer answer;
             switch (type) {
                 case AGREEMENT:
                     answer = new AgreementAnswer(answerId, questionStableId, answerGuid, view.getColumn("aa_value", Boolean.class),

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/AnswerDao.java
@@ -1,7 +1,6 @@
 package org.broadinstitute.ddp.db.dao;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/FileUploadDao.java
@@ -81,10 +81,11 @@ public interface FileUploadDao extends SqlObject {
             + "     f.created_at AS created_at, "
             + "     f.uploaded_at AS uploaded_at, "
             + "     f.scanned_at AS scanned_at, "
-            + "     fsr.file_scan_result_code AS scan_result, "
-            + "     f.notification_sent_at AS notification_sent_at "
+            + "     f.notification_sent_at AS notification_sent_at, "
+            + "     (SELECT file_scan_result_code "
+            + "         FROM file_scan_result "
+            + "         WHERE file_scan_result_id = f.scan_result_id) AS scan_result "
             + "FROM file_upload AS f "
-            + " JOIN file_scan_result AS fsr ON fsr.file_scan_result_id = f.scan_result_id "
             + "WHERE f.file_upload_id IN (<uploadIds>)")
     @RegisterConstructorMapper(FileUpload.class)
     List<FileUpload> findByIds(@BindList("uploadIds") long... uploadIds);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.java
@@ -2,6 +2,7 @@ package org.broadinstitute.ddp.db.dao;
 
 import static java.util.stream.Collectors.toList;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -88,6 +89,7 @@ public interface JdbiCompositeAnswer extends SqlObject {
                                 lastChildRowAnswerDtos
                                         .add(new AnswerDto(childAnswerId,
                                                 rs.getString("child_answer_guid"),
+                                                rs.getObject("child_last_updated_at", Instant.class),
                                                 rs.getLong("child_question_id"),
                                                 rs.getString("child_question_stable_id"),
                                                 QuestionType.valueOf(rs.getString("child_question_type_code")),

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.java
@@ -2,7 +2,6 @@ package org.broadinstitute.ddp.db.dao;
 
 import static java.util.stream.Collectors.toList;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -89,7 +88,7 @@ public interface JdbiCompositeAnswer extends SqlObject {
                                 lastChildRowAnswerDtos
                                         .add(new AnswerDto(childAnswerId,
                                                 rs.getString("child_answer_guid"),
-                                                rs.getObject("child_last_updated_at", Instant.class),
+                                                rs.getLong("child_last_updated_at"),
                                                 rs.getLong("child_question_id"),
                                                 rs.getString("child_question_stable_id"),
                                                 QuestionType.valueOf(rs.getString("child_question_type_code")),
@@ -99,6 +98,4 @@ public interface JdbiCompositeAnswer extends SqlObject {
                         });
         return Optional.ofNullable(answerSummary.getGuid() == null ? null : answerSummary);
     }
-
-
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/AnswerDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/AnswerDto.java
@@ -1,7 +1,5 @@
 package org.broadinstitute.ddp.db.dto;
 
-import java.time.Instant;
-
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
@@ -18,7 +16,7 @@ public class AnswerDto {
     String guid;
 
     @ColumnName("last_updated_at")
-    Instant lastUpdatedAt;
+    long lastUpdatedAt;
 
     @ColumnName("question_id")
     long questionId;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/AnswerDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/AnswerDto.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.ddp.db.dto;
 
+import java.time.Instant;
+
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import org.broadinstitute.ddp.model.activity.types.QuestionType;
@@ -14,6 +16,9 @@ public class AnswerDto {
     
     @ColumnName("answer_guid")
     String guid;
+
+    @ColumnName("last_updated_at")
+    Instant lastUpdatedAt;
 
     @ColumnName("question_id")
     long questionId;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubConnectionManager.java
@@ -196,7 +196,7 @@ public class PubSubConnectionManager {
 
     /**
      * Creates the creds provider needed for the emulator.
-     * @return
+     * @return an environment-correct credentials provider
      */
     private CredentialsProvider emulatedPubSubCredentialsProvider() {
         if (!useEmulator) {
@@ -208,7 +208,7 @@ public class PubSubConnectionManager {
 
     /**
      * Creates the channel need for the emulator
-     * @return
+     * @return an environment-correct managed channel instance
      */
     private ManagedChannel emulatedPubSubChannel() {
         if (!useEmulator) {

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.sql.stg
@@ -3,53 +3,55 @@ group JdbiCompositeAnswer;
 //Note the 2 left joins
 getCompositeAnswerSummary() ::= <<
 SELECT
-	pa.answer_id AS parent_answer_id,
-	pa.answer_guid AS parent_answer_guid,
-	pq.question_id AS parent_question_id,
-	pqsc.stable_id AS parent_question_stable_id,
-	pa.activity_instance_id as parent_activity_instance_id,
-	ar.answer_id AS child_answer_id,
-	ar.answer_guid AS child_answer_guid,
-	cqq.child_question_id AS child_question_id,
-	cqt.question_type_code AS child_question_type_code,
-	cqsc.stable_id AS child_question_stable_id,
-	cqq.display_order,
-	qr.response_order AS row_order
- FROM
-	answer pa
-		JOIN
+    pa.answer_id AS parent_answer_id,
+    pa.answer_guid AS parent_answer_guid,
+    pa.last_updated_at AS parent_last_updated_at,
+    pq.question_id AS parent_question_id,
+    pqsc.stable_id AS parent_question_stable_id,
+    pa.activity_instance_id as parent_activity_instance_id,
+    ar.answer_id AS child_answer_id,
+    ar.answer_guid AS child_answer_guid,
+    ar.last_updated_at AS child_last_updated_at,
+    cqq.child_question_id AS child_question_id,
+    cqt.question_type_code AS child_question_type_code,
+    cqsc.stable_id AS child_question_stable_id,
+    cqq.display_order,
+    qr.response_order AS row_order
+  FROM
+    answer pa
+        JOIN
     question pq ON pa.question_id=pq.question_id
         JOIN
     question_stable_code pqsc ON pq.question_stable_code_id = pqsc.question_stable_code_id
         JOIN
     composite_question__question cqq ON cqq.parent_question_id = pq.question_id
-		JOIN
-	question cq ON cqq.child_question_id=cq.question_id
-		JOIN
-	question_type cqt ON cqt.question_type_id = cq.question_type_id
-	    JOIN
+        JOIN
+    question cq ON cqq.child_question_id=cq.question_id
+        JOIN
+    question_type cqt ON cqt.question_type_id = cq.question_type_id
+        JOIN
     question_stable_code cqsc ON cq.question_stable_code_id = cqsc.question_stable_code_id
     -- creating a subquery "table" that has one entry per row of child answers
     -- there might be no child answer entries, so outer join
         LEFT JOIN
     (SELECT DISTINCT
-		parent_answer_id,response_order
-	FROM
-		composite_answer_item i) AS qr ON pa.answer_id=qr.parent_answer_id
+        parent_answer_id,response_order
+    FROM
+        composite_answer_item i) AS qr ON pa.answer_id=qr.parent_answer_id
     -- create another subquery "table" that has the child answers
     -- will need to join back to expected answer rows by parent answer id, child question
     -- and expected row position
     LEFT JOIN
     (SELECT
-		i.parent_answer_id,ca.question_id,ca.answer_guid,ca.answer_id,i.response_order
-	FROM
-		composite_answer_item i
-	LEFT JOIN
-		answer ca on ca.answer_id=i.child_answer_id) AS ar ON ar.parent_answer_id=pa.answer_id AND ar.question_id=cqq.child_question_id AND qr.response_order=ar.response_order
+        i.parent_answer_id,ca.question_id,ca.answer_guid,ca.answer_id,i.response_order
+    FROM
+        composite_answer_item i
+    LEFT JOIN
+        answer ca on ca.answer_id=i.child_answer_id) AS ar ON ar.parent_answer_id=pa.answer_id AND ar.question_id=cqq.child_question_id AND qr.response_order=ar.response_order
   WHERE
-	pa.answer_id=:parentAnswerId
+    pa.answer_id=:parentAnswerId
   ORDER BY
-	qr.response_order,
+    qr.response_order,
     cqq.display_order
 >>
 

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/JdbiCompositeAnswer.sql.stg
@@ -43,7 +43,7 @@ SELECT
     -- and expected row position
     LEFT JOIN
     (SELECT
-        i.parent_answer_id,ca.question_id,ca.answer_guid,ca.answer_id,i.response_order
+        i.parent_answer_id, ca.question_id, ca.answer_guid, ca.last_updated_at, ca.answer_id, i.response_order
     FROM
         composite_answer_item i
     LEFT JOIN


### PR DESCRIPTION
DDP-8508

## Context

This PR updates the `FileAnswer` handling such that when a client persists an uploaded file reference, the `uploaded_at` date of the `FileUpload` value is set to the update time of the answer. The justification used for this is, once a client has created & uploaded a file, the API expects clients to make a `PATCH` request to the `../answers` to finalize the upload.
