### PR TITLE
Better patch route error detection and reporting

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryUploadRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryUploadRoute.java
@@ -10,11 +10,8 @@ import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.service.onchistory.CodeStudyColumnsProvider;
 import org.broadinstitute.dsm.service.onchistory.OncHistoryUploadService;
 import org.broadinstitute.dsm.service.onchistory.OncHistoryValidationException;
-import org.broadinstitute.dsm.statics.RoutePath;
-import org.broadinstitute.dsm.statics.UserErrorMessages;
 import org.broadinstitute.dsm.util.UserUtil;
 import org.broadinstitute.lddp.handlers.util.Result;
-import spark.QueryParamsMap;
 import spark.Request;
 import spark.Response;
 
@@ -25,7 +22,7 @@ public class OncHistoryUploadRoute extends RequestHandler {
 
     @Override
     protected Object processRequest(Request request, Response response, String userId) throws Exception {
-        String realm = RouteUtil.getRealm(request);
+        String realm = RouteUtil.requireRealm(request);
 
         if (!canUploadOncHistory(realm, userId)) {
             throw new AuthorizationException("User is not authorized to upload onc history");

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryUploadRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/OncHistoryUploadRoute.java
@@ -3,6 +3,7 @@ package org.broadinstitute.dsm.route;
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.db.dao.user.UserDao;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
+import org.broadinstitute.dsm.exception.AuthorizationException;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.security.RequestHandler;
@@ -24,17 +25,10 @@ public class OncHistoryUploadRoute extends RequestHandler {
 
     @Override
     protected Object processRequest(Request request, Response response, String userId) throws Exception {
-        QueryParamsMap queryParams = request.queryMap();
-        String realm;
-        if (!queryParams.hasKey(RoutePath.REALM)) {
-            response.status(400);
-            return "Request requires realm parameter";
-        }
-        realm = queryParams.value(RoutePath.REALM);
+        String realm = RouteUtil.getRealm(request);
 
         if (!canUploadOncHistory(realm, userId)) {
-            response.status(403);
-            return (UserErrorMessages.NO_RIGHTS);
+            throw new AuthorizationException("User is not authorized to upload onc history");
         }
 
         String oncHistoryUserId;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
@@ -50,7 +50,7 @@ public class PatchRoute extends RequestHandler {
         String requestBody = request.body();
         try {
             Patch patch = GSON.fromJson(requestBody, Patch.class);
-            String realm = patch.getRealm();
+            String realm = RouteUtil.requireRealm(patch.getRealm());
             logger.info("Got patch request made by {} for realm {} and table alias {}", userId, realm, patch.getTableAlias());
 
             if ((UserUtil.checkUserAccessForPatch(realm, userId, DBConstants.MR_VIEW, userIdRequest, patch)

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
@@ -50,7 +50,7 @@ public class PatchRoute extends RequestHandler {
         String requestBody = request.body();
         try {
             Patch patch = GSON.fromJson(requestBody, Patch.class);
-            String realm = RouteUtil.requireRealm(patch.getRealm());
+            String realm = patch.getRealm();
             logger.info("Got patch request made by {} for realm {} and table alias {}", userId, realm, patch.getTableAlias());
 
             if ((UserUtil.checkUserAccessForPatch(realm, userId, DBConstants.MR_VIEW, userIdRequest, patch)

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/PatchRoute.java
@@ -2,7 +2,11 @@ package org.broadinstitute.dsm.route;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import lombok.NonNull;
+import org.broadinstitute.dsm.exception.AuthorizationException;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.exception.DuplicateException;
 import org.broadinstitute.dsm.model.patch.BasePatch;
 import org.broadinstitute.dsm.model.patch.Patch;
@@ -39,34 +43,33 @@ public class PatchRoute extends RequestHandler {
     @Override
     public Object processRequest(Request request, Response response, String userId) throws Exception {
         if (PatchUtil.getColumnNameMap() == null) {
-            response.status(500);
-            throw new RuntimeException("ColumnNameMap is null!");
+            throw new DsmInternalError("PatchUtil.ColumnNameMap is null");
         }
+
+        String userIdRequest = UserUtil.getUserId(request);
+        String requestBody = request.body();
         try {
-            String userIdRequest = UserUtil.getUserId(request);
-            String requestBody = request.body();
             Patch patch = GSON.fromJson(requestBody, Patch.class);
             String realm = patch.getRealm();
-            logger.info("Received a patch request, made by " + userId + " in realm "+realm +" for table alias " + patch.getTableAlias());
+            logger.info("Got patch request made by {} for realm {} and table alias {}", userId, realm, patch.getTableAlias());
+
             if ((UserUtil.checkUserAccessForPatch(realm, userId, DBConstants.MR_VIEW, userIdRequest, patch)
                     || UserUtil.checkUserAccessForPatch(realm, userId, DBConstants.MR_ABSTRACTER, userIdRequest, patch)
                     || UserUtil.checkUserAccessForPatch(realm, userId, DBConstants.PT_LIST_VIEW, userIdRequest, patch))
-                    || ( UserUtil.checkKitShippingAccessForPatch(realm, userId, userIdRequest, patch))) {
+                    || UserUtil.checkKitShippingAccessForPatch(realm, userId, userIdRequest, patch)) {
 
-                    BasePatch patcher = PatchFactory.makePatch(patch, notificationUtil);
-                    return patcher.doPatch();
+                BasePatch patcher = PatchFactory.makePatch(patch, notificationUtil);
+                return patcher.doPatch();
 
             } else {
-                response.status(403);
-                logger.warn("User with id {} does not have needed privileges", userId);
-                return UserErrorMessages.NO_RIGHTS;
+                throw new AuthorizationException("User is not authorized to patch participant data");
             }
+        } catch (JsonSyntaxException e) {
+            throw new DSMBadRequestException("Invalid request payload format for patch");
         } catch (DuplicateException e) {
-            response.status(500);
-            throw new RuntimeException("Duplicate value", e);
-        } catch (Exception e) {
-            response.status(500);
-            throw new RuntimeException("An error occurred while attempting to patch ", e);
+            // TODO: fix this by inspecting the DuplicateException throwers to see if cases are due to
+            // bad request data (400)
+            throw new DsmInternalError("Duplicate value", e);
         }
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsm.route;
+
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.statics.RoutePath;
+import spark.QueryParamsMap;
+import spark.Request;
+
+/**
+ * Collection of helper methods for route processing
+ */
+public class RouteUtil {
+
+    public static String getRealm(Request request) {
+        QueryParamsMap queryParams = request.queryMap();
+        if (!queryParams.hasKey(RoutePath.REALM)) {
+            throw new DSMBadRequestException("Request must include realm parameter");
+        }
+        String realm = queryParams.value(RoutePath.REALM);
+        if (StringUtils.isEmpty(realm)) {
+            throw new DSMBadRequestException("Invalid realm parameter: blank");
+        }
+        return realm;
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
@@ -11,12 +11,15 @@ import spark.Request;
  */
 public class RouteUtil {
 
-    public static String getRealm(Request request) {
+    public static String requireRealm(Request request) {
         QueryParamsMap queryParams = request.queryMap();
         if (!queryParams.hasKey(RoutePath.REALM)) {
             throw new DSMBadRequestException("Request must include realm parameter");
         }
-        String realm = queryParams.value(RoutePath.REALM);
+        return requireRealm(queryParams.value(RoutePath.REALM));
+    }
+
+    public static String requireRealm(String realm) {
         if (StringUtils.isEmpty(realm)) {
             throw new DSMBadRequestException("Invalid realm parameter: blank");
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -43,6 +43,7 @@ import org.broadinstitute.dsm.statics.ApplicationConfigConstants;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.lddp.handlers.util.MedicalInfo;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -717,8 +718,16 @@ public class ElasticSearchUtil {
         UpdateRequest updateRequest =
                 new UpdateRequest().index(index).type("_doc").id(participantId).doc(objectsMapES).docAsUpsert(true).retryOnConflict(5);
 
-        UpdateResponse updateResponse = client.update(updateRequest, RequestOptions.DEFAULT);
-        logger.info("Update workflow information for participant " + ddpParticipantId + " to ES index " + index);
+        try {
+            UpdateResponse updateResponse = client.update(updateRequest, RequestOptions.DEFAULT);
+            logger.info("Updated ES index {} data for participant {} with response: {}", index, ddpParticipantId, updateResponse);
+        } catch (IOException e) {
+            throw new DsmInternalError("Error connecting to Elasticsearch", e);
+        } catch (ElasticsearchException e) {
+            // TODO We may see these for version conflicts, which we need to handle, but first step is capturing
+            // and understanding the failures
+            throw new DsmInternalError("Error updating Elasticsearch", e);
+        }
     }
 
     public static void updateRequest(RestHighLevelClient client, @NonNull String ddpParticipantId, String index,


### PR DESCRIPTION
PEPPER-984

This PR does not contain fixes per se for PEPPER-984, but improves input checking and reporting. Said differently, with these changes we can hopefully understand *why* we are seeing the errors reported in the bug.
 
Specifically: 

- Added input checking improvements to PatchRoute, and updated the exception handling since DSM now has uniform exception handling at the Spark level for a handful of common exceptions (see DsmServer). 
- Added RouteUtil class. There are several common route patterns that should be handled uniformly, so this is just the start of getting those patterns in one place.
- Added input checking in OncHistoryDetailPatch and detangled the code a bit. As I noted in a prior PR, this code is very tangled and deserves a rewrite, but we probably need to do this methodically since there is limited testing support.
- Added exception handling in ElasticUtil.updateRequest. We are seeing instances of ES version conflicts in Prod, which should be reported at error level, since we need to fix these. (That means we are failing to update ES, thus ES is wrong until we do an export.)

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

