### PR TITLE
Set destruction policy for all medical records in study

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -70,9 +70,9 @@ public class MedicalRecord implements HasDdpInstanceId {
     public static final String AND_P_DDP_PARTICIPANT_ID_IN = " AND p.ddp_participant_id IN (?)";
     public static final String QUESTION_MARK = "?";
     @ColumnName(DBConstants.MEDICAL_RECORD_ID)
-    private long medicalRecordId;
+    private int medicalRecordId;
     @ColumnName(DBConstants.INSTITUTION_ID)
-    private long institutionId;
+    private int institutionId;
     @ColumnName(DBConstants.DDP_INSTITUTION_ID)
     private String ddpInstitutionId;
     @ColumnName(DBConstants.DDP_PARTICIPANT_ID)
@@ -157,7 +157,7 @@ public class MedicalRecord implements HasDdpInstanceId {
     private Boolean deleted;
 
 
-    public MedicalRecord(long medicalRecordId, long institutionId) {
+    public MedicalRecord(int medicalRecordId, int institutionId) {
         this.medicalRecordId = medicalRecordId;
         this.institutionId = institutionId;
     }
@@ -165,11 +165,11 @@ public class MedicalRecord implements HasDdpInstanceId {
     public MedicalRecord() {
     }
 
-    public MedicalRecord(long ddpInstanceId) {
+    public MedicalRecord(int ddpInstanceId) {
         this.ddpInstanceId = ddpInstanceId;
     }
 
-    public MedicalRecord(long medicalRecordId, long institutionId, String ddpInstitutionId, String type, String name, String contact,
+    public MedicalRecord(int medicalRecordId, int institutionId, String ddpInstitutionId, String type, String name, String contact,
                          String phone, String fax, String faxSent, String faxSentBy, String faxConfirmed, String faxSent2,
                          String faxSent2By, String faxConfirmed2, String faxSent3, String faxSent3By, String faxConfirmed3,
                          String mrReceived, String mrDocument, String mrDocumentFileNames, boolean mrProblem, String mrProblemText,
@@ -217,7 +217,7 @@ public class MedicalRecord implements HasDdpInstanceId {
     }
 
     public static MedicalRecord getMedicalRecord(@NonNull ResultSet rs) throws SQLException {
-        MedicalRecord medicalRecord = new MedicalRecord(rs.getLong(DBConstants.MEDICAL_RECORD_ID), rs.getLong(DBConstants.INSTITUTION_ID),
+        MedicalRecord medicalRecord = new MedicalRecord(rs.getInt(DBConstants.MEDICAL_RECORD_ID), rs.getInt(DBConstants.INSTITUTION_ID),
                 rs.getString(DBConstants.DDP_INSTITUTION_ID), rs.getString(DBConstants.TYPE), rs.getString(DBConstants.NAME),
                 rs.getString(DBConstants.CONTACT), rs.getString(DBConstants.PHONE), rs.getString(DBConstants.FAX),
                 rs.getString(DBConstants.FAX_SENT), rs.getString(DBConstants.FAX_SENT_BY), rs.getString(DBConstants.FAX_CONFIRMED),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.structure.ColumnName;
 import org.broadinstitute.dsm.db.structure.DbDateConversion;
 import org.broadinstitute.dsm.db.structure.SqlDateConverter;
@@ -90,8 +89,6 @@ public class OncHistoryDetail implements HasDdpInstanceId {
     public static final String PROBLEM_OTHER_OLD = "Other";
     public static final String ONC_HISTORY_DETAIL_ID = "oncHistoryDetailId";
     private static final Logger logger = LoggerFactory.getLogger(OncHistoryDetail.class);
-    private static final String SQL_CREATE_ONC_HISTORY =
-            "INSERT INTO ddp_onc_history_detail SET medical_record_id = ?, request = ?, last_changed = ?, changed_by = ?";
     private static final String SQL_SELECT_ONC_HISTORY =
             "SELECT onc_history_detail_id, medical_record_id, date_px, type_px, location_px, histology, accession_number, facility,"
                     + " phone, fax, notes, additional_values_json, request, fax_sent, fax_sent_by, fax_confirmed, fax_sent_2, "
@@ -100,11 +97,20 @@ public class OncHistoryDetail implements HasDdpInstanceId {
                     + "WHERE NOT (deleted <=> 1)";
     private static final String SQL_INSERT_ONC_HISTORY_DETAIL =
             "INSERT INTO ddp_onc_history_detail SET medical_record_id = ?, request = ?, last_changed = ?, changed_by = ?";
+
+    private static final String SQL_CREATE_ONC_HISTORY_DETAIL =
+            "INSERT INTO ddp_onc_history_detail SET medical_record_id = ?, date_px = ?, type_px = ?, location_px = ?, facility = ?, "
+                    + "request = ?, destruction_policy = ?, last_changed = ?, changed_by = ?";
+
+    private static final String SQL_UPDATE_DESTRUCTION_POLICY =
+            "UPDATE ddp_onc_history_detail SET destruction_policy = ?, last_changed = ?, changed_by = ? "
+                    + "WHERE facility = ?";
+
     @ColumnName(DBConstants.ONC_HISTORY_DETAIL_ID)
-    private Long oncHistoryDetailId;
+    private int oncHistoryDetailId;
 
     @ColumnName(DBConstants.MEDICAL_RECORD_ID)
-    private Long medicalRecordId;
+    private int medicalRecordId;
 
     @ColumnName(DBConstants.DATE_PX)
     @DbDateConversion(SqlDateConverter.STRING_DAY)
@@ -204,7 +210,7 @@ public class OncHistoryDetail implements HasDdpInstanceId {
         this.ddpInstanceId = ddpInstanceId;
     }
 
-    public OncHistoryDetail(Long oncHistoryDetailId, Long medicalRecordId, String datePx, String typePx, String locationPx,
+    public OncHistoryDetail(Integer oncHistoryDetailId, Integer medicalRecordId, String datePx, String typePx, String locationPx,
                             String histology, String accessionNumber, String facility, String phone, String fax, String notes,
                             String request, String faxSent, String faxSentBy, String faxConfirmed, String faxSent2, String faxSent2By,
                             String faxConfirmed2, String faxSent3, String faxSent3By, String faxConfirmed3, String tissueReceived,
@@ -240,7 +246,7 @@ public class OncHistoryDetail implements HasDdpInstanceId {
         this.unableObtainTissue = unableObtainTissue;
     }
 
-    public OncHistoryDetail(Long oncHistoryDetailId, Long medicalRecordId, String datePx, String typePx, String locationPx,
+    public OncHistoryDetail(Integer oncHistoryDetailId, Integer medicalRecordId, String datePx, String typePx, String locationPx,
                             String histology, String accessionNumber, String facility, String phone, String fax, String notes,
                             String request, String faxSent, String faxSentBy, String faxConfirmed, String faxSent2, String faxSent2By,
                             String faxConfirmed2, String faxSent3, String faxSent3By, String faxConfirmed3, String tissueReceived,
@@ -280,10 +286,21 @@ public class OncHistoryDetail implements HasDdpInstanceId {
         this.ddpInstanceId = ddpInstanceId;
     }
 
+    public OncHistoryDetail(Builder builder) {
+        this.medicalRecordId = builder.medicalRecordId;
+        this.datePx = builder.datePx;
+        this.typePx = builder.typePx;
+        this.locationPx = builder.locationPx;
+        this.facility = builder.facility;
+        this.request = builder.request;
+        this.destructionPolicy = builder.destructionPolicy;
+        this.changedBy = builder.changedBy;
+    }
+
     public static OncHistoryDetail getOncHistoryDetail(@NonNull ResultSet rs) throws SQLException {
         List tissues = new ArrayList<>();
         OncHistoryDetail oncHistoryDetail =
-                new OncHistoryDetail(rs.getLong(DBConstants.ONC_HISTORY_DETAIL_ID), rs.getLong(DBConstants.MEDICAL_RECORD_ID),
+                new OncHistoryDetail(rs.getInt(DBConstants.ONC_HISTORY_DETAIL_ID), rs.getInt(DBConstants.MEDICAL_RECORD_ID),
                         rs.getString(DBConstants.DATE_PX), rs.getString(DBConstants.TYPE_PX), rs.getString(DBConstants.LOCATION_PX),
                         rs.getString(DBConstants.HISTOLOGY), rs.getString(DBConstants.ACCESSION_NUMBER), rs.getString(DBConstants.FACILITY),
                         rs.getString(DBConstants.DDP_ONC_HISTORY_DETAIL_ALIAS + DBConstants.ALIAS_DELIMITER + DBConstants.PHONE),
@@ -443,6 +460,38 @@ public class OncHistoryDetail implements HasDdpInstanceId {
         }
     }
 
+    /**
+     * Note: this method does not create all OncHistoryDetail fields. Add those fields as needed.
+     */
+    public static int creatOncHistoryDetail(OncHistoryDetail oncHistoryDetail) {
+        int medicalRecordId = oncHistoryDetail.getMedicalRecordId();
+        return inTransaction(conn -> {
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_CREATE_ONC_HISTORY_DETAIL, Statement.RETURN_GENERATED_KEYS)) {
+                stmt.setInt(1, medicalRecordId);
+                stmt.setString(2, oncHistoryDetail.datePx);
+                stmt.setString(3, oncHistoryDetail.typePx);
+                stmt.setString(4, oncHistoryDetail.locationPx);
+                stmt.setString(5, oncHistoryDetail.facility);
+                stmt.setString(6, oncHistoryDetail.request);
+                stmt.setString(7, oncHistoryDetail.destructionPolicy);
+                stmt.setLong(8, System.currentTimeMillis());
+                stmt.setString(9, oncHistoryDetail.changedBy);
+                int result = stmt.executeUpdate();
+                if (result == 1) {
+                    try (ResultSet rs = stmt.getGeneratedKeys()) {
+                        if (rs.next()) {
+                            return rs.getInt(1);
+                        }
+                    }
+                }
+                throw new DsmInternalError(String.format("Error creating ddp_onc_history_detail for medical record %d: "
+                        + "result key not present", medicalRecordId));
+            } catch (SQLException ex) {
+                throw new DsmInternalError("Error creating ddp_onc_history_detail for medical record " + medicalRecordId);
+            }
+        });
+    }
+
     @JsonProperty("dynamicFields")
     public Map<String, Object> getDynamicFields() {
         return ObjectMapperSingleton.readValue(additionalValuesJson, new TypeReference<Map<String, Object>>() {
@@ -479,10 +528,11 @@ public class OncHistoryDetail implements HasDdpInstanceId {
                                                   boolean updateElastic) {
         Number mrId = MedicalRecordUtil.isInstitutionTypeInDB(Integer.toString(participantId));
         if (mrId == null) {
-            MedicalRecordUtil.writeInstitutionIntoDb(ddpParticipantId, MedicalRecordUtil.NOT_SPECIFIED, realm, updateElastic);
-            String id = MedicalRecordUtil.getParticipantIdByDdpParticipantId(ddpParticipantId, realm);
-            if (StringUtils.isBlank(id)) {
-                throw new RuntimeException("Error adding new institution for oncHistory. Participant ID: " + participantId);
+            MedicalRecordUtil.writeInstitutionIntoDb(participantId, ddpParticipantId, MedicalRecordUtil.NOT_SPECIFIED, realm,
+                    updateElastic);
+            Integer id = MedicalRecordUtil.getParticipantIdByDdpParticipantId(ddpParticipantId, realm);
+            if (id == null) {
+                throw new DsmInternalError("Error adding new institution for oncHistory. Participant ID: " + participantId);
             }
             mrId = MedicalRecordUtil.isInstitutionTypeInDB(Integer.toString(participantId));
             if (mrId == null) {
@@ -490,5 +540,75 @@ public class OncHistoryDetail implements HasDdpInstanceId {
             }
         }
         return mrId.intValue();
+    }
+
+    public static void updateDestructionPolicy(@NonNull String policy, @NonNull String facility, @NonNull String user) {
+        inTransaction(conn -> {
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_DESTRUCTION_POLICY)) {
+                stmt.setString(1, policy);
+                stmt.setString(2, String.valueOf(System.currentTimeMillis()));
+                stmt.setString(3, user);
+                stmt.setString(4, facility);
+                return stmt.executeUpdate();
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error updating destruction policy for facility " + facility, e);
+            }
+        });
+    }
+
+    // Note: this builder is not complete, add fields as needed
+    public static class Builder {
+        private int medicalRecordId;
+        private String datePx;
+        private String typePx;
+        private String locationPx;
+        private String facility;
+        private String request;
+        private String destructionPolicy;
+        private String changedBy;
+
+        public Builder withMedicalRecordId(int medicalRecordId) {
+            this.medicalRecordId = medicalRecordId;
+            return this;
+        }
+
+        public Builder withDatePx(String datePx) {
+            this.datePx = datePx;
+            return this;
+        }
+
+        public Builder withTypePx(String typePx) {
+            this.typePx = typePx;
+            return this;
+        }
+
+        public Builder withLocationPx(String locationPx) {
+            this.locationPx = locationPx;
+            return this;
+        }
+
+        public Builder withFacility(String facility) {
+            this.facility = facility;
+            return this;
+        }
+
+        public Builder withRequest(String request) {
+            this.request = request;
+            return this;
+        }
+
+        public Builder withDestructionPolicy(String destructionPolicy) {
+            this.destructionPolicy = destructionPolicy;
+            return this;
+        }
+
+        public Builder withChangedBy(String changedBy) {
+            this.changedBy = changedBy;
+            return this;
+        }
+
+        public OncHistoryDetail build() {
+            return new OncHistoryDetail(this);
+        }
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/onchistory/OncHistoryDetailDaoImpl.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/onchistory/OncHistoryDetailDaoImpl.java
@@ -53,7 +53,7 @@ public class OncHistoryDetailDaoImpl implements OncHistoryDetailDao<OncHistoryDe
         OncHistoryDetailDaoImpl.BuildOncHistoryDetailDto builder = new OncHistoryDetailDaoImpl.BuildOncHistoryDetailDto();
         SimpleResult res = DaoUtil.getById(id, SQL_SELECT_BY_ID, builder);
         if (res.resultException != null) {
-            throw new RuntimeException("Error getting onc history detail with id: " + id,
+            throw new DsmInternalError("Error getting onc history detail with id: " + id,
                     res.resultException);
         }
         return (Optional<OncHistoryDetailDto>) res.resultValue;
@@ -113,8 +113,8 @@ public class OncHistoryDetailDaoImpl implements OncHistoryDetailDao<OncHistoryDe
                 stmt.setString(2, oncHistoryDetailId);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
-                        oncHistoryDetail = new OncHistoryDetail(rs.getLong(DBConstants.ONC_HISTORY_DETAIL_ID),
-                                rs.getLong(DBConstants.MEDICAL_RECORD_ID), rs.getString(DBConstants.DATE_PX),
+                        oncHistoryDetail = new OncHistoryDetail(rs.getInt(DBConstants.ONC_HISTORY_DETAIL_ID),
+                                rs.getInt(DBConstants.MEDICAL_RECORD_ID), rs.getString(DBConstants.DATE_PX),
                                 rs.getString(DBConstants.TYPE_PX), rs.getString(DBConstants.LOCATION_PX),
                                 rs.getString(DBConstants.HISTOLOGY), rs.getString(DBConstants.ACCESSION_NUMBER),
                                 rs.getString(DBConstants.FACILITY),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/ddp/participant/ParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/ddp/participant/ParticipantDto.java
@@ -47,10 +47,6 @@ public class ParticipantDto implements Cloneable {
         this.assigneeIdTissue = Optional.ofNullable(assigneeIdTissue);
     }
 
-    public int getParticipantIdOrThrow() {
-        return participantId.orElseThrow();
-    }
-
     @Override
     public ParticipantDto clone() {
         try {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/ddp/participant/ParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/ddp/participant/ParticipantDto.java
@@ -31,6 +31,10 @@ public class ParticipantDto implements Cloneable {
         this.changedBy = builder.changedBy;
     }
 
+    public void setParticipantId(int participantId) {
+        this.participantId = Optional.of(participantId);
+    }
+
     public void setDdpInstanceId(int ddpInstanceId) {
         this.ddpInstanceId = ddpInstanceId;
     }
@@ -41,6 +45,10 @@ public class ParticipantDto implements Cloneable {
 
     public void setAssigneeIdTissue(Integer assigneeIdTissue) {
         this.assigneeIdTissue = Optional.ofNullable(assigneeIdTissue);
+    }
+
+    public int getParticipantIdOrThrow() {
+        return participantId.orElseThrow();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/TissueList.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/TissueList.java
@@ -79,7 +79,7 @@ public class TissueList {
     public static List<TissueList> getAllTissueListsForRealm(String realm, String query) {
         List<TissueList> results = new ArrayList<>();
         HashMap<Long, Tissue> tissues = new HashMap<>();
-        HashMap<Long, OncHistoryDetail> oncHistoryDetailHashMap = new HashMap<>();
+        HashMap<Integer, OncHistoryDetail> oncHistoryDetailHashMap = new HashMap<>();
         HashMap<String, Participant> participantHashMap = new HashMap<>();
         SimpleResult result = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/TissueSourceGenerator.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/TissueSourceGenerator.java
@@ -27,7 +27,7 @@ public class TissueSourceGenerator extends ParentChildRelationGenerator {
             DDPInstanceDto ddpInstanceDto = ddpInstanceDao.getDDPInstanceByInstanceName(generatorPayload.getInstanceName()).orElseThrow();
             OncHistoryDetail oncHistoryDetail = new OncHistoryDetail();
             String oncHistoryDetailId = generatorPayload.getParentId();
-            oncHistoryDetail.setOncHistoryDetailId(Long.valueOf(oncHistoryDetailId));
+            oncHistoryDetail.setOncHistoryDetailId(Integer.valueOf(oncHistoryDetailId));
             if (StringUtils.isNotBlank(generatorPayload.getValue().toString())) {
                 oncHistoryDetail.setRequest(OncHistoryDetail.STATUS_RETURNED);
             } else {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatch.java
@@ -63,15 +63,15 @@ public class OncHistoryDetailPatch extends BasePatch {
                 throw new DSMBadRequestException("DDP participant ID not provided for patch");
             }
 
-            String participantId = MedicalRecordUtil.getParticipantIdByDdpParticipantId(ddpParticipantId, realm);
-            if (StringUtils.isBlank(participantId)) {
+            Integer participantId = MedicalRecordUtil.getParticipantIdByDdpParticipantId(ddpParticipantId, realm);
+            if (participantId == null) {
                 throw new DSMBadRequestException("Participant does not exist. DDP participant ID=" + ddpParticipantId);
             }
 
             // mr of that type doesn't exist yet, so create an institution and mr
-            MedicalRecordUtil.writeInstitutionIntoDb(ddpParticipantId, MedicalRecordUtil.NOT_SPECIFIED,
+            MedicalRecordUtil.writeInstitutionIntoDb(participantId, ddpParticipantId, MedicalRecordUtil.NOT_SPECIFIED,
                     realm, true);
-            patch.setParentId(participantId);
+            patch.setParentId(participantId.toString());
             mrID = MedicalRecordUtil.isInstitutionTypeInDB(patch.getParentId());
         }
         if (mrID != null) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/InstitutionRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/InstitutionRoute.java
@@ -1,99 +1,79 @@
 package org.broadinstitute.dsm.route;
 
-import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
-
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import lombok.NonNull;
-import org.apache.commons.lang3.StringUtils;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.MedicalRecord;
+import org.broadinstitute.dsm.db.OncHistoryDetail;
+import org.broadinstitute.dsm.exception.AuthorizationException;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.statics.RequestParameter;
 import org.broadinstitute.dsm.statics.RoutePath;
-import org.broadinstitute.dsm.statics.UserErrorMessages;
 import org.broadinstitute.dsm.util.UserUtil;
-import org.broadinstitute.lddp.db.SimpleResult;
 import org.broadinstitute.lddp.handlers.util.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+@Slf4j
 public class InstitutionRoute extends RequestHandler {
-
-    public static final String APPLY_DESTRUCTION_POLICY =
-            "UPDATE ddp_onc_history_detail SET destruction_policy = ?, last_changed = ?, changed_by = ? "
-                    + "WHERE onc_history_detail_id <> 0 AND onc_history_detail_id in "
-                    + "(SELECT onc_history_detail_id FROM (SELECT * from ddp_onc_history_detail) as something "
-                    + "WHERE something.facility = ?)";
-    private static final Logger logger = LoggerFactory.getLogger(InstitutionRoute.class);
 
     @Override
     public Object processRequest(Request request, Response response, String userId) throws Exception {
-        String requestBody = request.body();
-        JsonObject jsonObject = JsonParser.parseString(requestBody).getAsJsonObject();
-        String user = String.valueOf(jsonObject.get(RequestParameter.USER_ID));
+        String requestBody = RouteUtil.requireRequestBody(request);
+
         if (RoutePath.RequestMethod.POST.toString().equals(request.requestMethod())) {
-            if (StringUtils.isNotBlank(requestBody)) {
-                String ddpParticipantId = jsonObject.get(RequestParameter.DDP_PARTICIPANT_ID).getAsString();
-                String realm = jsonObject.get(RequestParameter.DDP_REALM).getAsString();
-                if (UserUtil.checkUserAccess(realm, userId, "mr_view", user)) {
-                    if (StringUtils.isNotBlank(ddpParticipantId) && StringUtils.isNotBlank(realm)) {
-                        DDPInstance ddpInstance = DDPInstance.getDDPInstance(realm);
-                        if (ddpInstance != null) {
-                            return MedicalRecord.getDDPInstitutionInfo(ddpInstance, ddpParticipantId);
-                        }
-                    }
-                    logger.warn("Error missing ddpParticipantId " + ddpParticipantId + " or realm " + realm + " w/ userId " + user);
-                } else {
-                    response.status(500);
-                    return new Result(500, UserErrorMessages.NO_RIGHTS);
-                }
+            // TODO we should get rid of this code and the things it calls if it is obsolete.
+            log.error("InstitutionRoute POST called (expecting this request METHOD to be obsolete)");
+
+            JsonObject jsonObject = JsonParser.parseString(requestBody).getAsJsonObject();
+            String user = RouteUtil.requireStringFromJsonObject(jsonObject, RequestParameter.USER_ID);
+            String ddpParticipantId = RouteUtil.requireStringFromJsonObject(jsonObject, RequestParameter.DDP_PARTICIPANT_ID);
+            String realm = RouteUtil.requireStringFromJsonObject(jsonObject, RequestParameter.DDP_REALM);
+
+            if (!UserUtil.checkUserAccess(realm, userId, "mr_view", user)) {
+                throw new AuthorizationException();
             }
+            DDPInstance ddpInstance = DDPInstance.getDDPInstance(realm);
+            if (ddpInstance == null) {
+                throw new DsmInternalError("Invalid realm " + realm);
+            }
+            return MedicalRecord.getDDPInstitutionInfo(ddpInstance, ddpParticipantId);
+
         } else if (RoutePath.RequestMethod.PATCH.toString().equals(request.requestMethod())) {
-            String policy = "";
-            if (jsonObject.has(RequestParameter.POLICY)) {
-                policy = String.valueOf(jsonObject.get(RequestParameter.POLICY));
+            UpdateDestructionPolicyRequest req;
+            try {
+                req = new Gson().fromJson(requestBody, UpdateDestructionPolicyRequest.class);
+            } catch (Exception e) {
+                log.info("Invalid request format for {}", requestBody);
+                throw new DSMBadRequestException("Invalid request format");
             }
-            if (UserUtil.checkUserAccess(null, userId, "mr_request", user)) {
-                String facility = String.valueOf(jsonObject.get(RequestParameter.FACILITY));
-                String userMail = String.valueOf(jsonObject.get(RequestParameter.USER_MAIL));
-                applyDestructionPolicy(userMail, facility, policy);
-                return new Result(200);
-            } else {
-                response.status(500);
-                return new Result(500, UserErrorMessages.NO_RIGHTS);
+
+            String user = RouteUtil.requireParam(RequestParameter.USER_ID, req.getUserId());
+            if (!UserUtil.checkUserAccess(null, userId, "mr_request", user)) {
+                throw new AuthorizationException();
             }
+
+            OncHistoryDetail.updateDestructionPolicy(
+                    RouteUtil.requireParam(RequestParameter.POLICY, req.getPolicy()),
+                    RouteUtil.requireParam(RequestParameter.FACILITY, req.getFacility()),
+                    RouteUtil.requireParam(RequestParameter.USER_MAIL, req.getUserMail())
+            );
+            return new Result(200);
         }
-        logger.error("Request method not known");
-        response.status(500);
-        return new Result(500, UserErrorMessages.CONTACT_DEVELOPER);
+        RouteUtil.handleInvalidRouteMethod(request, "InstitutionRoute");
+        return null;
     }
 
-    private void applyDestructionPolicy(@NonNull String user, String facility, String policy) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement stmt = conn.prepareStatement(APPLY_DESTRUCTION_POLICY)) {
-                if (StringUtils.isNotBlank(user) && StringUtils.isNotBlank(facility) && StringUtils.isNotBlank(policy)) {
-                    stmt.setString(1, policy);
-                    stmt.setString(2, String.valueOf(System.currentTimeMillis()));
-                    stmt.setString(3, user);
-                    stmt.setString(4, facility);
-                    stmt.executeUpdate();
-                }
-            } catch (SQLException ex) {
-                dbVals.resultException = ex;
-            }
-            return dbVals;
-        });
-
-        if (results.resultException != null) {
-            throw new RuntimeException("Couldn't update the destruction policy for " + facility, results.resultException);
-        }
+    @Data
+    private static class UpdateDestructionPolicyRequest {
+        private String facility;
+        private String policy;
+        private String userId;
+        private String userMail;
     }
-
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/InstitutionRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/InstitutionRoute.java
@@ -45,6 +45,7 @@ public class InstitutionRoute extends RequestHandler {
             return MedicalRecord.getDDPInstitutionInfo(ddpInstance, ddpParticipantId);
 
         } else if (RoutePath.RequestMethod.PATCH.toString().equals(request.requestMethod())) {
+            String realm = RouteUtil.requireRealm(request);
             UpdateDestructionPolicyRequest req;
             try {
                 req = new Gson().fromJson(requestBody, UpdateDestructionPolicyRequest.class);
@@ -61,6 +62,7 @@ public class InstitutionRoute extends RequestHandler {
             OncHistoryDetail.updateDestructionPolicy(
                     RouteUtil.requireParam(RequestParameter.POLICY, req.getPolicy()),
                     RouteUtil.requireParam(RequestParameter.FACILITY, req.getFacility()),
+                    realm,
                     RouteUtil.requireParam(RequestParameter.USER_MAIL, req.getUserMail())
             );
             return new Result(200);
@@ -73,6 +75,7 @@ public class InstitutionRoute extends RequestHandler {
     private static class UpdateDestructionPolicyRequest {
         private String facility;
         private String policy;
+        private String realm;
         private String userId;
         private String userMail;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsm.route;
 
+import com.google.gson.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.statics.RoutePath;
 import spark.QueryParamsMap;
 import spark.Request;
@@ -16,13 +18,33 @@ public class RouteUtil {
         if (!queryParams.hasKey(RoutePath.REALM)) {
             throw new DSMBadRequestException("Request must include realm parameter");
         }
-        return requireRealm(queryParams.value(RoutePath.REALM));
+        return requireParam(RoutePath.REALM, queryParams.value(RoutePath.REALM));
     }
 
-    public static String requireRealm(String realm) {
-        if (StringUtils.isEmpty(realm)) {
-            throw new DSMBadRequestException("Invalid realm parameter: blank");
+    public static String requireParam(String paramName, String paramValue) {
+        if (StringUtils.isEmpty(paramValue)) {
+            throw new DSMBadRequestException("Missing request parameter: " + paramName);
         }
-        return realm;
+        return paramValue;
+    }
+
+    public static String requireRequestBody(Request request) {
+        String payload = request.body();
+        if (StringUtils.isBlank(payload)) {
+            throw new DSMBadRequestException("Request must include a body/payload");
+        }
+        return payload;
+    }
+
+    public static String requireStringFromJsonObject(JsonObject jsonObject, String field) {
+        String val = jsonObject.get(field).getAsString();
+        if (StringUtils.isBlank(val)) {
+            throw new DSMBadRequestException(String.format("Request body must include %s field", field));
+        }
+        return val;
+    }
+
+    public static void handleInvalidRouteMethod(Request request, String routeName) {
+        throw new DsmInternalError(String.format("Invalid HTTP method for %s: %s", routeName, request.requestMethod()));
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/admin/StudyRoleRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/admin/StudyRoleRoute.java
@@ -3,6 +3,7 @@ package org.broadinstitute.dsm.route.admin;
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.route.RouteUtil;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.service.admin.StudyRoleResponse;
 import org.broadinstitute.dsm.service.admin.UserAdminService;
@@ -16,26 +17,14 @@ public class StudyRoleRoute extends RequestHandler {
 
     @Override
     public Object processRequest(Request request, Response response, String userId) {
-        String studyGroup;
-        try {
-            studyGroup = UserAdminService.getStudyGroup(request.queryMap().toMap());
-        } catch (Exception e) {
-            return UserRoleRoute.handleError(e, "getting study group", response);
-        }
-
+        String studyGroup = UserAdminService.getStudyGroup(request.queryMap().toMap());
         UserAdminService adminService = new UserAdminService(userId, studyGroup);
 
         if (!request.requestMethod().equals(RoutePath.RequestMethod.GET.toString())) {
-            String msg = "Invalid HTTP method for UserRoleRoute: " + request.requestMethod();
-            log.error(msg);
-            response.status(500);
-            return msg;
+            RouteUtil.handleInvalidRouteMethod(request, "StudyRoleRoute");
+            return null;
         }
 
-        try {
-            return adminService.getStudyRoles();
-        } catch (Exception e) {
-            return UserRoleRoute.handleError(e, "getting study roles", response);
-        }
+        return adminService.getStudyRoles();
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/admin/UserRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/admin/UserRoute.java
@@ -2,7 +2,8 @@ package org.broadinstitute.dsm.route.admin;
 
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.route.RouteUtil;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.service.admin.UpdateUserRequest;
 import org.broadinstitute.dsm.service.admin.UserAdminService;
@@ -17,55 +18,32 @@ public class UserRoute extends RequestHandler {
 
     @Override
     public Object processRequest(Request request, Response response, String userId) {
-        String studyGroup;
-        try {
-            studyGroup = UserAdminService.getStudyGroup(request.queryMap().toMap());
-        } catch (Exception e) {
-            return UserRoleRoute.handleError(e, "getting study group", response);
-        }
-
-        String body = request.body();
-        if (StringUtils.isBlank(body)) {
-            response.status(400);
-            return "Request body is blank";
-        }
-
+        String studyGroup = UserAdminService.getStudyGroup(request.queryMap().toMap());
+        String body = RouteUtil.requireRequestBody(request);
         UserAdminService adminService = new UserAdminService(userId, studyGroup);
-        String requestMethod = request.requestMethod();
 
+        String requestMethod = request.requestMethod();
         if (requestMethod.equals(RoutePath.RequestMethod.POST.toString())) {
             UserRequest req;
             try {
                 req = new Gson().fromJson(body, UserRequest.class);
             } catch (Exception e) {
                 log.info("Invalid request format for {}", body);
-                response.status(400);
-                return "Invalid request format";
+                throw new DSMBadRequestException("Invalid request format");
             }
-            try {
-                adminService.addAndRemoveUsers(req);
-            } catch (Exception e) {
-                return UserRoleRoute.handleError(e, "adding user", response);
-            }
+            adminService.addAndRemoveUsers(req);
         } else if (requestMethod.equals(RoutePath.RequestMethod.PUT.toString())) {
             UpdateUserRequest req;
             try {
                 req = new Gson().fromJson(body, UpdateUserRequest.class);
             } catch (Exception e) {
                 log.info("Invalid request format for {}", body);
-                response.status(400);
-                return "Invalid request format";
+                throw new DSMBadRequestException("Invalid request format");
             }
-            try {
-                adminService.updateUser(req);
-            } catch (Exception e) {
-                return UserRoleRoute.handleError(e, "updating user", response);
-            }
+            adminService.updateUser(req);
         } else {
-            String msg = "Invalid HTTP method for UserRoute: " + requestMethod;
-            log.error(msg);
-            response.status(500);
-            return msg;
+            RouteUtil.handleInvalidRouteMethod(request, "UserRoute");
+            return null;
         }
 
         return new Result(200);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/DDPMedicalRecordDataRequest.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/DDPMedicalRecordDataRequest.java
@@ -144,6 +144,8 @@ public class DDPMedicalRecordDataRequest {
         Collection<Institution> institutions = institutionRequest.getInstitutions();
         if (!institutions.isEmpty()) {
             logger.info("Participant w/ id " + institutionRequest.getParticipantId() + " has " + institutions.size() + " institutions");
+            // TODO this should be rewritten to verify the DDP participant ID and get the participant ID to use in the following
+            // calls (which should be modified to use the participant ID instead of repeatedly looking it up -DC
             MedicalRecordUtil.writeNewRecordIntoDb(conn, SQL_INSERT_ONC_HISTORY, institutionRequest.getParticipantId(), instanceId);
             MedicalRecordUtil.writeNewRecordIntoDb(conn, SQL_INSERT_PARTICIPANT_RECORD, institutionRequest.getParticipantId(), instanceId);
             for (Institution institution : institutions) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/MedicalRecordUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/MedicalRecordUtil.java
@@ -31,15 +31,13 @@ public class MedicalRecordUtil {
     private static final String SQL_UPDATE_PARTICIPANT =
             "UPDATE ddp_participant SET last_version = ?, last_version_date = ?, last_changed = ?, changed_by = ? "
                     + "WHERE ddp_participant_id = ? AND ddp_instance_id = ? AND last_version != ?";
-    private static final String SQL_INSERT_INSTITUTION =
+    private static final String SQL_INSERT_INSTITUTION_WITH_DDP_PARTICIPANT_ID =
             "INSERT INTO ddp_institution (ddp_institution_id, type, participant_id, last_changed) VALUES (?, ?, (SELECT participant_id "
                     + "FROM ddp_participant WHERE ddp_participant_id = ? and ddp_instance_id = ?), ?) ON DUPLICATE "
                     + "KEY UPDATE last_changed = ?";
-    private static final String SQL_INSERT_INSTITUTION_WITH_REALM_NAME =
-            "INSERT INTO ddp_institution (ddp_institution_id, type, participant_id, last_changed) VALUES (?, ?, (SELECT participant_id "
-                    + "FROM ddp_participant p, ddp_instance realm WHERE realm.ddp_instance_id = p.ddp_instance_id "
-                    + "AND p.ddp_participant_id = ? and instance_name = ?), ?) ON DUPLICATE "
-                    + "KEY UPDATE last_changed = ?";
+    private static final String SQL_INSERT_INSTITUTION =
+            "INSERT INTO ddp_institution (ddp_institution_id, type, participant_id, last_changed) VALUES (?, ?, ?, ?) "
+                    + "ON DUPLICATE KEY UPDATE last_changed = ?";
     private static final String SQL_INSERT_MEDICAL_RECORD =
             "INSERT INTO ddp_medical_record SET institution_id = ?, last_changed = ?, changed_by = ?";
     private static final String SQL_SELECT_PARTICIPANT_EXISTS = "SELECT count(ddp_participant_id) as participantCount FROM ddp_participant "
@@ -62,7 +60,7 @@ public class MedicalRecordUtil {
             MedicalRecord medicalRecord = new MedicalRecord();
             medicalRecord.setMedicalRecordId(mrId);
             medicalRecord.setDdpParticipantId(ddpParticipantId);
-            medicalRecord.setInstitutionId(Long.parseLong(institutionId));
+            medicalRecord.setInstitutionId(Integer.parseInt(institutionId));
             medicalRecord.setDdpInstanceId(ddpInstanceDto.getDdpInstanceId());
             medicalRecord.setDdpInstitutionId(ddpInstitutionId);
 
@@ -137,46 +135,43 @@ public class MedicalRecordUtil {
         }
     }
 
-    public static void writeInstitutionIntoDb(@NonNull String ddpParticipantId, @NonNull String type, String instanceName,
-                                              boolean updateElastic) {
+    public static int writeInstitutionIntoDb(int participantId, @NonNull String ddpParticipantId, @NonNull String type,
+                                             @NonNull String instanceName, boolean updateElastic) {
         long currentMilli = System.currentTimeMillis();
         String ddpInstitutionId = java.util.UUID.randomUUID().toString();
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement insertInstitution = conn.prepareStatement(SQL_INSERT_INSTITUTION_WITH_REALM_NAME,
+        return inTransaction(conn -> {
+            try (PreparedStatement insertInstitution = conn.prepareStatement(SQL_INSERT_INSTITUTION,
                     Statement.RETURN_GENERATED_KEYS)) {
                 insertInstitution.setString(1, ddpInstitutionId);
                 insertInstitution.setString(2, type);
-                insertInstitution.setString(3, ddpParticipantId);
-                insertInstitution.setString(4, instanceName);
+                insertInstitution.setInt(3, participantId);
+                insertInstitution.setLong(4, currentMilli);
                 insertInstitution.setLong(5, currentMilli);
-                insertInstitution.setLong(6, currentMilli);
                 int result = insertInstitution.executeUpdate();
                 // 1 (inserted) or 2 (updated) is good
                 if (result == 2) {
-                    logger.info("Updated institution for participant w/ id " + ddpParticipantId);
+                    logger.info("Updated institution for participant {}", participantId);
                 } else if (result == 1) {
-                    logger.info("Inserted new institution for participant w/ id " + ddpParticipantId);
+                    logger.info("Inserted new institution for participant {}", participantId);
                     createInstitutionMedicalRecord(conn, insertInstitution, ddpParticipantId, instanceName,
                             ddpInstitutionId, updateElastic);
                 } else {
-                    throw new RuntimeException("Error updating row");
+                    throw new DsmInternalError(String.format("Error inserting new institution for participant %s: "
+                            + "wrong number of rows inserted %s", ddpParticipantId, result));
                 }
+                return result;
             } catch (SQLException e) {
-                dbVals.resultException = e;
+                throw new DsmInternalError("Error inserting new institution for participant " + ddpParticipantId, e);
             }
-            return dbVals;
         });
-        if (results.resultException != null) {
-            throw new RuntimeException("Error inserting new institution", results.resultException);
-        }
     }
 
     public static void writeInstitutionIntoDb(@NonNull Connection conn, @NonNull String ddpParticipantId, @NonNull String instanceId,
                                               @NonNull String ddpInstitutionId, @NonNull String type, String instanceName) {
         if (conn != null) {
             long currentMilli = System.currentTimeMillis();
-            try (PreparedStatement insertInstitution = conn.prepareStatement(SQL_INSERT_INSTITUTION, Statement.RETURN_GENERATED_KEYS)) {
+            try (PreparedStatement insertInstitution = conn.prepareStatement(SQL_INSERT_INSTITUTION_WITH_DDP_PARTICIPANT_ID,
+                    Statement.RETURN_GENERATED_KEYS)) {
                 insertInstitution.setString(1, ddpInstitutionId);
                 insertInstitution.setString(2, type);
                 insertInstitution.setString(3, ddpParticipantId);
@@ -289,29 +284,21 @@ public class MedicalRecordUtil {
         return (Number) results.resultValue;
     }
 
-    public static String getParticipantIdByDdpParticipantId(@NonNull String ddpParticipantId, @NonNull String realm) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
+    public static Integer getParticipantIdByDdpParticipantId(@NonNull String ddpParticipantId, @NonNull String realm) {
+        return inTransaction(conn -> {
+            Integer participantId = null;
             try (PreparedStatement checkParticipant = conn.prepareStatement(SQL_SELECT_PARTICIPANT)) {
                 checkParticipant.setString(1, ddpParticipantId);
                 checkParticipant.setString(2, realm);
                 try (ResultSet rs = checkParticipant.executeQuery()) {
                     if (rs.next()) {
-                        dbVals.resultValue = rs.getString(DBConstants.PARTICIPANT_ID);
+                        participantId = rs.getInt(DBConstants.PARTICIPANT_ID);
                     }
                 }
-            } catch (SQLException ex) {
-                dbVals.resultException = ex;
+                return participantId;
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error getting participant id for ddpParticipantId " + ddpParticipantId, e);
             }
-            return dbVals;
         });
-
-        if (results.resultException != null) {
-            throw new RuntimeException("Error getting participant id for pt w/ ddpParticipantId " + ddpParticipantId,
-                    results.resultException);
-        }
-        return (String) results.resultValue;
     }
-
-
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
@@ -90,7 +90,10 @@ public class UserUtil {
     }
 
     public static String getUserId(Request request) {
-        QueryParamsMap queryParams = request.queryMap();
+        return getUserId(request.queryMap());
+    }
+
+    public static String getUserId(QueryParamsMap queryParams) {
         String userId = "";
         if (queryParams.value(USER_ID) != null) {
             userId = queryParams.get(USER_ID).value();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -1,0 +1,104 @@
+package org.broadinstitute.dsm.db;
+
+import java.time.Instant;
+
+import org.broadinstitute.dsm.DbTxnBaseTest;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dao.ddp.institution.DDPInstitutionDao;
+import org.broadinstitute.dsm.db.dao.ddp.medical.records.MedicalRecordDao;
+import org.broadinstitute.dsm.db.dao.ddp.onchistory.OncHistoryDetailDaoImpl;
+import org.broadinstitute.dsm.db.dao.ddp.onchistory.OncHistoryDetailDto;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
+import org.broadinstitute.dsm.util.DBTestUtil;
+import org.broadinstitute.dsm.util.TestParticipantUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OncHistoryDetailTest extends DbTxnBaseTest {
+
+    private static final String TEST_USER = "TEST_USER";
+    private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
+    private static DDPInstanceDto ddpInstanceDto;
+    private static ParticipantDto testParticipant = null;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        String instanceName = String.format("ReferralSourceServiceTest_%d", Instant.now().toEpochMilli());
+        ddpInstanceDto = DBTestUtil.createTestDdpInstance(ddpInstanceDao, instanceName);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        ddpInstanceDao.delete(ddpInstanceDto.getDdpInstanceId());
+    }
+
+
+    @After
+    public void deleteParticipants() {
+        if (testParticipant != null) {
+            TestParticipantUtil.deleteParticipant(testParticipant.getParticipantId().orElseThrow());
+            testParticipant = null;
+        }
+    }
+
+    @Test
+    public void updateDestructionPolicyTest() {
+        String ddpParticipantId = TestParticipantUtil.genDDPParticipantId("OncHistoryDetailTest");
+        testParticipant = TestParticipantUtil.createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
+
+        int medicalRecordId = OncHistoryDetail.verifyOrCreateMedicalRecord(testParticipant.getParticipantId().orElseThrow(),
+                ddpParticipantId, ddpInstanceDto.getInstanceName(), false);
+
+        // add some onc history detail records
+        OncHistoryDetail.Builder builder = new OncHistoryDetail.Builder()
+                .withMedicalRecordId(medicalRecordId)
+                .withFacility("Office")
+                .withDestructionPolicy("12")
+                .withChangedBy(TEST_USER);
+
+        int recId1 = -1;
+        int recId2 = -1;
+        int recId3 = -1;
+        OncHistoryDetailDaoImpl oncHistoryDetailDao = new OncHistoryDetailDaoImpl();
+        try {
+            OncHistoryDetail rec1 = builder.build();
+            recId1 = OncHistoryDetail.creatOncHistoryDetail(rec1);
+
+            builder.withDestructionPolicy("3");
+            OncHistoryDetail rec2 = builder.build();
+            recId2 = OncHistoryDetail.creatOncHistoryDetail(rec2);
+
+            builder.withFacility("Other office");
+            OncHistoryDetail rec3 = builder.build();
+            recId3 = OncHistoryDetail.creatOncHistoryDetail(rec3);
+
+            // update and verify
+            OncHistoryDetail.updateDestructionPolicy("5", "Office", TEST_USER);
+
+            OncHistoryDetailDto updateRec1 = oncHistoryDetailDao.get(recId1).orElseThrow();
+            Assert.assertEquals("5", updateRec1.getColumnValues().get("POLICY"));
+        } catch (Exception e) {
+            Assert.fail("Unexpected exception" + e.toString());
+            e.printStackTrace();
+        } finally {
+            if (recId1 != -1) {
+                oncHistoryDetailDao.delete(recId1);
+            }
+            if (recId2 != -1) {
+                oncHistoryDetailDao.delete(recId2);
+            }
+            if (recId3 != -1) {
+                oncHistoryDetailDao.delete(recId3);
+            }
+            MedicalRecordDao medicalRecordDao = new MedicalRecordDao();
+            MedicalRecord medicalRecord = medicalRecordDao.get(medicalRecordId).get();
+            medicalRecordDao.delete(medicalRecordId);
+            DDPInstitutionDao ddpInstitutionDao = new DDPInstitutionDao();
+            ddpInstitutionDao.delete(medicalRecord.getInstitutionId());
+        }
+    }
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsm.db;
 
 import java.time.Instant;
 
+import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.DbTxnBaseTest;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.ddp.institution.DDPInstitutionDao;
@@ -18,6 +19,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+@Slf4j
 public class OncHistoryDetailTest extends DbTxnBaseTest {
 
     private static final String TEST_USER = "TEST_USER";
@@ -80,7 +82,11 @@ public class OncHistoryDetailTest extends DbTxnBaseTest {
             OncHistoryDetail.updateDestructionPolicy("5", "Office", TEST_USER);
 
             OncHistoryDetailDto updateRec1 = oncHistoryDetailDao.get(recId1).orElseThrow();
-            Assert.assertEquals("5", updateRec1.getColumnValues().get("POLICY"));
+            Assert.assertEquals("5", updateRec1.getColumnValues().get("destruction_policy"));
+            OncHistoryDetailDto updateRec2 = oncHistoryDetailDao.get(recId2).orElseThrow();
+            Assert.assertEquals("5", updateRec2.getColumnValues().get("destruction_policy"));
+            OncHistoryDetailDto updateRec3 = oncHistoryDetailDao.get(recId3).orElseThrow();
+            Assert.assertEquals("3", updateRec3.getColumnValues().get("destruction_policy"));
         } catch (Exception e) {
             Assert.fail("Unexpected exception" + e.toString());
             e.printStackTrace();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -68,18 +68,18 @@ public class OncHistoryDetailTest extends DbTxnBaseTest {
         OncHistoryDetailDaoImpl oncHistoryDetailDao = new OncHistoryDetailDaoImpl();
         try {
             OncHistoryDetail rec1 = builder.build();
-            recId1 = OncHistoryDetail.creatOncHistoryDetail(rec1);
+            recId1 = OncHistoryDetail.createOncHistoryDetail(rec1);
 
             builder.withDestructionPolicy("3");
             OncHistoryDetail rec2 = builder.build();
-            recId2 = OncHistoryDetail.creatOncHistoryDetail(rec2);
+            recId2 = OncHistoryDetail.createOncHistoryDetail(rec2);
 
             builder.withFacility("Other office");
             OncHistoryDetail rec3 = builder.build();
-            recId3 = OncHistoryDetail.creatOncHistoryDetail(rec3);
+            recId3 = OncHistoryDetail.createOncHistoryDetail(rec3);
 
             // update and verify
-            OncHistoryDetail.updateDestructionPolicy("5", "Office", TEST_USER);
+            OncHistoryDetail.updateDestructionPolicy("5", "Office", ddpInstanceDto.getInstanceName(), TEST_USER);
 
             OncHistoryDetailDto updateRec1 = oncHistoryDetailDao.get(recId1).orElseThrow();
             Assert.assertEquals("5", updateRec1.getColumnValues().get("destruction_policy"));
@@ -88,8 +88,8 @@ public class OncHistoryDetailTest extends DbTxnBaseTest {
             OncHistoryDetailDto updateRec3 = oncHistoryDetailDao.get(recId3).orElseThrow();
             Assert.assertEquals("3", updateRec3.getColumnValues().get("destruction_policy"));
         } catch (Exception e) {
-            Assert.fail("Unexpected exception" + e.toString());
             e.printStackTrace();
+            Assert.fail("Unexpected exception" + e);
         } finally {
             if (recId1 != -1) {
                 oncHistoryDetailDao.delete(recId1);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
@@ -19,7 +19,7 @@ public class BaseCollectionMigratorTest {
         baseCollectionMigrator.transformObject(mockOncHistoryDetail());
         Map<String, Object> objectMap = baseCollectionMigrator.transformedList.get(0);
         Object primaryId = objectMap.get("oncHistoryDetailId");
-        Assert.assertEquals(23L, primaryId);
+        Assert.assertEquals(23, primaryId);
 
         baseCollectionMigrator.transformObject(mockTissues());
         Map<String, Object> stringObjectMap = baseCollectionMigrator.transformedList.get(0);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/BaseCollectionMigratorTest.java
@@ -29,7 +29,7 @@ public class BaseCollectionMigratorTest {
 
     private List mockOncHistoryDetail() {
         OncHistoryDetail oncHistoryDetail =
-                new OncHistoryDetail(23L, 0L, null, null, null, null, null, null, null, null, null, null, null, null, null,
+                new OncHistoryDetail(23, 0, null, null, null, null, null, null, null, null, null, null, null, null, null,
                         null, null, null, null, null, null, null, null, null, mockTissues(), null, null, false, null, null, 0);
         return Collections.singletonList(oncHistoryDetail);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/route/RouteUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/route/RouteUtilTest.java
@@ -1,0 +1,31 @@
+package org.broadinstitute.dsm.route;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.broadinstitute.dsm.util.UserUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import spark.QueryParamsMap;
+
+public class RouteUtilTest {
+
+    @Test
+    public void getUserIdTest() {
+        String jsonQueryParams = "{\"queryMap\":{\"userId\":{\"queryMap\":{},\"values\":[\"4\"]},\"realm\":{\"queryMap\":{},"
+                + "\"values\":[\"RGP\"]}}}";
+        QueryParamsMap queryParams = new Gson().fromJson(jsonQueryParams, QueryParamsMap.class);
+        Assert.assertEquals(Integer.toString(4), queryParams.value("userId"));
+        String userId = UserUtil.getUserId(queryParams);
+        Assert.assertEquals("4", userId);
+
+        String payload = "{\"facility\": null,\"policyId\": \"12\",\"userId\": \"4\"}";
+        JsonObject jsonObject = JsonParser.parseString(payload).getAsJsonObject();
+        // wrong way
+        String user = String.valueOf(jsonObject.get("userId"));
+        Assert.assertEquals("\"4\"", user);
+        // correct way
+        user = jsonObject.get("userId").getAsString();
+        Assert.assertEquals("4", user);
+    }
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsm.util;
+
+import java.time.Instant;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import org.broadinstitute.dsm.db.Participant;
+import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDao;
+import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
+
+public class TestParticipantUtil {
+    private static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
+    private static final ParticipantDao participantDao = new ParticipantDao();
+    private static final Gson gson = new Gson();
+
+    public static ParticipantData createParticipantData(String ddpParticipantId, Map<String, String> dataMap,
+                                                        String fieldTypeId, int dppInstanceId, String userEmail) {
+
+        ParticipantData participantData = new ParticipantData.Builder()
+                .withDdpParticipantId(ddpParticipantId)
+                .withDdpInstanceId(dppInstanceId)
+                .withFieldTypeId(fieldTypeId)
+                .withData(gson.toJson(dataMap))
+                .withLastChanged(System.currentTimeMillis())
+                .withChangedBy(userEmail).build();
+
+        participantData.setParticipantDataId(participantDataDao.create(participantData));
+        return participantData;
+    }
+
+    public static String genDDPParticipantId(String baseName) {
+        return String.format("%s_%d", baseName, Instant.now().toEpochMilli());
+    }
+
+    public static void deleteParticipantData(int participantDataId) {
+        if (participantDataId >= 0) {
+            participantDataDao.delete(participantDataId);
+        }
+    }
+
+    public static ParticipantDto createParticipant(String ddpParticipantId, int ddpInstanceId) {
+        ParticipantDto participantDto = new ParticipantDto.Builder(ddpInstanceId, System.currentTimeMillis())
+                .withDdpParticipantId(ddpParticipantId)
+                .withLastVersion(0)
+                .withLastVersionDate("")
+                .withChangedBy("TEST_USER")
+                .build();
+
+        participantDto.setParticipantId(new ParticipantDao().create(participantDto));
+        return participantDto;
+    }
+
+    public static void deleteParticipant(int participantId) {
+        if (participantId >= 0) {
+            participantDao.delete(participantId);
+        }
+    }
+}


### PR DESCRIPTION
PEPPER-635

This feature was broken in a few ways:

1. The request input was not processed properly, leading to a 500 response in all cases.
2. The change was applied to all tenants (data integrity violation).
3. There were no automated tests.

This PR includes the following:

- Replaced InstitutionRoute with new code.
- Added updateDestructionPolicy to OncHistoryDetail.
- Added a createOncHistoryDetail method and a OncHistoryDetail builder. These will be at least useful to create onc history detail tests that are now missing.
- Added OncHistoryDetailTest as the start of writing tests for OncHistoryDetail.
- Added TestParticipantUtil to provide centralized participant management for tests.
- Added RouteUtilTest to demonstrate the central problem described in PEPPER-635.
- Added more methods to RouteUtil, to unify request and response handling and reduce the complexity of router handling code. 
- Updated user admin route handling code to use RouteUtil methods and align with the latest exception handling practices.
- Fixed the data type used in several places for institution ID, medical record ID, and onc history detail ID from long to integer. Long is wrong since it does not align with the date type in the DB (int).
- Improved writeInstitutionIntoDb to use the available participant ID, rather than repeatedly looking it up.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [x] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

