### PR TITLE
Use medicalRecord as source for ddpInstanceId

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/OncHistoryDetail.java
@@ -587,8 +587,8 @@ public class OncHistoryDetail implements HasDdpInstanceId {
                     + "{if (a.facility == '%s') {a.destructionPolicy = '%s';}}", facility, policy);
             BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
             int instanceId = ddpInstance.getDdpInstanceId();
-            MatchQueryBuilder qb = new MatchQueryBuilder("dsm.oncHistoryDetail.ddpInstanceId", instanceId);
-            queryBuilder.must(QueryBuilders.nestedQuery("dsm.oncHistoryDetail", qb, ScoreMode.None));
+            MatchQueryBuilder qb = new MatchQueryBuilder("dsm.medicalRecord.ddpInstanceId", instanceId);
+            queryBuilder.must(QueryBuilders.nestedQuery("dsm.medicalRecord", qb, ScoreMode.None));
 
             try {
                 UpsertPainless upsert = new UpsertPainless(null, index, null, queryBuilder);


### PR DESCRIPTION
## Context

PEPPER-635

When updating ES for changes to destruction policy for a particular facility across an entire realm, we were using the `ddpInstanceId` found in `oncHistoryDetail`. Unfortunately that field is not set for all participants, so updates would not be made for participants lacking an `ddpInstanceId` in their `oncHistoryDetail`

This PR changes the source of `ddpInstanceId` to `medicalRecord`, which is set consistently in the studies I sampled. (Participants must have a `medicalRecord` to have a `oncHistoryDetail`.

I verified this code with an JUnit test written using Elastic test containers. That test technique is not yet ready for merging with develop, so the test is not included in this PR.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [x] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

