### PR TITLE
Fix exception handling in OncHistoryTemplateRoute

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryTemplateRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryTemplateRoute.java
@@ -2,12 +2,12 @@ package org.broadinstitute.dsm.route;
 
 import static org.broadinstitute.dsm.route.OncHistoryUploadRoute.canUploadOncHistory;
 
+import java.io.ByteArrayOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.entity.ContentType;
-import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.service.onchistory.CodeStudyColumnsProvider;
@@ -33,42 +33,34 @@ public class OncHistoryTemplateRoute extends RequestHandler {
 
         if (!canUploadOncHistory(realm, userId)) {
             response.status(403);
-            return (UserErrorMessages.NO_RIGHTS);
+            return UserErrorMessages.NO_RIGHTS;
         }
 
-        try {
-            // setup response before we start writing to stream
-            String zipFileName = String.format("%s_OncHistoryTemplate.zip", realm);
-            response.type(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
-            response.header("Access-Control-Expose-Headers", "Content-Disposition");
-            response.header("Content-Disposition", "attachment;filename=" + zipFileName);
-            response.status(200);
+        OncHistoryTemplateService service =
+                new OncHistoryTemplateService(realm, new CodeStudyColumnsProvider());
+        // write to an intermediate stream then copy to response stream.
+        // Spark gets into a mode once the header is set up, and ends up ignoring calls to
+        // response.status. So handle the exceptions from the service before setting up
+        // the response header (which has to be in place before streaming). BTW, feel
+        // free to improve this. The Spark doc is thin, and I did not see any info about
+        // this situation via Web search.
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        ZipOutputStream zos = new ZipOutputStream(os);
+        zos.putNextEntry(new ZipEntry(service.getTemplateFileName()));
+        service.writeTemplate(zos);
+        zos.putNextEntry(new ZipEntry(service.getDictionaryFileName()));
+        service.writeDictionary(zos);
+        zos.closeEntry();
+        zos.finish();
 
-            OncHistoryTemplateService service =
-                    new OncHistoryTemplateService(realm, new CodeStudyColumnsProvider());
+        // setup response before we start writing to stream
+        String zipFileName = String.format("%s_OncHistoryTemplate.zip", realm);
+        response.type(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
+        response.header("Access-Control-Expose-Headers", "Content-Disposition");
+        response.header("Content-Disposition", "attachment;filename=" + zipFileName);
+        response.status(200);
 
-            ZipOutputStream zos = new ZipOutputStream(response.raw().getOutputStream());
-            zos.putNextEntry(new ZipEntry(service.getTemplateFileName()));
-            service.writeTemplate(zos);
-            zos.putNextEntry(new ZipEntry(service.getDictionaryFileName()));
-            service.writeDictionary(zos);
-            zos.closeEntry();
-            zos.finish();
-
-            return response.raw();
-        } catch (DSMBadRequestException e) {
-            response.status(400);
-            log.info("Bad request for onc history template: {}", e.toString());
-            return e.getMessage();
-        } catch (DsmInternalError e) {
-            response.status(500);
-            log.info("Internal error processing onc history template request: {}", e.toString());
-            return e.getMessage();
-        } catch (Exception e) {
-            // TODO in some future day we are not throwing exceptions that we do not have a mapped status code
-            log.warn("Unhandled exception processing onc history template request: {}", e.toString());
-            response.status(500);
-            return e.getMessage();
-        }
+        os.writeTo(response.raw().getOutputStream());
+        return response.raw();
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/onchistory/OncHistoryTemplateService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/onchistory/OncHistoryTemplateService.java
@@ -141,7 +141,6 @@ public class OncHistoryTemplateService {
         boldStyle = createBoldStyle(workbook);
         largeBoldStyle = createLargeBoldStyle(workbook);
 
-        log.info("TEMP: before workbook.createSheet");
         SXSSFSheet sheet = workbook.createSheet("Onc History Upload Template");
 
         sheet.setColumnWidth(0, HEADER_COL_WIDTH);


### PR DESCRIPTION
PEPPER-1072

This PR fixes an error/exception handling issue observed on Prod: After setting up the response headers a subsequent call to response.status() did nothing due to how the Spark code is implemented. (The Spark documentation is minimal, so although I was able to see this in the Spark code, it was unclear how to work around the issue.) Since response headers must be in place before writing to the response output stream, we now write to a temporary stream so we can provide the correct response status for exceptions thrown by OncHistoryTemplateService. 

Also, the exception handling in OncHistoryTemplateRoute was removed since we now do this in DsmServer.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

