### PR TITLE
PEPPER-175: Create addendum activity once blood/saliva kit marked as received

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
@@ -36,7 +36,7 @@ public interface EventDao extends SqlObject {
 
     default List<EventConfiguration> getAllEventConfigurationsByStudyId(long studyId) {
         return getEventConfigurationDtosByStudyId(studyId).stream()
-                .map(dto -> new EventConfiguration(dto))
+                .map(EventConfiguration::new)
                 .collect(Collectors.toList());
     }
 

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertEvents.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertEvents.java
@@ -1,0 +1,52 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import lombok.extern.slf4j.Slf4j;
+import one.util.streamex.StreamEx;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.dsm.DsmNotificationEventType;
+import org.broadinstitute.ddp.model.event.DsmNotificationTrigger;
+import org.broadinstitute.ddp.model.event.EventConfiguration;
+import org.jdbi.v3.core.Handle;
+
+@Slf4j
+public class OsteoInsertEvents extends InsertStudyEvents {
+    OsteoInsertEvents() {
+        super("osteo", "patches/osteo-new-events.conf");
+    }
+
+    @Override
+    public void run(final Handle handle) {
+        removeExistingEvents(handle);
+        super.run(handle);
+    }
+
+    private void removeExistingEvents(final Handle handle) {
+        final var studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
+
+        var eventDao = handle.attach(EventDao.class);
+        StreamEx.of(eventDao.getAllEventConfigurationsByStudyId(studyDto.getId()))
+                .filterBy(EventConfiguration::getEventActionType, EventActionType.ACTIVITY_INSTANCE_CREATION)
+                .filterBy(EventConfiguration::getEventTriggerType, EventTriggerType.DSM_NOTIFICATION)
+                .filter(this::hasDSMNotificationTrigger)
+                .filter(this::isExpectedTrigger)
+                .forEach(e -> handle.attach(JdbiEventConfiguration.class).updateIsActiveById(e.getEventConfigurationId(), false));
+
+        log.info("Successfully removed DSM Notification events that create new activities of {}.", studyGuid);
+    }
+
+    private boolean hasDSMNotificationTrigger(final EventConfiguration event) {
+        return event.getEventTrigger() instanceof DsmNotificationTrigger;
+    }
+
+    private boolean isExpectedTrigger(final EventConfiguration event) {
+        return isExpectedTrigger(((DsmNotificationTrigger) event.getEventTrigger()).getDsmEventType());
+    }
+
+    private boolean isExpectedTrigger(final DsmNotificationEventType eventType) {
+        return eventType == DsmNotificationEventType.BLOOD_RECEIVED || eventType == DsmNotificationEventType.SALIVA_RECEIVED;
+    }
+}

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertEvents.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertEvents.java
@@ -14,8 +14,8 @@ import org.jdbi.v3.core.Handle;
 
 @Slf4j
 public class OsteoInsertEvents extends InsertStudyEvents {
-    OsteoInsertEvents() {
-        super("osteo", "patches/osteo-new-events.conf");
+    public OsteoInsertEvents() {
+        super("CMI-OSTEO", "patches/osteo-new-events.conf");
     }
 
     @Override

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoV2Updates.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoV2Updates.java
@@ -53,6 +53,7 @@ public class OsteoV2Updates implements CustomTask {
         tasks.add(new UpdateStudyNonSyncEvents());
         tasks.add(new OsteoInsertSyncEvents());
         tasks.add(new UpdateStudyWorkflows()); //updated conf file to remove FAMILY_HISTORY reference
+        tasks.add(new OsteoInsertEvents());
 
         tasks.forEach(t -> t.init(cfgPath, studyCfg, varsCfg));
     }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoV3Updates.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoV3Updates.java
@@ -22,6 +22,7 @@ public class OsteoV3Updates implements CustomTask {
         tasks.add(new UpdateStudyNonSyncEvents());
         tasks.add(new OsteoInsertSyncEvents());
         tasks.add(new UpdateStudyWorkflows());
+        tasks.add(new OsteoInsertEvents());
 
         tasks.forEach(t -> t.init(cfgPath, studyCfg, varsCfg));
     }

--- a/pepper-apis/studybuilder-cli/studies/osteo/patches/osteo-new-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/patches/osteo-new-events.conf
@@ -1,0 +1,117 @@
+{
+  "events": [
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
+      "preconditionExpr": """
+        user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+        user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
+        (
+          (
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          )
+           ||
+          (
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+        )""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 3
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
+      "preconditionExpr": """
+          !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+           user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
+          ((
+            !user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+          ||
+          (
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+          ))
+          """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
+      "preconditionExpr": """
+          !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+           user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
+          ((
+            !user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+          ||
+          (
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+          ))
+          """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
+      "preconditionExpr": """
+        user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+        user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
+        (
+          (
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          )
+           ||
+          (
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+        )""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    }
+  ]
+}

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -1471,6 +1471,7 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
       },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
       "preconditionExpr": """
         user.studies["CMI-OSTEO"].isGovernedParticipant() &&
         user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
@@ -1488,7 +1489,35 @@
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 2
-    }
+    },
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
+      "preconditionExpr": """
+        user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+        user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
+        (
+          (
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+           user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("US")
+          )
+           ||
+          (
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+        )""",
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 3
+    },
 
     # enrollment events
     {
@@ -1913,6 +1942,34 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": "GERMLINE_CONSENT_ADDENDUM"
       },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
+      "preconditionExpr": """
+          !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
+           user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
+          ((
+            !user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
+          )
+          ||
+          (
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
+              user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+          ))
+          """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    },
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
+      },
+      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
       "preconditionExpr": """
           !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
            user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
@@ -1944,7 +2001,7 @@
        user.studies["CMI-OSTEO"].isGovernedParticipant()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 3
+      "order": 4
     },
     ## CONSENT TO RELEASE
     {

--- a/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/study-events.conf
@@ -1471,7 +1471,6 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
       "preconditionExpr": """
         user.studies["CMI-OSTEO"].isGovernedParticipant() &&
         user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
@@ -1489,35 +1488,7 @@
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
       "order": 2
-    },
-    {
-      "trigger": {
-        "type": "DSM_NOTIFICATION",
-        "dsmEvent": "BLOOD_RECEIVED"
-      },
-      "action": {
-        "type": "ACTIVITY_INSTANCE_CREATION",
-        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
-      },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
-      "preconditionExpr": """
-        user.studies["CMI-OSTEO"].isGovernedParticipant() &&
-        user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") &&
-        (
-          (
-           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
-           user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("US")
-          )
-           ||
-          (
-            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].hasInstance() &&
-            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
-          )
-        )""",
-      "maxOccurrencesPerUser": 1,
-      "dispatchToHousekeeping": false,
-      "order": 3
-    },
+    }
 
     # enrollment events
     {
@@ -1942,34 +1913,6 @@
         "type": "ACTIVITY_INSTANCE_CREATION",
         "activityCode": "GERMLINE_CONSENT_ADDENDUM"
       },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
-      "preconditionExpr": """
-          !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
-           user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
-          ((
-            !user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
-            user.studies["CMI-OSTEO"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US")
-          )
-          ||
-          (
-              user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance() &&
-              user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
-          ))
-          """,
-      "maxOccurrencesPerUser": 1,
-      "dispatchToHousekeeping": false,
-      "order": 2
-    },
-    {
-      "trigger": {
-        "type": "DSM_NOTIFICATION",
-        "dsmEvent": "BLOOD_RECEIVED"
-      },
-      "action": {
-        "type": "ACTIVITY_INSTANCE_CREATION",
-        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
-      },
-      "cancelExpr": """user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
       "preconditionExpr": """
           !user.studies["CMI-OSTEO"].isGovernedParticipant() &&
            user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") &&
@@ -2001,7 +1944,7 @@
        user.studies["CMI-OSTEO"].isGovernedParticipant()""",
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": false,
-      "order": 4
+      "order": 3
     },
     ## CONSENT TO RELEASE
     {


### PR DESCRIPTION
The patch was applied locally against the database that was exported from the dev server
```
[builder] executing custom task: OsteoInsertEvents
16:52:43.975   C: S: [main] INFO  o.b.d.s.task.OsteoInsertEvents Event configuration #52445 was deactivated
16:52:43.988   C: S: [main] INFO  o.b.d.s.task.OsteoInsertEvents Event configuration #52433 was deactivated
16:52:43.991   C: S: [main] INFO  o.b.d.s.task.OsteoInsertEvents Event configuration #52318 was deactivated
16:52:43.992   C: S: [main] INFO  o.b.d.s.task.OsteoInsertEvents Event configuration #52306 was deactivated
16:52:43.994   C: S: [main] INFO  o.b.d.s.task.OsteoInsertEvents Successfully deactivated 4 DSM Notification events that create new activities of CMI-OSTEO.
16:52:43.994   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents TASK:: InsertStudyEvents 
16:52:44.029   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents Inserting events configuration...
16:52:44.196   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52529, trigger=DSM_NOTIFICATION/BLOOD_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM_PEDIATRIC
16:52:44.221   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52530, trigger=DSM_NOTIFICATION/BLOOD_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM
16:52:44.247   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52531, trigger=DSM_NOTIFICATION/SALIVA_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM
16:52:44.270   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52532, trigger=DSM_NOTIFICATION/SALIVA_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM_PEDIATRIC
16:52:44.270   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents Events configuration has added in study CMI-OSTEO
[builder] done
Disconnected from the target VM, address: '127.0.0.1:59168', transport: 'socket'
```