### PR TITLE
Moving DSM emails to the production sendgrid account

### DIFF
--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -101,5 +101,12 @@
             <artifactId>mysql</artifactId>
             <scope>compile</scope>
         </dependency>
+        <!-- sendgrid for email sending -->
+        <dependency>
+            <!-- https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java -->
+            <groupId>com.sendgrid</groupId>
+            <artifactId>sendgrid-java</artifactId>
+        </dependency>
+
     </dependencies>
 </project>

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -106,6 +106,7 @@
             <!-- https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java -->
             <groupId>com.sendgrid</groupId>
             <artifactId>sendgrid-java</artifactId>
+            <version>4.8.1</version>
         </dependency>
 
     </dependencies>

--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/SendGridFactory.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/SendGridFactory.java
@@ -1,0 +1,41 @@
+package org.broadinstitute.ddp.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.sendgrid.Client;
+import com.sendgrid.SendGrid;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpHost;
+import org.apache.http.impl.NoConnectionReuseStrategy;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Central factory for creating {@link SendGrid} instances in
+ * DSM and DSS.
+ */
+@Slf4j
+public class SendGridFactory {
+
+    /**
+     * Creates a new SendGrid instance using the proxy url for
+     * outbound egress if not null.
+     */
+    public static SendGrid createSendGridInstance(String sendGridApiKey, String proxy) {
+        var httpClientBuilder = HttpClients.custom();
+        if (proxy != null && !proxy.isBlank()) {
+            URL proxyUrl;
+            try {
+                proxyUrl = new URL(proxy);
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("proxy needs to be a valid url");
+            }
+            httpClientBuilder.setProxy(new HttpHost(proxyUrl.getHost(), proxyUrl.getPort(), proxyUrl.getProtocol()));
+            httpClientBuilder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+            log.info("Using SendGrid proxy: {}", proxy);
+        }
+        var client = new Client(httpClientBuilder.build());
+        return new SendGrid(sendGridApiKey, client);
+    }
+
+}

--- a/pepper-apis/dsm-core/pom.xml
+++ b/pepper-apis/dsm-core/pom.xml
@@ -255,16 +255,6 @@
             <artifactId>google-analytics-java</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sendgrid</groupId>
-            <artifactId>sendgrid-java</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
             <version>2.4.11</version>

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/ApplicationConfigConstants.java
@@ -71,6 +71,10 @@ public class ApplicationConfigConstants {
     public static final String EMAIL_FRONTEND_URL_FOR_LINKS = "email.frontendUrl";
     public static final String EMAIL_GP_RECIPIENT = "email.gp_recipient";
     public static final String EMAIL_KEY = "email.key";
+    /**
+     * proxy url that should be used when sending sendgrid API requests
+     */
+    public static final String EMAIL_PROXY_URL = "email.proxyUrl";
     public static final String EMAIL_CLIENT_SETTINGS = "email.clientSettings";
     public static final String EMAIL_NOTIFICATIONS = "email.notifications";
     public static final String EMAIL_REMINDER_NOTIFICATIONS = "email.reminderNotifications";

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/NotificationUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/NotificationUtil.java
@@ -11,10 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import com.typesafe.config.Config;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
@@ -83,8 +80,8 @@ public class NotificationUtil {
     public synchronized void startup(@NonNull Config config) {
         emailKey = config.getString(ApplicationConfigConstants.EMAIL_KEY);
         emailProxyUrl = config.getString(ApplicationConfigConstants.EMAIL_PROXY_URL);
-        JsonObject senderInfo = (JsonObject) (new JsonParser().parse(config.getString(ApplicationConfigConstants.EMAIL_CLIENT_SETTINGS)));
-        emailSender = new EmailSender(senderInfo.get("sendGridFrom").getAsString(), senderInfo.get("sendGridFromName").getAsString());
+
+        new Gson().fromJson(config.getString(ApplicationConfigConstants.EMAIL_CLIENT_SETTINGS), EmailSender.class);
         logger.info("Will send email from " + emailSender.getFromEmailAddress() + " " + emailSender.getFromName());
 
         JsonArray array = (JsonArray) (new JsonParser().parse(config.getString(ApplicationConfigConstants.EMAIL_NOTIFICATIONS)));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/NotificationUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/NotificationUtil.java
@@ -208,11 +208,7 @@ public class NotificationUtil {
         emailRecipient.setPersonalization(mapy);
         try {
             SendGridClient sendGridClient = new SendGridClient(SendGridFactory.createSendGridInstance(emailKey, emailProxyUrl));
-            JsonObject emailClientSettings = new JsonObject();
-            emailClientSettings.addProperty("sendGridFrom", from);
-            emailClientSettings.addProperty("sendGridFromName", name);
-            sendGridClient.sendSingleEmail(sendGridTemplate, emailRecipient,
-                    new EmailSender(from, name));
+            sendGridClient.sendSingleEmail(sendGridTemplate, emailRecipient, new EmailSender(from, name));
         } catch (Exception ex) {
             logger.error("An error occurred trying to send abstraction expert question.", ex);
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/EmailSender.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/EmailSender.java
@@ -1,12 +1,18 @@
 package org.broadinstitute.lddp.email;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * Simple tuple class that keeps track of
  * information about the sender of an email
  * when using sendgrid.
  */
 public class EmailSender {
+
+    @SerializedName("sendGridFrom")
     private String fromEmailAddress;
+
+    @SerializedName("sendGridFromName")
     private String fromName;
 
     public EmailSender(String fromEmailAddress, String fromName) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/EmailSender.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/EmailSender.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.lddp.email;
+
+/**
+ * Simple tuple class that keeps track of
+ * information about the sender of an email
+ * when using sendgrid.
+ */
+public class EmailSender {
+    private String fromEmailAddress;
+    private String fromName;
+
+    public EmailSender(String fromEmailAddress, String fromName) {
+        this.fromEmailAddress = fromEmailAddress;
+        this.fromName = fromName;
+    }
+
+    public String getFromEmailAddress() {
+        return fromEmailAddress;
+    }
+
+    public String getFromName() {
+        return fromName;
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/SendGridClient.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/lddp/email/SendGridClient.java
@@ -20,29 +20,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Used for integrating with SendGrid...
+ * SendGridClient is a legacy wrapper for using SendGrid, carried over from
+ * the legacy DDP repo, and used exclusively by DSM.
  */
 public class SendGridClient {
 
     private static final Logger logger = LoggerFactory.getLogger(SendGridClient.class);
 
     private static final String LOG_PREFIX = "SendGrid";
+    private final SendGrid sendGrid;
 
-    private String sendGridKey;
-    private JsonObject settings = null;
-
-    public void configure(String sendGridKey, JsonObject settings) {
-        this.sendGridKey = sendGridKey;
-        this.settings = settings;
+    public SendGridClient(SendGrid sendGrid) {
+        this.sendGrid = sendGrid;
     }
 
     /**
      * Used to send emails using SendGrid templates.
      */
-    public void sendSingleEmail(@NonNull String sendGridTemplate, @NonNull Recipient recipient) {
+    public void sendSingleEmail(@NonNull String sendGridTemplate, @NonNull Recipient recipient, JsonObject settings) {
         ArrayList<Recipient> recipientList = new ArrayList<>();
         recipientList.add(recipient);
-        sendEmail(sendGridTemplate, recipientList);
+        sendEmail(sendGridTemplate, recipientList, settings);
     }
 
     /**
@@ -51,13 +49,13 @@ public class SendGridClient {
      * Probably best/safest to use that for marketing campaigns that are sent immediately and would require lots of calls to
      * SendGrid otherwise.
      */
-    private void sendEmail(@NonNull String sendGridTemplate, @NonNull Collection<Recipient> recipientList) {
+    private void sendEmail(@NonNull String sendGridTemplate, @NonNull Collection<Recipient> recipientList,
+                           JsonObject settings) {
         try {
             if (recipientList.size() == 0) {
                 throw new IllegalArgumentException("RecipientList cannot be empty.");
             }
-            SendGrid sendGrid = new SendGrid(sendGridKey);
-            sendRequestUsingTemplate((Recipient) (recipientList.toArray())[0], sendGridTemplate, sendGrid);
+            sendRequestUsingTemplate((Recipient) (recipientList.toArray())[0], sendGridTemplate, sendGrid, settings);
         } catch (Exception ex) {
             throw new NotificationSentException("An error occurred trying to send emails. " + ex.getMessage());
         }
@@ -67,10 +65,11 @@ public class SendGridClient {
     /**
      * Sends a request per recipient to SendGrid.
      */
-    private void sendRequestUsingTemplate(@NonNull Recipient recipient, @NonNull String sendGridTemplate, @NonNull SendGrid sendGrid)
+    private void sendRequestUsingTemplate(@NonNull Recipient recipient, @NonNull String sendGridTemplate,
+                                          @NonNull SendGrid sendGrid, JsonObject settings)
             throws Exception {
         logger.info(LOG_PREFIX + " - About to send 1 email request for " + sendGridTemplate + "...");
-        Mail mail = configureTemplateEmail(sendGridTemplate, recipient);
+        Mail mail = configureTemplateEmail(sendGridTemplate, recipient, settings);
         send(sendGrid, mail);
     }
 
@@ -91,7 +90,7 @@ public class SendGridClient {
         return sendGridPersonalization;
     }
 
-    private Mail configureTemplateEmail(@NonNull String template, Recipient recipient) {
+    private Mail configureTemplateEmail(@NonNull String template, Recipient recipient, JsonObject settings) {
         Personalization sendGridPersonalization = addToHeader(recipient);
 
         Email fromEmail = new Email(settings.get("sendGridFrom").getAsString(), settings.get("sendGridFromName").getAsString());

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/NotificationJobTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/NotificationJobTest.java
@@ -5,8 +5,8 @@ import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+
+import org.broadinstitute.ddp.util.SendGridFactory;
 import org.broadinstitute.dsm.jobs.GPNotificationJob;
 import org.broadinstitute.dsm.model.KitDDPSummary;
 import org.broadinstitute.dsm.util.DBTestUtil;
@@ -133,12 +133,8 @@ public class NotificationJobTest extends TestHelper {
     }
 
     @Test
-    @Ignore("Throws that error when run at ALL Tests, not if run alone! Caused by: java.security.cert.CertificateException: "
-            + "No X509TrustManager implementation available")
     public void testSendSingleEmail() throws Exception {
         String emailClientKey = cfg.getString("errorAlert.key");
-        JsonObject emailClientSettings = (JsonObject) ((new JsonParser()).parse(cfg.getString("errorAlert.clientSettings")));
-        SendGridClient sendGridClient = new SendGridClient();
-        sendGridClient.configure(emailClientKey, emailClientSettings);
+        SendGridClient sendGridClient = new SendGridClient(SendGridFactory.createSendGridInstance(emailClientKey, null));
     }
 }

--- a/pepper-apis/dss-core/pom.xml
+++ b/pepper-apis/dss-core/pom.xml
@@ -91,13 +91,6 @@
 
         </dependency>
 
-        <!-- sendgrid for email sending -->
-        <dependency>
-            <!-- https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java -->
-            <groupId>com.sendgrid</groupId>
-            <artifactId>sendgrid-java</artifactId>
-        </dependency>
-
         <dependency>
             <!-- simplifies making http calls to other systems -->
             <groupId>org.apache.httpcomponents</groupId>

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/SendGridMailUtil.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/util/SendGridMailUtil.java
@@ -1,11 +1,8 @@
 package org.broadinstitute.ddp.util;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 
-import com.sendgrid.Client;
 import com.sendgrid.helpers.mail.objects.Email;
 import com.sendgrid.helpers.mail.Mail;
 import com.sendgrid.Method;
@@ -14,10 +11,7 @@ import com.sendgrid.Request;
 import com.sendgrid.Response;
 import com.sendgrid.SendGrid;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
-import org.apache.http.impl.NoConnectionReuseStrategy;
-import org.apache.http.impl.client.HttpClients;
 
 /**
  * A little util class to make it more convenient to send a SendGrid email message
@@ -78,7 +72,7 @@ public class SendGridMailUtil {
             throw new RuntimeException(msg, e);
         }
 
-        SendGrid sendGrid = createSendGridInstance(sendGridApiKey, proxy);
+        SendGrid sendGrid = SendGridFactory.createSendGridInstance(sendGridApiKey, proxy);
         Response response;
         try {
             response = sendGrid.api(request);
@@ -95,22 +89,5 @@ public class SendGridMailUtil {
         } else {
             log.info("Successfully submitted message to SendGrid with subject {}", mailMessage.subject);
         }
-    }
-
-    private static SendGrid createSendGridInstance(String sendGridApiKey, String proxy) {
-        var httpClientBuilder = HttpClients.custom();
-        if (proxy != null && !proxy.isBlank()) {
-            URL proxyUrl;
-            try {
-                proxyUrl = new URL(proxy);
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException("proxy needs to be a valid url");
-            }
-            httpClientBuilder.setProxy(new HttpHost(proxyUrl.getHost(), proxyUrl.getPort(), proxyUrl.getProtocol()));
-            httpClientBuilder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
-            log.info("Using SendGrid proxy: {}", proxy);
-        }
-        var client = new Client(httpClientBuilder.build());
-        return new SendGrid(sendGridApiKey, client);
     }
 }

--- a/pepper-apis/parent-pom.xml
+++ b/pepper-apis/parent-pom.xml
@@ -111,14 +111,6 @@
 
         </dependency>
 
-        <!-- sendgrid for email sending -->
-        <dependency>
-            <!-- https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java -->
-            <groupId>com.sendgrid</groupId>
-            <artifactId>sendgrid-java</artifactId>
-            <version>4.8.1</version>
-        </dependency>
-
         <dependency>
             <!-- simplifies making http calls to other systems -->
             <groupId>org.apache.httpcomponents</groupId>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -191,14 +191,6 @@
                 <version>2.3.0</version>
             </dependency>
 
-            <!-- sendgrid for email sending -->
-            <dependency>
-                <!-- https://mvnrepository.com/artifact/com.sendgrid/sendgrid-java -->
-                <groupId>com.sendgrid</groupId>
-                <artifactId>sendgrid-java</artifactId>
-                <version>4.7.1</version>
-            </dependency>
-
             <dependency>
                 <!-- simplifies making http calls to other systems -->
                 <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
PEPPER-784 Centralized some sendgrid-related code so that DSM can use the egress proxy as part of switching to the production sendgrid account.

DSM uses sendgrid utilities that are left over from the LDDP days, and were not aware of the egress proxy that we use as part of our IP allow list in production.  The main change here is the creation of `SendGridFactory`, a simple factory that creates `SendGrid` instances that are proxy-aware.  Most of the code in this class was factored out of DSS's `SendGridMailUtil`.

DSM is still relying on the `SendGridClient` class, which is the main holdover from LDDP.  This class had some state management complexity that required callers to set state and then queue emails.  I've removed this rules-of-use type code and replaced it with parameters to existing methods.


## FUD Score

_Overall, how are you feeling about these changes?_

- [ x] :sweat_smile: There might be some issues here

## How do we demo these changes?

@pegahtah I'll need some help with exercising these changes, maybe adjusting some quartz jobs and getting data into the right state in DSM for it to send us emails in non-prod.

## Testing

@ssettipalli we'll want to turn on email sending briefly to verify that DSS is sending emails properly with these changes. 

## Release

In addition to the code here, we will need to change the sendgrid API key in DSM secret manager, and update the template ids as per [this sheet](https://docs.google.com/spreadsheets/d/1rx0W6KNmNoS2ab8P2KLbKAji7B6gAanhJ9D0Mn9CHmU/edit#gid=0) that shows the current template ids in dev and the new template ids in prod.

