### PR TITLE
[Pepper-16] Add singular ADD_PARTICIPANT location questions to study config

### DIFF
--- a/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
@@ -316,7 +316,153 @@
             ]
           }
         },
-        // 1d. Does your dependent have a cognitive impairment that impacts their understanding of words commonly used by others in their age group?
+
+        // 1d. Where does your child currently live?
+        {
+          "blockType": "QUESTION",
+          "shownExpr": null,
+          "question": {
+            include required("../../snippets/picklist-question-country-required-eligible-first.conf"),
+            "stableId": "ADD_PARTICIPANT_COUNTRY_DEPENDENT",
+            "hideNumber": true,
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": """
+                <h3 class="activity-question-title">$add_participant_dependent_country_prompt</h3>
+                <p class="activity-question-footnote">$add_participant_dependent_country_footnote</p>
+              """,
+              "variables": [
+                {
+                  "name": "add_participant_dependent_country_prompt",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.country.prompt} }
+                  ]
+                },
+                {
+                  "name": "add_participant_dependent_country_footnote",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.country.footnote} }
+                  ]
+                }
+              ]
+            },
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_dependent_country_label",
+              "variables": [
+                {
+                  "name": "add_participant_dependent_country_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.country.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_dependent_country_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_dependent_country_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.dependent.country.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
+        // State for US
+        {
+          "blockType": "QUESTION",
+          "shownExpr": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_COUNTRY_DEPENDENT"].answers.hasOption("US")
+          """,
+          "question": {
+            include required("../../snippets/picklist-question-state-required.conf"),
+            "stableId": "ADD_PARTICIPANT_STATE_DEPENDENT",
+            "hideNumber": true,
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_dependent_state_label",
+              "variables": [
+                {
+                  "name": "add_participant_dependent_state_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.state.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_dependent_state_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_dependent_state_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.dependent.state.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
+        // Province for Canada
+        {
+          "blockType": "QUESTION",
+          "shownExpr": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_COUNTRY_DEPENDENT"].answers.hasOption("CA")
+          """,
+          "question": {
+            include required("../../snippets/picklist-question-province-required.conf"),
+            "stableId": "ADD_PARTICIPANT_PROVINCE_DEPENDENT",
+            "hideNumber": true,
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_dependent_province_label",
+              "variables": [
+                {
+                  "name": "add_participant_dependent_province_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.province.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_dependent_province_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_dependent_province_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.dependent.province.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
+        // 1e. Does your dependent have a cognitive impairment that impacts their understanding of words commonly used by others in their age group?
         {
           "blockType": "QUESTION",
           "shownExpr": """

--- a/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-dependent.conf
@@ -317,7 +317,7 @@
           }
         },
 
-        // 1d. Where does your child currently live?
+        // 1d. Where does your dependent currently live?
         {
           "blockType": "QUESTION",
           "shownExpr": null,

--- a/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-parental.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-parental.conf
@@ -316,6 +316,152 @@
             ]
           }
         },
+
+        // 2a. Where does your child currently live?
+        {
+          "blockType": "QUESTION",
+          "shownExpr": null,
+          "question": {
+            include required("../../snippets/picklist-question-country-required-eligible-first.conf"),
+            "stableId": "ADD_PARTICIPANT_COUNTRY_CHILD",
+            "hideNumber": true,
+            "promptTemplate": {
+              "templateType": "HTML",
+              "templateText": """
+                <h3 class="activity-question-title">$add_participant_child_country_prompt</h3>
+                <p class="activity-question-footnote">$add_participant_child_country_footnote</p>
+              """,
+              "variables": [
+                {
+                  "name": "add_participant_child_country_prompt",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.parental.country.prompt} }
+                  ]
+                },
+                {
+                  "name": "add_participant_child_country_footnote",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.parental.country.footnote} }
+                  ]
+                }
+              ]
+            },
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_child_country_label",
+              "variables": [
+                {
+                  "name": "add_participant_child_country_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.parental.country.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_child_country_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_child_country_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.parental.country.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
+        // State for US
+        {
+          "blockType": "QUESTION",
+          "shownExpr": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_COUNTRY_CHILD"].answers.hasOption("US")
+          """,
+          "question": {
+            include required("../../snippets/picklist-question-state-required.conf"),
+            "stableId": "ADD_PARTICIPANT_STATE_CHILD",
+            "hideNumber": true,
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_child_state_label",
+              "variables": [
+                {
+                  "name": "add_participant_child_state_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.parental.state.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_child_state_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_child_state_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.parental.state.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
+        // Province for Canada
+        {
+          "blockType": "QUESTION",
+          "shownExpr": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_COUNTRY_CHILD"].answers.hasOption("CA")
+          """,
+          "question": {
+            include required("../../snippets/picklist-question-province-required.conf"),
+            "stableId": "ADD_PARTICIPANT_PROVINCE_CHILD",
+            "hideNumber": true,
+            "picklistLabelTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$add_participant_child_province_label",
+              "variables": [
+                {
+                  "name": "add_participant_child_province_label",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.add_participant.dependent.province.label} }
+                  ]
+                }
+              ]
+            },
+            "validations": [
+              {
+                "ruleType": "REQUIRED",
+                "hintTemplate": {
+                  "templateType": "TEXT",
+                  "templateText": "$add_participant_child_province_required_hint",
+                  "variables": [
+                    {
+                      "name": "add_participant_child_province_required_hint",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.add_participant.parental.province.required_hint} }
+                      ]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+
         // 1d. Does your child have a cognitive impairment that impacts their understanding of words commonly used by others in their age group?
         {
           "blockType": "QUESTION",

--- a/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-parental.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/activities/add-participant-parental.conf
@@ -317,7 +317,7 @@
           }
         },
 
-        // 2a. Where does your child currently live?
+        // 1d. Where does your child currently live?
         {
           "blockType": "QUESTION",
           "shownExpr": null,
@@ -462,7 +462,7 @@
           }
         },
 
-        // 1d. Does your child have a cognitive impairment that impacts their understanding of words commonly used by others in their age group?
+        // 1e. Does your child have a cognitive impairment that impacts their understanding of words commonly used by others in their age group?
         {
           "blockType": "QUESTION",
           "shownExpr": """

--- a/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/i18n/en.conf
@@ -258,6 +258,44 @@
   },
 
   "add_participant": {
+    "parental": {
+      "country": {
+        "prompt": "Where does your child currently live?*",
+        "label": "Select Country",
+        "footnote": "Participants must currently reside in the United States or Canada.",
+        "required_hint": "Please choose a country",
+        "ineligible_hint": "Project Singular is currently open only to participants in the United States and Territories or Canada. Thank you for your interest."
+      },
+
+      "state": {
+        "label": "Select State",
+        "required_hint": "Please choose a state"
+      },
+
+      "province": {
+        "label": "Select Province",
+        "required_hint": "Please choose a province"
+      },
+    },
+    "dependent": {
+      "country": {
+        "prompt": "Where does your dependent currently live?*",
+        "label": "Select Country",
+        "footnote": "Participants must currently reside in the United States or Canada.",
+        "required_hint": "Please choose a country",
+        "ineligible_hint": "Project Singular is currently open only to participants in the United States and Territories or Canada. Thank you for your interest."
+      },
+
+      "state": {
+        "label": "Select State",
+        "required_hint": "Please choose a state"
+      },
+
+      "province": {
+        "label": "Select Province",
+        "required_hint": "Please choose a province"
+      },
+    }
     "name-myself": "Enroll myself",
     "title-myself": "Enroll myself",
     "name-my-child": "Enroll my child",

--- a/pepper-apis/studybuilder-cli/studies/singular/study-activities.conf
+++ b/pepper-apis/studybuilder-cli/studies/singular/study-activities.conf
@@ -124,6 +124,27 @@
           }
         },
         {
+          "stableIds": ["ADD_PARTICIPANT_COUNTRY_CHILD"],
+          "precondition": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_COUNTRY_CHILD"].isAnswered()
+          """,
+          "expression": """
+            !user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ADD_PARTICIPANT_COUNTRY_CHILD"].answers.hasAnyOption("US", "CA", "PR", "GU", "VI", "MP", "AS")
+          """,
+          "messageTemplate": {
+            "templateType": "TEXT",
+            "templateText": "$add_participant_enrolling_child_country_ineligible_hint",
+            "variables": [
+              {
+                "name": "add_participant_enrolling_child_country_ineligible_hint",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.add_participant.parental.country.ineligible_hint} }
+                ]
+              }
+            ]
+          }
+        },
+        {
           "stableIds": ["ENROLLING_CHILD_AGE"],
           "precondition": """
             user.studies["singular"].forms["ADD_PARTICIPANT_PARENTAL"].questions["ENROLLING_CHILD_AGE"].isAnswered()
@@ -166,6 +187,27 @@
                 "name": "add_participant_enrolling_dependent_diagnosed_ineligible_hint",
                 "translations": [
                   { "language": "en", "text": ${i18n.en.add_participant.enrolling_dependent_diagnosed.ineligible_hint} }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "stableIds": ["ADD_PARTICIPANT_COUNTRY_DEPENDENT"],
+          "precondition": """
+            user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_COUNTRY_DEPENDENT"].isAnswered()
+          """,
+          "expression": """
+            !user.studies["singular"].forms["ADD_PARTICIPANT_DEPENDENT"].questions["ADD_PARTICIPANT_COUNTRY_DEPENDENT"].answers.hasAnyOption("US", "CA", "PR", "GU", "VI", "MP", "AS")
+          """,
+          "messageTemplate": {
+            "templateType": "TEXT",
+            "templateText": "$add_participant_enrolling_dependent_country_ineligible_hint",
+            "variables": [
+              {
+                "name": "add_participant_enrolling_dependent_country_ineligible_hint",
+                "translations": [
+                  { "language": "en", "text": ${i18n.en.add_participant.dependent.country.ineligible_hint} }
                 ]
               }
             ]


### PR DESCRIPTION
# Pepper-16
_related to [\[PEPPER-16\] Adds location questions to child & dependent add participant activities #2388](https://github.com/broadinstitute/ddp-study-server/pull/2388)_

## Summary
Adds the following questions to the `ADD_PARTICIPANT_PARENTAL` and `ADD_PARTICIPANT_DEPENDENT` surveys, in addition to activity validations for requiring that the location questions are answered, and have an allowable location for the study.

This PR adds the questions for PEPPER-16 to the base configuration for `singular`.

# Testing Process
_this pr is intended to be deployed from a clean state_
Deploy a new instance of `singular` as normal (either from a previously invalidated instance, or from a fresh DSS database)

## Study setup
1. Rebuild dss-server and studybuilder-cli
    * `mvn -pl dss-server -pl studybuilder-cli -am -DskipTests clean package`
1. Invalidate the existing `singular` instance in your local environment, if one exists, and re-deploy the `singular` study
2. Perform any necessary for your local environment (adding Auth0 clients, etc)
3. Configure & run DDP-Angular `singular` instance
    ```
    npx ng serve ddp-singular
    ```


[PEPPER-16]: https://broadworkbench.atlassian.net/browse/PEPPER-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ