### PR TITLE
PEPPER-176: Create addendum activity once blood/saliva kit marked as received

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/LmsInsertEvents.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/LmsInsertEvents.java
@@ -1,0 +1,58 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import lombok.extern.slf4j.Slf4j;
+import one.util.streamex.StreamEx;
+import org.broadinstitute.ddp.db.dao.EventDao;
+import org.broadinstitute.ddp.db.dao.JdbiEventConfiguration;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.model.activity.types.EventActionType;
+import org.broadinstitute.ddp.model.activity.types.EventTriggerType;
+import org.broadinstitute.ddp.model.dsm.DsmNotificationEventType;
+import org.broadinstitute.ddp.model.event.DsmNotificationTrigger;
+import org.broadinstitute.ddp.model.event.EventConfiguration;
+import org.jdbi.v3.core.Handle;
+
+@Slf4j
+public class LmsInsertEvents extends InsertStudyEvents {
+    public LmsInsertEvents() {
+        super("cmi-lms", "patches/lms-new-events.conf");
+    }
+
+    @Override
+    public void run(final Handle handle) {
+        removeExistingEvents(handle);
+        super.run(handle);
+    }
+
+    private void removeExistingEvents(final Handle handle) {
+        final var eventDao = handle.attach(EventDao.class);
+        final var count = StreamEx.of(eventDao.getAllEventConfigurationsByStudyId(handle.attach(JdbiUmbrellaStudy.class)
+                        .findByStudyGuid(studyGuid).getId()))
+                .filterBy(EventConfiguration::getEventActionType, EventActionType.ACTIVITY_INSTANCE_CREATION)
+                .filterBy(EventConfiguration::getEventTriggerType, EventTriggerType.DSM_NOTIFICATION)
+                .filter(this::hasDSMNotificationTrigger)
+                .filter(this::isExpectedTrigger)
+                .map(EventConfiguration::getEventConfigurationId)
+                .map(id -> deactivateEventConfiguration(handle, id))
+                .count();
+
+        log.info("Successfully deactivated {} DSM Notification events that create new activities of {}.", count, studyGuid);
+    }
+
+    private static int deactivateEventConfiguration(final Handle handle, final Long id) {
+        log.info("Event configuration #{} was deactivated", id);
+        return handle.attach(JdbiEventConfiguration.class).updateIsActiveById(id, false);
+    }
+
+    private boolean hasDSMNotificationTrigger(final EventConfiguration event) {
+        return event.getEventTrigger() instanceof DsmNotificationTrigger;
+    }
+
+    private boolean isExpectedTrigger(final EventConfiguration event) {
+        return isExpectedTrigger(((DsmNotificationTrigger) event.getEventTrigger()).getDsmEventType());
+    }
+
+    private boolean isExpectedTrigger(final DsmNotificationEventType eventType) {
+        return eventType == DsmNotificationEventType.BLOOD_RECEIVED || eventType == DsmNotificationEventType.SALIVA_RECEIVED;
+    }
+}

--- a/pepper-apis/studybuilder-cli/studies/lms/patches/lms-new-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/patches/lms-new-events.conf
@@ -1,0 +1,101 @@
+{
+  "events": [
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
+      },
+      "cancelExpr": """user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
+      "preconditionExpr": """
+          user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].hasInstance() &&
+          user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US") &&
+          user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].isStatus("COMPLETE") &&
+          user.studies["cmi-lms"].isGovernedParticipant()
+      """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 3
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "BLOOD_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
+      },
+      "cancelExpr": """user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
+      "preconditionExpr": """
+          ((
+            !user.studies["cmi-lms"].forms["PREQUAL"].hasInstance() &&
+            user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US") &&
+            user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].instances[latest].hasPreviousInstance()
+          )
+          ||
+          (
+              user.studies["cmi-lms"].forms["PREQUAL"].hasInstance() &&
+              user.studies["cmi-lms"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+          )) && !user.studies["cmi-lms"].isGovernedParticipant()
+          && user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].instances[latest].isStatus("COMPLETE")
+          """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM"
+      },
+      "cancelExpr": """user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM"].hasInstance()""",
+      "preconditionExpr": """
+          ((
+            !user.studies["cmi-lms"].forms["PREQUAL"].hasInstance() &&
+            user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US") &&
+            user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].instances[latest].hasPreviousInstance()
+          )
+          ||
+          (
+              user.studies["cmi-lms"].forms["PREQUAL"].hasInstance() &&
+              user.studies["cmi-lms"].forms["PREQUAL"].questions["SELF_COUNTRY"].answers.hasOption("US")
+          )) && !user.studies["cmi-lms"].isGovernedParticipant()
+          && user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].instances[latest].isStatus("COMPLETE")
+          """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_RECEIVED"
+      },
+      "action": {
+        "type": "ACTIVITY_INSTANCE_CREATION",
+        "activityCode": "GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"
+      },
+      "cancelExpr": """user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].hasInstance()""",
+      "preconditionExpr": """
+          user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].hasInstance() &&
+          user.studies["cmi-lms"].forms["ADD_PARTICIPANT"].questions["CHILD_COUNTRY_COPY"].answers.hasOption("US") &&
+          user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].isStatus("COMPLETE") &&
+          user.studies["cmi-lms"].isGovernedParticipant()
+      """,
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": false,
+      "order": 2
+    }
+  ]
+}


### PR DESCRIPTION
Local patch execution logs:
```
[builder] resolving study configuration...
[builder] executing custom task: LmsInsertEvents
11:14:03.742   C: S: [main] INFO  o.b.d.s.task.LmsInsertEvents Event configuration #50956 was deactivated
11:14:03.761   C: S: [main] INFO  o.b.d.s.task.LmsInsertEvents Event configuration #50955 was deactivated
11:14:03.764   C: S: [main] INFO  o.b.d.s.task.LmsInsertEvents Successfully deactivated 2 DSM Notification events that create new activities of cmi-lms.
11:14:03.764   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents TASK:: InsertStudyEvents 
11:14:03.877   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents Inserting events configuration...
11:14:04.050   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52533, trigger=DSM_NOTIFICATION/BLOOD_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM_PEDIATRIC
11:14:04.073   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52534, trigger=DSM_NOTIFICATION/BLOOD_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM
11:14:04.095   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52535, trigger=DSM_NOTIFICATION/SALIVA_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM
11:14:04.117   C: S: [main] INFO  o.b.ddp.studybuilder.EventBuilder Created event with id=52536, trigger=DSM_NOTIFICATION/SALIVA_RECEIVED, action=ACTIVITY_INSTANCE_CREATION/GERMLINE_CONSENT_ADDENDUM_PEDIATRIC
11:14:04.117   C: S: [main] INFO  o.b.d.s.task.InsertStudyEvents Events configuration has added in study cmi-lms
[builder] done
```