### PR TITLE
PEPPER-506 Upgrading vulnerable dependencies

### DIFF
--- a/pepper-apis/README.md
+++ b/pepper-apis/README.md
@@ -20,7 +20,7 @@ install the `google-cloud-sdk` cask. Otherwise, follow the instructions
 [here][gcloud-install]. Once the SDK is installed, we can install the emulator:
 
 ```bash
-gcloud components install beta --quiet
+gcloud components install --quiet
 gcloud components install pubsub-emulator --quiet
 gcloud components update --quiet
 ```
@@ -96,7 +96,7 @@ database, which is the default.
    
 4. Copy the command-line flags from `output-build-config/local-java-props.txt`
 5. Run the JAR
-    * `java [the copied cmd line flags] -jar ./target/DataDonationPlatform.jar`
+    * `java [the copied cmd line flags] -jar ./dss-server/target/DataDonationPlatform.jar`
 6. Make sure the server has started
     * `curl -i http://localhost:5555`
     * You'll get a `404` but at least it verifies the server is responding
@@ -113,14 +113,17 @@ The `api-build.sh` script helps with a few automation steps. Try the `--help` fl
 ### Running tests and main apps (DataDonationPlatform.java and Housekeeping.java) in intellij and mvn
 After running `api-build.sh` (you ran that already, right?), take a look at the `output-build-config/local-java-props.txt`
 file.  This file contains a bunch of `-D` vars that you'll need to put into either your
-intellij run/debug profiles or your command-line `mvn` command.
+intellij run/debug profiles or your command-line `mvn` command.  When you use file paths from the `local-java-props.txt` file,
+replace any relative paths with absolute paths.  Otherwise you may see errors about `java.lang.NoClassDefFoundError: Could not initialize class org.broadinstitute.ddp.util.ConfigManager`
+due to static initializers failing to find necessary config values.
 
 Before starting the tests or running the apps, you need to setup the coordinates for the pubsub emulator:
 ```
 $ export PUBSUB_EMULATOR_HOST=localhost:8442
 ```
 
-The you can run the tests:
+The you can run the tests on the command line.  Copy the `-D` vars from `output-build-config/local-java-props.txt` into the shell command,
+replacing relative paths with the full paths on your machine.
 ```sh
 $ mvn test [pile of -D vars copy-pasted from output-build-config/local-java-props.txt]
 ```

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -11,9 +11,11 @@
 
     <artifactId>ddp-common</artifactId>
 
+    <properties>
+        <logback.version>1.4.5</logback.version>
+    </properties>
+
     <dependencies>
-        <!-- unclear why we need to put logback here explicitly vs. inheriting it, but without it dsm's SlackAppender.java won't
-        compile -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -12,6 +12,19 @@
     <artifactId>ddp-common</artifactId>
 
     <dependencies>
+        <!-- unclear why we need to put logback here explicitly vs. inheriting it, but without it dsm's SlackAppender.java won't
+        compile -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/ConfigManager.java
@@ -44,7 +44,8 @@ public class ConfigManager {
 
         TYPESAFE_CONFIG_FILE = Optional.ofNullable(configFileName).map(File::new).orElse(null);
         if (TYPESAFE_CONFIG_FILE != null && !TYPESAFE_CONFIG_FILE.exists()) {
-            throw new DDPException("The config file " + TYPESAFE_CONFIG_FILE.getAbsolutePath() + " doesn't exist");
+            throw new DDPException("The config file " + TYPESAFE_CONFIG_FILE.getAbsolutePath() + " doesn't exist.  If you're using a "
+                    + "relative path in your config, try an absolute path instead.");
         }
     }
 

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
@@ -142,8 +142,8 @@ public class LiquibaseUtil implements AutoCloseable {
             liquibase.update(new Contexts());
         } catch (LiquibaseException originalError) {
             if (liquibase != null && tag != null) {
-                if (originalError.getCause().getClass() == MigrationFailedException.class ||
-                        originalError.getCause().getMessage().contains("Migration failed for change set " + changelogFile)) {
+                if (originalError.getCause().getClass() == MigrationFailedException.class
+                        || originalError.getCause().getMessage().contains("Migration failed for change set " + changelogFile)) {
                     try {
                         log.info("Attempting to rollback changesets to tag {}", tag);
                         liquibase.rollback(tag, new Contexts());

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
@@ -18,7 +18,6 @@ import liquibase.exception.MigrationFailedException;
 import liquibase.exception.RollbackFailedException;
 import liquibase.lockservice.DatabaseChangeLogLock;
 import liquibase.resource.ClassLoaderResourceAccessor;
-import liquibase.servicelocator.ServiceLocator;
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.constants.RouteConstants;
@@ -90,7 +89,6 @@ public class LiquibaseUtil implements AutoCloseable {
     }
 
     public static void releaseResources() {
-        ServiceLocator.setInstance(null);
         DatabaseFactory.setInstance(null);
     }
 
@@ -133,9 +131,6 @@ public class LiquibaseUtil implements AutoCloseable {
     private void runMigrations(String changelogFile) throws LiquibaseException, SQLException {
         Liquibase liquibase = null;
         String tag = null;
-        if (ServiceLocator.getInstance() == null) {
-            ServiceLocator.reset();
-        }
         try {
             liquibase = new Liquibase(changelogFile, new ClassLoaderResourceAccessor(), new JdbcConnection(dataSource.getConnection()));
             logLocks(liquibase.listLocks());

--- a/pepper-apis/dss-core/pom.xml
+++ b/pepper-apis/dss-core/pom.xml
@@ -70,16 +70,6 @@
             <artifactId>google-analytics-java</artifactId>
         </dependency>
 
-        <!-- logging and notifications -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-
         <dependency>
             <!-- configuration -->
             <groupId>com.typesafe</groupId>

--- a/pepper-apis/dss-core/pom.xml
+++ b/pepper-apis/dss-core/pom.xml
@@ -221,7 +221,8 @@
         <!-- utilities for parsing and templating -->
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>${velocity.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/VelocityUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/VelocityUtil.java
@@ -9,13 +9,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.velocity.app.Velocity;
+
 import org.apache.velocity.runtime.RuntimeInstance;
 import org.apache.velocity.runtime.parser.ParseException;
 import org.apache.velocity.runtime.parser.Token;
 import org.apache.velocity.runtime.parser.node.ASTReference;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
 import org.apache.velocity.runtime.visitor.BaseVisitor;
+
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.model.activity.definition.template.Template;
 import org.broadinstitute.ddp.model.activity.definition.template.TemplateVariable;
@@ -94,8 +95,7 @@ public class VelocityUtil {
     public static List<String> extractVelocityVariablesFromTemplate(String templateText) {
         try {
             RuntimeInstance ri = new RuntimeInstance();
-            // todo arz double check
-            SimpleNode node = ri.parse(new StringReader(templateText), Velocity.getTemplate(TEMPLATE_NAME));
+            SimpleNode node = ri.parse(new StringReader(templateText), new org.apache.velocity.Template());
             TemplateParserVisitor visitor = new TemplateParserVisitor();
             visitor.visit(node, null);
             return visitor.getVariables();

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/VelocityUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/VelocityUtil.java
@@ -4,10 +4,12 @@ import static org.apache.commons.lang3.StringUtils.contains;
 import static org.broadinstitute.ddp.content.I18nTemplateConstants.DDP;
 import static org.broadinstitute.ddp.util.PropertiesToMapTreeUtil.propertiesToMap;
 
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.velocity.app.Velocity;
 import org.apache.velocity.runtime.RuntimeInstance;
 import org.apache.velocity.runtime.parser.ParseException;
 import org.apache.velocity.runtime.parser.Token;
@@ -92,7 +94,8 @@ public class VelocityUtil {
     public static List<String> extractVelocityVariablesFromTemplate(String templateText) {
         try {
             RuntimeInstance ri = new RuntimeInstance();
-            SimpleNode node = ri.parse(templateText, TEMPLATE_NAME);
+            // todo arz double check
+            SimpleNode node = ri.parse(new StringReader(templateText), Velocity.getTemplate(TEMPLATE_NAME));
             TemplateParserVisitor visitor = new TemplateParserVisitor();
             visitor.visit(node, null);
             return visitor.getVariables();

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/environment/HostUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/environment/HostUtil.java
@@ -5,7 +5,7 @@ import java.net.UnknownHostException;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import spark.utils.StringUtils;
 
 /**

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorAbstract.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/pubsubtask/api/PubSubTaskProcessorAbstract.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.event.pubsubtask.api;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException.Severity.WARN;
 import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskLogUtil.infoMsg;
 import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskResult.PubSubTaskResultType.SUCCESS;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileProcessor.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/pubsubtask/impl/updateprofile/UpdateProfileProcessor.java
@@ -1,11 +1,11 @@
 package org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile;
 
 import static java.lang.String.format;
-import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask.ATTR_NAME__PARTICIPANT_GUID;
 import static org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException.Severity.WARN;
 import static org.broadinstitute.ddp.event.pubsubtask.impl.updateprofile.UpdateProfileConstants.ATTR_NAME__USER_ID;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTask;
 import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskException;
 import org.broadinstitute.ddp.event.pubsubtask.api.PubSubTaskProcessorAbstract;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -36,7 +36,7 @@ import com.opencsv.CSVWriter;
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.content.I18nTemplateRenderFacade;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetDsmInstitutionRequestsRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GetDsmInstitutionRequestsRoute.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.route;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang.time.DateUtils.MILLIS_PER_SECOND;
+import static org.apache.commons.lang3.time.DateUtils.MILLIS_PER_SECOND;
 import static org.broadinstitute.ddp.constants.RouteConstants.PathParam.MAX_ID;
 import static org.broadinstitute.ddp.constants.RouteConstants.PathParam.STUDY_GUID;
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/PostMedicalProviderRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/PostMedicalProviderRoute.java
@@ -6,7 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.constants.RouteConstants.PathParam;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserCreationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserCreationRoute.java
@@ -4,7 +4,7 @@ import java.time.Instant;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.db.TransactionWrapper;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.broadinstitute.ddp.analytics.GoogleAnalyticsMetrics;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/EventService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/EventService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.db.DaoException;
 import org.broadinstitute.ddp.db.dao.EventDao;
 import org.broadinstitute.ddp.db.dao.JdbiEventConfigurationOccurrenceCounter;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/PicklistCreatorHelper.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/actvityinstancebuilder/form/block/question/PicklistCreatorHelper.java
@@ -2,7 +2,7 @@ package org.broadinstitute.ddp.service.actvityinstancebuilder.form.block.questio
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistGroupDef;
 import org.broadinstitute.ddp.model.activity.definition.question.PicklistOptionDef;
 import org.broadinstitute.ddp.model.activity.instance.question.PicklistGroup;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/DataLoader.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/DataLoader.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.ddp.util;
 
-import static org.apache.commons.lang.time.DateUtils.MILLIS_PER_SECOND;
+import static org.apache.commons.lang3.time.DateUtils.MILLIS_PER_SECOND;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/I18nUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/I18nUtil.java
@@ -16,7 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.constants.LanguageConstants;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/PropertiesToMapTreeUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/PropertiesToMapTreeUtil.java
@@ -33,8 +33,7 @@ public class PropertiesToMapTreeUtil {
             Map<String, Object> valueMap = createTree(keyList, map);
             Object value = properties.get(key);
             if (value instanceof String) {
-                // todo arz double check this
-                value = StringEscapeUtils.unescapeHtml3((String)value);
+                value = StringEscapeUtils.unescapeHtml4((String)value);
             }
             valueMap.put(keyList.get(keyList.size() - 1), value);
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/PropertiesToMapTreeUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/PropertiesToMapTreeUtil.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 /**
  * Converts properties to hierarchy of maps: properties names are split into parts which separated by '.'
@@ -33,7 +33,8 @@ public class PropertiesToMapTreeUtil {
             Map<String, Object> valueMap = createTree(keyList, map);
             Object value = properties.get(key);
             if (value instanceof String) {
-                value = StringEscapeUtils.unescapeHtml((String)value);
+                // todo arz double check this
+                value = StringEscapeUtils.unescapeHtml3((String)value);
             }
             valueMap.put(keyList.get(keyList.size() - 1), value);
         }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/RedisConnectionValidator.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/RedisConnectionValidator.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.util;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import redis.clients.jedis.Jedis;
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/StudyDataLoader.java
@@ -1,7 +1,7 @@
 package org.broadinstitute.ddp.util;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang.time.DateUtils.MILLIS_PER_SECOND;
+import static org.apache.commons.lang3.time.DateUtils.MILLIS_PER_SECOND;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/RateLimitTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/RateLimitTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.entity.ContentType;

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/db/dao/FileUploadDaoTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/db/dao/FileUploadDaoTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
 
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.model.activity.instance.answer.FileInfo;
@@ -16,7 +17,6 @@ import org.broadinstitute.ddp.model.files.FileUpload;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 
 public class FileUploadDaoTest extends TxnAwareBaseTest {
 

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/study/PasswordPolicyTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/model/study/PasswordPolicyTest.java
@@ -6,8 +6,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 
 public class PasswordPolicyTest {
 

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/PatchFormAnswersRouteStandaloneTest.java
@@ -38,7 +38,7 @@ import com.google.gson.JsonPrimitive;
 import io.restassured.http.ContentType;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
-import liquibase.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.fluent.Request;
 import org.apache.http.util.EntityUtils;

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/service/OLCServiceTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/service/OLCServiceTest.java
@@ -21,6 +21,7 @@ import com.google.maps.model.PlusCode;
 import com.google.openlocationcode.OpenLocationCode;
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.TxnAwareBaseTest;
 import org.broadinstitute.ddp.client.ApiResult;
 import org.broadinstitute.ddp.client.GoogleMapsClient;
@@ -37,7 +38,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
 
 @Slf4j
 public class OLCServiceTest extends TxnAwareBaseTest {

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/util/LiquibaseUtilTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/util/LiquibaseUtilTest.java
@@ -91,7 +91,9 @@ public class LiquibaseUtilTest extends TxnAwareBaseTest {
             // these assertions are brittle--upgrades to liquibase may require some fiddling
             // as exception types change and messages in exceptions change
             assertTrue(e.getMessage().contains("migrations"));
-            assertTrue(e.getCause() instanceof MigrationFailedException || e.getCause().getMessage().contains("RollbackImpossibleException") ||  e.getCause().getMessage().contains("RollbackFailedException"));
+            assertTrue(e.getCause() instanceof MigrationFailedException
+                    || e.getCause().getMessage().contains("RollbackImpossibleException")
+                    ||  e.getCause().getMessage().contains("RollbackFailedException"));
             TransactionWrapper.useTxn(handle -> {
                 // Check that test data is not rolled back since rollback instructions are not provided.
                 List<String> names = handle.select("select name from liquibase_test_table").mapTo(String.class).list();

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -17,8 +17,10 @@
         <jdbi.version>3.28.0</jdbi.version>
         <itext.version>7.1.4</itext.version>
         <itext.licensekey.version>3.0.3</itext.licensekey.version>
-        <liquibase.version>3.6.3</liquibase.version>
+        <liquibase.version>4.8.0</liquibase.version>
         <elasticsearch.version>6.8.2</elasticsearch.version>
+        <logback.version>1.4.5</logback.version>
+        <velocity.version>2.3</velocity.version>
     </properties>
 
     <modules>
@@ -105,7 +107,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.25</version>
+                <version>2.0.6</version>
             </dependency>
 
             <dependency>
@@ -142,12 +144,12 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.2.3</version>
+                <version>${logback.version}</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.2.3</version>
+                <version>${logback.version}</version>
             </dependency>
 
             <dependency>
@@ -339,8 +341,8 @@
             <!-- utilities for parsing and templating -->
             <dependency>
                 <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>1.7</version>
+                <artifactId>velocity-engine-core</artifactId>
+                <version>${velocity.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jsoup</groupId>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -19,7 +19,6 @@
         <itext.licensekey.version>3.0.3</itext.licensekey.version>
         <liquibase.version>4.8.0</liquibase.version>
         <elasticsearch.version>6.8.2</elasticsearch.version>
-        <logback.version>1.4.5</logback.version>
         <velocity.version>2.3</velocity.version>
     </properties>
 
@@ -138,18 +137,6 @@
                 <groupId>com.brsanthu</groupId>
                 <artifactId>google-analytics-java</artifactId>
                 <version>2.0.0</version>
-            </dependency>
-
-            <!-- logging and notifications -->
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-core</artifactId>
-                <version>${logback.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>ch.qos.logback</groupId>
-                <artifactId>logback-classic</artifactId>
-                <version>${logback.version}</version>
             </dependency>
 
             <dependency>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -339,11 +339,21 @@
             </dependency>
 
             <!-- utilities for parsing and templating -->
+            <!-- new -->
             <dependency>
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity-engine-core</artifactId>
                 <version>${velocity.version}</version>
             </dependency>
+            <!-- old -->
+            <!--
+            <dependency>
+                <groupId>org.apache.velocity</groupId>
+                <artifactId>velocity</artifactId>
+                <version>1.7</version>
+            </dependency>
+
+            -->
             <dependency>
                 <groupId>org.jsoup</groupId>
                 <artifactId>jsoup</artifactId>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -511,7 +511,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>mysql</artifactId>
-                <version>1.12.3</version>
+                <version>1.17.6</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
## Context

PEPPER-506 lists a number of high priority vulnerabilities, including liquibase, apache velocity, and log4j.  Only log4j didn't require code changes.  Since the version jump for liquibase and velocity was quite large, there were some code changes due to backwards incompatibility issues.  Upgrading the libraries also exposed issues with imports of various apache commons (particularly the `lang` vs. `lang3` package).  A number of classes where importing apache commons from testcontainer and other test-related libraries.  The right place to import from for these are the apache commons packages themselves, which we already have as direct dependencies in our poms.

I also updated the main README.md because I found some of the instructions to be out of date.

Along the way, I ran into flakiness with testcontainers, so I upgraded to 1.17.6.  This has fixed my local stability issues.  After the tests ran for a while, I got an endless pile of these errors, which I have yet to see when running tests locally with 1.17.6.

```
08:18:26.001 C: S: [testcontainers-ryuk] WARN  o.t.utility.ResourceReaper - Can not connect to Ryuk at localhost:55029
java.net.ConnectException: Connection refused (Connection refused)
	at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:399)
	at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:242)
	at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:224)
	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:403)
	at java.base/java.net.Socket.connect(Socket.java:591)
	at java.base/java.net.Socket.connect(Socket.java:540)
	at java.base/java.net.Socket.<init>(Socket.java:436)
	at java.base/java.net.Socket.<init>(Socket.java:213)
	at org.testcontainers.utility.ResourceReaper.lambda$start$1(ResourceReaper.java:114)

```
The best place to start reviewing is with the poms themselves: [pepper-api's pom](https://github.com/broadinstitute/ddp-study-server/pull/2440/files#r1084070110), [ddp-common](https://github.com/broadinstitute/ddp-study-server/pull/2440/files#r1084120148), and [dss-core](https://github.com/broadinstitute/ddp-study-server/pull/2440/files#r1084121047).

Most of the test classes only have changes to import statements so that the proper `lang3` classes are imported from apache commons directly, so just cruising through the files top to bottom looking for comments is probably the way to go after reviewing the library changes.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## Testing

- [x ] Existing tests should sufficiently cover the changes.  A number of tests were failing while I worked through the API changes with velocity in particular.  They're passing now.

## Release

- [x ] These changes require no special release procedures--just code!

