### PR TITLE
PEPPER-803 fix flaky testCreateAndLoginNewTestUser test

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -542,11 +542,11 @@ public class Auth0ManagementClient {
             }
             long wait = backoffMillis * numTries + new Random().nextInt(MAX_JITTER_MILLIS);
             if (res.getError() instanceof RateLimitException && res.getStatusCode() == 429) {
-                log.error(retryMessage, res.getError());
+                log.warn(retryMessage, res.getError());
                 // Get information from auth0 about how long to wait
                 RateLimitException rateLimit = (RateLimitException) res.getError();
                 long retryAfter = auth0BackoffTime(rateLimit);
-                wait = retryAfter > 0 ? retryAfter : wait;
+                wait = retryAfter != -1 ? retryAfter : wait;
                 log.warn("Hit Auth0 rate limit: Pausing for " + wait + " milliseconds");
                 try {
                     TimeUnit.MILLISECONDS.sleep(wait);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -559,6 +559,8 @@ public class Auth0ManagementClient {
                 } catch (InterruptedException e) {
                     log.warn("Interrupted while waiting after rate limit", e);
                 }
+            } else {
+                break;
             }
         }
         return res;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -533,7 +533,7 @@ public class Auth0ManagementClient {
         ApiResult<B, E> res = null;
         int numTries = 0;
         int maxTries = maxRetries + 1;
-        long totalSleepTimeSeconds = 0L;
+        long totalSleepTimeMilliSecond = 0L;
         while (numTries < maxTries) {
             res = callback.get();
             numTries++;
@@ -551,21 +551,22 @@ public class Auth0ManagementClient {
                         long suggestedWaitTime = unixTimeAtWhichToRetry - Instant.now().getEpochSecond();
                         if (suggestedWaitTime > 0) {
                             // Set 10 seconds max wait time
-                            long timeSeconds = suggestedWaitTime * 1000;
-                            wait = timeSeconds > 10000 ? 10000 : timeSeconds;
+                            long suggestedWaitTimeMilliSecond = suggestedWaitTime * 1000;
+                            // Set max wait time to 10 seconds
+                            wait = suggestedWaitTimeMilliSecond > 10000 ? 10000 : suggestedWaitTimeMilliSecond;
                         }
                     }
-                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " seconds based on Auth0 headers.");
+                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " milliseconds based on Auth0 headers.");
                 } else {
-                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " seconds");
+                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " milliseconds");
                 }
                 try {
                     TimeUnit.MILLISECONDS.sleep(wait);
                 } catch (InterruptedException e) {
                     log.warn("Interrupted while waiting after rate limit", e);
                 }
-                totalSleepTimeSeconds += wait;
-                log.warn("Hit Auth0 rate limit: Total wait time is " + totalSleepTimeSeconds + " seconds");
+                totalSleepTimeMilliSecond += wait;
+                log.warn("Hit Auth0 rate limit: Total wait time is " + totalSleepTimeMilliSecond + " milliseconds");
             } else {
                 break;
             }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -550,7 +550,6 @@ public class Auth0ManagementClient {
                     if (unixTimeAtWhichToRetry != -1) {
                         long suggestedWaitTime = unixTimeAtWhichToRetry - Instant.now().getEpochSecond();
                         if (suggestedWaitTime > 0) {
-                            // Set 10 seconds max wait time
                             long suggestedWaitTimeMilliSecond = suggestedWaitTime * 1000;
                             // Set max wait time to 10 seconds
                             wait = suggestedWaitTimeMilliSecond > 10000 ? 10000 : suggestedWaitTimeMilliSecond;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -546,9 +546,13 @@ public class Auth0ManagementClient {
                 if (res.getError() instanceof RateLimitException) {
                     RateLimitException rateLimit = (RateLimitException) res.getError();
                     long unixTimeAtWhichToRetry = rateLimit.getReset();
-                    long suggestedWaitTime = unixTimeAtWhichToRetry - Instant.now().getEpochSecond();
-                    if (suggestedWaitTime > 0) {
-                        wait = suggestedWaitTime * 1000;
+                    if (unixTimeAtWhichToRetry != -1) {
+                        long suggestedWaitTime = unixTimeAtWhichToRetry - Instant.now().getEpochSecond();
+                        if (suggestedWaitTime > 0) {
+                            // Set 10 seconds max wait time
+                            long waitTime = suggestedWaitTime * 1000;
+                            wait = waitTime > 10000 ? 10000 : waitTime ;
+                        }
                     }
                     log.warn("Hit auth0 rate limit.  Pausing for " + wait + "s based on auth0 headers.");
                 } else {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -533,6 +533,7 @@ public class Auth0ManagementClient {
         ApiResult<B, E> res = null;
         int numTries = 0;
         int maxTries = maxRetries + 1;
+        long totalSleepTimeSeconds = 0L;
         while (numTries < maxTries) {
             res = callback.get();
             numTries++;
@@ -554,15 +555,17 @@ public class Auth0ManagementClient {
                             wait = timeSeconds > 10000 ? 10000 : timeSeconds;
                         }
                     }
-                    log.warn("Hit auth0 rate limit.  Pausing for " + wait + "s based on auth0 headers.");
+                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " seconds based on Auth0 headers.");
                 } else {
-                    log.warn("Hit auth0 rate limit.  Pausing for " + wait + "ms");
+                    log.warn("Hit Auth0 rate limit: Pausing for " + wait + " seconds");
                 }
                 try {
                     TimeUnit.MILLISECONDS.sleep(wait);
                 } catch (InterruptedException e) {
                     log.warn("Interrupted while waiting after rate limit", e);
                 }
+                totalSleepTimeSeconds += wait;
+                log.warn("Hit Auth0 rate limit: Total wait time is " + totalSleepTimeSeconds + " seconds");
             } else {
                 break;
             }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -297,16 +297,16 @@ public class Auth0ManagementClient {
         String msg = String.format(
                 "Hit rate limit while creating auth0 user with email %s in connection %s, retrying",
                 email, connection);
-        User user = new User();
-        user.setEmail(email);
-        user.setPassword(password);
-        user.setConnection(connection);
-        if (emailVerified != null) {
-            user.setEmailVerified(emailVerified);
-        }
         return withRetries(msg, () -> {
             try {
                 mgmtApi.setApiToken(getToken());
+                User user = new User();
+                user.setEmail(email);
+                user.setPassword(password);
+                user.setConnection(connection);
+                if (emailVerified != null) {
+                    user.setEmailVerified(emailVerified);
+                }
                 User createdUser = mgmtApi.users().create(user).execute();
                 return ApiResult.ok(200, createdUser);
             } catch (APIException e) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -567,7 +567,7 @@ public class Auth0ManagementClient {
      *   or -1 if no time information from Auth0.
      * @param rateLimitException {@link RateLimitException}
      */
-    private long auth0BackoffTime(RateLimitException rateLimitException) {
+    public long auth0BackoffTime(RateLimitException rateLimitException) {
         long wait = -1;
         long timeWhenReset = rateLimitException.getReset();
         if (timeWhenReset != -1) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -540,7 +540,7 @@ public class Auth0ManagementClient {
                 break;
             }
             if (res.getStatusCode() == 429) {
-                log.error(res.getError() + " " + res.getError().getClass().getName());
+                log.error(retryMessage, res.getError() + " " + res.getError().getClass().getName());
                 long wait = backoffMillis * numTries + new Random().nextInt(MAX_JITTER_MILLIS);
                 // if we have more information from auth0 about how long to wait, use it.
                 if (res.getError() instanceof RateLimitException) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/client/Auth0ManagementClient.java
@@ -550,8 +550,8 @@ public class Auth0ManagementClient {
                         long suggestedWaitTime = unixTimeAtWhichToRetry - Instant.now().getEpochSecond();
                         if (suggestedWaitTime > 0) {
                             // Set 10 seconds max wait time
-                            long waitTime = suggestedWaitTime * 1000;
-                            wait = waitTime > 10000 ? 10000 : waitTime ;
+                            long timeSeconds = suggestedWaitTime * 1000;
+                            wait = timeSeconds > 10000 ? 10000 : timeSeconds;
                         }
                     }
                     log.warn("Hit auth0 rate limit.  Pausing for " + wait + "s based on auth0 headers.");

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/client/Auth0ManagementClientTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/client/Auth0ManagementClientTest.java
@@ -122,9 +122,9 @@ public class Auth0ManagementClientTest extends TxnAwareBaseTest {
 
     @Test
     public void testAuth0RateLimitBackoffTimeNotFound() {
-        long rateLimit = Long.parseLong("2");
-        long rateRemaining = Long.parseLong("1");
-        long rateReset = Long.parseLong("-1");
+        long rateLimit = 2L;
+        long rateRemaining = 1L;
+        long rateReset = -1L;
         RateLimitException rateLimitException = new RateLimitException(rateLimit, rateRemaining, rateReset);
 
         long wait = client.auth0BackoffTime(rateLimitException);
@@ -133,8 +133,8 @@ public class Auth0ManagementClientTest extends TxnAwareBaseTest {
 
     @Test
     public void testAuth0RateLimitBackoffTime() {
-        long rateLimit = Long.parseLong("2");
-        long rateRemaining = Long.parseLong("1");
+        long rateLimit = 2L;
+        long rateRemaining = 1L;
         long rateReset = (Instant.now().getEpochSecond() + 1);
         RateLimitException rateLimitException = new RateLimitException(rateLimit, rateRemaining, rateReset);
 

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/client/Auth0ManagementClientTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/client/Auth0ManagementClientTest.java
@@ -9,9 +9,11 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+import com.auth0.exception.RateLimitException;
 import com.auth0.json.mgmt.Connection;
 import com.auth0.json.mgmt.users.User;
 import com.typesafe.config.Config;
@@ -116,5 +118,27 @@ public class Auth0ManagementClientTest extends TxnAwareBaseTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testAuth0RateLimitBackoffTimeNotFound() {
+        long rateLimit = Long.parseLong("2");
+        long rateRemaining = Long.parseLong("1");
+        long rateReset = Long.parseLong("-1");
+        RateLimitException rateLimitException = new RateLimitException(rateLimit, rateRemaining, rateReset);
+
+        long wait = client.auth0BackoffTime(rateLimitException);
+        assertEquals(-1, wait);
+    }
+
+    @Test
+    public void testAuth0RateLimitBackoffTime() {
+        long rateLimit = Long.parseLong("2");
+        long rateRemaining = Long.parseLong("1");
+        long rateReset = (Instant.now().getEpochSecond() + 1);
+        RateLimitException rateLimitException = new RateLimitException(rateLimit, rateRemaining, rateReset);
+
+        long wait = client.auth0BackoffTime(rateLimitException);
+        assertEquals(1000, wait);
     }
 }

--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -238,7 +238,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>auth0</artifactId>
-            <version>1.8.0</version>
+            <version>1.9.0</version>
         </dependency>
 
         <dependency>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -332,7 +332,7 @@
             <dependency>
                 <groupId>com.auth0</groupId>
                 <artifactId>auth0</artifactId>
-                <version>1.8.0</version>
+                <version>1.9.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
[PEPPER-803](https://broadworkbench.atlassian.net/browse/PEPPER-803)

[Auth0 Rate Limit Policy](https://auth0.com/docs/troubleshoot/customer-support/operational-policies/rate-limit-policy)


Failed CI [run](https://app.circleci.com/pipelines/github/broadinstitute/ddp-study-server/18620/workflows/8c16c4b1-a7dd-4580-837d-1061c8923318/jobs/36053/parallel-runs/6).

Logs of retries with timestamp:
```
14:21:14.321 C: S: [main] ERROR o.b.ddp.client.Auth0ManagementClient - Hit rate limit while creating auth0 user with email test+1683901274155@datadonationplatform.org in connection Username-Password-Authentication, retrying
com.auth0.exception.APIException: Request failed with status code 429: Global limit has been reached

14:21:14.906 C: S: [main] ERROR o.b.ddp.client.Auth0ManagementClient - Hit rate limit while creating auth0 user with email test+1683901274155@datadonationplatform.org in connection Username-Password-Authentication, retrying
com.auth0.exception.APIException: Request failed with status code 429: Global limit has been reached

14:21:15.978 C: S: [main] ERROR o.b.ddp.client.Auth0ManagementClient - Hit rate limit while creating auth0 user with email test+1683901274155@datadonationplatform.org in connection Username-Password-Authentication, retrying
com.auth0.exception.APIException: Request failed with status code 429: Global limit has been reached
```

Retry backoff time should be longer when encountering Auth0 API error code 429. Another change that might help, lowering test parallism from 15 to a lower number in CircleCI [config.yml](https://github.com/broadinstitute/ddp-study-server/blob/9010fd076bb7d9cbf32f85f9ff1c7ae921ec9fb3/.circleci/main-config.yml#L41).

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-803]: https://broadworkbench.atlassian.net/browse/PEPPER-803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ