### PR TITLE
Pepper-233 Kit page bug Fix

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -685,45 +685,45 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                     target) || OVERVIEW.equals(target) || WAITING.equals(target)) {
 
                 DDPInstance ddpInstance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.NEEDS_NAME_LABELS);
+                Map<String, Map<String, Object>> participantsESData = null;
                 if (StringUtils.isNotBlank(ddpInstance.getParticipantIndexES())) {
-
-                    Map<String, Map<String, Object>> participantsESData =
+                    participantsESData =
                             ElasticSearchUtil.getDDPParticipantsFromES(ddpInstance.getName(), ddpInstance.getParticipantIndexES());
+                }
 
-                    for (String key : kitRequests.keySet()) {
-                        List<KitRequestShipping> kitRequest = kitRequests.get(key);
-                        DDPParticipant ddpParticipant = null;
-                        boolean checkedParticipant = false;
+                for (String key : kitRequests.keySet()) {
+                    List<KitRequestShipping> kitRequest = kitRequests.get(key);
+                    DDPParticipant ddpParticipant = null;
+                    boolean checkedParticipant = false;
 
-                        for (KitRequestShipping kit : kitRequest) {
-                            if (StringUtils.isNotBlank(kit.getRealm())) {
-                                if (participantsESData != null && !participantsESData.isEmpty()) {
-                                    kit.setPreferredLanguage(ElasticSearchUtil.getPreferredLanguage(participantsESData, key));
-                                }
-                                // ERROR need address; QUEUE need name label if realm = RGP
-                                // UPLOADED and DEACTIVATED and TRIGGERED and WAITING need shortId if getCollaboratorParticipantId is blank
-                                if ((ERROR.equals(target) || ((QUEUE.equals(target) || UPLOADED.equals(target)) && ddpInstance.isHasRole()))
-                                        || (
-                                        (UPLOADED.equals(target) || DEACTIVATED.equals(target) || TRIGGERED.equals(target) || OVERVIEW.equals(
-                                                target) || WAITING.equals(target))
-                                                && StringUtils.isBlank(kit.getBspCollaboratorParticipantId()))) {
-                                    String apiKey = DSMServer.getDDPEasypostApiKey(ddpInstance.getName());
-                                    if (StringUtils.isNotBlank(apiKey) && kit.getEasypostAddressId() != null && StringUtils.isNotBlank(
-                                            kit.getEasypostAddressId())) {
-                                        getAddressPerEasypost(ddpInstance, kit, apiKey);
-                                    } else {
-                                        if (participantsESData != null && !participantsESData.isEmpty()) {
-                                            ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, key);
-                                            if (ddpParticipant != null) {
-                                                kit.setParticipant(ddpParticipant);
-                                            } else {
-                                                kit.setMessage(PARTICIPANT_NOT_FOUND_MESSAGE + kit.getRealm());
-                                                kit.setError(true);
-                                            }
+                    for (KitRequestShipping kit : kitRequest) {
+                        if (StringUtils.isNotBlank(kit.getRealm())) {
+                            if (participantsESData != null && !participantsESData.isEmpty()) {
+                                kit.setPreferredLanguage(ElasticSearchUtil.getPreferredLanguage(participantsESData, key));
+                            }
+                            // ERROR need address; QUEUE need name label if realm = RGP
+                            // UPLOADED and DEACTIVATED and TRIGGERED and WAITING need shortId if getCollaboratorParticipantId is blank
+                            if ((ERROR.equals(target) || ((QUEUE.equals(target) || UPLOADED.equals(target)) && ddpInstance.isHasRole()))
+                                    || (
+                                    (UPLOADED.equals(target) || DEACTIVATED.equals(target) || TRIGGERED.equals(target) || OVERVIEW.equals(
+                                            target) || WAITING.equals(target))
+                                            && StringUtils.isBlank(kit.getBspCollaboratorParticipantId()))) {
+                                String apiKey = DSMServer.getDDPEasypostApiKey(ddpInstance.getName());
+                                if (StringUtils.isNotBlank(apiKey) && kit.getEasypostAddressId() != null && StringUtils.isNotBlank(
+                                        kit.getEasypostAddressId())) {
+                                    getAddressPerEasypost(ddpInstance, kit, apiKey);
+                                } else {
+                                    if (participantsESData != null && !participantsESData.isEmpty()) {
+                                        ddpParticipant = ElasticSearchUtil.getParticipantAsDDPParticipant(participantsESData, key);
+                                        if (ddpParticipant != null) {
+                                            kit.setParticipant(ddpParticipant);
                                         } else {
-                                            kit.setMessage(NO_PARTICIPANT_INFORMATION);
+                                            kit.setMessage(PARTICIPANT_NOT_FOUND_MESSAGE + kit.getRealm());
                                             kit.setError(true);
                                         }
+                                    } else {
+                                        kit.setMessage(NO_PARTICIPANT_INFORMATION);
+                                        kit.setError(true);
                                     }
                                 }
                             }


### PR DESCRIPTION
## Context

Since we need to allow Darwin with no participants to have kits I check if there are participants before entering the initial for loop. Thus it skips that part if we are in Darwin. The changes looks worse than it is because I had to indent everything under the `if (StringUtils.isNotBlank(ddpInstance.getParticipantIndexES())) {`

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

