### PR TITLE
Add elastic search update for destruction policy change

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.db;
 
 import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
+import static org.broadinstitute.dsm.statics.ESObjectConstants.ONC_HISTORY_DETAIL;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -19,18 +20,25 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
 import lombok.NonNull;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.structure.ColumnName;
 import org.broadinstitute.dsm.db.structure.DbDateConversion;
 import org.broadinstitute.dsm.db.structure.SqlDateConverter;
 import org.broadinstitute.dsm.db.structure.TableName;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.model.elastic.export.painless.UpsertPainless;
 import org.broadinstitute.dsm.model.filter.postfilter.HasDdpInstanceId;
+import org.broadinstitute.dsm.service.onchistory.OncHistoryElasticUpdater;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.statics.QueryExtension;
 import org.broadinstitute.dsm.util.DBUtil;
 import org.broadinstitute.dsm.util.MedicalRecordUtil;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 import org.broadinstitute.lddp.db.SimpleResult;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -107,9 +115,8 @@ public class OncHistoryDetail implements HasDdpInstanceId {
                     + "LEFT JOIN ddp_medical_record med ON med.medical_record_id = onc.medical_record_id "
                     + "LEFT JOIN ddp_institution di ON di.institution_id = med.institution_id "
                     + "LEFT JOIN ddp_participant dp ON dp.participant_id = di.participant_id "
-                    + "LEFT JOIN ddp_instance instance ON dp.ddp_instance_id = instance.ddp_instance_id "
                     + "SET onc.destruction_policy = ?, onc.last_changed = ?, onc.changed_by = ? "
-                    + "WHERE onc.facility = ? AND instance.instance_name = ?";
+                    + "WHERE onc.facility = ? AND dp.ddp_instance_id = ?";
 
     @ColumnName(DBConstants.ONC_HISTORY_DETAIL_ID)
     private int oncHistoryDetailId;
@@ -547,20 +554,47 @@ public class OncHistoryDetail implements HasDdpInstanceId {
         return mrId.intValue();
     }
 
+    // TODO temporary hack until we have an ES test container working -DC
     public static void updateDestructionPolicy(@NonNull String policy, @NonNull String facility, @NonNull String realm,
                                                @NonNull String user) {
-        inTransaction(conn -> {
+        updateDestructionPolicy(policy, facility, realm, user, true);
+    }
+
+    protected static void updateDestructionPolicy(@NonNull String policy, @NonNull String facility, @NonNull String realm,
+                                                  @NonNull String user, boolean updateEs) {
+
+        DDPInstanceDto ddpInstance = DDPInstanceDao.of().getDDPInstanceByInstanceName(realm).orElseThrow(() ->
+                new DSMBadRequestException("Invalid realm : " + realm));
+
+        int updateCnt = inTransaction(conn -> {
             try (PreparedStatement stmt = conn.prepareStatement(SQL_UPDATE_DESTRUCTION_POLICY)) {
                 stmt.setString(1, policy);
                 stmt.setString(2, String.valueOf(System.currentTimeMillis()));
                 stmt.setString(3, user);
                 stmt.setString(4, facility);
-                stmt.setString(5, realm);
+                stmt.setInt(5, ddpInstance.getDdpInstanceId());
                 return stmt.executeUpdate();
             } catch (SQLException e) {
                 throw new DsmInternalError("Error updating destruction policy for facility " + facility, e);
             }
         });
+
+        if (updateEs && updateCnt > 0) {
+            String index = ddpInstance.getEsParticipantIndex();
+            Map<String, Object> source = new HashMap<>();
+            String scriptText = String.format("ctx._source.dsm.oncHistoryDetail.destructionPolicy = %s);", policy);
+            BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
+            queryBuilder.must(QueryBuilders.termsQuery("dsm.oncHistoryDetail.facility", facility));
+
+            try {
+                UpsertPainless upsert = new UpsertPainless(null, index, null, queryBuilder);
+                upsert.export(scriptText, source, "destructionPolicy");
+            } catch (Exception e) {
+                String msg = String.format("Error updating ElasticSearch oncHistoryDetail destruction policy for index %s, "
+                                + "facility=%s, policy=%s", index, facility, policy);
+                throw new DsmInternalError(msg, e);
+            }
+        }
     }
 
     // Note: this builder is not complete, add fields as needed

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -79,7 +79,7 @@ public class OncHistoryDetailTest extends DbTxnBaseTest {
             recId3 = OncHistoryDetail.createOncHistoryDetail(rec3);
 
             // update and verify
-            OncHistoryDetail.updateDestructionPolicy("5", "Office", ddpInstanceDto.getInstanceName(), TEST_USER);
+            OncHistoryDetail.updateDestructionPolicy("5", "Office", ddpInstanceDto.getInstanceName(), TEST_USER, false);
 
             OncHistoryDetailDto updateRec1 = oncHistoryDetailDao.get(recId1).orElseThrow();
             Assert.assertEquals("5", updateRec1.getColumnValues().get("destruction_policy"));


### PR DESCRIPTION
## Context

PEPPER-635

This PR adds Elasticsearch updating when updating the destruction policy for all facilities in a realm. I have no idea how this feature worked before since there was no ES update in the prior code (and it was unclear if the DB code was correct).

I verified this change with JUnit tests using an ES test container. The code changes to support ES test containers are larger than we want to take on at this point late in the release cycle, so those will be submitted under a separate PR aimed at the next sprint.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

