### PR TITLE
PEPPER-528: ny and ca

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitExpressRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitExpressRoute.java
@@ -30,6 +30,7 @@ import org.broadinstitute.dsm.statics.RoutePath;
 import org.broadinstitute.dsm.statics.UserErrorMessages;
 import org.broadinstitute.dsm.util.DSMConfig;
 import org.broadinstitute.dsm.util.EasyPostUtil;
+import org.broadinstitute.dsm.util.KitUtil;
 import org.broadinstitute.dsm.util.NotificationUtil;
 import org.broadinstitute.dsm.util.UserUtil;
 import org.broadinstitute.lddp.db.SimpleResult;
@@ -115,6 +116,7 @@ public class KitExpressRoute extends RequestHandler {
         } catch (Exception e) {
             errorMessage = "To: " + e.getMessage();
         }
+        errorMessage = KitUtil.messageBasedOnLocationAndInstance(errorMessage, ddpInstanceDto, toAddress);
         KitRequestShipping.updateKit(kitId, participantShipment, null, errorMessage, toAddress, true, ddpInstanceDto);
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
@@ -120,7 +120,7 @@ public class KitUtil {
     private static final String EASYPOST_FAILURE_STATUS = "failure";
     private static final String EASYPOST_RETURN_SENDER_STATUS = "return_to_sender";
     private static final String EASYPOST_ERROR_STATUS = "error";
-    private static final String PECGS_RESEARCH = "PECGS_RESEARCH";
+    public static final String PECGS_RESEARCH = "PECGS_RESEARCH";
 
     public static void createLabel(List<KitRequestCreateLabel> kitsLabelTriggered) {
         DBUtil.updateBookmark(System.currentTimeMillis(), BOOKMARK_LABEL_CREATION_RUNNING);


### PR DESCRIPTION
adding logic to add ny and ca to error page
final scan should check that kits that have the ny and ca error should not get PECGS prefix on final scan