### PR TITLE
[PEPPER-36] Adds additional diagnoses to the Pancan cancer lists

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/PicklistQuestionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/PicklistQuestionDao.java
@@ -35,7 +35,7 @@ public interface PicklistQuestionDao extends SqlObject {
 
     Logger LOG = LoggerFactory.getLogger(PicklistQuestionDao.class);
 
-    int DISPLAY_ORDER_GAP = 10;
+    public final int DISPLAY_ORDER_GAP = 10;
 
     @CreateSqlObject
     JdbiPicklistQuestion getJdbiPicklistQuestion();
@@ -178,6 +178,8 @@ public interface PicklistQuestionDao extends SqlObject {
 
     /**
      * Create a new picklist option for given question.
+     * 
+     * <p>The `option` parameter <b>will be modified</b> by this method.
      *
      * @param questionId   the associated picklist question
      * @param option       the picklist option definition
@@ -185,7 +187,7 @@ public interface PicklistQuestionDao extends SqlObject {
      * @param revisionId   the revision to use, will be shared for all created data
      * @return the option id
      */
-    default long insertOption(long questionId, PicklistOptionDef option, int displayOrder, long revisionId) {
+    public default long insertOption(long questionId, PicklistOptionDef option, int displayOrder, long revisionId) {
         JdbiPicklistOption jdbiOption = getJdbiPicklistOption();
         TemplateDao templateDao = getTemplateDao();
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/PicklistQuestionDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/PicklistQuestionDao.java
@@ -35,7 +35,7 @@ public interface PicklistQuestionDao extends SqlObject {
 
     Logger LOG = LoggerFactory.getLogger(PicklistQuestionDao.class);
 
-    public final int DISPLAY_ORDER_GAP = 10;
+    int DISPLAY_ORDER_GAP = 10;
 
     @CreateSqlObject
     JdbiPicklistQuestion getJdbiPicklistQuestion();
@@ -187,7 +187,7 @@ public interface PicklistQuestionDao extends SqlObject {
      * @param revisionId   the revision to use, will be shared for all created data
      * @return the option id
      */
-    public default long insertOption(long questionId, PicklistOptionDef option, int displayOrder, long revisionId) {
+    default long insertOption(long questionId, PicklistOptionDef option, int displayOrder, long revisionId) {
         JdbiPicklistOption jdbiOption = getJdbiPicklistOption();
         TemplateDao templateDao = getTemplateDao();
 

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
@@ -2,7 +2,7 @@ package org.broadinstitute.ddp.studybuilder.task;
 
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.LinkedList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,14 +15,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
-import org.broadinstitute.ddp.db.dao.JdbiPicklistGroup;
 import org.broadinstitute.ddp.db.dao.JdbiPicklistOption;
-import org.broadinstitute.ddp.db.dao.TemplateDao;
+import org.broadinstitute.ddp.db.dao.PicklistQuestionDao;
 import org.broadinstitute.ddp.db.dto.PicklistGroupDto;
 import org.broadinstitute.ddp.db.dto.PicklistOptionDto;
 import org.broadinstitute.ddp.exception.DDPException;
-import org.broadinstitute.ddp.model.activity.definition.question.PicklistGroupDef;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.util.ConfigUtil;
 import org.broadinstitute.ddp.util.GsonUtil;
 import org.jdbi.v3.core.Handle;
@@ -30,6 +28,7 @@ import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 @Slf4j
 public final class PancanAddAdditionalDiagnosis implements CustomTask {
@@ -39,7 +38,10 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
     private static enum Metadata {
         DESCRIPTION("description"),
         STUDY("study"),
-        OPTION_GROUP("option-group");
+        EXPECTED_OPTIONS("expected-options"),
+        TARGET_GROUP_SID("target-group-sid"),
+        INSERT_AFTER_SID("insert-after-sid"),
+        NEW_OPTIONS("options");
 
         @Getter
         private final String key;
@@ -111,6 +113,19 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
                 + "  FROM picklist_option AS po"
                 + "  WHERE po.picklist_option_id = :groupId")
         public long fetchQuestionIdForOption(@Bind("optionId") long optionId);
+
+        @SqlQuery("SELECT"
+                + "    qsc.stable_id"
+                + "  FROM question AS q"
+                + "    JOIN question_stable_code AS qsc ON qsc.question_stable_code_id = q.question_stable_code_id"
+                + " WHERE q.question_id = :questionId")
+        public String fetchQuestionStableIdById(@Bind("questionId") long questionId);
+
+
+        @SqlUpdate("INSERT INTO picklist_grouped_option (picklist_group_id, picklist_option_id)"
+                + " VALUES (:groupId, :optionId)")
+        public void linkOptionToGroupId(@Bind("optionId") long optionId,
+                @Bind("groupId") long groupId);
     }
     
     private Path configurationRoot;
@@ -124,6 +139,7 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
     }
 
     protected Path getPatchRoot() {
+        assert configurationRoot != null;
         return getConfigurationRoot().resolve("patches");
     }
 
@@ -132,12 +148,17 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
     }
 
     protected String getConfigurationStudy() {
+        assert studyConfiguration != null;
         return studyConfiguration.getString("study.guid");
     }
 
     protected String getTargetStudy() {
         assert patchConfiguration != null;
         return patchConfiguration.getString(Metadata.STUDY.getKey());
+    }
+
+    protected String getTaskName() {
+        return this.getClass().getSimpleName();
     }
 
     @Override
@@ -148,8 +169,10 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
         final var patchConfigurationPath = getPatchConfigurationPath();
         try {
             var patchConfiguration = ConfigFactory.parseFile(patchConfigurationPath.toFile());
+
             final var resolveOptions = ConfigResolveOptions.defaults().setAllowUnresolved(true);
             patchConfiguration = patchConfiguration.resolve(resolveOptions);
+
             this.patchConfiguration = patchConfiguration.resolveWith(varsCfg);
         } catch (ConfigException configException) {
             throw failedToLoadPatchError(patchConfigurationPath.toString(), configException);
@@ -162,23 +185,139 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
 
     @Override
     public void run(Handle handle) {
-        final var optionGroupConfig = patchConfiguration.getConfig(Metadata.OPTION_GROUP.getKey());
-        final var optionGroupDef = gson.fromJson(ConfigUtil.toJson(optionGroupConfig), PicklistGroupDef.class);
+        log.info("TASK::{}", getTaskName());
 
         final var jdbiPatchHelper = handle.attach(SqlHelper.class);
+        final var jdbiPicklistQuestion = handle.attach(PicklistQuestionDao.class);
+        final var jdbiPicklistOption = handle.attach(JdbiPicklistOption.class);
 
-        final var nowTimestamp = Instant.now().toEpochMilli();
-        final var existingGroups = jdbiPatchHelper.fetchPicklistGroupsByName(getTargetStudy(), optionGroupDef.getStableId())
+        final var picklistGroupName = patchConfiguration.getString(Metadata.TARGET_GROUP_SID.getKey());
+        final var containingQuestionIds = jdbiPatchHelper.fetchPicklistGroupsByName(getTargetStudy(), picklistGroupName)
                 .stream()
-                .filter((group) -> group.getRevisionStartTimestamp() <= nowTimestamp)
-                .filter((group) -> (group.getRevisionEndTimestamp() == null) || (group.getRevisionEndTimestamp() > nowTimestamp))
+                .map((group) -> jdbiPatchHelper.fetchQuestionIdForGroup(group.getId()))
                 .collect(Collectors.toList());
 
-        for (final var group : existingGroups) {
+        final var nowTimestamp = Instant.now().toEpochMilli();
+        final var questionToGroupObjects = jdbiPicklistQuestion.findOrderedGroupAndOptionDtos(containingQuestionIds, nowTimestamp);
 
+        for (final var questionOptionDetails : questionToGroupObjects.entrySet()) {
+            /*
+            * Deserializing the new PicklistOptionDefs inside of the loop (and repeating the serialize/deserialize every loop)
+            *   because PicklistQuestionDao.insertOption(long, PicklistOptionDef, int, long) modifies the PicklistOptionDef
+            *   passed in the 2nd parameter. This is a risky behavior to refactor, so my workaround for now is to reload the entire
+            *   list of new PicklistOptionDefs on every loop.
+            */
+            final var newOptionDefs = patchConfiguration.getConfigList(Metadata.NEW_OPTIONS.getKey())
+                    .stream()
+                    .map((optionDefConfig) -> gson.fromJson(ConfigUtil.toJson(optionDefConfig), PicklistOptionDef.class))
+                    .collect(Collectors.toList());
+            
+            final var questionId = questionOptionDetails.getKey();
+            final var questionStableId = jdbiPatchHelper.fetchQuestionStableIdById(questionId);
+            log.info("Updating picklist options for [study:{}, question:{}]", getTargetStudy(), questionStableId);
+
+            // The picklist option group
+            final var optionGroup = questionOptionDetails.getValue().getGroups()
+                    .stream()
+                    .filter((group) -> picklistGroupName.equals(group.getStableId()))
+                    .findFirst()
+                    .orElseThrow(() -> picklistGroupNotFound(getTargetStudy(), questionStableId, picklistGroupName));
+
+            // The picklist options contained within the previous group
+            final var groupOptions = questionOptionDetails.getValue().getGroupIdToOptions().get(optionGroup.getId());
+
+            // Check to see if all the options expected to be in the group are there (see `expected-options` in the patch configuration).
+            // This check disregards the ordering of the stable ids.
+            final var existingPicklistOptionStableIds = groupOptions.stream()
+                    .map(PicklistOptionDto::getStableId)
+                    .collect(Collectors.toSet());
+            
+            final var expectedOptions = new HashSet<String>(patchConfiguration.getStringList(Metadata.EXPECTED_OPTIONS.getKey()));
+            if (!existingPicklistOptionStableIds.equals(expectedOptions)) {
+                throw studyHasBeenModified(getTargetStudy(),
+                        questionStableId,
+                        expectedOptions,
+                        existingPicklistOptionStableIds);
+            }
+
+            // This is the option after which all the new should be inserted (in display order).
+            // See the `insert-after-sid` option in the patch config file to fine tune this if changes are needed.
+            final var insertAfterOptionStableId = patchConfiguration.getString(Metadata.INSERT_AFTER_SID.getKey());
+            final var targetOption = groupOptions
+                    .stream()
+                    .filter((option) -> option.getStableId().equals(insertAfterOptionStableId))
+                    .findFirst()
+                    .orElseThrow(() -> picklistOptionNotFound(getTargetStudy(), questionStableId, insertAfterOptionStableId));
+
+            var displayOrder = targetOption.getDisplayOrder() + PicklistQuestionDao.DISPLAY_ORDER_GAP;
+            for (final var option : newOptionDefs) {
+                log.info("Inserting picklist option {} for [study:{}, question:{}] at display order {}",
+                        option.getStableId(),
+                        getTargetStudy(),
+                        questionStableId,
+                        displayOrder);
+
+                final var optionId = jdbiPicklistQuestion.insertOption(questionId,
+                        option,
+                        displayOrder,
+                        optionGroup.getRevisionId());
+                
+                log.info("Linking option {}({}) to group {}({})",
+                        option.getStableId(),
+                        optionId,
+                        optionGroup.getStableId(),
+                        optionGroup.getId());
+                jdbiPatchHelper.linkOptionToGroupId(optionId, optionGroup.getId());
+
+                displayOrder += PicklistQuestionDao.DISPLAY_ORDER_GAP;
+            }
+
+            /*
+             * Go back to all the PicklistOptionDtos we originally fetched, and figure out
+             * which ones need to have their display order offset (each option should be
+             * advanced by numberOfInsertedOptions * DISPLAY_ORDER_GAP)
+             */
+            final var optionsToUpdate = groupOptions.subList(groupOptions.indexOf(targetOption) + 1, groupOptions.size());
+            for (final var option : optionsToUpdate) {
+                log.info("Changing display order for picklist option {}({}) from {} to {}",
+                        option.getStableId(),
+                        option.getId(),
+                        option.getDisplayOrder(),
+                        displayOrder);
+                option.setDisplayOrder(displayOrder);
+                jdbiPicklistOption.update(option);
+                displayOrder += PicklistQuestionDao.DISPLAY_ORDER_GAP;
+            }
         }
 
-        return;
+        log.info("TASK::{} completed successfully", getTaskName());
+    }
+
+    private DDPException studyHasBeenModified(String study,
+            String questionStableId,
+            Iterable<String> expectedOptionStableIds,
+            Iterable<String> currentOptionStableIds) {
+        return new DDPException(String.format("Mismatch in expected options for [study:%s, question:%s]. "
+                + "Fetched picklist options [%s], but expected picklist options [%s]. The study has been modified, and"
+                + " the patch's `expected-options` value must be updated to match the current state of the study.",
+                study,
+                questionStableId,
+                String.join(", ", expectedOptionStableIds),
+                String.join(", ", currentOptionStableIds)));
+    }
+
+    private DDPException picklistOptionNotFound(String study, String question, String option) {
+        return new DDPException(String.format("unable to find picklist option %s in [study:%s, question:%s]",
+                option,
+                study,
+                question));
+    }
+
+    private DDPException picklistGroupNotFound(String study, String question, String groupName) {
+        return new DDPException(String.format("unable to find picklist group %s in [study:%s, question:%s]",
+                groupName,
+                study,
+                question));
     }
 
     private DDPException invalidStudyError(String configuredStudy, String targetStudy) {

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
@@ -1,0 +1,193 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigResolveOptions;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.broadinstitute.ddp.db.dao.JdbiPicklistGroup;
+import org.broadinstitute.ddp.db.dao.JdbiPicklistOption;
+import org.broadinstitute.ddp.db.dao.TemplateDao;
+import org.broadinstitute.ddp.db.dto.PicklistGroupDto;
+import org.broadinstitute.ddp.db.dto.PicklistOptionDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.question.PicklistGroupDef;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+@Slf4j
+public final class PancanAddAdditionalDiagnosis implements CustomTask {
+    private static final String PATCH_CONF_NAME = "add-additional-diagnosis.conf";
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    private static enum Metadata {
+        DESCRIPTION("description"),
+        STUDY("study"),
+        OPTION_GROUP("option-group");
+
+        @Getter
+        private final String key;
+    }
+
+    @FunctionalInterface
+    private static interface DeleteAction {
+        public void delete(Handle handle);
+    }
+
+    private static interface SqlHelper extends SqlObject {
+        
+        @SqlQuery("SELECT"
+                + "    pg.picklist_group_id AS picklist_group_id,"
+                + "    pg.group_stable_id AS group_stable_id,"
+                + "    pg.name_template_id AS name_template_id,"
+                + "    pg.display_order AS display_order,"
+                + "    pg.revision_id AS revision_id,"
+                + "    revision.start_date AS revision_start_timestamp,"
+                + "    revision.end_date AS revision_end_timestamp"
+                + "  FROM picklist_group AS pg"
+                + "  JOIN picklist_question AS pq ON pq.question_id = pg.picklist_question_id"
+                + "  JOIN question AS q ON q.question_id = pq.question_id"
+                + "  JOIN study_activity AS sa ON q.study_activity_id = sa.study_activity_id"
+                + "  JOIN umbrella_study AS us ON sa.study_id = us.umbrella_study_id"
+                + "  JOIN revision ON revision.revision_id = pg.revision_id"
+                + "  WHERE group_stable_id = :groupStableId"
+                + "    AND us.guid = :studyGuid")
+        @RegisterConstructorMapper(PicklistGroupDto.class)
+        public List<PicklistGroupDto> fetchPicklistGroupsByName(
+                @Bind("studyGuid") String studyGuid, 
+                @Bind("groupStableId") String groupStableId);
+
+        @SqlQuery("SELECT"
+                + "    po.picklist_option_id AS picklist_option_id,"
+                + "    po.picklist_option_stable_id AS picklist_option_stable_id,"
+                + "    po.value AS value,"
+                + "    po.option_label_template_id AS option_label_template_id,"
+                + "    po.tooltip_template_id AS tooltip_template_id,"
+                + "    po.detail_label_template_id AS detail_label_template_id,"
+                + "    po.allow_details AS allow_details,"
+                + "    po.is_exclusive AS is_exclusive,"
+                + "    po.is_default AS is_default,"
+                + "    po.display_order AS display_order,"
+                + "    po.nested_options_template_id AS nested_options_template_id,"
+                + "    revision.revision_id AS revision_id,"
+                + "    revision.start_date AS revision_start_timestamp,"
+                + "    revision.end_date AS revision_end_timestamp"
+                + "  FROM picklist_option AS po"
+                + "    JOIN picklist_grouped_option AS pgo ON pgo.picklist_option_id = po.picklist_option_id"
+                + "    JOIN picklist_group AS pg ON pg.picklist_group_id = pgo.picklist_group_id"
+                + "    JOIN picklist_question AS pq ON pq.question_id = po.picklist_question_id"
+                + "    JOIN revision ON revision.revision_id = po.revision_id"
+                + "  WHERE"
+                + "    pg.picklist_group_id = :groupId"
+                + "  ORDER BY"
+                + "    po.display_order ASC")
+        @RegisterConstructorMapper(PicklistOptionDto.class)
+        public List<PicklistOptionDto> fetchPicklistOptionsByGroup(@Bind("groupId") long groupId);
+
+        @SqlQuery("SELECT"
+                + "    pg.picklist_question_id"
+                + "  FROM picklist_group AS pg"
+                + "  WHERE pg.picklist_group_id = :groupId")
+        public long fetchQuestionIdForGroup(@Bind("groupId") long groupId);
+
+        @SqlQuery("SELECT"
+                + "    po.picklist_question_id"
+                + "  FROM picklist_option AS po"
+                + "  WHERE po.picklist_option_id = :groupId")
+        public long fetchQuestionIdForOption(@Bind("optionId") long optionId);
+    }
+    
+    private Path configurationRoot;
+    private Config studyConfiguration;
+    private Config patchConfiguration;
+    
+    private final Gson gson = GsonUtil.standardGson();
+
+    protected Path getConfigurationRoot() {
+        return configurationRoot;
+    }
+
+    protected Path getPatchRoot() {
+        return getConfigurationRoot().resolve("patches");
+    }
+
+    protected Path getPatchConfigurationPath() {
+        return getPatchRoot().resolve(PATCH_CONF_NAME);
+    }
+
+    protected String getConfigurationStudy() {
+        return studyConfiguration.getString("study.guid");
+    }
+
+    protected String getTargetStudy() {
+        assert patchConfiguration != null;
+        return patchConfiguration.getString(Metadata.STUDY.getKey());
+    }
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.configurationRoot = cfgPath.getParent();
+        this.studyConfiguration = studyCfg;
+
+        final var patchConfigurationPath = getPatchConfigurationPath();
+        try {
+            var patchConfiguration = ConfigFactory.parseFile(patchConfigurationPath.toFile());
+            final var resolveOptions = ConfigResolveOptions.defaults().setAllowUnresolved(true);
+            patchConfiguration = patchConfiguration.resolve(resolveOptions);
+            this.patchConfiguration = patchConfiguration.resolveWith(varsCfg);
+        } catch (ConfigException configException) {
+            throw failedToLoadPatchError(patchConfigurationPath.toString(), configException);
+        }
+
+        if (!getTargetStudy().equals(getConfigurationStudy())) {
+            throw invalidStudyError(getConfigurationStudy(), getTargetStudy());
+        }
+    }
+
+    @Override
+    public void run(Handle handle) {
+        final var optionGroupConfig = patchConfiguration.getConfig(Metadata.OPTION_GROUP.getKey());
+        final var optionGroupDef = gson.fromJson(ConfigUtil.toJson(optionGroupConfig), PicklistGroupDef.class);
+
+        final var jdbiPatchHelper = handle.attach(SqlHelper.class);
+
+        final var nowTimestamp = Instant.now().toEpochMilli();
+        final var existingGroups = jdbiPatchHelper.fetchPicklistGroupsByName(getTargetStudy(), optionGroupDef.getStableId())
+                .stream()
+                .filter((group) -> group.getRevisionStartTimestamp() <= nowTimestamp)
+                .filter((group) -> (group.getRevisionEndTimestamp() == null) || (group.getRevisionEndTimestamp() > nowTimestamp))
+                .collect(Collectors.toList());
+
+        for (final var group : existingGroups) {
+
+        }
+
+        return;
+    }
+
+    private DDPException invalidStudyError(String configuredStudy, String targetStudy) {
+        return new DDPException(String.format("patch targets the %s study, and can not be run against study %s",
+                targetStudy,
+                configuredStudy));
+    }
+
+    private DDPException failedToLoadPatchError(String path, Exception cause) {
+        return new DDPException(String.format("failed to load patch data located at '%s'", path), cause);
+    }
+}

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
@@ -47,11 +47,6 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
         private final String key;
     }
 
-    @FunctionalInterface
-    private static interface DeleteAction {
-        public void delete(Handle handle);
-    }
-
     private static interface SqlHelper extends SqlObject {
         
         @SqlQuery("SELECT"
@@ -109,18 +104,11 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
         public long fetchQuestionIdForGroup(@Bind("groupId") long groupId);
 
         @SqlQuery("SELECT"
-                + "    po.picklist_question_id"
-                + "  FROM picklist_option AS po"
-                + "  WHERE po.picklist_option_id = :groupId")
-        public long fetchQuestionIdForOption(@Bind("optionId") long optionId);
-
-        @SqlQuery("SELECT"
                 + "    qsc.stable_id"
                 + "  FROM question AS q"
                 + "    JOIN question_stable_code AS qsc ON qsc.question_stable_code_id = q.question_stable_code_id"
                 + " WHERE q.question_id = :questionId")
         public String fetchQuestionStableIdById(@Bind("questionId") long questionId);
-
 
         @SqlUpdate("INSERT INTO picklist_grouped_option (picklist_group_id, picklist_option_id)"
                 + " VALUES (:groupId, :optionId)")

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
@@ -71,33 +71,6 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
                 @Bind("groupStableId") String groupStableId);
 
         @SqlQuery("SELECT"
-                + "    po.picklist_option_id AS picklist_option_id,"
-                + "    po.picklist_option_stable_id AS picklist_option_stable_id,"
-                + "    po.value AS value,"
-                + "    po.option_label_template_id AS option_label_template_id,"
-                + "    po.tooltip_template_id AS tooltip_template_id,"
-                + "    po.detail_label_template_id AS detail_label_template_id,"
-                + "    po.allow_details AS allow_details,"
-                + "    po.is_exclusive AS is_exclusive,"
-                + "    po.is_default AS is_default,"
-                + "    po.display_order AS display_order,"
-                + "    po.nested_options_template_id AS nested_options_template_id,"
-                + "    revision.revision_id AS revision_id,"
-                + "    revision.start_date AS revision_start_timestamp,"
-                + "    revision.end_date AS revision_end_timestamp"
-                + "  FROM picklist_option AS po"
-                + "    JOIN picklist_grouped_option AS pgo ON pgo.picklist_option_id = po.picklist_option_id"
-                + "    JOIN picklist_group AS pg ON pg.picklist_group_id = pgo.picklist_group_id"
-                + "    JOIN picklist_question AS pq ON pq.question_id = po.picklist_question_id"
-                + "    JOIN revision ON revision.revision_id = po.revision_id"
-                + "  WHERE"
-                + "    pg.picklist_group_id = :groupId"
-                + "  ORDER BY"
-                + "    po.display_order ASC")
-        @RegisterConstructorMapper(PicklistOptionDto.class)
-        public List<PicklistOptionDto> fetchPicklistOptionsByGroup(@Bind("groupId") long groupId);
-
-        @SqlQuery("SELECT"
                 + "    pg.picklist_question_id"
                 + "  FROM picklist_group AS pg"
                 + "  WHERE pg.picklist_group_id = :groupId")
@@ -186,8 +159,8 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
                 .map((group) -> jdbiPatchHelper.fetchQuestionIdForGroup(group.getId()))
                 .collect(Collectors.toList());
 
-        final var nowTimestamp = Instant.now().toEpochMilli();
-        final var questionToGroupObjects = jdbiPicklistQuestion.findOrderedGroupAndOptionDtos(containingQuestionIds, nowTimestamp);
+        final var questionToGroupObjects = jdbiPicklistQuestion.findOrderedGroupAndOptionDtos(containingQuestionIds,
+                Instant.now().toEpochMilli());
 
         for (final var questionOptionDetails : questionToGroupObjects.entrySet()) {
             /*

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PancanAddAdditionalDiagnosis.java
@@ -174,6 +174,7 @@ public final class PancanAddAdditionalDiagnosis implements CustomTask {
     @Override
     public void run(Handle handle) {
         log.info("TASK::{}", getTaskName());
+        log.info("description: {}", patchConfiguration.getString(Metadata.DESCRIPTION.getKey()));
 
         final var jdbiPatchHelper = handle.attach(SqlHelper.class);
         final var jdbiPicklistQuestion = handle.attach(PicklistQuestionDao.class);

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
@@ -20,16 +20,16 @@
 
     "es": {
       "cancer": {
-        "c_genitourinary_chrcc_renal_cell": "",
-        "c_genitourinary_ccrcc_renal_cell": "",
-        "c_genitourinary_collecting_duct_carcinoma": "",
-        "c_genitourinary_fh_deficient_rcc": "",
-        "c_genitourinary_prcc_renal_cell": "",
-        "c_genitourinary_renal_medullary_carcinoma": "",
-        "c_genitourinary_renal_oncocytoma": "",
-        "c_genitourinary_sdha_b_rcc": "",
-        "c_genitourinary_trcc_renal_cell": "",
-        "c_genitourinary_unclassified_rcc": ""
+        "c_genitourinary_chrcc_renal_cell": "Cancer de riñon / Carcinoma de células renales cromófobo",
+        "c_genitourinary_ccrcc_renal_cell": "Cancer de riñon / Carcinoma de células renales de células claras",
+        "c_genitourinary_collecting_duct_carcinoma": "Cancer de riñon / Carcinoma de los túbulos colectores (o de ducto colector de Bellini)",
+        "c_genitourinary_fh_deficient_rcc": "Cancer de riñon/ Carcinoma renal asociado a leiomiomatosis hereditaria (CCRLH)",
+        "c_genitourinary_prcc_renal_cell": "Cancer de riñon / Carcinoma papilar (o de células renales)",
+        "c_genitourinary_renal_medullary_carcinoma": "Cancer de riñon / Carcinoma medular renal",
+        "c_genitourinary_renal_oncocytoma": "Cancer de riñon / Oncocitoma renal",
+        "c_genitourinary_sdha_b_rcc": "Cancer de riñon / Carcinoma de células renales con deficiencia de SDH(succinato deshidrogenasa)",
+        "c_genitourinary_trcc_renal_cell": "Cancer de riñon / Carcinoma de células renales con translocación Xp11.2 (o de la familia MiT(t-RCC))",
+        "c_genitourinary_unclassified_rcc": "Cancer de riñon / Carcinoma de celulas renales no clasificado"
       }
     }
   },
@@ -48,424 +48,194 @@
     "C_GENITOURINARY_URETHRAL_CANCER",
     "C_GENITOURINARY_WILMS_TUMOR",
   ],
-  "option-group": {
-    "stableId": "C_GROUP_GENITOURINARY_GENITOURINARY_CANCERS",
-    "nameTemplate": {
-      "templateType": "HTML",
-      "templateText": "$prompt",
-      "variables": [
-        {
-          "name": "prompt",
-          "translations": [
-            { "language": "en", "text": ${i18n.en.cancer.c_group_genitourinary_genitourinary_cancers} },
-            { "language": "es", "text": ${i18n.es.cancer.c_group_genitourinary_genitourinary_cancers} },
-          ]
-        }
-      ]
+  
+  "target-group-sid": "C_GROUP_GENITOURINARY_GENITOURINARY_CANCERS"
+  "insert-after-sid": "C_GENITOURINARY_RCC_RENAL_CELL"
+  "options": [
+    // BEGIN: PEPPER-36 additions
+    {
+      "stableId": "C_GENITOURINARY_CHRCC_RENAL_CELL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_chrcc_renal_cell",
+        "variables": [
+          {
+            "name": "c_genitourinary_chrcc_renal_cell",
+            "translations": [
+              {
+                "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_chrcc_renal_cell}
+              },
+              {
+                "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_chrcc_renal_cell}
+              },
+            ]
+          }
+        ]
+      }
     },
-    "options": [
-      {
-        "stableId": "C_GENITOURINARY_ACC_ADRENOCORTICAL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_acc_adrenocortical",
-          "variables": [
-            {
-              "name": "c_genitourinary_acc_adrenocortical",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_acc_adrenocortical} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_acc_adrenocortical} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_BLADDER_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_bladder_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_bladder_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_bladder_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_bladder_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_GERM_CELL_TUMOR",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_germ_cell_tumor",
-          "variables": [
-            {
-              "name": "c_genitourinary_germ_cell_tumor",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_germ_cell_tumor} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_germ_cell_tumor} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_GTD_GESTATIONAL_TROPHOBL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_gtd_gestational_trophobl",
-          "variables": [
-            {
-              "name": "c_genitourinary_gtd_gestational_trophobl",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_gtd_gestational_trophobl} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_gtd_gestational_trophobl} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_RCC_RENAL_CELL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_rcc_renal_cell",
-          "variables": [
-            {
-              "name": "c_genitourinary_rcc_renal_cell",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_rcc_renal_cell} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_rcc_renal_cell} },
-              ]
-            }
-          ]
-        }
-      },
-      // BEGIN: PEPPER-36 additions
-      {
-        "stableId": "C_GENITOURINARY_CHRCC_RENAL_CELL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_chrcc_renal_cell",
-          "variables": [
-            {
-              "name": "c_genitourinary_chrcc_renal_cell",
-              "translations": [
-                {
-                  "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_chrcc_renal_cell}
-                },
-                {
-                  "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_chrcc_renal_cell}
-                },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_CCRCC_RENAL_CELL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_ccrcc_renal_cell",
-          "variables": [
-            {
-              "name": "c_genitourinary_ccrcc_renal_cell",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_ccrcc_renal_cell} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_ccrcc_renal_cell} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_COLLECTING_DUCT_CARCINOMA",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_collecting_duct_carcinoma",
-          "variables": [
-            {
-              "name": "c_genitourinary_collecting_duct_carcinoma",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_collecting_duct_carcinoma} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_collecting_duct_carcinoma} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_FH_DEFICIENT_RCC",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_fh_deficient_rcc",
-          "variables": [
-            {
-              "name": "c_genitourinary_fh_deficient_rcc",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_fh_deficient_rcc} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_fh_deficient_rcc} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_PRCC_RENAL_CELL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_prcc_renal_cell",
-          "variables": [
-            {
-              "name": "c_genitourinary_prcc_renal_cell",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_prcc_renal_cell} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_prcc_renal_cell} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_RENAL_MEDULLARY_CARCINOMA",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_renal_medullary_carcinoma",
-          "variables": [
-            {
-              "name": "c_genitourinary_renal_medullary_carcinoma",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_renal_medullary_carcinoma} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_renal_medullary_carcinoma} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_RENAL_ONCOCYTOMA",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_renal_oncocytoma",
-          "variables": [
-            {
-              "name": "c_genitourinary_renal_oncocytoma",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_renal_oncocytoma} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_renal_oncocytoma} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_SDHA_B_RCC",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_sdha_b_rcc",
-          "variables": [
-            {
-              "name": "c_genitourinary_sdha_b_rcc",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_sdha_b_rcc} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_sdha_b_rcc} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_TRCC_RENAL_CELL",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_trcc_renal_cell",
-          "variables": [
-            {
-              "name": "c_genitourinary_trcc_renal_cell",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_trcc_renal_cell} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_trcc_renal_cell} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_UNCLASSIFIED_RCC",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_unclassified_rcc",
-          "variables": [
-            {
-              "name": "c_genitourinary_unclassified_rcc",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_unclassified_rcc} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_unclassified_rcc} },
-              ]
-            }
-          ]
-        }
-      },
-      // END: PEPPER-36
-      {
-        "stableId": "C_GENITOURINARY_PENILE_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_penile_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_penile_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_penile_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_penile_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_PROSTATE_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_prostate_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_prostate_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_prostate_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_prostate_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_TCC_RENAL_PELVIS_URETER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_tcc_renal_pelvis_ureter",
-          "variables": [
-            {
-              "name": "c_genitourinary_tcc_renal_pelvis_ureter",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_tcc_renal_pelvis_ureter} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_tcc_renal_pelvis_ureter} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_TESTICULAR_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_testicular_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_testicular_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_testicular_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_testicular_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_URACHAL_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_urachal_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_urachal_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_urachal_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_urachal_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_URETHRAL_CANCER",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_urethral_cancer",
-          "variables": [
-            {
-              "name": "c_genitourinary_urethral_cancer",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_urethral_cancer} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_urethral_cancer} },
-              ]
-            }
-          ]
-        }
-      },
-      {
-        "stableId": "C_GENITOURINARY_WILMS_TUMOR",
-        "optionLabelTemplate": {
-          "templateType": "TEXT",
-          "templateText": "$c_genitourinary_wilms_tumor",
-          "variables": [
-            {
-              "name": "c_genitourinary_wilms_tumor",
-              "translations": [
-                { "language": "en",
-                  "text": ${i18n.en.cancer.c_genitourinary_wilms_tumor} },
-                { "language": "es",
-                  "text": ${i18n.es.cancer.c_genitourinary_wilms_tumor} },
-              ]
-            }
-          ]
-        }
-      },
-    ]
-  }
+    {
+      "stableId": "C_GENITOURINARY_CCRCC_RENAL_CELL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_ccrcc_renal_cell",
+        "variables": [
+          {
+            "name": "c_genitourinary_ccrcc_renal_cell",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_ccrcc_renal_cell} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_ccrcc_renal_cell} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_COLLECTING_DUCT_CARCINOMA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_collecting_duct_carcinoma",
+        "variables": [
+          {
+            "name": "c_genitourinary_collecting_duct_carcinoma",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_collecting_duct_carcinoma} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_collecting_duct_carcinoma} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_FH_DEFICIENT_RCC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_fh_deficient_rcc",
+        "variables": [
+          {
+            "name": "c_genitourinary_fh_deficient_rcc",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_fh_deficient_rcc} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_fh_deficient_rcc} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_PRCC_RENAL_CELL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_prcc_renal_cell",
+        "variables": [
+          {
+            "name": "c_genitourinary_prcc_renal_cell",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_prcc_renal_cell} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_prcc_renal_cell} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_RENAL_MEDULLARY_CARCINOMA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_renal_medullary_carcinoma",
+        "variables": [
+          {
+            "name": "c_genitourinary_renal_medullary_carcinoma",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_renal_medullary_carcinoma} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_renal_medullary_carcinoma} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_RENAL_ONCOCYTOMA",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_renal_oncocytoma",
+        "variables": [
+          {
+            "name": "c_genitourinary_renal_oncocytoma",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_renal_oncocytoma} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_renal_oncocytoma} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_SDHA_B_RCC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_sdha_b_rcc",
+        "variables": [
+          {
+            "name": "c_genitourinary_sdha_b_rcc",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_sdha_b_rcc} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_sdha_b_rcc} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_TRCC_RENAL_CELL",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_trcc_renal_cell",
+        "variables": [
+          {
+            "name": "c_genitourinary_trcc_renal_cell",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_trcc_renal_cell} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_trcc_renal_cell} },
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "stableId": "C_GENITOURINARY_UNCLASSIFIED_RCC",
+      "optionLabelTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$c_genitourinary_unclassified_rcc",
+        "variables": [
+          {
+            "name": "c_genitourinary_unclassified_rcc",
+            "translations": [
+              { "language": "en",
+                "text": ${i18n.en.cancer.c_genitourinary_unclassified_rcc} },
+              { "language": "es",
+                "text": ${i18n.es.cancer.c_genitourinary_unclassified_rcc} },
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
@@ -20,16 +20,16 @@
 
     "es": {
       "cancer": {
-        "c_genitourinary_chrcc_renal_cell": "Cancer de riñon / Carcinoma de células renales cromófobo",
-        "c_genitourinary_ccrcc_renal_cell": "Cancer de riñon / Carcinoma de células renales de células claras",
-        "c_genitourinary_collecting_duct_carcinoma": "Cancer de riñon / Carcinoma de los túbulos colectores (o de ducto colector de Bellini)",
-        "c_genitourinary_fh_deficient_rcc": "Cancer de riñon/ Carcinoma renal asociado a leiomiomatosis hereditaria (CCRLH)",
-        "c_genitourinary_prcc_renal_cell": "Cancer de riñon / Carcinoma papilar (o de células renales)",
-        "c_genitourinary_renal_medullary_carcinoma": "Cancer de riñon / Carcinoma medular renal",
-        "c_genitourinary_renal_oncocytoma": "Cancer de riñon / Oncocitoma renal",
-        "c_genitourinary_sdha_b_rcc": "Cancer de riñon / Carcinoma de células renales con deficiencia de SDH(succinato deshidrogenasa)",
-        "c_genitourinary_trcc_renal_cell": "Cancer de riñon / Carcinoma de células renales con translocación Xp11.2 (o de la familia MiT(t-RCC))",
-        "c_genitourinary_unclassified_rcc": "Cancer de riñon / Carcinoma de celulas renales no clasificado"
+        "c_genitourinary_chrcc_renal_cell": "Cáncer de riñón / Carcinoma de células renales cromófobo",
+        "c_genitourinary_ccrcc_renal_cell": "Cáncer de riñón / Carcinoma de células renales de células claras",
+        "c_genitourinary_collecting_duct_carcinoma": "Cáncer de riñón / Carcinoma de los túbulos colectores (o de ducto colector de Bellini)",
+        "c_genitourinary_fh_deficient_rcc": "Cáncer de riñón / Carcinoma renal asociado a leiomiomatosis hereditaria (CCRLH)",
+        "c_genitourinary_prcc_renal_cell": "Cáncer de riñón / Carcinoma papilar (o de células renales)",
+        "c_genitourinary_renal_medullary_carcinoma": "Cáncer de riñón / Carcinoma medular renal",
+        "c_genitourinary_renal_oncocytoma": "Cáncer de riñón / Oncocitoma renal",
+        "c_genitourinary_sdha_b_rcc": "Cáncer de riñón / Carcinoma de células renales con deficiencia de SDH (succinato deshidrogenasa)",
+        "c_genitourinary_trcc_renal_cell": "Cáncer de riñón / Carcinoma de células renales con translocación Xp11.2 (o de la familia MiT(t-RCC))",
+        "c_genitourinary_unclassified_rcc": "Cáncer de riñón / Carcinoma de células renales no clasificado"
       }
     }
   },

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/add-additional-diagnosis.conf
@@ -1,0 +1,471 @@
+{
+  "description": "Adds additional cancer diagnosis to the Genitourinary category (PEPPER-36)",
+  "study": "cmi-pancan",
+
+  "i18n": {
+    "en": {
+      "cancer": {
+        "c_genitourinary_chrcc_renal_cell": "Kidney Cancer / Chromophobe renal cell carcinoma (chRCC)",
+        "c_genitourinary_ccrcc_renal_cell": "Kidney Cancer / Clear-cell renal cell carcinoma (ccRCC)",
+        "c_genitourinary_collecting_duct_carcinoma": "Kidney Cancer / Collecting duct carcinoma",
+        "c_genitourinary_fh_deficient_rcc": "Kidney Cancer / FH deficient RCC",
+        "c_genitourinary_prcc_renal_cell": "Kidney Cancer / Papillary renal cell carcinoma (PRCC)",
+        "c_genitourinary_renal_medullary_carcinoma": "Kidney Cancer / Renal medullary carcinoma",
+        "c_genitourinary_renal_oncocytoma": "Kidney Cancer / Renal oncocytoma",
+        "c_genitourinary_sdha_b_rcc": "Kidney Cancer / SDHA/B RCC",
+        "c_genitourinary_trcc_renal_cell": "Kidney Cancer / Translocation renal cell carcinoma (tRCC)",
+        "c_genitourinary_unclassified_rcc": "Kidney Cancer / Unclassified RCC"
+      }
+    },
+
+    "es": {
+      "cancer": {
+        "c_genitourinary_chrcc_renal_cell": "",
+        "c_genitourinary_ccrcc_renal_cell": "",
+        "c_genitourinary_collecting_duct_carcinoma": "",
+        "c_genitourinary_fh_deficient_rcc": "",
+        "c_genitourinary_prcc_renal_cell": "",
+        "c_genitourinary_renal_medullary_carcinoma": "",
+        "c_genitourinary_renal_oncocytoma": "",
+        "c_genitourinary_sdha_b_rcc": "",
+        "c_genitourinary_trcc_renal_cell": "",
+        "c_genitourinary_unclassified_rcc": ""
+      }
+    }
+  },
+
+  "expected-options": [
+    "C_GENITOURINARY_ACC_ADRENOCORTICAL"
+    "C_GENITOURINARY_BLADDER_CANCER",
+    "C_GENITOURINARY_GERM_CELL_TUMOR",
+    "C_GENITOURINARY_GTD_GESTATIONAL_TROPHOBL",
+    "C_GENITOURINARY_RCC_RENAL_CELL",
+    "C_GENITOURINARY_PENILE_CANCER",
+    "C_GENITOURINARY_PROSTATE_CANCER",
+    "C_GENITOURINARY_TCC_RENAL_PELVIS_URETER",
+    "C_GENITOURINARY_TESTICULAR_CANCER",
+    "C_GENITOURINARY_URACHAL_CANCER",
+    "C_GENITOURINARY_URETHRAL_CANCER",
+    "C_GENITOURINARY_WILMS_TUMOR",
+  ],
+  "option-group": {
+    "stableId": "C_GROUP_GENITOURINARY_GENITOURINARY_CANCERS",
+    "nameTemplate": {
+      "templateType": "HTML",
+      "templateText": "$prompt",
+      "variables": [
+        {
+          "name": "prompt",
+          "translations": [
+            { "language": "en", "text": ${i18n.en.cancer.c_group_genitourinary_genitourinary_cancers} },
+            { "language": "es", "text": ${i18n.es.cancer.c_group_genitourinary_genitourinary_cancers} },
+          ]
+        }
+      ]
+    },
+    "options": [
+      {
+        "stableId": "C_GENITOURINARY_ACC_ADRENOCORTICAL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_acc_adrenocortical",
+          "variables": [
+            {
+              "name": "c_genitourinary_acc_adrenocortical",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_acc_adrenocortical} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_acc_adrenocortical} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_BLADDER_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_bladder_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_bladder_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_bladder_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_bladder_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_GERM_CELL_TUMOR",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_germ_cell_tumor",
+          "variables": [
+            {
+              "name": "c_genitourinary_germ_cell_tumor",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_germ_cell_tumor} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_germ_cell_tumor} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_GTD_GESTATIONAL_TROPHOBL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_gtd_gestational_trophobl",
+          "variables": [
+            {
+              "name": "c_genitourinary_gtd_gestational_trophobl",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_gtd_gestational_trophobl} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_gtd_gestational_trophobl} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_RCC_RENAL_CELL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_rcc_renal_cell",
+          "variables": [
+            {
+              "name": "c_genitourinary_rcc_renal_cell",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_rcc_renal_cell} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_rcc_renal_cell} },
+              ]
+            }
+          ]
+        }
+      },
+      // BEGIN: PEPPER-36 additions
+      {
+        "stableId": "C_GENITOURINARY_CHRCC_RENAL_CELL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_chrcc_renal_cell",
+          "variables": [
+            {
+              "name": "c_genitourinary_chrcc_renal_cell",
+              "translations": [
+                {
+                  "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_chrcc_renal_cell}
+                },
+                {
+                  "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_chrcc_renal_cell}
+                },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_CCRCC_RENAL_CELL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_ccrcc_renal_cell",
+          "variables": [
+            {
+              "name": "c_genitourinary_ccrcc_renal_cell",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_ccrcc_renal_cell} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_ccrcc_renal_cell} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_COLLECTING_DUCT_CARCINOMA",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_collecting_duct_carcinoma",
+          "variables": [
+            {
+              "name": "c_genitourinary_collecting_duct_carcinoma",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_collecting_duct_carcinoma} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_collecting_duct_carcinoma} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_FH_DEFICIENT_RCC",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_fh_deficient_rcc",
+          "variables": [
+            {
+              "name": "c_genitourinary_fh_deficient_rcc",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_fh_deficient_rcc} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_fh_deficient_rcc} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_PRCC_RENAL_CELL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_prcc_renal_cell",
+          "variables": [
+            {
+              "name": "c_genitourinary_prcc_renal_cell",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_prcc_renal_cell} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_prcc_renal_cell} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_RENAL_MEDULLARY_CARCINOMA",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_renal_medullary_carcinoma",
+          "variables": [
+            {
+              "name": "c_genitourinary_renal_medullary_carcinoma",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_renal_medullary_carcinoma} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_renal_medullary_carcinoma} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_RENAL_ONCOCYTOMA",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_renal_oncocytoma",
+          "variables": [
+            {
+              "name": "c_genitourinary_renal_oncocytoma",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_renal_oncocytoma} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_renal_oncocytoma} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_SDHA_B_RCC",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_sdha_b_rcc",
+          "variables": [
+            {
+              "name": "c_genitourinary_sdha_b_rcc",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_sdha_b_rcc} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_sdha_b_rcc} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_TRCC_RENAL_CELL",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_trcc_renal_cell",
+          "variables": [
+            {
+              "name": "c_genitourinary_trcc_renal_cell",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_trcc_renal_cell} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_trcc_renal_cell} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_UNCLASSIFIED_RCC",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_unclassified_rcc",
+          "variables": [
+            {
+              "name": "c_genitourinary_unclassified_rcc",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_unclassified_rcc} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_unclassified_rcc} },
+              ]
+            }
+          ]
+        }
+      },
+      // END: PEPPER-36
+      {
+        "stableId": "C_GENITOURINARY_PENILE_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_penile_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_penile_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_penile_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_penile_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_PROSTATE_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_prostate_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_prostate_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_prostate_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_prostate_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_TCC_RENAL_PELVIS_URETER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_tcc_renal_pelvis_ureter",
+          "variables": [
+            {
+              "name": "c_genitourinary_tcc_renal_pelvis_ureter",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_tcc_renal_pelvis_ureter} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_tcc_renal_pelvis_ureter} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_TESTICULAR_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_testicular_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_testicular_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_testicular_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_testicular_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_URACHAL_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_urachal_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_urachal_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_urachal_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_urachal_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_URETHRAL_CANCER",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_urethral_cancer",
+          "variables": [
+            {
+              "name": "c_genitourinary_urethral_cancer",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_urethral_cancer} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_urethral_cancer} },
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "stableId": "C_GENITOURINARY_WILMS_TUMOR",
+        "optionLabelTemplate": {
+          "templateType": "TEXT",
+          "templateText": "$c_genitourinary_wilms_tumor",
+          "variables": [
+            {
+              "name": "c_genitourinary_wilms_tumor",
+              "translations": [
+                { "language": "en",
+                  "text": ${i18n.en.cancer.c_genitourinary_wilms_tumor} },
+                { "language": "es",
+                  "text": ${i18n.es.cancer.c_genitourinary_wilms_tumor} },
+              ]
+            }
+          ]
+        }
+      },
+    ]
+  }
+}


### PR DESCRIPTION
PEPPER-36

## Context
This PR adds a patch named `PancanAddAdditionalDiagnoses`. This patch inserts the additional options named in the description of PEPPER-36 to the Genitourinary (`C_GROUP_GENITOURINARY_GENITOURINARY_CANCERS`) group in all Pancan activities which make use of the shared `cancer-picklist-groups.conf` snippet.

## Running the patch
The patch can be run using the standard `studybuilder-cli` `--run-task` flag using the task name `PancanAddAdditionalDiagnoses`. No addition configuration changes are necessary outside of those required to deploy the `pancan` study via studybuilder.

The list of impacted activities & questions is available in [this comment](https://broadworkbench.atlassian.net/browse/PEPPER-36?focusedCommentId=71686) on the Jira ticket.