### PR TITLE
Extends studybuilder-cli to support syncing & rotating client secrets

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/db/dao/JdbiAuth0Tenant.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/db/dao/JdbiAuth0Tenant.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.ddp.db.dao;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.broadinstitute.ddp.db.dto.Auth0TenantDto;
@@ -11,6 +12,15 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 public interface JdbiAuth0Tenant extends SqlObject {
+
+    @SqlQuery("SELECT "
+            + "  auth0_tenant_id,"
+            + "  management_client_id,"
+            + "  management_client_secret,"
+            + "  auth0_domain"
+            + " FROM auth0_tenant")
+    @RegisterConstructorMapper(Auth0TenantDto.class)
+    List<Auth0TenantDto> fetchAll();
 
     @SqlQuery("select * from auth0_tenant where auth0_tenant_id = :id")
     @RegisterConstructorMapper(Auth0TenantDto.class)

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiClient.java
@@ -188,13 +188,13 @@ public interface JdbiClient extends SqlObject {
     @SqlQuery("SELECT COUNT(*) FROM client WHERE auth0_client_id = :auth0ClientId")
     int countClientsWithSameAuth0ClientId(@Bind("auth0ClientId") String auth0ClientId);
 
-    @SqlQuery("UPDATE client"
+    @SqlUpdate("UPDATE client"
             + "  SET"
             + "    auth0_client_id = :auth0ClientId,"
             + "    auth0_signing_secret = :auth0EncryptedSecret,"
             + "    web_password_redirect_url = :webPasswordRedirectUrl,"
             + "    is_revoked = :revoked,"
             + "    auth0_tenant_id = :auth0TenantId"
-            + "  WHERE client.client_id = :id")
+            + "  WHERE client_id = :id")
     int update(@BindBean ClientDto client);
 }

--- a/pepper-apis/studybuilder-cli/README.md
+++ b/pepper-apis/studybuilder-cli/README.md
@@ -128,4 +128,6 @@ Each study required at least 2 Auth0 clients for proper functioning. The first i
   * `update:client_keys`
 
 ### Rotating the client secrets
-In the event that the client secrets need to be rotated, `studybuilder-cli` has functionality perform that operation using `--only-rotate-client-secrets`. This functionality will go through each tenant and, using the tenant's management client, rotate the client secret for each client, encrypt the result, and update the database. This functionality is also useful if the `encryptionSecret` is changed in the DSS configuration.
+In the event that the client secrets need to be re-synced (in this context, fetched from Auth0, encrypted using the `auth0.encryptedKey` value, and stored in the database), `studybuilder-cli` has functionality perform that operation using `--only-sync-client-secrets`. This functionality will go through each tenant and, using the tenant's management client, encrypt the result, and update the database. This functionality is also useful if the `encryptionSecret` is changed in the DSS configuration.
+
+If the `--rotate` flag is specified, each client's client secrets will be rotate before being fetched from Auth0.

--- a/pepper-apis/studybuilder-cli/README.md
+++ b/pepper-apis/studybuilder-cli/README.md
@@ -111,3 +111,21 @@ via Auth0's dashboard.
 
 [cli]: https://auth0.com/docs/extensions/deploy-cli
 [install-docs]: https://auth0.com/docs/extensions/deploy-cli/guides/install-deploy-cli
+
+## Auth0 Configuration
+Each study required at least 2 Auth0 clients for proper functioning. The first is a client with access to the Management API for the tenant. This client should have the following permissions to Auth0:
+  * `read:users`
+  * `update:users`
+  * `delete:users`
+  * `create:users`
+  * `read:users_app_metadata`
+  * `update:users_app_metadata`
+  * `delete:users_app_metadata`
+  * `create:users_app_metadata`
+  * `read:clients`
+  * `update:clients`
+  * `read:client_keys`
+  * `update:client_keys`
+
+### Rotating the client secrets
+In the event that the client secrets need to be rotated, `studybuilder-cli` has functionality perform that operation using `--only-rotate-client-secrets`. This functionality will go through each tenant and, using the tenant's management client, rotate the client secret for each client, encrypt the result, and update the database. This functionality is also useful if the `encryptionSecret` is changed in the DSS configuration.


### PR DESCRIPTION
## Context

Updating the DSS database with updated secrets in the event of a change of the `auth0.encryptionKey` value, or a breach requiring the Auth0 client secrets to be rotated is currently a extremely time-intensive task- each client takes 5-10 minutes to rotate, and there are upwards of 30 clients per environment (not including management clients). This PR adds the `--only-sync-client-secrets` action to `studybuilder-cli`.

When invoked, `--only-sync-client-secrets` will loop through all the available tenants and, using their associated management clients, fetch the client secrets for each client in the tenant, encrypt it using the `auth0.encryptionKey` value and `AesUtil`, and update the database. This operation is non-destructive, and will not change any values in Auth0.

The `--only-sync-client-secrets` action has an additional flag, `--rotate`. When `--rotate` is specified, the clients will have their client secret rotated prior to updating the database. This is a destructive option, and other configuration sources may need to be updated with the new client secrets after the rotation is complete.

When operating in sync-only mode, the management clients for each tenant require the following permissions to be granted for the Auth0 Management API
* read:clients
* read:client_keys

When operating in `rotate` mode, the management clients for each tenant require the following additional permissions to be granted for the Auth0 Management API
*  update:clients
*  update:client_keys

## Limitations
This functionality does not handle rotation of the management clients. If the Auth0 Management Clients require their secrets to be re-encrypted or rotated, this *must* first be done manually before this operation can be successfully used.

## Examples
1. Perform a client secret sync
    ```
    java -Dconfig.file="path/to/dss/application.conf" \
      -jar "target/StudyBuilder.jar" \
      --vars "path/to/vars.conf" \
      --substitutions path/to/subs.conf \
      path/to/study.conf \
      --only-sync-client-secrets
    ```
2. Rotate & update all client secrets
    ```
    java -Dconfig.file="path/to/dss/application.conf" \
      -jar "target/StudyBuilder.jar" \
      --vars "path/to/vars.conf" \
      --substitutions path/to/subs.conf \
      path/to/study.conf \
      --only-sync-client-secrets \
      --rotate
    ```

## Further work
In the future, adding flags to limit the rotation behavior to a specific domain or study would expand the usefulness of this feature, and limit potential impacts.

## Release

No special release procedures are necessary, this functionality must be manually invoked via `studybuilder-cli` if necessary.

