### PR TITLE
PEPPER-14 fixing the nested type of files

### DIFF
--- a/elasticsearch/templates/participants_structured.json
+++ b/elasticsearch/templates/participants_structured.json
@@ -425,6 +425,7 @@
           }
         },
         "files": {
+          "type": "nested",
           "properties": {
             "guid": {
               "type": "keyword"
@@ -436,7 +437,17 @@
               "type": "text"
             },
             "fileName": {
-              "type": "text"
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                },
+                "lower_case_sort": {
+                  "type": "text",
+                  "analyzer": "case_insensitive_sort",
+                  "fielddata": true
+                }
+              }
             },
             "fileSize": {
               "type": "long"

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/PropertyInfo.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/PropertyInfo.java
@@ -52,7 +52,7 @@ public class PropertyInfo {
         TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.PROFILE, new PropertyInfo(Profile.class, false));
         TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.INVITATIONS, new PropertyInfo(Invitations.class, false));
         TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.ADDRESS, new PropertyInfo(Address.class, false));
-        TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.FILES, new PropertyInfo(Files.class, false));
+        TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.FILES, new PropertyInfo(Files.class, true));
         TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.DSM, new PropertyInfo(Dsm.class, false));
         TABLE_ALIAS_MAPPINGS.put(ESObjectConstants.DATA, new PropertyInfo(Status.class, false));
     }


### PR DESCRIPTION
The bug was happening because `files` didn't have the right `nested` type, I changed that and fixed the properties of fileName so it can still be searchable with the right query.
<img width="1680" alt="Screen Shot 2022-10-13 at 2 07 15 PM" src="https://user-images.githubusercontent.com/47120870/195673313-a6fffe60-eb18-4c90-a14b-a5613946cb7b.png">


