### PR TITLE
[PEPPER-18] Scope activity validation deletion to study

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
@@ -1,13 +1,17 @@
 package org.broadinstitute.ddp.studybuilder.task;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.ddp.db.dao.JdbiActivity;
 import org.broadinstitute.ddp.db.dao.JdbiActivityVersion;
-import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
 import org.broadinstitute.ddp.db.dao.JdbiRevision;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
 import org.broadinstitute.ddp.db.dto.ActivityDto;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -16,10 +20,6 @@ import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
-
-import java.io.File;
-import java.nio.file.Path;
-import java.util.List;
 
 /**
  * Task to replace age validations to singular activities

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
@@ -27,13 +27,15 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 @Slf4j
 @NoArgsConstructor
 public class SingularAgeValidationUpdate implements CustomTask {
+    private static final String TARGET_STUDY = "singular";
+
     private Path cfgPath;
     private Config cfg;
     private Config varsCfg;
 
     @Override
     public void init(final Path cfgPath, final Config studyCfg, final Config varsCfg) {
-        if (!studyCfg.getString("study.guid").equals("singular")) {
+        if (!studyCfg.getString("study.guid").equals(TARGET_STUDY)) {
             throw new DDPException("This task is only for the singular study!");
         }
 

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
@@ -129,7 +129,7 @@ public class SingularAgeValidationUpdate implements CustomTask {
                  + "JOIN study_activity sa ON av.study_activity_id = sa.study_activity_id "
                  + "JOIN umbrella_study us ON us.umbrella_study_id = sa.study_id "
                  + "WHERE sa.study_activity_code = :activityCode "
-                 + "  AND sa.guid = :studyGuid "
+                 + "  AND us.guid = :studyGuid "
                  + "AND REPLACE(REPLACE(REPLACE(REPLACE(av.expression_text, ' ', ''), CHAR(13), ''), CHAR(10), ''), CHAR(9), '') = "
                  + "    REPLACE(REPLACE(REPLACE(REPLACE(:expression, ' ', ''), CHAR(13), ''), CHAR(10), ''), CHAR(9), '') "
                  + "AND REPLACE(REPLACE(REPLACE(REPLACE(av.precondition_text, ' ', ''), CHAR(13), ''), CHAR(10), ''), CHAR(9), '') = "

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/SingularAgeValidationUpdate.java
@@ -27,9 +27,9 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 @Slf4j
 @NoArgsConstructor
 public class SingularAgeValidationUpdate implements CustomTask {
-    protected Path cfgPath;
-    protected Config cfg;
-    protected Config varsCfg;
+    private Path cfgPath;
+    private Config cfg;
+    private Config varsCfg;
 
     @Override
     public void init(final Path cfgPath, final Config studyCfg, final Config varsCfg) {


### PR DESCRIPTION
## Context

Update the patch's activity validation delete SQL expression to limit any identified validation expressions to only the study targeted by the patch.

## Deployment
There are no deployment instructions necessary for this change. This update will only have an effect on environments where the patch is being applied for the first time.