### PR TITLE
Pepper-46: filtering borked

### DIFF
--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/ActivitiesCollectionQueryBuilderTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/ActivitiesCollectionQueryBuilderTest.java
@@ -74,14 +74,11 @@ public class ActivitiesCollectionQueryBuilderTest {
         BoolQueryBuilder nestedBoolQuery = new BoolQueryBuilder();
         nestedBoolQuery.must(new MatchQueryBuilder("activities.activityCode", "ANGIORELEASE").operator(Operator.AND));
         nestedBoolQuery.must(new RangeQueryBuilder("activities.lastUpdatedAt").gte("2022-04-21"));
+        nestedBoolQuery.must(new MatchQueryBuilder("activities.activityCode", "ANGIORELEASE").operator(Operator.AND));
+        nestedBoolQuery.must(new RangeQueryBuilder("activities.lastUpdatedAt").lte("2022-07-28"));
         NestedQueryBuilder expectedNestedQuery = new NestedQueryBuilder("activities", nestedBoolQuery, ScoreMode.Avg);
         expected.must(expectedNestedQuery);
-
-        BoolQueryBuilder nestedBoolQuery2 = new BoolQueryBuilder();
-        nestedBoolQuery2.must(new MatchQueryBuilder("activities.activityCode", "ANGIORELEASE").operator(Operator.AND));
-        nestedBoolQuery2.must(new RangeQueryBuilder("activities.lastUpdatedAt").lte("2022-07-28"));
-        NestedQueryBuilder expectedNestedQuery2 = new NestedQueryBuilder("activities", nestedBoolQuery2, ScoreMode.Avg);
-        expected.must(expectedNestedQuery2);
+        
         Assert.assertEquals(expected, actual);
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/CollectionQueryBuilderTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/CollectionQueryBuilderTest.java
@@ -2,7 +2,6 @@ package org.broadinstitute.dsm.model.elastic.filter.query;
 
 import java.util.regex.Pattern;
 
-import org.apache.lucene.queryparser.xml.builders.BooleanQueryBuilder;
 import org.apache.lucene.search.join.ScoreMode;
 import org.broadinstitute.dsm.model.elastic.filter.FilterParser;
 import org.broadinstitute.dsm.model.filter.participant.BaseFilterParticipantList;
@@ -25,13 +24,12 @@ public class CollectionQueryBuilderTest {
 
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
-        AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.medicalRecord", new MatchQueryBuilder("dsm.medicalRecord.medicalRecordId", "15")
-                                .operator(Operator.AND),
+        AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder()
+                .must(new NestedQueryBuilder("dsm.medicalRecord", new BoolQueryBuilder()
+                                .must(new MatchQueryBuilder("dsm.medicalRecord.medicalRecordId", "15").operator(Operator.AND))
+                                .must(new MatchQueryBuilder("dsm.medicalRecord.type", "PHYSICIAN").operator(Operator.AND)),
                                 ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord", new MatchQueryBuilder("dsm.medicalRecord.type", "PHYSICIAN")
-                        .operator(Operator.AND),
-                        ScoreMode.Avg)).should(new NestedQueryBuilder("dsm.kitRequestShipping",
+                .should(new NestedQueryBuilder("dsm.kitRequestShipping",
                         new MatchQueryBuilder("dsm.kitRequestShipping.bspCollaboratorSampleId", "ASCProject_PZ8GJC_SALIVA")
                                 .operator(Operator.AND),
                         ScoreMode.Avg));
@@ -53,10 +51,11 @@ public class CollectionQueryBuilderTest {
         boolQueryBuilder.must(new ExistsQueryBuilder("dsm.participant.participantId"));
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.medicalRecord", new RangeQueryBuilder("dsm.medicalRecord.medicalRecordId").gte("15"),
+                        new NestedQueryBuilder("dsm.medicalRecord", new BoolQueryBuilder()
+                                .must(new RangeQueryBuilder("dsm.medicalRecord.medicalRecordId").gte("15"))
+                                .must(new MatchQueryBuilder("dsm.medicalRecord.type", "PHYSICIAN")),
                                 ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord", new MatchQueryBuilder("dsm.medicalRecord.type", "PHYSICIAN"),
-                        ScoreMode.Avg)).should(new NestedQueryBuilder("dsm.kitRequestShipping",
+                .should(new NestedQueryBuilder("dsm.kitRequestShipping",
                         new MatchQueryBuilder("dsm.kitRequestShipping.bspCollaboratorSampleId", "ASCProject_PZ8GJC_SALIVA")
                                 .operator(Operator.AND), ScoreMode.Avg))
                 .must(new NestedQueryBuilder("dsm.tissue", new RangeQueryBuilder("dsm.tissue.returnDate").lte("2015-01-01"), ScoreMode.Avg))
@@ -69,32 +68,7 @@ public class CollectionQueryBuilderTest {
     public void mrNotRequestedYet() {
 
         String filter = "AND k.receive_date IS NOT NULL AND m.fax_sent IS NULL AND NOT m.mr_problem <=> 1 "
-                        + "AND NOT m.unable_obtain <=> 1 AND NOT m.duplicate <=> 1 AND ( data.status = 'ENROLLED' )";
-
-        AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
-
-
-        AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder()
-                .must(new NestedQueryBuilder("dsm.kitRequestShipping",
-                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.kitRequestShipping.receiveDate")), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord",
-                new BoolQueryBuilder().mustNot(new ExistsQueryBuilder("dsm.medicalRecord.faxSent")), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord",
-                        new MatchQueryBuilder("dsm.medicalRecord.mrProblem", false).operator(Operator.AND), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord",
-                        new MatchQueryBuilder("dsm.medicalRecord.unableObtain", false).operator(Operator.AND), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord",
-                        new MatchQueryBuilder("dsm.medicalRecord.duplicate", false).operator(Operator.AND), ScoreMode.Avg))
-                .must(new BoolQueryBuilder().should(new MatchQueryBuilder("status", "ENROLLED")));
-
-        Assert.assertEquals(expected, actual);
-    }
-
-    @Test
-    public void mrNotRequestedYetTry() {
-
-        String filter = "AND k.receive_date IS NOT NULL AND m.fax_sent IS NULL AND NOT m.mr_problem <=> 1 "
-                        + "AND NOT m.unable_obtain <=> 1 AND NOT m.duplicate <=> 1 AND ( data.status = 'ENROLLED' )";
+                + "AND NOT m.unable_obtain <=> 1 AND NOT m.duplicate <=> 1 AND ( data.status = 'ENROLLED' )";
 
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
@@ -108,7 +82,7 @@ public class CollectionQueryBuilderTest {
                 .must(new BoolQueryBuilder().should(new MatchQueryBuilder("status", "ENROLLED")))
                 .must(new NestedQueryBuilder("dsm.medicalRecord", nestedPart, ScoreMode.Avg))
                 .must(new NestedQueryBuilder("dsm.kitRequestShipping",
-                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.kitRequestShipping.receiveDate")), ScoreMode.Avg));
+                        new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.kitRequestShipping.receiveDate")), ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -121,10 +95,9 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.medicalRecord",
-                                new RangeQueryBuilder("dsm.medicalRecord.age").gte("15"), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord",
-                        new RangeQueryBuilder("dsm.medicalRecord.age").lte("30"), ScoreMode.Avg));
+                new NestedQueryBuilder("dsm.medicalRecord", new BoolQueryBuilder()
+                        .must(new RangeQueryBuilder("dsm.medicalRecord.age").gte("15"))
+                        .must(new RangeQueryBuilder("dsm.medicalRecord.age").lte("30")), ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -178,10 +151,10 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder()
-                .must(new NestedQueryBuilder("dsm.kitRequestShipping",
-                        new RangeQueryBuilder("dsm.kitRequestShipping.scanDate").gte(1664928000000L), ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.kitRequestShipping",
-                        new RangeQueryBuilder("dsm.kitRequestShipping.scanDate").lte(1665014399999L), ScoreMode.Avg));
+                .must(new NestedQueryBuilder("dsm.kitRequestShipping", new BoolQueryBuilder()
+                                .must(new RangeQueryBuilder("dsm.kitRequestShipping.scanDate").gte(1664928000000L))
+                                .must(new RangeQueryBuilder("dsm.kitRequestShipping.scanDate").lte(1665014399999L)),
+                        ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -206,8 +179,9 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         BoolQueryBuilder expected = new BoolQueryBuilder();
-        expected.must(new RangeQueryBuilder("profile.createdAt").gte("01/01/2020"));
-        expected.must(new RangeQueryBuilder("profile.createdAt").lte("01/01/2022"));
+        expected.must(new BoolQueryBuilder()
+                .must(new RangeQueryBuilder("profile.createdAt").gte("01/01/2020"))
+                .must(new RangeQueryBuilder("profile.createdAt").lte("01/01/2022")));
 
         Assert.assertEquals(expected, actual);
     }
@@ -226,7 +200,8 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                new NestedQueryBuilder("dsm.medicalRecord", new MatchQueryBuilder("dsm.medicalRecord.followUp", true), ScoreMode.Avg));
+                new NestedQueryBuilder("dsm.medicalRecord", new MatchQueryBuilder("dsm.medicalRecord.followUp", true),
+                        ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -237,7 +212,7 @@ public class CollectionQueryBuilderTest {
 
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(new NestedQueryBuilder("dsm.smId",
-                            new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.smId.smIdValue")), ScoreMode.Avg));
+                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.smId.smIdValue")), ScoreMode.Avg));
         Assert.assertEquals(expected, actual);
     }
 
@@ -276,10 +251,10 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.medicalRecord", new RangeQueryBuilder("dsm.medicalRecord.received").gte("2012-01-01"),
-                                ScoreMode.Avg))
-                .must(new NestedQueryBuilder("dsm.medicalRecord", new RangeQueryBuilder("dsm.medicalRecord.received").lte("2015-01-01"),
-                        ScoreMode.Avg));
+                        new NestedQueryBuilder("dsm.medicalRecord", new BoolQueryBuilder()
+                                .must(new RangeQueryBuilder("dsm.medicalRecord.received").gte("2012-01-01"))
+                                .must(new RangeQueryBuilder("dsm.medicalRecord.received").lte("2015-01-01")),
+                                ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -293,14 +268,11 @@ public class CollectionQueryBuilderTest {
 
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
-
-        NestedQueryBuilder nestedQueryBuilder = new NestedQueryBuilder("dsm.medicalRecord",
-                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.medicalRecord.dynamicFields.tryAgain")),
-                ScoreMode.Avg);
-
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(new NestedQueryBuilder("dsm.medicalRecord",
-                new MatchQueryBuilder("dsm.medicalRecord.dynamicFields.seeingIfBugExists", true).operator(Operator.AND),
-                ScoreMode.Avg)).must(nestedQueryBuilder);
+                new BoolQueryBuilder()
+                        .must(new MatchQueryBuilder("dsm.medicalRecord.dynamicFields.seeingIfBugExists", true).operator(Operator.AND))
+                        .must(new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.medicalRecord.dynamicFields.tryAgain"))),
+                ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }
@@ -319,8 +291,8 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.cohortTag",
-                                new MatchQueryBuilder("dsm.cohortTag.cohortTagName", "Oct 7 2022")
+                new NestedQueryBuilder("dsm.cohortTag",
+                        new MatchQueryBuilder("dsm.cohortTag.cohortTagName", "Oct 7 2022")
                                 .operator(Operator.AND), ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
@@ -333,8 +305,8 @@ public class CollectionQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
 
         AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder().must(
-                        new NestedQueryBuilder("dsm.cohortTag",
-                                new MatchQueryBuilder("dsm.cohortTag.cohortTagName", "7")
+                new NestedQueryBuilder("dsm.cohortTag",
+                        new MatchQueryBuilder("dsm.cohortTag.cohortTagName", "7")
                                 .operator(Operator.AND), ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/CollectionQueryBuilderTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/CollectionQueryBuilderTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsm.model.elastic.filter.query;
 
 import java.util.regex.Pattern;
 
+import org.apache.lucene.queryparser.xml.builders.BooleanQueryBuilder;
 import org.apache.lucene.search.join.ScoreMode;
 import org.broadinstitute.dsm.model.elastic.filter.FilterParser;
 import org.broadinstitute.dsm.model.filter.participant.BaseFilterParticipantList;
@@ -60,6 +61,54 @@ public class CollectionQueryBuilderTest {
                                 .operator(Operator.AND), ScoreMode.Avg))
                 .must(new NestedQueryBuilder("dsm.tissue", new RangeQueryBuilder("dsm.tissue.returnDate").lte("2015-01-01"), ScoreMode.Avg))
                 .must(boolQueryBuilder);
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void mrNotRequestedYet() {
+
+        String filter = "AND k.receive_date IS NOT NULL AND m.fax_sent IS NULL AND NOT m.mr_problem <=> 1 "
+                        + "AND NOT m.unable_obtain <=> 1 AND NOT m.duplicate <=> 1 AND ( data.status = 'ENROLLED' )";
+
+        AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
+
+
+        AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder()
+                .must(new NestedQueryBuilder("dsm.kitRequestShipping",
+                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.kitRequestShipping.receiveDate")), ScoreMode.Avg))
+                .must(new NestedQueryBuilder("dsm.medicalRecord",
+                new BoolQueryBuilder().mustNot(new ExistsQueryBuilder("dsm.medicalRecord.faxSent")), ScoreMode.Avg))
+                .must(new NestedQueryBuilder("dsm.medicalRecord",
+                        new MatchQueryBuilder("dsm.medicalRecord.mrProblem", false).operator(Operator.AND), ScoreMode.Avg))
+                .must(new NestedQueryBuilder("dsm.medicalRecord",
+                        new MatchQueryBuilder("dsm.medicalRecord.unableObtain", false).operator(Operator.AND), ScoreMode.Avg))
+                .must(new NestedQueryBuilder("dsm.medicalRecord",
+                        new MatchQueryBuilder("dsm.medicalRecord.duplicate", false).operator(Operator.AND), ScoreMode.Avg))
+                .must(new BoolQueryBuilder().should(new MatchQueryBuilder("status", "ENROLLED")));
+
+        Assert.assertEquals(expected, actual);
+    }
+
+    @Test
+    public void mrNotRequestedYetTry() {
+
+        String filter = "AND k.receive_date IS NOT NULL AND m.fax_sent IS NULL AND NOT m.mr_problem <=> 1 "
+                        + "AND NOT m.unable_obtain <=> 1 AND NOT m.duplicate <=> 1 AND ( data.status = 'ENROLLED' )";
+
+        AbstractQueryBuilder<?> actual = getAbstractQueryBuilder(filter).build();
+
+        BoolQueryBuilder nestedPart = new BoolQueryBuilder();
+        nestedPart.must(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder("dsm.medicalRecord.faxSent")))
+                .must(new MatchQueryBuilder("dsm.medicalRecord.mrProblem", false).operator(Operator.AND))
+                .must(new MatchQueryBuilder("dsm.medicalRecord.unableObtain", false).operator(Operator.AND))
+                .must(new MatchQueryBuilder("dsm.medicalRecord.duplicate", false).operator(Operator.AND));
+
+        AbstractQueryBuilder<BoolQueryBuilder> expected = new BoolQueryBuilder()
+                .must(new BoolQueryBuilder().should(new MatchQueryBuilder("status", "ENROLLED")))
+                .must(new NestedQueryBuilder("dsm.medicalRecord", nestedPart, ScoreMode.Avg))
+                .must(new NestedQueryBuilder("dsm.kitRequestShipping",
+                new BoolQueryBuilder().must(new ExistsQueryBuilder("dsm.kitRequestShipping.receiveDate")), ScoreMode.Avg));
 
         Assert.assertEquals(expected, actual);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/SingleQueryBuilderTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/filter/query/SingleQueryBuilderTest.java
@@ -81,8 +81,9 @@ public class SingleQueryBuilderTest {
         AbstractQueryBuilder<?> actual = getNonActivityQueryBuilder(filter);
 
         BoolQueryBuilder expected = new BoolQueryBuilder();
-        expected.must(new RangeQueryBuilder("profile.createdAt").gte("01/01/2020"));
-        expected.must(new RangeQueryBuilder("profile.createdAt").lte("01/01/2022"));
+        expected.must(new BoolQueryBuilder()
+                .must(new RangeQueryBuilder("profile.createdAt").gte("01/01/2020"))
+                .must(new RangeQueryBuilder("profile.createdAt").lte("01/01/2022")));
 
         Assert.assertEquals(expected, actual);
     }
@@ -98,8 +99,9 @@ public class SingleQueryBuilderTest {
         mustExists2.must(new ExistsQueryBuilder("profile.lastName"));
 
         BoolQueryBuilder expectedQuery = new BoolQueryBuilder();
-        expectedQuery.must(mustExists1);
-        expectedQuery.must(mustExists2);
+        expectedQuery.must(new BoolQueryBuilder()
+                .must(mustExists1)
+                .must(mustExists2));
 
         Assert.assertEquals(expectedQuery, getNonActivityQueryBuilder(filter));
     }


### PR DESCRIPTION
changed query creation logic from 
```"bool" : {
          "must" : [
            {
              "nested" : {
                "query" : {
                  "bool" : {
                    "must_not" : [
                      {
                        "exists" : {
                          "field" : "dsm.medicalRecord.faxSent",
                          "boost" : 1.0
                        }
                      }
                    ],
                    "adjust_pure_negative" : true,
                    "boost" : 1.0
                  }
                },
                "path" : "dsm.medicalRecord",
                "ignore_unmapped" : false,
                "score_mode" : "avg",
                "boost" : 1.0
              }
            },
            {
              "nested" : {
                "query" : {
                  "match" : {
                    "dsm.medicalRecord.mrProblem" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                },
                "path" : "dsm.medicalRecord",
                "ignore_unmapped" : false,
                "score_mode" : "avg",
                "boost" : 1.0
              }
            },
            {
              "nested" : {
                "query" : {
                  "match" : {
                    "dsm.medicalRecord.unableObtain" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                },
                "path" : "dsm.medicalRecord",
                "ignore_unmapped" : false,
                "score_mode" : "avg",
                "boost" : 1.0
              }
            },
            {
              "nested" : {
                "query" : {
                  "match" : {
                    "dsm.medicalRecord.duplicate" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                },
                "path" : "dsm.medicalRecord",
                "ignore_unmapped" : false,
                "score_mode" : "avg",
                "boost" : 1.0
              }
            }
          ],
          "adjust_pure_negative" : true,
          "boost" : 1.0
        }
      },
``` 
to 
```{
  "bool" : {
    "must" : [
      {
        "nested" : {
          "query" : {
            "bool" : {
              "must" : [
                {
                  "bool" : {
                    "must_not" : [
                      {
                        "exists" : {
                          "field" : "dsm.medicalRecord.faxSent",
                          "boost" : 1.0
                        }
                      }
                    ],
                    "adjust_pure_negative" : true,
                    "boost" : 1.0
                  }
                },
                {
                  "match" : {
                    "dsm.medicalRecord.mrProblem" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                },
                {
                  "match" : {
                    "dsm.medicalRecord.unableObtain" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                },
                {
                  "match" : {
                    "dsm.medicalRecord.duplicate" : {
                      "query" : false,
                      "operator" : "AND",
                      "prefix_length" : 0,
                      "max_expansions" : 50,
                      "fuzzy_transpositions" : true,
                      "lenient" : false,
                      "zero_terms_query" : "NONE",
                      "auto_generate_synonyms_phrase_query" : true,
                      "boost" : 1.0
                    }
                  }
                }
              ],
              "adjust_pure_negative" : true,
              "boost" : 1.0
            }
          },
          "path" : "dsm.medicalRecord",
          "ignore_unmapped" : false,
          "score_mode" : "avg",
          "boost" : 1.0
        }
      },```