### PR TITLE
Pepper-235 create kit request event

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -919,7 +919,7 @@ public class Housekeeping {
 
             var action = (CreateKitEventAction) event.getEventAction();
             action.doActionSynchronously(apisHandle, signal);
-            jdbiQueuedEvent.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
+            jdbiQueuedEvent.delete(pendingEvent.getQueuedEventId());
             log.info("Deleted queued create kit event {}", pendingEvent.getQueuedEventId());
             return true;
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -91,7 +91,7 @@ import org.broadinstitute.ddp.model.activity.types.EventActionType;
 import org.broadinstitute.ddp.model.event.ActivityInstanceCreationEventAction;
 import org.broadinstitute.ddp.model.event.EventConfiguration;
 import org.broadinstitute.ddp.model.event.EventSignal;
-import org.broadinstitute.ddp.model.event.KitCreationEventAction;
+import org.broadinstitute.ddp.model.event.CreateKitEventAction;
 import org.broadinstitute.ddp.model.event.UpdateUserStatusEventAction;
 import org.broadinstitute.ddp.model.study.StudySettings;
 import org.broadinstitute.ddp.model.user.User;
@@ -917,7 +917,7 @@ public class Housekeeping {
                     studyDto.getGuid(),
                     pendingEvent.getTriggerType());
 
-            var action = (KitCreationEventAction) event.getEventAction();
+            var action = (CreateKitEventAction) event.getEventAction();
             action.doActionSynchronously(apisHandle, signal);
 
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -908,7 +908,7 @@ public class Housekeeping {
                     ? pendingEvent.getOperatorGuid() : participant.getGuid();
             StudyDto studyDto = new JdbiUmbrellaStudyCached(apisHandle)
                     .findByStudyGuid(pendingEvent.getStudyGuid());
-            var signal = new EventSignal(
+            EventSignal signal = new EventSignal(
                     operatorUserId,
                     participant.getId(),
                     participant.getGuid(),
@@ -917,7 +917,7 @@ public class Housekeeping {
                     studyDto.getGuid(),
                     pendingEvent.getTriggerType());
 
-            var action = (CreateKitEventAction) event.getEventAction();
+            CreateKitEventAction action = (CreateKitEventAction) event.getEventAction();
             action.doActionSynchronously(apisHandle, signal);
             jdbiQueuedEvent.delete(pendingEvent.getQueuedEventId());
             log.info("Deleted queued create kit event {}", pendingEvent.getQueuedEventId());

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/Housekeeping.java
@@ -385,7 +385,7 @@ public class Housekeeping {
                                                             .orElse(false);
                                                     if (shouldDeleteEvent) {
                                                         log.warn("Unable to create message for event with "
-                                                                + "queued_event_id={}, proceeding to delete",
+                                                                        + "queued_event_id={}, proceeding to delete",
                                                                 pendingEvent.getQueuedEventId(), e);
                                                         queuedEventDao.deleteAllByQueuedEventId(
                                                                 pendingEvent.getQueuedEventId());
@@ -393,8 +393,8 @@ public class Housekeeping {
                                                         // event.
                                                     } else {
                                                         log.error("Could not create message for event with "
-                                                                + "queued_event_id={}"
-                                                                + " because there is no email address to sent to",
+                                                                        + "queued_event_id={}"
+                                                                        + " because there is no email address to sent to",
                                                                 pendingEvent.getQueuedEventId(), e);
                                                     }
                                                 } catch (MessageBuilderException e) {
@@ -919,7 +919,9 @@ public class Housekeeping {
 
             var action = (CreateKitEventAction) event.getEventAction();
             action.doActionSynchronously(apisHandle, signal);
-
+            jdbiQueuedEvent.deleteAllByQueuedEventId(pendingEvent.getQueuedEventId());
+            log.info("Deleted queued create kit event {}", pendingEvent.getQueuedEventId());
+            return true;
         }
 
         return false;
@@ -954,7 +956,8 @@ public class Housekeeping {
     /**
      * Supplier of SendGrid service.
      */
-    @FunctionalInterface interface SendGridSupplier {
+    @FunctionalInterface
+    interface SendGridSupplier {
         SendGridClient get(String apiKey);
     }
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionDao.java
@@ -157,7 +157,7 @@ public interface EventActionDao extends SqlObject {
 
     default long insertCreateKitAction(long kitTypeId) {
         long actionId = getJdbiEventAction().insert(null, EventActionType.CREATE_KIT);
-        DBUtils.checkInsert(1, getEventActionSql().insertCreateKitEventAction(actionId,kitTypeId));
+        DBUtils.checkInsert(1, getEventActionSql().insertCreateKitEventAction(actionId, kitTypeId));
         return actionId;
     }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionDao.java
@@ -155,6 +155,12 @@ public interface EventActionDao extends SqlObject {
         return actionId;
     }
 
+    default long insertCreateKitAction(long kitTypeId) {
+        long actionId = getJdbiEventAction().insert(null, EventActionType.CREATE_KIT);
+        DBUtils.checkInsert(1, getEventActionSql().insertCreateKitEventAction(actionId,kitTypeId));
+        return actionId;
+    }
+
     default void deleteAnnouncementAction(long eventActionId) {
         int numDeleted = getJdbiUserAnnouncementEventAction().deleteById(eventActionId);
         if (numDeleted != 1) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionSql.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventActionSql.java
@@ -56,6 +56,13 @@ public interface EventActionSql extends SqlObject {
             @Bind("status") String status
      );
 
+    @SqlUpdate("insert into create_kit_event_action (event_action_id, kit_type_id)"
+            + " values (:actionId, :kitTypeId)")
+    int insertCreateKitEventAction(
+            @Bind("actionId") long actionId,
+            @Bind("kitTypeId") long kitTypeId
+    );
+
     @SqlUpdate("delete from activity_instance_creation_action where activity_instance_creation_action_id = :actionId")
     int deleteActivityInstanceCreationAction(@Bind("actionId") long eventActionId);
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/EventDao.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.broadinstitute.ddp.constants.SqlConstants;
+import org.broadinstitute.ddp.db.dto.CreateKitDto;
 import org.broadinstitute.ddp.db.dto.EventConfigurationDto;
 import org.broadinstitute.ddp.db.dto.NotificationDetailsDto;
 import org.broadinstitute.ddp.db.dto.NotificationTemplateSubstitutionDto;
@@ -157,6 +158,7 @@ public interface EventDao extends SqlObject {
     @RegisterConstructorMapper(NotificationDetailsDto.class)
     @RegisterConstructorMapper(NotificationTemplateSubstitutionDto.class)
     @RegisterConstructorMapper(QueuedPdfGenerationDto.class)
+    @RegisterConstructorMapper(CreateKitDto.class)
     @UseRowReducer(QueuedEventDtoReducer.class)
     List<QueuedEventDto> findPublishableQueuedEvents();
 
@@ -169,6 +171,7 @@ public interface EventDao extends SqlObject {
     @RegisterConstructorMapper(QueuedPdfGenerationDto.class)
     @UseRowReducer(QueuedEventDtoReducer.class)
     @RegisterConstructorMapper(QueuedEventDto.class)
+    @RegisterConstructorMapper(CreateKitDto.class)
     List<QueuedEventDto> findAllQueuedEvents();
 
     @UseStringTemplateSqlLocator
@@ -180,6 +183,7 @@ public interface EventDao extends SqlObject {
     @RegisterConstructorMapper(QueuedPdfGenerationDto.class)
     @UseRowReducer(QueuedEventDtoReducer.class)
     @RegisterConstructorMapper(QueuedEventDto.class)
+    @RegisterConstructorMapper(CreateKitDto.class)
     Optional<QueuedEventDto> findQueuedEventById(@Bind("id") long queuedEventId);
 
     // Used by Study Builder do not delete

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/CreateKitDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/CreateKitDto.java
@@ -1,0 +1,19 @@
+package org.broadinstitute.ddp.db.dto;
+
+import lombok.Value;
+import org.jdbi.v3.core.mapper.Nested;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
+
+@Value
+public class CreateKitDto extends QueuedEventDto {
+    long createKitConfigurationId;
+
+    @JdbiConstructor
+    public CreateKitDto(
+            @Nested QueuedEventDto pendingEvent,
+            @ColumnName("create_kit_configuration_id") long createKitConfigurationId) {
+        super(pendingEvent);
+        this.createKitConfigurationId = createKitConfigurationId;
+    }
+}

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dto/EventConfigurationDto.java
@@ -111,6 +111,9 @@ public class EventConfigurationDto {
     /* MARK_ACTIVITIES_READ_ONLY, HIDE_ACTIVITIES */
     Set<Long> targetActivityIds = new HashSet<>();
 
+    /* CREATE_KIT kit_type_id */
+    Long kitTypeId;
+
     public void addNotificationPdfAttachment(Long pdfDocumentConfigurationId, Boolean alwaysGenerate) {
         notificationPdfAttachments.add(new PdfAttachment(pdfDocumentConfigurationId, alwaysGenerate));
     }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
@@ -299,11 +299,11 @@ public class PubSubMessageBuilder {
                     queuedPdfGenerationDto.getPdfDocumentConfigurationId());
             messageJson = gson.toJson(pdfGenerationMessage);
         } else if (pendingEvent.getActionType() == EventActionType.CREATE_KIT) {
-            CreateKitMessage pdfGenerationMessage = new CreateKitMessage(
+            CreateKitMessage createKitMessage = new CreateKitMessage(
                     participantGuid,
                     studyGuid,
                     pendingEvent.getEventConfigurationId());
-            messageJson = gson.toJson(pdfGenerationMessage);
+            messageJson = gson.toJson(createKitMessage);
         } else {
             throw new MessageBuilderException("message has not been determined for queued event " + pendingEvent
                     .getQueuedEventId());

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
@@ -47,6 +47,7 @@ import org.broadinstitute.ddp.db.dto.QueuedPdfGenerationDto;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.exception.MessageBuilderException;
 import org.broadinstitute.ddp.exception.NoSendableEmailAddressException;
+import org.broadinstitute.ddp.housekeeping.message.CreateKitMessage;
 import org.broadinstitute.ddp.housekeeping.message.NotificationMessage;
 import org.broadinstitute.ddp.housekeeping.message.PdfGenerationMessage;
 import org.broadinstitute.ddp.model.activity.types.EventActionType;
@@ -297,10 +298,17 @@ public class PubSubMessageBuilder {
                     queuedPdfGenerationDto.getEventConfigurationId(),
                     queuedPdfGenerationDto.getPdfDocumentConfigurationId());
             messageJson = gson.toJson(pdfGenerationMessage);
+        } else if (pendingEvent.getActionType() == EventActionType.CREATE_KIT) {
+            CreateKitMessage pdfGenerationMessage = new CreateKitMessage(
+                    participantGuid,
+                    studyGuid,
+                    pendingEvent.getEventConfigurationId());
+            messageJson = gson.toJson(pdfGenerationMessage);
         } else {
             throw new MessageBuilderException("message has not been determined for queued event " + pendingEvent
                     .getQueuedEventId());
         }
+
         PubsubMessage.Builder messageBuilder = PubsubMessage.newBuilder()
                 .setData(ByteString.copyFromUtf8(messageJson))
                 .putAttributes(DDP_EVENT_ID, pendingEvent.getDdpEventId())

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/message/CreateKitMessage.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/message/CreateKitMessage.java
@@ -1,0 +1,36 @@
+package org.broadinstitute.ddp.housekeeping.message;
+
+import com.google.gson.annotations.SerializedName;
+
+public class CreateKitMessage implements HousekeepingMessage {
+    @SerializedName("participantGuid")
+    private String participantGuid;
+
+    @SerializedName("studyGuid")
+    private String studyGuid;
+
+    @SerializedName("eventConfigId")
+    private long eventConfigurationId;
+
+    public CreateKitMessage(String participantGuid,
+                            String studyGuid,
+                            long eventConfigurationId) {
+        this.participantGuid = participantGuid;
+        this.studyGuid = studyGuid;
+        this.eventConfigurationId = eventConfigurationId;
+    }
+
+    @Override
+    public long getEventConfigurationId() {
+        return eventConfigurationId;
+    }
+
+    public String getParticipantGuid() {
+        return participantGuid;
+    }
+
+    public String getStudyGuid() {
+        return studyGuid;
+    }
+
+}

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/types/EventActionType.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/activity/types/EventActionType.java
@@ -12,7 +12,9 @@ public enum EventActionType {
     REVOKE_PROXIES(true),
     UPDATE_CUSTOM_WORKFLOW(false),
     UPDATE_USER_STATUS(false),
-    USER_ENROLLED(true);
+    USER_ENROLLED(true),
+    CREATE_KIT(false);
+
 
     private boolean isStatic;
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/dsm/DsmNotificationEventType.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/dsm/DsmNotificationEventType.java
@@ -6,6 +6,10 @@ public enum DsmNotificationEventType {
      */
     SALIVA_RECEIVED,
     /**
+     * Message sent by DSM when saliva kit has been sent
+     */
+    SALIVA_SENT,
+    /**
      * Message sent by DSM when blood kit has been returned to Broad
      */
     BLOOD_RECEIVED,

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
@@ -40,10 +40,6 @@ public class CreateKitEventAction extends EventAction {
     public CreateKitEventAction(EventConfiguration eventConfiguration, EventConfigurationDto dto) {
         super(eventConfiguration, dto);
         kitTypeId = dto.getKitTypeId();
-        if (kitTypeId == null) {
-            //todo
-            throw new DDPException("NO kitType in config");
-        }
     }
 
     @Override

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
@@ -64,7 +64,7 @@ public class CreateKitEventAction extends EventAction {
         List<KitConfigurationDto> kitConfigs = handle.attach(KitConfigurationDao.class)
                 .getKitConfigurationDtosByStudyId(signal.getStudyId());
         if (kitConfigs == null || kitConfigs.isEmpty()) {
-            return;
+            return; //todo.. event.. no kitConfig
         }
 
         //load user and address
@@ -93,7 +93,8 @@ public class CreateKitEventAction extends EventAction {
         Optional<KitConfigurationDto> kitConfigByTypeOpt = kitConfigs.stream().filter(dto -> dto.getKitTypeId()
                 == kitTypeId).findFirst();
         if (!kitConfigByTypeOpt.isPresent()) {
-            // todo warn and move on
+            // todo warn and move on ?
+            //log.warn("No KitConfig for study : {} . kit type Id: {}", signal.getStudyGuid(), kitTypeId);
         } else {
             kitConfig = handle.attach(KitConfigurationDao.class).getKitConfigurationForDto(kitConfigByTypeOpt.get());
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
@@ -24,8 +24,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.broadinstitute.ddp.service.DsmAddressValidationStatus.DSM_INVALID_ADDRESS_STATUS;
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/CreateKitEventAction.java
@@ -1,0 +1,135 @@
+package org.broadinstitute.ddp.model.event;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.dao.JdbiMailAddress;
+import org.broadinstitute.ddp.db.dao.KitConfigurationDao;
+import org.broadinstitute.ddp.db.dao.QueuedEventDao;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.EventConfigurationDto;
+import org.broadinstitute.ddp.db.dto.kit.KitConfigurationDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.address.MailAddress;
+import org.broadinstitute.ddp.model.kit.KitConfiguration;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.monitoring.PointsReducerFactory;
+import org.broadinstitute.ddp.monitoring.StackdriverCustomMetric;
+import org.broadinstitute.ddp.monitoring.StackdriverMetricsTracker;
+import org.broadinstitute.ddp.pex.PexInterpreter;
+import org.broadinstitute.ddp.service.DsmAddressValidationStatus;
+import org.broadinstitute.ddp.service.KitCheckService;
+import org.jdbi.v3.core.Handle;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class CreateKitEventAction extends EventAction {
+
+    Long kitTypeId;
+    /**
+     * Key is study guid, value is the metrics transmitter for the study
+     */
+    private static final Map<String, StackdriverMetricsTracker> kitCounterMonitorByStudy = new HashMap<>();
+
+    public CreateKitEventAction(EventConfiguration eventConfiguration, EventConfigurationDto dto) {
+        super(eventConfiguration, dto);
+        kitTypeId = dto.getKitTypeId();
+        if (kitTypeId == null) {
+            //todo
+            throw new DDPException("NO kitType in config");
+        }
+    }
+
+    @Override
+    public void doAction(PexInterpreter pexInterpreter, Handle handle, EventSignal signal) {
+        Integer delayBeforePosting = eventConfiguration.getPostDelaySeconds();
+        if (delayBeforePosting != null && delayBeforePosting > 0) {
+            if (!eventConfiguration.dispatchToHousekeeping()) {
+                throw new DDPException("Incompatible event configuration:"
+                        + " delayed Kit Creation events should set dispatchToHousekeeping");
+            }
+            long queuedEventId = queueDelayedEvent(handle, signal);
+            log.info("Queued Kit Creation event with id {}", queuedEventId);
+        } else {
+            doActionSynchronously(handle, signal);
+        }
+    }
+
+    public void doActionSynchronously(Handle handle, EventSignal signal) {
+
+        List<KitConfigurationDto> kitConfigs = handle.attach(KitConfigurationDao.class)
+                .getKitConfigurationDtosByStudyId(signal.getStudyId());
+        if (kitConfigs == null || kitConfigs.isEmpty()) {
+            return;
+        }
+
+        //load user and address
+        User user = handle.attach(UserDao.class).findUserByGuid(signal.getParticipantGuid()).get();
+        List<MailAddress> allAddresses = handle.attach(JdbiMailAddress.class)
+                .findAllAddressesForParticipant(signal.getParticipantGuid());
+        MailAddress address = null;
+        DsmAddressValidationStatus statusType = null;
+        Optional<MailAddress> defaultAddressOpt = allAddresses.stream().filter(mailAddress -> mailAddress.isDefault()).findFirst();
+        if (!defaultAddressOpt.isPresent()) {
+            log.warn("No default address for ptp : {} ", signal.getParticipantGuid());
+            //no default mailing address ??
+        } else {
+            address = defaultAddressOpt.get();
+            try {
+                statusType = DsmAddressValidationStatus.getByCode(address.getValidationStatus());
+                //address.setValidationStatus(DsmAddressValidationStatus.getByCode(address.getValidationStatus()));
+            } catch (Exception e) {
+                //todo warn and move on or halt
+                log.warn("Invalid address validation statusId {}  found for participant: {} ",
+                        address.getValidationStatus(), signal.getParticipantGuid());
+            }
+        }
+
+        KitConfiguration kitConfig = null;
+        Optional<KitConfigurationDto> kitConfigByTypeOpt = kitConfigs.stream().filter(dto -> dto.getKitTypeId()
+                == kitTypeId).findFirst();
+        if (!kitConfigByTypeOpt.isPresent()) {
+            // todo warn and move on
+        } else {
+            kitConfig = handle.attach(KitConfigurationDao.class).getKitConfigurationForDto(kitConfigByTypeOpt.get());
+        }
+        //should be only one !
+        KitCheckService service = new KitCheckService();
+        KitCheckService.PotentialRecipient candidate = new KitCheckService.PotentialRecipient(user.getId(),
+                user.getGuid(), address.getId(), statusType);
+        KitCheckService.KitCheckResult kitCheckResult = new KitCheckService.KitCheckResult();
+        kitCheckResult = service.processPotentialKitRecipient(signal.getParticipantGuid(), kitTypeId,
+                kitCheckResult, kitConfig, candidate);
+
+        //send metric by study
+        if (kitCheckResult != null) {
+            sendKitMetrics(kitCheckResult);
+            log.info("Queued {} participants for Kit creation", kitCheckResult.getTotalNumberOfParticipantsQueuedForKit());
+        }
+    }
+
+    @VisibleForTesting
+    long queueDelayedEvent(Handle handle, EventSignal signal) {
+        return handle.attach(QueuedEventDao.class).addToQueue(
+                eventConfiguration.getEventConfigurationId(),
+                signal.getOperatorId(),
+                signal.getParticipantId(),
+                eventConfiguration.getPostDelaySeconds());
+    }
+
+    private void sendKitMetrics(KitCheckService.KitCheckResult kitCheckResult) {
+        for (var queuedParticipantsByStudy : kitCheckResult.getQueuedParticipantsByStudy()) {
+            String studyGuid = queuedParticipantsByStudy.getKey();
+            int numQueuedParticipants = queuedParticipantsByStudy.getValue().size();
+            var tracker = kitCounterMonitorByStudy.computeIfAbsent(studyGuid, key ->
+                    new StackdriverMetricsTracker(StackdriverCustomMetric.KITS_REQUESTED, studyGuid,
+                            PointsReducerFactory.buildSumReducer()));
+            tracker.addPoint(numQueuedParticipants, Instant.now().toEpochMilli());
+        }
+    }
+
+}

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
@@ -117,6 +117,9 @@ public class EventConfiguration {
             case UPDATE_CUSTOM_WORKFLOW:
                 eventAction = new UpdateCustomWorkflowEventAction(this, dto, new TaskPubSubPublisher());
                 break;
+            case CREATE_KIT:
+                eventAction = new KitCreationEventAction(this, dto);
+                break;
             default:
                 throw new DDPException("Event action type: " + eventActionType.name() + " is not properly configured in "
                         + "the EventConfiguration ctor");

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/model/event/EventConfiguration.java
@@ -118,7 +118,7 @@ public class EventConfiguration {
                 eventAction = new UpdateCustomWorkflowEventAction(this, dto, new TaskPubSubPublisher());
                 break;
             case CREATE_KIT:
-                eventAction = new KitCreationEventAction(this, dto);
+                eventAction = new CreateKitEventAction(this, dto);
                 break;
             default:
                 throw new DDPException("Event action type: " + eventActionType.name() + " is not properly configured in "

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -111,7 +111,7 @@ public class KitCheckService {
         return kitCheckResult;
     }
 
-    private void processPotentialKitRecipient(String studyGuid, long kitTypeId,
+    public KitCheckResult processPotentialKitRecipient(String studyGuid, long kitTypeId,
                                               KitCheckResult kitCheckResult,
                                               KitConfiguration kitConfiguration,
                                               PotentialRecipient candidate) {
@@ -119,13 +119,13 @@ public class KitCheckService {
 
         if (candidate.getAddressId() == null) {
             log.warn("Participant {} is missing a default mailing address", userGuid);
-            return;
+            return null;
         }
 
         if (candidate.getAddressValidationStatus() == null
                 || candidate.getAddressValidationStatus() == DSM_INVALID_ADDRESS_STATUS) {
             log.warn("Participant {} has an invalid mailing address", userGuid);
-            return;
+            return null;
         }
 
         boolean wasSuccessful = withAPIsTxn(handle -> {
@@ -159,6 +159,8 @@ public class KitCheckService {
         } else {
             log.warn("Participant {} was ineligible for a kit", userGuid);
         }
+
+        return kitCheckResult;
     }
 
     /**

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -136,11 +136,13 @@ public class KitCheckService {
 
             if (success) {
                 //default numKits to 1 if event and no config or config.numKits < 1
-                int numKits = (event && (kitConfiguration == null || kitConfiguration.getNumKits() <= 1)) ? 1: kitConfiguration.getNumKits();
+                int numKits = (event && (kitConfiguration == null || kitConfiguration.getNumKits() <= 1))
+                        ? 1 : kitConfiguration.getNumKits();
                 for (int i = 0; i < numKits; i++) {
                     log.info("Creating kit request for {} by {}", userGuid, event ? "event" : "job");
                     Long kitRequestId = kitRequestDao.createKitRequest(studyGuid, candidate.getUserId(),
-                            candidate.getAddressId(), kitTypeId, kitConfiguration.needsApproval());
+                            candidate.getAddressId(), kitTypeId,
+                            kitConfiguration != null ? kitConfiguration.needsApproval() : false);
                     log.info("Created kit request id {} for {}. Completed {} out of {} kits",
                             kitRequestId, userGuid, i + 1, numKits);
                 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -135,9 +135,10 @@ public class KitCheckService {
             DsmKitRequestDao kitRequestDao = handle.attach(DsmKitRequestDao.class);
 
             if (success) {
-                int numKits = kitConfiguration != null ? kitConfiguration.getNumKits() : 0;
+                //default numKits to 1 if event and no config or config.numKits < 1
+                int numKits = (event && (kitConfiguration == null || kitConfiguration.getNumKits() <= 1)) ? 1: kitConfiguration.getNumKits();
                 for (int i = 0; i < numKits; i++) {
-                    log.info("Creating kit request for {}", userGuid);
+                    log.info("Creating kit request for {} by {}", userGuid, event ? "event" : "job");
                     Long kitRequestId = kitRequestDao.createKitRequest(studyGuid, candidate.getUserId(),
                             candidate.getAddressId(), kitTypeId, kitConfiguration.needsApproval());
                     log.info("Created kit request id {} for {}. Completed {} out of {} kits",

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -139,7 +139,7 @@ public class KitCheckService {
                 int numKits = (event && (kitConfiguration == null || kitConfiguration.getNumKits() <= 1))
                         ? 1 : kitConfiguration.getNumKits();
                 for (int i = 0; i < numKits; i++) {
-                    log.info("Creating kit request for {} by {}", userGuid, event ? "event" : "job");
+                    log.info("Creating kit request for {} by {}. kit type Id: {} ", userGuid, event ? "event" : "job", kitTypeId);
                     Long kitRequestId = kitRequestDao.createKitRequest(studyGuid, candidate.getUserId(),
                             candidate.getAddressId(), kitTypeId,
                             kitConfiguration != null ? kitConfiguration.needsApproval() : false);

--- a/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/EventDao.sql.stg
+++ b/pepper-apis/dss-core/src/main/resources/org/broadinstitute/ddp/db/dao/EventDao.sql.stg
@@ -52,7 +52,8 @@ SELECT
      ucwea.custom_workflow_status,
      aica.create_from_answer,
      aica.source_question_stable_id,
-     aica.target_question_stable_id
+     aica.target_question_stable_id,
+     ckea.kit_type_id
 FROM
      event_configuration ec
 JOIN event_trigger et ON ec.event_trigger_id = et.event_trigger_id
@@ -79,6 +80,8 @@ LEFT JOIN copy_answer_event_action as cp_answer on cp_answer.event_action_id=ea.
 LEFT JOIN create_invitation_event_action as ciea on ciea.event_action_id = ea.event_action_id
 LEFT JOIN event_action_target_activity as eata on eata.event_action_id = ea.event_action_id
 LEFT JOIN update_custom_workflow_event_action as ucwea on ucwea.event_action_id = ea.event_action_id
+LEFT JOIN create_kit_event_action as ckea on ckea.event_action_id = ea.event_action_id
+
 >>
 
 getEventConfigurationByEventConfigurationId() ::= <<

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/event/NotificationEventActionTest.java
@@ -180,7 +180,7 @@ public class NotificationEventActionTest extends TxnAwareBaseTest {
                 null, null, null, null, null, null, null, null, null, null,
                 notificationType, serviceType, linkedActivityId,
                 null, null, null, null, null, null,
-                null, null, false, null, null);
+                null, null, false, null, null, null);
     }
 
     private long insertInvitationEmailEventConfiguration(Handle handle, EventTriggerType staticTriggerType) {

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/event/UpdateCustomWorkflowEventActionTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/event/UpdateCustomWorkflowEventActionTest.java
@@ -50,7 +50,7 @@ public class UpdateCustomWorkflowEventActionTest extends TxnAwareBaseTest {
                     null, 1L, null, null, null, null, null, null, null,
                     null, null, null, 1L,
                     null, null, null, null, null, null,
-                    workflow, status, false, null, null);
+                    workflow, status, false, null, null, null);
             var event = new EventConfiguration(eventDto);
             var updateCustomWorkflowEventAction = new UpdateCustomWorkflowEventAction(event, eventDto, new TestTaskPublisher());
             updateCustomWorkflowEventAction.doAction(null, handle, signal);

--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -323,4 +323,5 @@
 <!--    <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>-->
     <include file="db-changes/schema/PEPPER-235-create-kit-event-action.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/PEPPER-235-add-kit-creation.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/PEPPER-235-add-saliva-sent-dsm-event-type.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -306,7 +306,7 @@
     <include file="db-changes/seed/DDP-7709-add-boolean-render-mode-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7709-add-boolean-render-mode.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8012.xml" relativeToChangelogFile="true"/>
-    <include file="db-changes/schema/DDP-7713.xml" relativeToChangelogFile="true"/>
+<!--    <include file="db-changes/schema/DDP-7713.xml" relativeToChangelogFile="true"/>-->
     <include file="db-changes/schema/DDP-7248.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7890-add-new-event-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7931.xml" relativeToChangelogFile="true"/>
@@ -314,13 +314,13 @@
     <include file="db-changes/schema/DDP-7931-user-email.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7931-user-created-by-not-required.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8309-fon-zip-code-validation.xml" relativeToChangelogFile="true"/>
-    <include file="db-changes/schema/DDP-8270-composite-add-tabular-separator.xml" relativeToChangelogFile="true"/>
+<!--    <include file="db-changes/schema/DDP-8270-composite-add-tabular-separator.xml" relativeToChangelogFile="true"/>-->
     <include file="db-changes/schema/DDP-8248.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8484-copy-configuration-operator.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8631-add-country-field-to-medical-provider.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8606.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8554.xml" relativeToChangelogFile="true"/>
-    <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>
+<!--    <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>-->
     <include file="db-changes/schema/PEPPER-235-create-kit-event-action.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/PEPPER-235-add-kit-creation.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -306,7 +306,7 @@
     <include file="db-changes/seed/DDP-7709-add-boolean-render-mode-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7709-add-boolean-render-mode.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8012.xml" relativeToChangelogFile="true"/>
-<!--    <include file="db-changes/schema/DDP-7713.xml" relativeToChangelogFile="true"/>-->
+    <include file="db-changes/schema/DDP-7713.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7248.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7890-add-new-event-type.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7931.xml" relativeToChangelogFile="true"/>
@@ -314,13 +314,13 @@
     <include file="db-changes/schema/DDP-7931-user-email.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-7931-user-created-by-not-required.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8309-fon-zip-code-validation.xml" relativeToChangelogFile="true"/>
-<!--    <include file="db-changes/schema/DDP-8270-composite-add-tabular-separator.xml" relativeToChangelogFile="true"/>-->
+    <include file="db-changes/schema/DDP-8270-composite-add-tabular-separator.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8248.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8484-copy-configuration-operator.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8631-add-country-field-to-medical-provider.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8606.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8554.xml" relativeToChangelogFile="true"/>
-<!--    <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>-->
+    <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/PEPPER-235-create-kit-event-action.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/PEPPER-235-add-kit-creation.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/PEPPER-235-add-saliva-sent-dsm-event-type.xml" relativeToChangelogFile="true"/>

--- a/pepper-apis/dss-database/src/main/resources/changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/changelog-master.xml
@@ -321,4 +321,6 @@
     <include file="db-changes/schema/DDP-8606.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/DDP-8554.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/PEPPER-37-add-auth0-log-event-code.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/schema/PEPPER-235-create-kit-event-action.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/PEPPER-235-add-kit-creation.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/schema/PEPPER-235-create-kit-event-action.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/schema/PEPPER-235-create-kit-event-action.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="sampath" id="20221208-create-kit-action-table">
+        <createTable tableName="create_kit_event_action">
+            <column name="event_action_id" type="bigint">
+                <constraints primaryKey="true"
+                             primaryKeyName="create_kit_event_action_pk"
+                             foreignKeyName="create_kit_event_action_fk"
+                             references="event_action(event_action_id)"/>
+            </column>
+            <column name="kit_type_id" type="bigint">
+                <constraints nullable="false"
+                             foreignKeyName="create_kit_event_action_kit_type_fk"
+                             references="kit_type(kit_type_id)"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/seed/PEPPER-235-add-kit-creation.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/seed/PEPPER-235-add-kit-creation.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="sampath" id="20221207-add-create-kit-event-action-type">
+        <insert tableName="event_action_type">
+            <column name="event_action_type_code" value="CREATE_KIT"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/seed/PEPPER-235-add-saliva-sent-dsm-event-type.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/seed/PEPPER-235-add-saliva-sent-dsm-event-type.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="sampath" id="20221211-add-saliva-sent-dsm-event-type">
+        <insert tableName="dsm_notification_event_type">
+            <column name="dsm_notification_event_type_code" value="SALIVA_SENT"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/db-changes/seed/housekeeping/PEPPER-235-add-create-kit-event-type.xml
+++ b/pepper-apis/dss-database/src/main/resources/db-changes/seed/housekeeping/PEPPER-235-add-create-kit-event-type.xml
@@ -1,0 +1,11 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    <changeSet id="20221209-add-create-kit-event-type" author="sampath">
+        <insert tableName="event_type">
+            <column name="event_type_code" value="CREATE_KIT"/>
+        </insert>
+    </changeSet>
+</databaseChangeLog>

--- a/pepper-apis/dss-database/src/main/resources/housekeeping-changelog-master.xml
+++ b/pepper-apis/dss-database/src/main/resources/housekeeping-changelog-master.xml
@@ -4,4 +4,5 @@
     <include file="db-changes/seed/housekeeping/event-types.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/schema/housekeeping/create-backup-job-table.xml" relativeToChangelogFile="true"/>
     <include file="db-changes/seed/housekeeping/DDP-3618-add-pdf-generation-event-type.xml" relativeToChangelogFile="true"/>
+    <include file="db-changes/seed/housekeeping/PEPPER-235-add-create-kit-event-type.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/EventBuilder.java
@@ -23,6 +23,7 @@ import org.broadinstitute.ddp.db.dao.JdbiExpression;
 import org.broadinstitute.ddp.db.dao.JdbiRevision;
 import org.broadinstitute.ddp.db.dao.JdbiUserNotificationPdf;
 import org.broadinstitute.ddp.db.dao.JdbiWorkflowState;
+import org.broadinstitute.ddp.db.dao.KitTypeDao;
 import org.broadinstitute.ddp.db.dao.PdfDao;
 import org.broadinstitute.ddp.db.dao.TemplateDao;
 import org.broadinstitute.ddp.db.dao.WorkflowDao;
@@ -336,6 +337,10 @@ public class EventBuilder {
             String workflow = actionCfg.getString("workflow");
             String status = actionCfg.getString("status");
             return actionDao.insertUpdateCustomWorkflowAction(workflow, status);
+        } else if (EventActionType.CREATE_KIT.name().equals(type)) {
+            String kitType = actionCfg.getString("kitType");
+            long kitTypeId = handle.attach(KitTypeDao.class).getKitTypeByName(kitType).get().getId();
+            return actionDao.insertCreateKitAction(kitTypeId);
         } else {
             return actionDao.insertStaticAction(EventActionType.valueOf(type));
         }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/LmsInsertKitCreateEvent.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/LmsInsertKitCreateEvent.java
@@ -1,0 +1,43 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.KitConfigurationDao;
+import org.broadinstitute.ddp.db.dao.KitTypeDao;
+import org.broadinstitute.ddp.db.dto.kit.KitConfigurationDto;
+import org.broadinstitute.ddp.model.kit.KitConfiguration;
+import org.jdbi.v3.core.Handle;
+
+import java.util.List;
+
+@Slf4j
+public class LmsInsertKitCreateEvent extends InsertStudyEvents {
+    public LmsInsertKitCreateEvent() {
+        super("cmi-lms", "patches/lms-blood-kit-event.conf");
+    }
+
+    @Override
+    public void run(final Handle handle) {
+        removeExistingBloodKitConfig(handle);
+        super.run(handle);
+    }
+
+    private void removeExistingBloodKitConfig(final Handle handle) {
+        KitConfigurationDao kitConfigDao = handle.attach(KitConfigurationDao.class);
+        List<KitConfigurationDto> kitConfigs = kitConfigDao.getKitConfigurationDtosByStudyId(handle.attach(JdbiUmbrellaStudy.class)
+                        .findByStudyGuid(studyGuid).getId());
+
+        long bloodKitTypeid = handle.attach(KitTypeDao.class).getBloodKitType().getId();
+        KitConfigurationDto kitConfigDto = kitConfigs.stream().filter(dto -> dto.getKitTypeId()
+                == bloodKitTypeid).findFirst().get();
+
+        KitConfiguration kitConfig = kitConfigDao.getKitConfigurationForDto(kitConfigDto);
+        kitConfig.getRules().stream().forEach(kitRule -> kitConfigDao.getJdbiKitRules().deleteRuleFromConfiguration(
+                kitConfig.getId(), kitRule.getId()));
+
+        DBUtils.checkDelete(1, kitConfigDao.deleteConfiguration(kitConfigDto.getId()));
+        log.info("Successfully deleted {} Blood Kit Config {} of {}.", 1, kitConfigDto.getId(), studyGuid);
+    }
+
+}

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertKitCreateEvent.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/OsteoInsertKitCreateEvent.java
@@ -1,0 +1,17 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Handle;
+
+@Slf4j
+public class OsteoInsertKitCreateEvent extends InsertStudyEvents {
+    public OsteoInsertKitCreateEvent() {
+        super("CMI-OSTEO", "patches/osteo-blood-kit-event.conf");
+    }
+
+    @Override
+    public void run(final Handle handle) {
+        super.run(handle);
+    }
+
+}

--- a/pepper-apis/studybuilder-cli/studies/lms/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/patch-log.conf
@@ -1,5 +1,6 @@
 {
   "patches": [
-    "LmsEmailReminderUpdate"
+    "LmsEmailReminderUpdate",
+    "LmsInsertKitCreateEvent"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/lms/patches/lms-blood-kit-event.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/patches/lms-blood-kit-event.conf
@@ -1,0 +1,24 @@
+{
+  "events": [
+    #BLOOD KIT_CREATE event
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_SENT"
+      },
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD"
+      },
+      "preconditionExpr": """
+            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
+            """
+      "delaySeconds": ${delay.weeks.one},
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": true,
+      "order": 1
+    }
+  ]
+}

--- a/pepper-apis/studybuilder-cli/studies/lms/patches/lms-blood-kit-event.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/patches/lms-blood-kit-event.conf
@@ -11,6 +11,7 @@
         "kitType": "BLOOD"
       },
       "preconditionExpr": """
+      user.studies["cmi-lms"].forms["MEDICAL_RELEASE"].isStatus("COMPLETE") &&
             (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
             || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
             || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())

--- a/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
@@ -520,6 +520,38 @@
       "dispatchToHousekeeping": false,
       "order": 1
     },
+
+
+    {
+      "trigger": {
+        "type": "ACTIVITY_STATUS",
+        "activityCode": "MEDICAL_RELEASE",
+        "statusType": "COMPLETE"
+      },
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD"
+      },
+      "delaySeconds": 60,
+      "maxOccurrencesPerUser": 10,
+      "dispatchToHousekeeping": true,
+      "order": 5
+    },
+
+    {
+      "trigger": {
+        "type": "MEDICAL_UPDATE"
+      },
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD"
+      },
+      "delaySeconds": 120,
+      "maxOccurrencesPerUser": 10,
+      "dispatchToHousekeeping": false,
+      "order": 1
+    },
+
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",

--- a/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
@@ -1590,26 +1590,6 @@
       "dispatchToHousekeeping": true,
       "order": 1
     },
-    #BLOOD KIT_CREATE event
-    {
-      "trigger": {
-        "type": "DSM_NOTIFICATION",
-        "dsmEvent": "SALIVA_SENT"
-      },
-      "action": {
-        "type": "CREATE_KIT",
-        "kitType": "BLOOD"
-      },
-      "preconditionExpr": """
-            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
-            """
-      "delaySeconds": ${delay.weeks.one},
-      "maxOccurrencesPerUser": 1,
-      "dispatchToHousekeeping": true,
-      "order": 1
-    },
 
     {
       "trigger": {

--- a/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
@@ -533,7 +533,7 @@
         "kitType": "BLOOD"
       },
       "delaySeconds": 60,
-      "maxOccurrencesPerUser": 10,
+      "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 5
     },
@@ -546,9 +546,14 @@
         "type": "CREATE_KIT",
         "kitType": "BLOOD"
       },
+      "preconditionExpr": """
+            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
+            """
       "delaySeconds": 120,
       "maxOccurrencesPerUser": 10,
-      "dispatchToHousekeeping": false,
+      "dispatchToHousekeeping": true,
       "order": 1
     },
 
@@ -1619,6 +1624,26 @@
       },
       "delaySeconds": ${delay.weeks.one},
       "preconditionExpr": """user.studies["cmi-lms"].isGovernedParticipant()""",
+      "dispatchToHousekeeping": true,
+      "order": 1
+    },
+
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_SENT"
+      },
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD"
+      },
+      "preconditionExpr": """
+            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
+            """
+      "delaySeconds": 120, //todo 7 days
+      "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1
     },

--- a/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study-events.conf
@@ -520,43 +520,6 @@
       "dispatchToHousekeeping": false,
       "order": 1
     },
-
-
-    {
-      "trigger": {
-        "type": "ACTIVITY_STATUS",
-        "activityCode": "MEDICAL_RELEASE",
-        "statusType": "COMPLETE"
-      },
-      "action": {
-        "type": "CREATE_KIT",
-        "kitType": "BLOOD"
-      },
-      "delaySeconds": 60,
-      "maxOccurrencesPerUser": 1,
-      "dispatchToHousekeeping": true,
-      "order": 5
-    },
-
-    {
-      "trigger": {
-        "type": "MEDICAL_UPDATE"
-      },
-      "action": {
-        "type": "CREATE_KIT",
-        "kitType": "BLOOD"
-      },
-      "preconditionExpr": """
-            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
-            """
-      "delaySeconds": 120,
-      "maxOccurrencesPerUser": 10,
-      "dispatchToHousekeeping": true,
-      "order": 1
-    },
-
     {
       "trigger": {
         "type": "ACTIVITY_STATUS",
@@ -1627,7 +1590,7 @@
       "dispatchToHousekeeping": true,
       "order": 1
     },
-
+    #BLOOD KIT_CREATE event
     {
       "trigger": {
         "type": "DSM_NOTIFICATION",
@@ -1642,7 +1605,7 @@
             || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
             || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
             """
-      "delaySeconds": 120, //todo 7 days
+      "delaySeconds": ${delay.weeks.one},
       "maxOccurrencesPerUser": 1,
       "dispatchToHousekeeping": true,
       "order": 1

--- a/pepper-apis/studybuilder-cli/studies/lms/study.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study.conf
@@ -96,6 +96,49 @@
           "country": "as"     # American Samoa
         }
       ]
+    },
+    #below BLOOD kit config deleted by patch and replaced with CREATE_KIT event
+    {
+      "type": "BLOOD",
+      "quantity": 1,
+      "rules": [
+        {
+          "type": "PEX",
+          "expression": """
+            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
+            """
+        },
+        {
+          "type": "COUNTRY",
+          "country": "us"     # United States
+        },
+        {
+          "type": "COUNTRY",
+          "country": "ca"     # Canada
+        },
+        {
+          "type": "COUNTRY",
+          "country": "pr"     # Puerto Rico
+        },
+        {
+          "type": "COUNTRY",
+          "country": "gu"     # Guam
+        },
+        {
+          "type": "COUNTRY",
+          "country": "vi"     # U.S. Virgin Islands
+        },
+        {
+          "type": "COUNTRY",
+          "country": "mp"     # Northern Mariana Islands
+        },
+        {
+          "type": "COUNTRY",
+          "country": "as"     # American Samoa
+        }
+      ]
     }
   ],
 

--- a/pepper-apis/studybuilder-cli/studies/lms/study.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/study.conf
@@ -96,48 +96,6 @@
           "country": "as"     # American Samoa
         }
       ]
-    },
-    {
-      "type": "BLOOD",
-      "quantity": 1,
-      "rules": [
-        {
-          "type": "PEX",
-          "expression": """
-            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
-            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
-            """
-        },
-        {
-          "type": "COUNTRY",
-          "country": "us"     # United States
-        },
-        {
-          "type": "COUNTRY",
-          "country": "ca"     # Canada
-        },
-        {
-          "type": "COUNTRY",
-          "country": "pr"     # Puerto Rico
-        },
-        {
-          "type": "COUNTRY",
-          "country": "gu"     # Guam
-        },
-        {
-          "type": "COUNTRY",
-          "country": "vi"     # U.S. Virgin Islands
-        },
-        {
-          "type": "COUNTRY",
-          "country": "mp"     # Northern Mariana Islands
-        },
-        {
-          "type": "COUNTRY",
-          "country": "as"     # American Samoa
-        }
-      ]
     }
   ],
 

--- a/pepper-apis/studybuilder-cli/studies/osteo/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/patch-log.conf
@@ -1,6 +1,7 @@
 {
   "patches": [
     "OsteoDobValidations",
-    "OsteoEmailReminderUpdate"
+    "OsteoEmailReminderUpdate",
+    "OsteoInsertKitCreateEvent"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/osteo/patches/osteo-blood-kit-event.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/patches/osteo-blood-kit-event.conf
@@ -1,0 +1,24 @@
+{
+  "events": [
+    #BLOOD KIT_CREATE event
+    {
+      "trigger": {
+        "type": "DSM_NOTIFICATION",
+        "dsmEvent": "SALIVA_SENT"
+      },
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD"
+      },
+      "preconditionExpr": """
+            (user.studies["CMI-OSTEO"].forms["RELEASE_SELF"].isStatus("COMPLETE") && user.studies["CMI-OSTEO"].forms["CONSENT"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
+            || (user.studies["CMI-OSTEO"].forms["RELEASE_MINOR"].isStatus("COMPLETE") && user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["CMI-OSTEO"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
+            """
+      "delaySeconds": ${delay.weeks.one},
+      "maxOccurrencesPerUser": 1,
+      "dispatchToHousekeeping": true,
+      "order": 1
+    }
+  ]
+}

--- a/pepper-apis/studybuilder-cli/studies/study-example.conf
+++ b/pepper-apis/studybuilder-cli/studies/study-example.conf
@@ -942,6 +942,7 @@
     # Create Kit Request.
     # KitType is mandatory. numOfKits created is 1 and needsApproval is false
     # Any additional KitConfiguration provided with kits[] is also considered.
+    # Its recommended to have kit creation in kits[] and use event action in scenarios where CheckKitsJob doesn't fit.
     {
       "action": {
         "type": "CREATE_KIT",

--- a/pepper-apis/studybuilder-cli/studies/study-example.conf
+++ b/pepper-apis/studybuilder-cli/studies/study-example.conf
@@ -562,7 +562,7 @@
     {
       "trigger": {
         "type": "DSM_NOTIFICATION",
-        "dsmEvent": """SALIVA_RECEIVED | BLOOD_RECEIVED | BLOOD_SENT | BLOOD_SENT_4WK
+        "dsmEvent": """SALIVA_RECEIVED | BLOOD_RECEIVED | BLOOD_SENT | SALIVA_SENT | BLOOD_SENT_4WK
                   | TESTBOSTON_SENT | TESTBOSTON_DELIVERED | TESTBOSTON_RECEIVED | TEST_RESULT"""
       },
       # ...
@@ -937,6 +937,20 @@
       },
       "dispatchToHousekeeping": "false",  # Action handled synchronously.
       # ...
+    },
+
+    # Create Kit Request.
+    # KitType is mandatory. numOfKits created is 1 and needsApproval is false
+    # Any additional KitConfiguration provided with kits[] is also considered.
+    {
+      "action": {
+        "type": "CREATE_KIT",
+        "kitType": "BLOOD | SALIVA"
+      },
+      # This action can be executed synchronously or asynchronously. Delayed actions is also supported
+      "dispatchToHousekeeping": "bool",
+      # ...
     }
+
   ]
 }


### PR DESCRIPTION
look at https://broadworkbench.atlassian.net/browse/PEPPER-235

## Context

Add new event action type "CREATE_KIT"
Currently "Kit Creation" is done by KitCheck job. 
Configuration for the job is from the "kits": []
With event / event action support we will be able to support kit creation as event actions both sync and async calls with delaySeconds.
Config is limited to whats needed as of current requirement.
In event support, numOfKits is defaulted to 1 . 
As of now , we don't have any case where kits created each time is not 1 and no approvals are needed.

Update StudyBuilder code to handle this new event/action.

Osteo & LMS study kit config & event config will be updated to use this new event / event action feature.

SALIVA_SENT event is added to DSS dsm notification events supported

Tried to keep changes to existing KitCheckService as minimal as possible 


###Review notes:
Start with schema changes, then look at EventBuilder.java (StudyBuilder related class to load this new event action).
Then look at CreateKitEventAction.java which has all the implementation details. 
Refer to KitCheckService.java as needed and then Housekeeping.java 



## How do we demo these changes?
For LMS, do new sign up submit medical history.
Trigger SALIVA_SENT and that should trigger kit creation after specified delaySeconds.
CREATE_KIT event can always be added for any trigger type (like Medical_release submitted) for quick demo/test.

## Testing in DEV/Test/Stage
Once code is deployed to {env} and patches are applied. 
Find new create_kit event and update post_delay_seconds to some 60 
Do a new sign up, fill MEDICAL_RELEASE.
At this stage, SALIVA_KIT should be created by CheckKitsJob and saliva kit request should be created for the participant.
Query DB and verify.
select from_unixtime(floor(kr.created_at)), kr.* from kit_request kr order by kr.kit_request_id desc;
From DSM trigger SALIVA_SENT DSM_NOTIFICATION event. Document on how to trigger DSM notification event: https://docs.google.com/document/d/118iNC6JB5L8XWjBBhL3W37NOyCxP4ihJYi621cVLfjM/edit?usp=sharing

DSS should trigger CREATE_KIT event for Blood kit 60seconds (whatever is postDelay) after SALIVA_SENT notification is received.
Query DB and verify that BLOOD kit request was created for the participant.

## Testing in local
For LMS, do new sign up submit medical history.
Trigger SALIVA_SENT and that should trigger kit creation after specified delaySeconds.
CREATE_KIT event can always be added for any trigger type (like Medical_release submitted) for quick demo/test.
Query kit_request table to verify that kit request is created
select from_unixtime(floor(kr.created_at)), kr.* from kit_request kr order by kr.kit_request_id desc;


Sample event config to test
    {
      "trigger": {
        "type": "MEDICAL_UPDATE"
      },
      "action": {
        "type": "CREATE_KIT",
        "kitType": "BLOOD"
      },
      "preconditionExpr": """
            (user.studies["cmi-lms"].forms["CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT"].questions["CONSENT_BLOOD"].answers.hasTrue())
            || (user.studies["cmi-lms"].forms["CONSENT_ASSENT"].hasInstance() && user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_BLOOD"].answers.hasTrue())
            || (user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].hasInstance() && user.studies["cmi-lms"].forms["PARENTAL_CONSENT"].questions["PARENTAL_CONSENT_BLOOD"].answers.hasTrue())
            """
      "delaySeconds": 120,
      "maxOccurrencesPerUser": 10,
      "dispatchToHousekeeping": true,
      "order": 1
    },


## Release
Deploy code
Run patches for LMS and Osteo

