### PR TITLE
PEPPER-824 . somatic-results workflow special case handling

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/PutFormAnswersRoute.java
@@ -43,6 +43,7 @@ import org.broadinstitute.ddp.db.dto.UserActivityInstanceSummary;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.json.PutAnswersResponse;
 import org.broadinstitute.ddp.json.errors.ApiError;
+import org.broadinstitute.ddp.json.workflow.WorkflowActivityResponse;
 import org.broadinstitute.ddp.json.workflow.WorkflowResponse;
 import org.broadinstitute.ddp.model.activity.definition.FormActivityDef;
 import org.broadinstitute.ddp.model.activity.instance.ActivityInstance;
@@ -214,6 +215,14 @@ public class PutFormAnswersRoute implements Route {
                     WorkflowResponse workflowResp = workflowService
                             .suggestNextState(handle, operatorGuid, userGuid, studyGuid, fromState)
                             .map(nextState -> {
+                                //special case for SOMATIC_RESULTS ... need to pass same instance in next state and NOT latest
+                                if (instanceDto.getActivityCode().equalsIgnoreCase("SOMATIC_RESULTS")
+                                        && fromState.matches(nextState)) {
+                                    return new WorkflowActivityResponse(
+                                            instanceDto.getActivityCode(),
+                                            instanceDto.getGuid(),
+                                            instanceDto.isAllowUnauthenticated());
+                                }
                                 log.info("Suggesting user {} to next state {}", userGuid, nextState);
                                 return workflowService.buildStateResponse(handle, userGuid, nextState);
                             })

--- a/pepper-apis/studybuilder-cli/studies/lms/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/i18n/en.conf
@@ -126,8 +126,8 @@
       }
     },
     "info": "<p>What we've learned from sequencing $ddp.isGovernedParticipant(\"your child's\",\"your\") tumor DNA</p>",
-    "info_disagree": """<p>Thank you for your response. If you change your mind and would like to view/download this document in the future, please contact the study team at <a href="mailto:info@lmsproject.org" class="Link">info@lmsproject.org</a>,
-     or call us at <a href="tel:651-403-5556" class="Link">651-403-5556</a></p>."""
+    "info_disagree": """Thank you for your response. If you change your mind and would like to view/download this document in the future, please contact the study team at <a href="mailto:info@lmsproject.org" class="Link">info@lmsproject.org</a>,
+     or call us at <a href="tel:651-403-5556" class="Link">651-403-5556</a>."""
   },
 
 

--- a/pepper-apis/studybuilder-cli/studies/lms/i18n/es.json
+++ b/pepper-apis/studybuilder-cli/studies/lms/i18n/es.json
@@ -65,8 +65,8 @@
       }
     },
     "info": "<p>What we've learned from sequencing $ddp.isGovernedParticipant(\"your child's\",\"your\") tumor DNA</p>",
-    "info_disagree": """<p>Thank you for your response. If you change your mind and would like to view/download this document in the future, please contact the study team at <a href="mailto:info@lmsproject.org" class="Link">info@lmsproject.org</a>,
-    or call us at <a href="tel:651-403-5556" class="Link">651-403-5556</a></p>."""
+    "info_disagree": """Thank you for your response. If you change your mind and would like to view/download this document in the future, please contact the study team at <a href="mailto:info@lmsproject.org" class="Link">info@lmsproject.org</a>,
+    or call us at <a href="tel:651-403-5556" class="Link">651-403-5556</a>."""
   },
 
 


### PR DESCRIPTION
## Context

SOMATIC_RESULTS has special use case where same activity should be displayed to user even when current SOMATIC_RESULTS activity is submitted. 
SOMATIC_RESULTS can have multiple instances at any gives point of time.
Current DSS platform pulls latest activity instance if multiple instances exist.
Added a special case for SOMATIC_RESULTS.


## FUD Score

_Overall, how are you feeling about these changes?_

- [x ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [x ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

