### PR TITLE
Added force refresh on elastic update

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/ElasticDataExportAdapter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/ElasticDataExportAdapter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.broadinstitute.dsm.model.elastic.Util;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.slf4j.Logger;
@@ -18,6 +19,7 @@ public class ElasticDataExportAdapter extends BaseExporter {
         logger.info("initialize exporting data to ES");
         UpdateRequest updateRequest = new UpdateRequest(requestPayload.getIndex(), Util.DOC, requestPayload.getDocId())
                 .doc(source)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .retryOnConflict(5);
         try {
             ElasticSearchUtil.getClientInstance().update(updateRequest, RequestOptions.DEFAULT);


### PR DESCRIPTION
pepper-924

We are seeing a version conflict when updating onc history records via spreadsheet upload. The conditions are that the participant lacks onc history records. My theory is that the conflict is caused by a uncommitted (using that term loosely) update to the participant ES document. When a participant has no onc history records, the upload code adds a dsm.oncHistory.created key/value to the ES participant document, before adding the onc history records. The dsm.oncHistory.created update uses the default refresh policy (NONE), which I believe leads to the conflict. I changed that to IMMEDIATE in this PR.

I am unable to reproduce this behavior locally, but can in Dev. I want to try this change on Dev. If successful, we should discuss whether to make the refresh policy change for just onc history upload, or for all ElasticDataExportAdapter.export callers.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

