### PR TITLE
PEPPER-BACKEND Update function openJdbiWithAuthRetry

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/db/TransactionWrapper.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/db/TransactionWrapper.java
@@ -343,9 +343,8 @@ public class TransactionWrapper {
                         log.error("Sleep before dbpool credential reload has been interrupted.", interrupted);
                     }
                     reloadDbPoolConfiguration(false);
-                } else {
-                    log.info("Open jdbi connection retried {} time.", tryCount + 1);
                 }
+                log.info("Open jdbi connection retried {} time.", tryCount + 1);
             } catch (InvalidConfigurationException e) {
                 lastThrownException = e;
                 log.error("Database connection configuration is invalid. Proceeding with original configuration values.");


### PR DESCRIPTION
Observed a trend in GCP logs, too many `org.broadinstitute.ddp.exception.DDPException: Could not get a connection from the pool`. After some digging, it seems to me there is a bug in `openJdbiWithAuthRetry` function which retries never happen when open DB connection failed because new DDPException is thrown. Judging by the name of function, I believe connection should be retried.

Minor update to fix it:  Retry Jdbi connection to DB up to `PASSWORD_ROTATION_MAX_RETRIES` times.

GCP log screenshot:

<img width="1726" alt="Screenshot 2023-07-26 at 2 35 26 PM" src="https://github.com/broadinstitute/ddp-study-server/assets/35533885/28819c24-9c66-4d6c-93c2-f4c2e496bdf8">


GCP log [filter](https://console.cloud.google.com/logs/query;query=%2528resource.type%3D%22gae_app%22%20AND%20resource.labels.project_id%3D%22broad-ddp-dev%22%2529%0Aseverity%3E%3DERROR%20AND%0AtextPayload%3D~%22org.broadinstitute.ddp.db.TransactionWrapper.openJdbiWithAuthRetry%22;summaryFields=:false:32:beginning;cursorTimestamp=2023-07-26T16:48:53.770835Z;duration=P2D?_ga=2.19987832.1777900978.1690290588-1108477672.1690290588&project=broad-ddp-dev).


## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

