### PR TITLE
PEPPER-306 . matrix question elastic export fix.

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/json/structured/MatrixQuestionRecord.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/json/structured/MatrixQuestionRecord.java
@@ -17,7 +17,7 @@ public final class MatrixQuestionRecord extends QuestionRecord {
     @SerializedName("matrixSelected")
     private Map<String, String> selected = new HashMap<>();
     @SerializedName("answer")
-    private Map<String, String> answer = new HashMap<>();
+    private List<String> answer = new ArrayList<>();
 
     public MatrixQuestionRecord(String stableId, List<SelectedMatrixCell> cells) {
         super(QuestionType.MATRIX, stableId);
@@ -27,7 +27,7 @@ public final class MatrixQuestionRecord extends QuestionRecord {
                     String rowStableId = cell.getRowStableId();
                     String optionStableId = cell.getOptionStableId();
                     selected.put(rowStableId, optionStableId);
-                    answer.put(rowStableId, optionStableId);
+                    answer.add(String.join(":", rowStableId, optionStableId));
                 }
                 if (!cell.getGroupStableId().isBlank()) {
                     matrixGroups.add(cell.getGroupStableId());
@@ -40,7 +40,7 @@ public final class MatrixQuestionRecord extends QuestionRecord {
         return selected;
     }
 
-    public Map<String, String> getAnswer() {
+    public List<String> getAnswer() {
         return answer;
     }
 }


### PR DESCRIPTION
look at https://broadworkbench.atlassian.net/browse/PEPPER-306

Updated the answer object in elastic export so that it is compatible with existing answer and mapping.
Tested by doing pancan export and verifying in DSM that Diet Life Style data is visible. 
test ptp: guid:PS12236C7UHQV1E14AC6/PDH8XT

[PEPPER-306]: https://broadworkbench.atlassian.net/browse/PEPPER-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ