### PR TITLE
Limiting IMMEDIATE refresh to only onc history upload

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/ElasticDataExportAdapter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/ElasticDataExportAdapter.java
@@ -13,13 +13,14 @@ import org.slf4j.LoggerFactory;
 public class ElasticDataExportAdapter extends BaseExporter {
 
     private static final Logger logger = LoggerFactory.getLogger(ElasticDataExportAdapter.class);
+    private WriteRequest.RefreshPolicy refreshPolicy = WriteRequest.RefreshPolicy.NONE;
 
     @Override
     public void export() {
         logger.info("initialize exporting data to ES");
         UpdateRequest updateRequest = new UpdateRequest(requestPayload.getIndex(), Util.DOC, requestPayload.getDocId())
                 .doc(source)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .setRefreshPolicy(refreshPolicy)
                 .retryOnConflict(5);
         try {
             ElasticSearchUtil.getClientInstance().update(updateRequest, RequestOptions.DEFAULT);
@@ -28,5 +29,13 @@ public class ElasticDataExportAdapter extends BaseExporter {
             throw new RuntimeException("Error occurred while exporting data to ES", e);
         }
         logger.info("successfully exported data to ES");
+    }
+
+    /**
+     * Set refresh policy for all the updates handled by this instance
+     * Default refresh policy is WriteRequest.RefreshPolicy.NONE
+     */
+    public void setRefreshPolicy(WriteRequest.RefreshPolicy policy) {
+        refreshPolicy = policy;
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/onchistory/OncHistoryElasticUpdater.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/onchistory/OncHistoryElasticUpdater.java
@@ -5,23 +5,24 @@ import static org.broadinstitute.dsm.statics.ESObjectConstants.ONC_HISTORY_DETAI
 import java.util.Map;
 
 import org.broadinstitute.dsm.exception.DsmInternalError;
-import org.broadinstitute.dsm.model.elastic.export.BaseExporter;
 import org.broadinstitute.dsm.model.elastic.export.ElasticDataExportAdapter;
 import org.broadinstitute.dsm.model.elastic.export.RequestPayload;
 import org.broadinstitute.dsm.model.elastic.export.generate.Generator;
 import org.broadinstitute.dsm.model.elastic.export.painless.ScriptBuilder;
 import org.broadinstitute.dsm.model.elastic.export.painless.UpsertPainless;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 
 public class OncHistoryElasticUpdater {
 
-    private final BaseExporter exporter;
+    private final ElasticDataExportAdapter exporter;
     private final String index;
 
     public OncHistoryElasticUpdater(String index) {
         this.index = index;
         this.exporter = new ElasticDataExportAdapter();
+        this.exporter.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
     }
 
     /**


### PR DESCRIPTION
pepper-924

This is a follow-up to PR https://github.com/broadinstitute/ddp-study-server/pull/2606.
Since we are late in the release cycle and ES refreshes are expensive, this limits the use of IMMEDIATE refresh to onc history upload. 
I don't think we see this type of issue elsewhere in DSM, but that may be because we make the changes in-place in the UI, and therefore an immediate document refresh is not necessary. In any case, we can sort that out after this release.

It's possible IMMEDIATE refresh of onc history upload documents affects ES performance, but we can keep an eye on that and perhaps run some tests with larger upload files. It will help to have an ES container to work with, so we can consider that testing for an upcoming sprint.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [x] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

