### PR TITLE
[STUDYBUILDER-CLI] PEPPER-557 A-T Assent Text Update (English Only)

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/AtcpAssentV2.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/AtcpAssentV2.java
@@ -101,7 +101,6 @@ public class AtcpAssentV2 implements CustomTask {
         long tmplVarId = handle.attach(SqlHelper.class).findTemplateVariableIdByVariableName(varName);
         JdbiVariableSubstitution jdbiVarSubst = handle.attach(JdbiVariableSubstitution.class);
         List<Translation> transList = jdbiVarSubst.fetchSubstitutionsForTemplateVariable(tmplVarId);
-        List<Long> transListIds = transList.stream().map(Translation::getId).map(Optional::get).collect(Collectors.toList());
         List<Long> revisionIdList = transList.stream().map(Translation::getRevisionId).map(Optional::get).collect(Collectors.toList());
         JdbiRevision jdbiRevision = handle.attach(JdbiRevision.class);
         long newSubRevId = jdbiRevision.copyAndTerminate(revisionIdList.get(0), meta.getTimestamp(), meta.getUserId(), meta.getReason());

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/AtcpAssentV2.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/AtcpAssentV2.java
@@ -1,0 +1,124 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.dao.ActivityDao;
+import org.broadinstitute.ddp.db.dao.JdbiRevision;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.JdbiVariableSubstitution;
+import org.broadinstitute.ddp.db.dao.UserDao;
+import org.broadinstitute.ddp.db.dto.ActivityVersionDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.i18n.Translation;
+import org.broadinstitute.ddp.model.activity.revision.RevisionMetadata;
+import org.broadinstitute.ddp.model.user.User;
+import org.broadinstitute.ddp.studybuilder.ActivityBuilder;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+@Slf4j
+public class AtcpAssentV2 implements CustomTask {
+    private static final String DATA_FILE = "patches/assent-v2.conf";
+    private static final String STUDY = "atcp";
+    private static final String TRANSLATION_UPDATES = "translation-updates";
+    private static final String TRANSLATION_KEY = "variableName";
+    private static final String TRANSLATION_NEW = "newValue";
+    private static final String LANGUAGE_CODE = "language";
+
+    private Path cfgPath;
+    private Config cfg;
+    private Config dataCfg;
+    private Instant timestamp;
+    private String versionTag;
+    private Gson gson;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        File file = cfgPath.getParent().resolve(DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        dataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+
+        if (!studyCfg.getString("study.guid").equals(STUDY)) {
+            throw new DDPException("This task is only for the " + STUDY + " study!");
+        }
+
+        cfg = studyCfg;
+        versionTag = dataCfg.getString("versionTag");
+        timestamp = Instant.now();
+        this.cfgPath = cfgPath;
+        gson = GsonUtil.standardGson();
+    }
+
+    @Override
+    public void run(Handle handle) {
+        User adminUser = handle.attach(UserDao.class).findUserByGuid(cfg.getString("adminUser.guid")).get();
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(cfg.getString("study.guid"));
+
+        String activityCode = dataCfg.getString("activityCode");
+        log.info("Changing version of {} to {} with timestamp={}", activityCode, versionTag, timestamp.toEpochMilli());
+        revisionConsent(handle, adminUser.getId(), studyDto, activityCode, versionTag, timestamp.toEpochMilli());
+    }
+
+    private void revisionConsent(Handle handle, long adminUserId, StudyDto studyDto,
+                                 String activityCode, String versionTag, long timestamp) {
+        String reason = String.format(
+                "Update activity with studyGuid=%s activityCode=%s to versionTag=%s",
+                studyDto.getGuid(), activityCode, versionTag);
+        RevisionMetadata meta = new RevisionMetadata(timestamp, adminUserId, reason);
+
+        long activityId = ActivityBuilder.findActivityId(handle, studyDto.getId(), activityCode);
+        ActivityVersionDto version2 = handle.attach(ActivityDao.class).changeVersion(activityId, versionTag, meta);
+
+        updateVariables(handle, meta, version2);
+    }
+
+    private void updateVariables(Handle handle, RevisionMetadata meta, ActivityVersionDto version2) {
+        List<? extends Config> configList = dataCfg.getConfigList(TRANSLATION_UPDATES);
+        for (Config config : configList) {
+            revisionVariableTranslation(config.getString(TRANSLATION_KEY), config.getString(TRANSLATION_NEW),
+                    config.getString(LANGUAGE_CODE), handle, meta, version2);
+        }
+    }
+
+    private void revisionVariableTranslation(String varName, String newTemplateText, String isoLanguageCode, Handle handle,
+                                             RevisionMetadata meta, ActivityVersionDto version2) {
+        long tmplVarId = handle.attach(SqlHelper.class).findTemplateVariableIdByVariableName(varName);
+        JdbiVariableSubstitution jdbiVarSubst = handle.attach(JdbiVariableSubstitution.class);
+        List<Translation> transList = jdbiVarSubst.fetchSubstitutionsForTemplateVariable(tmplVarId);
+        List<Long> transListIds = transList.stream().map(Translation::getId).map(Optional::get).collect(Collectors.toList());
+        List<Long> revisionIdList = transList.stream().map(Translation::getRevisionId).map(Optional::get).collect(Collectors.toList());
+        JdbiRevision jdbiRevision = handle.attach(JdbiRevision.class);
+        long newSubRevId = jdbiRevision.copyAndTerminate(revisionIdList.get(0), meta.getTimestamp(), meta.getUserId(), meta.getReason());
+        long[] retiringId = {newSubRevId};
+        transList.forEach(transListEntry -> {
+            jdbiVarSubst.bulkUpdateRevisionIdsBySubIds(Arrays.asList(transListEntry.getId().get()), retiringId);
+            if (isoLanguageCode.equalsIgnoreCase(transListEntry.getLanguageCode())) {
+                jdbiVarSubst.insert(transListEntry.getLanguageCode(), newTemplateText, version2.getRevId(), tmplVarId);
+            } else {
+                jdbiVarSubst.insert(transListEntry.getLanguageCode(), transListEntry.getText(), version2.getRevId(), tmplVarId);
+            }
+        });
+    }
+
+    private interface SqlHelper extends SqlObject {
+        @SqlQuery("select template_variable_id from template_variable where variable_name = :variable_name "
+                + "order by template_variable_id desc")
+        long findTemplateVariableIdByVariableName(@Bind("variable_name") String variableName);
+    }
+}

--- a/pepper-apis/studybuilder-cli/studies/atcp/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/atcp/patch-log.conf
@@ -1,5 +1,5 @@
 {
   "patches": [
-    "AtcpLanguageFix"
+    "AtcpAssentV2"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/atcp/patch-log.conf
+++ b/pepper-apis/studybuilder-cli/studies/atcp/patch-log.conf
@@ -1,5 +1,6 @@
 {
   "patches": [
+    "AtcpLanguageFix",
     "AtcpAssentV2"
   ]
 }

--- a/pepper-apis/studybuilder-cli/studies/atcp/patches/assent-v2.conf
+++ b/pepper-apis/studybuilder-cli/studies/atcp/patches/assent-v2.conf
@@ -1,0 +1,11 @@
+{
+  "versionTag": "v2",
+  "activityCode": "ASSENT",
+  "translation-updates": [
+    {
+      "variableName": "assent_contact_details_p2",
+      "language":"en",
+      "newValue": """If you want to ask questions about what it means to be in a research study, you or your mom or dad can email North Star Review Board at <a class="Link" href="mailto:info@northstarreviewboard.org">info@northstarreviewboard.org</a>."""
+    }
+  ]
+}


### PR DESCRIPTION
### Overview
[PEPPER-557](https://broadworkbench.atlassian.net/browse/PEPPER-557) requests an English text update for a specific variable in the Assent flow.

Changes in this PR accommodate that request by retiring the existing version translations, inserting the new version of the English text for English translation and copying the old translation text into the new version for all other languages.

### UI Impacts
Once the change is applied, new Assents started after the patch is applied will see the updated English text from the screenshot below.
![Screenshot 2023-03-28 at 11 11 41 AM](https://user-images.githubusercontent.com/111771148/228284404-f065d1d2-4a5c-47b6-ac12-abd7708522b6.png)

Assents started prior to the patch being applied will see the original text:
![Screenshot 2023-03-28 at 11 11 05 AM](https://user-images.githubusercontent.com/111771148/228284765-29bcb7c7-72c3-4864-91a8-e215f6148098.png)

Switching to any foreign language after this patch is applied will display the original translation.  A French example before and after is below

Before:
![Screenshot 2023-03-28 at 11 17 49 AM](https://user-images.githubusercontent.com/111771148/228285820-4d5b8e88-a066-41fe-8620-a386c1545d92.png)

After:
![Screenshot 2023-03-28 at 11 15 50 AM](https://user-images.githubusercontent.com/111771148/228285799-9bcca0d7-e2a6-4e08-9585-c34b39d225fc.png)

### Stability, fault tolerance, graceful degradation, performance bottlenecks
No known impacts

### Deployment
To deploy in each environment:
In pepper-apis/studybuilder-cli:
1. Use render.sh to build output-config/application.conf for the target environment.
2. Run: java -Dconfig.file=output-config/application.conf -jar /path/to/StudyBuilder.jar --vars output-config/vars.conf --substitutions ./studies/atcp/substitutions.conf ./studies/atcp/study.conf --run-task AtcpAssentV2

## Checklist

- [X] I have labeled the type of changes involved using the `C-*` labels.
- [X] I have assessed potential risks and labeled using the `R-*` labels.
- [X] I have considered error handling and alerts, and added `L-*` labels as needed.
- [X] I have considered security and privacy, and added `I-*` labels as needed
- [X] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [X] n/a If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ PENDING ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [X] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [X] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [X] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [X] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-557]: https://broadworkbench.atlassian.net/browse/PEPPER-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ