### PR TITLE
Add conditional Liquibase access_role row creation

### DIFF
--- a/pepper-apis/dsm-core/src/main/resources/liquibase/PEPPER-971_fix_access_role.xml
+++ b/pepper-apis/dsm-core/src/main/resources/liquibase/PEPPER-971_fix_access_role.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="PEPPER-971_fix_access_role-1" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "kit_deactivation";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="kit_deactivation"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-2" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "kit_express";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="kit_express"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-3" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "kit_receiving";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="kit_receiving"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-4" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "kit_shipping";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="kit_shipping"/>
+        </insert>
+    </changeSet>
+    
+    <changeSet id="PEPPER-971_fix_access_role-5" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "kit_upload";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="kit_upload"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-6" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "mailingList_view";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="mailingList_view"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-7" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "mr_request";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="mr_request"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-8" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "mr_view";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="mr_view"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-9" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "participant_edit";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="participant_edit"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-10" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "participant_event";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="participant_event"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-11" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "participant_exit";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="participant_exit"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PEPPER-971_fix_access_role-12" author="cunningh">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0"> SELECT count(*) FROM access_role WHERE name = "survey_creation";</sqlCheck>
+        </preConditions>
+        <insert tableName="access_role">
+            <column name="name" value="survey_creation"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/pepper-apis/dsm-core/src/main/resources/master-changelog.xml
+++ b/pepper-apis/dsm-core/src/main/resources/master-changelog.xml
@@ -132,4 +132,5 @@
     <include file="liquibase/PEPPER-915_field_settings.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/PEPPER-873_mercury_order_fields.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/PEPPER-964_group_role.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/PEPPER-971_fix_access_role.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
Part of PEPPER-971

Some roles in access_role were not created by Liquibase, but should have been. This allows us to spin up a new DB with the correct data and dependencies for a cohesive schema. (We do this for testing, but is also provides a way to migrate the schema.) In this case we need to assure the roles are in place before creating a dependency from the ddp_group_role table, which will contain all the valid roles for each study group.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

