### PR TITLE
PEPPER-1157 ValueParser fault tolerance

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/parse/BaseParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/parse/BaseParser.java
@@ -62,7 +62,7 @@ public abstract class BaseParser implements Parser {
                 || Integer.class.isAssignableFrom(fieldType);
     }
 
-    protected abstract Object forNumeric(String value);
+    abstract Object forNumeric(String value);
 
     protected abstract Object forBoolean(String value);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/parse/ValueParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/parse/ValueParser.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.model.elastic.export.parse;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 
 public class ValueParser extends BaseParser {
 
@@ -9,12 +10,15 @@ public class ValueParser extends BaseParser {
     public static final String N_A_SYMBOLIC_DATE = "1000-01-01";
 
     @Override
-    protected Object forNumeric(String value) {
+    public Object forNumeric(String value) {
         if (isEmptyOrNullString(value)) {
-            //returning null if numeric value is deleted
             return null;
         }
-        return Long.valueOf(value);
+        if (Double.valueOf(value) % 1 == 0) {
+            return Double.valueOf(value).longValue(); // allows for robust parsing of decimals
+        } else {
+            throw new DsmInternalError(String.format("Could not convert %s to a long", value));
+        }
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/filter/FilterParser.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/filter/FilterParser.java
@@ -36,7 +36,7 @@ public class FilterParser extends ValueParser {
     }
 
     @Override
-    protected Object forNumeric(String value) {
+    public Object forNumeric(String value) {
         return value;
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/ValueParserTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/export/ValueParserTest.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsm.model.elastic.export;
+
+import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.model.elastic.export.parse.ValueParser;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ValueParserTest {
+
+    private static final ValueParser parser = new ValueParser();
+
+    @Test
+    public void testParsingOfDecimalPointZeroToLong() {
+        Long longValue = (Long)parser.forNumeric("13.0");
+        Assert.assertEquals(13L, longValue.longValue());
+    }
+
+    @Test
+    public void testParsingOfDecimalToLong() {
+        String decimal = "13.353535";
+        try {
+            parser.forNumeric(decimal);
+            Assert.fail("Should not be able to parse " + decimal + " into a long");
+        } catch (DsmInternalError e) {
+            Assert.assertTrue(e.getMessage().contains(decimal));
+        }
+    }
+
+    @Test
+    public void testParsingOfIntToLong() {
+        Long longValue = (Long)parser.forNumeric("200");
+        Assert.assertEquals(200L, longValue.longValue());
+    }
+
+    @Test
+    public void testParsingEmptyToNull() {
+        Assert.assertNull(parser.forNumeric(null));
+        Assert.assertNull(parser.forNumeric(""));
+    }
+}


### PR DESCRIPTION
PEPPER-1157 highlights some faulty parsing, the root of which we still do not understand.  This change does not address the root cause, but adds fault tolerance for the case where string'd numbers like `"13"` somehow make it to the parser as `"13.0"`, resulting in stack traces like:

```
java.lang.NumberFormatException: For input string: "13.0"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.base/java.lang.Long.parseLong(Long.java:692)
	at java.base/java.lang.Long.valueOf(Long.java:1144)
	at org.broadinstitute.dsm.model.elastic.export.parse.ValueParser.forNumeric(ValueParser.java:17)
```
I have attempted to reproduce the issue in database free tests by using suspected problematic rows in `ddp_participant_data`, setting breakpoints in various converted and parsing classes to find out how we get from 13 to 13.0 in various exporter/transformer operations, but after a few hours, have not been able to track the root cause so I am proposing this band aid.

With these changes, any decimal that represents a whole number will be parsed into a long without any exceptions.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

Run the DSM export job via pubsub in dev.  Watch as no exceptions for ".0" show up.

## Testing

- [ x] I have written automated positive tests
- [ x] I have written automated negative tests

## Release

- [x ] These changes require no special release procedures--just code!


