### PR TITLE
PEPPER-1151 . remove slack appender config entries

### DIFF
--- a/pepper-apis/config/application.conf.ctmpl
+++ b/pepper-apis/config/application.conf.ctmpl
@@ -44,8 +44,8 @@
     {{end}}
 	},
     "slack": {
-        "hook": "{{$slack.hook}}",
-        "channel": "{{$slack.channel}}",
+        "hook": "",
+        "channel": "",
         "queueSize": 10,
         "intervalInMillis": 60000
     },


### PR DESCRIPTION
PEPPER-1151
SlackAppender code in DSS is causing issue for Housekeeping . 
Deprecate it 
quick fix is by removing the config entries for slack
Long term, we will do more investigation and remove the custom code as well. 
Have GCP hooks to sent errors to email/slack channels

This PR does not cover DSM 
For DSM, looks like we can remove the slack {} entries from ALL env: secret-manager and that should skip the SlackAppender error notifications