### PR TITLE
[DSM] Fix for Mercury's long status message breaking while ES update

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/MercuryOrderDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/MercuryOrderDao.java
@@ -89,6 +89,7 @@ public class MercuryOrderDao implements Dao<MercuryOrderDto> {
                 int result = stmt.executeUpdate();
                 if (result != 0) {
                     log.info("Updated Mercury status for order id " + mercuryStatusMessage.getOrderID());
+                    baseMercuryStatusMessage.getStatus().setDetails(statusDetail);
                     if (baseMercuryStatusMessage.getStatus().getOrderStatus().equals(FAILED)) {
                         log.error(String.format("Mercury rejected the sequencing order %s with order number %s",
                                 baseMercuryStatusMessage.getStatus().getJson(), baseMercuryStatusMessage.getStatus().getOrderID()));


### PR DESCRIPTION
Kiara caught this bug that when the code chooses to only update the database with the first 2000 characters in the details it is not reflected in the ES upsert. That's because the string we use in update is not changed in the original baseMercuryStatusMessage object and we still use the original object to upsert.