### PR TITLE
DDP-8618 singular aom fixes.

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAOMSupport.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAOMSupport.java
@@ -23,8 +23,10 @@ public class SingularAOMSupport implements CustomTask {
     private static final String STUDY_GUID  = "singular";
     private static final String PRECOND_EXPR = "!user.studies[\"singular\"].forms[\"CHILD_CONTACT\"].isStatus(\"COMPLETE\")";
     private static final String COPY_PRECOND_EXPR = "user.studies[\"singular\"].forms[\"CONSENT_SELF\"].isStatus(\"COMPLETE\")";
-    private static final String RELEASE_EXPR  = "!(user.studies[\"singular\"].forms[\"MEDICAL_RECORD_RELEASE\"].questions[\"MRR_STAFF_GETS_RECORDS_DIRECTLY\"].isAnswered() &&\n" +
-            "user.studies[\"singular\"].forms[\"MEDICAL_RECORD_RELEASE\"].questions[\"MRR_STAFF_GETS_RECORDS_DIRECTLY\"].answers.hasOption(\"TRUE\"))";
+    private static final String RELEASE_EXPR  = "!(user.studies[\"singular\"].forms[\"MEDICAL_RECORD_RELEASE\"]"
+            + ".questions[\"MRR_STAFF_GETS_RECORDS_DIRECTLY\"]"
+            + ".isAnswered() && user.studies[\"singular\"].forms[\"MEDICAL_RECORD_RELEASE\"]"
+            + ".questions[\"MRR_STAFF_GETS_RECORDS_DIRECTLY\"].answers.hasOption(\"TRUE\"))";
 
     protected Config dataCfg;
     protected Path cfgPath;
@@ -59,7 +61,6 @@ public class SingularAOMSupport implements CustomTask {
         long questionId = helper.findQuestionId(studyDto.getId(), "MEDICAL_RECORD_RELEASE", "MRR_SIGNATURE");
         helper.updateQuestionDef(questionId);
         log.info("Update QuestionDef with id: {} ", questionId);
-
     }
 
     private void updateEvents(Handle handle, StudyDto studyDto) {

--- a/pepper-apis/studybuilder-cli/studies/singular/patches/singular-aom-new-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/patches/singular-aom-new-events.conf
@@ -9,7 +9,7 @@
       },
       "action": {
         "type": "HIDE_ACTIVITIES",
-        "activityCodes": ["CONSENT_PARENTAL", "CONSENT_ASSENT", "ABOUT_HEALTHY", "MEDICAL_RECORD_RELEASE", "CHILD_CONTACT", "MEDICAL_RECORD_FILE_UPLOAD", "PATIENT_SURVEY"]
+        "activityCodes": ["ABOUT_HEALTHY", "MEDICAL_RECORD_RELEASE", "CHILD_CONTACT", "MEDICAL_RECORD_FILE_UPLOAD", "PATIENT_SURVEY"]
       },
       "preconditionExpr": """user.studies["singular"].forms["CHILD_CONTACT"].isStatus("COMPLETE")""",
       "dispatchToHousekeeping": false,


### PR DESCRIPTION
Couple of fixes related to DDP-8618
1. Do not hide old consent (parental) forms on age-up
2. Fix t make sure RELEASE MRR_STAFF_GETS_RECORDS_DIRECTLY options are enabled on age-up if parental RELEASE has MRR_STAFF_GETS_RECORDS_DIRECTLY checked.