### PR TITLE
[PEPPER-658] Updates the log statement to use the generated row key integer value instead of 0.

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/participant/ParticipantDataDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/participant/ParticipantDataDao.java
@@ -77,8 +77,8 @@ public class ParticipantDataDao implements Dao<ParticipantData> {
             throw new RuntimeException(String.format("Could not create data for participant data with id: %s for participant with guid: %s",
                     participantData.getParticipantDataId(), participantData.getDdpParticipantId()));
         }
-        logger.info(String.format("Created data for participant data with id: %s for participant with guid: %s",
-                participantData.getParticipantDataId(), participantData.getDdpParticipantId()));
+        logger.info(String.format("Created data for participant data with id: %d for participant with guid: %s",
+                (int) simpleResult.resultValue, participantData.getDdpParticipantId()));
         return (int) simpleResult.resultValue;
 
     }


### PR DESCRIPTION
[PEPPER-658](https://broadworkbench.atlassian.net/browse/PEPPER-658) corrects a logging defect that was discovered during an unrelated production issue.

While checking logs, @Rinchan20 noticed that the logs contained an entry like the one below:
`o.b.d.d.d.d.p.ParticipantDataDao Created data for participant data with id: 0 for participant with guid`...

This pull request updates the log entry to include the intended row key as returned from the database.

These log entries are observable to authorized users from existing logging infrastructure or while running the AddFamilyMemberRouteTest.noFamilyMemberDataProvided test.

## Checklist

- [X] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [X] n/a If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [X] n/a If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [X] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [X] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [X] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [X] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-658]: https://broadworkbench.atlassian.net/browse/PEPPER-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ