### PR TITLE
Pepper 506 templating bug

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/content/I18nContentRenderer.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.contains;
 import static org.broadinstitute.ddp.content.VelocityUtil.VARIABLE_PREFIX;
 
 import java.io.StringWriter;
+import java.util.Properties;
 import java.util.TimeZone;
 import java.time.ZoneId;
 import java.time.LocalDate;
@@ -130,8 +131,10 @@ public class I18nContentRenderer {
      * @return An initialized VelocityEngine instance
      */
     private VelocityEngine createVelocityEngine() {
+        Properties velocityProps = new Properties();
+        velocityProps.setProperty("parser.allow_hyphen_in_identifiers", "true");
         VelocityEngine engine = new VelocityEngine();
-        engine.init();
+        engine.init(velocityProps);
         return engine;
     }
 

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/content/I18nContentRendererTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/content/I18nContentRendererTest.java
@@ -69,34 +69,6 @@ public class I18nContentRendererTest extends TxnAwareBaseTest {
         });
     }
 
-    /*
-
-    "picklistOptions": [
-              {
-                "stableId": "GRADE-HIGH",
-                "optionLabelTemplate": {
-                  "templateType": "TEXT",
-                  "templateCode": null,
-                  "templateText": "$BRAIN_CANCER_GRADE_grade-high",
-                  "variables": [
-                    {
-                      "name": "BRAIN_CANCER_GRADE_grade-high",
-                      "translations": [
-                        {
-                          "language": "en",
-                          "text": "High"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                "detailLabelTemplate": null,
-                "allowDetails": false,
-                "exclusive": false
-              },
-     */
-
-
     @Test
     public void testRenderPepper506CancerGrade() {
         TransactionWrapper.useTxn(handle -> {
@@ -166,29 +138,6 @@ public class I18nContentRendererTest extends TxnAwareBaseTest {
         });
     }
 
-    /*
-
-  "questionType": "DATE",
-          "stableId": "CHILD_DIAGNOSIS_DATE",
-          "isRestricted": false,
-          "isDeprecated": false,
-          "promptTemplate": {
-            "templateType": "HTML",
-            "templateCode": null,
-            "templateText": "$prompt_CHILD_DIAGNOSIS_DATE",
-            "variables": [
-              {
-                "name": "prompt_CHILD_DIAGNOSIS_DATE",
-                "translations": [
-                  {
-                    "language": "en",
-                    "text": "When was your child first diagnosed with brain cancer? Please include \"month\" if known"
-                  }
-                ]
-              }
-            ]
-          },
-   */
     @Test
     public void testRenderPepper506Cancer() {
         TransactionWrapper.useTxn(handle -> {
@@ -197,7 +146,8 @@ public class I18nContentRendererTest extends TxnAwareBaseTest {
 
             Template tmpl = new Template(TemplateType.HTML, null, "$prompt_CHILD_DIAGNOSIS_DATE");
             tmpl.addVariable(new TemplateVariable("prompt_CHILD_DIAGNOSIS_DATE", Arrays.asList(
-                    new Translation("en", "When was your child first diagnosed with brain cancer? Please include \\\"month\\\" if known"))));
+                    new Translation("en", "When was your child first diagnosed with brain cancer? "
+                            + "Please include \\\"month\\\" if known"))));
             long timestamp = Instant.now().toEpochMilli();
             long revId = jdbiRev.insert(userId, timestamp, null, "add test template");
             tmplDao.insertTemplate(tmpl, revId);

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/content/I18nContentRendererTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/content/I18nContentRendererTest.java
@@ -69,6 +69,149 @@ public class I18nContentRendererTest extends TxnAwareBaseTest {
         });
     }
 
+    /*
+
+    "picklistOptions": [
+              {
+                "stableId": "GRADE-HIGH",
+                "optionLabelTemplate": {
+                  "templateType": "TEXT",
+                  "templateCode": null,
+                  "templateText": "$BRAIN_CANCER_GRADE_grade-high",
+                  "variables": [
+                    {
+                      "name": "BRAIN_CANCER_GRADE_grade-high",
+                      "translations": [
+                        {
+                          "language": "en",
+                          "text": "High"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "detailLabelTemplate": null,
+                "allowDetails": false,
+                "exclusive": false
+              },
+     */
+
+
+    @Test
+    public void testRenderPepper506CancerGrade() {
+        TransactionWrapper.useTxn(handle -> {
+            TemplateDao tmplDao = handle.attach(TemplateDao.class);
+            JdbiRevision jdbiRev = handle.attach(JdbiRevision.class);
+
+            Template tmpl = new Template(TemplateType.HTML, null, "$BRAIN_CANCER_GRADE_grade-high");
+            tmpl.addVariable(new TemplateVariable("BRAIN_CANCER_GRADE_grade-high", Arrays.asList(
+                    new Translation("en", "High"))));
+            long timestamp = Instant.now().toEpochMilli();
+            long revId = jdbiRev.insert(userId, timestamp, null, "add test template");
+            tmplDao.insertTemplate(tmpl, revId);
+            assertNotNull(tmpl.getTemplateId());
+
+            long langId = LanguageStore.getDefault().getId();
+            String expected = "High";
+            String actual = renderer.renderContent(handle, tmpl.getTemplateId(), langId, timestamp);
+            assertEquals(expected, actual);
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void testRenderPepper506CancerGradeUnderscore() {
+        TransactionWrapper.useTxn(handle -> {
+            TemplateDao tmplDao = handle.attach(TemplateDao.class);
+            JdbiRevision jdbiRev = handle.attach(JdbiRevision.class);
+
+            Template tmpl = new Template(TemplateType.HTML, null, "$BRAIN_CANCER_GRADE_grade_high");
+            tmpl.addVariable(new TemplateVariable("BRAIN_CANCER_GRADE_grade_high", Arrays.asList(
+                    new Translation("en", "High"))));
+            long timestamp = Instant.now().toEpochMilli();
+            long revId = jdbiRev.insert(userId, timestamp, null, "add test template");
+            tmplDao.insertTemplate(tmpl, revId);
+            assertNotNull(tmpl.getTemplateId());
+
+            long langId = LanguageStore.getDefault().getId();
+            String expected = "High";
+            String actual = renderer.renderContent(handle, tmpl.getTemplateId(), langId, timestamp);
+            assertEquals(expected, actual);
+
+            handle.rollback();
+        });
+    }
+
+    @Test
+    public void testRenderPepper506CancerGradeLowerCase() {
+        TransactionWrapper.useTxn(handle -> {
+            TemplateDao tmplDao = handle.attach(TemplateDao.class);
+            JdbiRevision jdbiRev = handle.attach(JdbiRevision.class);
+
+            Template tmpl = new Template(TemplateType.HTML, null, "$brain_cancer_grade_grade-high");
+            tmpl.addVariable(new TemplateVariable("brain_cancer_grade_grade-high", Arrays.asList(
+                    new Translation("en", "High"))));
+            long timestamp = Instant.now().toEpochMilli();
+            long revId = jdbiRev.insert(userId, timestamp, null, "add test template");
+            tmplDao.insertTemplate(tmpl, revId);
+            assertNotNull(tmpl.getTemplateId());
+
+            long langId = LanguageStore.getDefault().getId();
+            String expected = "High";
+            String actual = renderer.renderContent(handle, tmpl.getTemplateId(), langId, timestamp);
+            assertEquals(expected, actual);
+
+            handle.rollback();
+        });
+    }
+
+    /*
+
+  "questionType": "DATE",
+          "stableId": "CHILD_DIAGNOSIS_DATE",
+          "isRestricted": false,
+          "isDeprecated": false,
+          "promptTemplate": {
+            "templateType": "HTML",
+            "templateCode": null,
+            "templateText": "$prompt_CHILD_DIAGNOSIS_DATE",
+            "variables": [
+              {
+                "name": "prompt_CHILD_DIAGNOSIS_DATE",
+                "translations": [
+                  {
+                    "language": "en",
+                    "text": "When was your child first diagnosed with brain cancer? Please include \"month\" if known"
+                  }
+                ]
+              }
+            ]
+          },
+   */
+    @Test
+    public void testRenderPepper506Cancer() {
+        TransactionWrapper.useTxn(handle -> {
+            TemplateDao tmplDao = handle.attach(TemplateDao.class);
+            JdbiRevision jdbiRev = handle.attach(JdbiRevision.class);
+
+            Template tmpl = new Template(TemplateType.HTML, null, "$prompt_CHILD_DIAGNOSIS_DATE");
+            tmpl.addVariable(new TemplateVariable("prompt_CHILD_DIAGNOSIS_DATE", Arrays.asList(
+                    new Translation("en", "When was your child first diagnosed with brain cancer? Please include \\\"month\\\" if known"))));
+            long timestamp = Instant.now().toEpochMilli();
+            long revId = jdbiRev.insert(userId, timestamp, null, "add test template");
+            tmplDao.insertTemplate(tmpl, revId);
+            assertNotNull(tmpl.getTemplateId());
+
+            long langId = LanguageStore.getDefault().getId();
+            String expected = "When was your child first diagnosed with brain cancer? Please include \\\"month\\\" if known";
+            String actual = renderer.renderContent(handle, tmpl.getTemplateId(), langId, timestamp);
+            assertEquals(expected, actual);
+
+            handle.rollback();
+        });
+    }
+
     @Test
     public void testDoubleRenderPass() {
         TransactionWrapper.useTxn(handle -> {


### PR DESCRIPTION
## Context

Regression testing is showing some issues with templating coming off of PEPPER-506.  This is an experimental PR to isolate the issue in unit tests and come up with ideas for fixes.

I added a few different `testRenderPepper506*` tests that try different changes to the template to better understand what data is causing the isssues.  Still need to decide whether we should change the data or adjust the code.

Looks like we should be setting `parser.allow_hyphen_in_identifiers` as per [the 2.1 - > 2.2 migration doc here](https://velocity.apache.org/engine/2.2/upgrading.html)

