### PR TITLE
PEPPER-784 moved email.notifications to secret manager

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -241,6 +241,11 @@ public class DSMServer {
                 File vaultConfigInDeployDir = new File(GAE_DEPLOY_DIR, VAULT_CONF);
                 File vaultConfig = vaultConfigInCwd.exists() ? vaultConfigInCwd : vaultConfigInDeployDir;
                 logger.info("Reading config values from {}", vaultConfig.getAbsolutePath());
+
+                if (cfg.hasPath(ApplicationConfigConstants.EMAIL_NOTIFICATIONS)) {
+                    logger.warn("{} should be in environment-specific configuration, not static source code",
+                            ApplicationConfigConstants.EMAIL_NOTIFICATIONS);
+                }
                 cfg = cfg.withFallback(ConfigFactory.parseFile(vaultConfig));
 
                 if (cfg.hasPath(GCP_PATH_TO_SERVICE_ACCOUNT) && StringUtils.isNotBlank(cfg.getString(GCP_PATH_TO_SERVICE_ACCOUNT))) {

--- a/pepper-apis/dsm-core/src/main/resources/application.conf
+++ b/pepper-apis/dsm-core/src/main/resources/application.conf
@@ -1,14 +1,3 @@
-email {
-  notifications: """
-        [{"reason": "PARTICIPANT_ASSIGNED", "sendGridTemplate": "c163e30a-8e5d-4fd0-b239-798554015575", "url": ""},
-        {"reason": "GP_NOTIFICATION", "sendGridTemplate": "3ba8c85f-6448-4cbc-8c2b-49d20003e995", "url": ""},
-        {"reason": "DSM_ABSTRACTION_EXPERT_QUESTION", "sendGridTemplate": "abeb7ed6-5a1f-4222-8516-3352cc0fb155", "url": ""},
-        {"reason": "GP_EXPRESS_NOTIFICATION", "sendGridTemplate": "78da396d-e70e-4850-8bd9-bf9194fd6c38", "url": ""},
-        {"reason": "EXITED_KIT_RECEIVED_NOTIFICATION", "sendGridTemplate": "14cd7b4d-9154-4c49-8e91-eb77ba8a5074", "url": ""},
-        {"reason": "UNIVERSAL_NOTIFICATION_TEMPLATE", "sendGridTemplate": "d7e96a2d-c4d2-4bf0-8fdc-d666560248ec", "url": ""}]
-    """
-}
-
 portal {
     maxConnections: 25,
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/NotificationUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/NotificationUtilTest.java
@@ -2,8 +2,10 @@ package org.broadinstitute.dsm.util;
 
 import static org.junit.Assert.fail;
 
+import com.google.gson.JsonElement;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class NotificationUtilTest {
@@ -14,6 +16,11 @@ public class NotificationUtilTest {
         try {
             var notificationUtil = new NotificationUtil(cfg);
             notificationUtil.initialize(cfg);
+            JsonElement ptpReminder = notificationUtil.getPortalReminderNotifications("PARTICIPANT_REMINDER");
+            Assert.assertEquals("templateId",
+                    ptpReminder.getAsJsonArray().get(0).getAsJsonObject().get("sendGridTemplate").getAsString());
+            String notification = notificationUtil.getTemplate("PARTICIPANT_ASSIGNED");
+            Assert.assertEquals("templateId2", notification);
         } catch (Exception e) {
             fail("Could not start notification util due to " + e.getMessage());
         }

--- a/pepper-apis/dsm-core/src/test/resources/NotificationUtilTest.conf
+++ b/pepper-apis/dsm-core/src/test/resources/NotificationUtilTest.conf
@@ -1,6 +1,9 @@
 email: {
-    reminderNotifications: """[]""",
-    notifications: """[]""",
+    reminderNotifications: """[
+        {"reason":"PARTICIPANT_REMINDER",
+         "reminders":[{"adminRecipient":"test","hours":"100","sendGridTemplate":"templateId"}]}]""",
+    notifications: """[
+        {"reason": "PARTICIPANT_ASSIGNED", "sendGridTemplate": "templateId2", "url": ""}]""",
     key: "fake",
     clientSettings: """{"sendGridFrom":"test@datadonationplatform.org","sendGridFromName":"tester"}"""
 }


### PR DESCRIPTION
Follow-up to PEPPER-784!  Moved `email.notifications` from `application.conf` to secret manager so that different environments can use different notification template ids, instead of having one set of template ids apply to all environments.  Along the way, I expanded `NotificationUtilTest` so that it asserts the proper structure of email templates, although this does not actually verify these changes directly.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ x] :relaxed: All good, business as usual!

## How do we demo these changes?

After deploying these changes, notifications should be sent as per usual, even though the `email.notifications` stanza in `application.conf` is gone.  It will be in secret manager, just like with `reminderNotifications`.

## Testing

The code that does hocon configuration is doing a "merge" of sorts with config files, using a `withFallback` approach that will read `email.notifications` from either SM or `application.conf`.  If `email.notifications` is found in the static config file when `DSMServer` starts, a warning will be logged.

## Release

- [ ] These changes require no special release procedures--just code!
- [x ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

