### PR TITLE
PEPPER-1212 "add participant" preferred language fix

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRoute.java
@@ -75,6 +75,7 @@ public class GovernedParticipantRegistrationRoute extends ValidatedJsonInputRout
 
             String preferredLanguageCode = payload.getLanguageCode();
             if (preferredLanguageCode == null) {
+                log.info("setting operator: {} preferred language for governed user: {}", operatorUser.getHruid(), governedUser.getHruid());
                 var profileDao = handle.attach(UserProfileDao.class);
                 //try to get Operator/Proxy users preferred language code
                 UserProfile userProfile = profileDao.findProfileByUserGuid(operatorUser.getGuid()).orElse(null);

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRoute.java
@@ -1,8 +1,5 @@
 package org.broadinstitute.ddp.route;
 
-import java.time.ZoneId;
-import java.util.Optional;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -40,6 +37,8 @@ import org.broadinstitute.ddp.util.ValidatedJsonInputRoute;
 import org.jdbi.v3.core.Handle;
 import spark.Request;
 import spark.Response;
+
+import java.time.ZoneId;
 
 
 @Slf4j

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GetActivityInstanceRouteStandaloneTest.java
@@ -158,7 +158,7 @@ public class GetActivityInstanceRouteStandaloneTest extends IntegrationTestSuite
     public static void setup() throws Exception {
         gson = new Gson();
         TransactionWrapper.useTxn(handle -> {
-            testData = TestDataSetupUtil.generateBasicUserTestData(handle);
+            testData = TestDataSetupUtil.generateBasicUserTestData(handle, true);
             token = testData.getTestingUser().getToken();
             userGuid = testData.getUserGuid();
             setupActivityAndInstance(handle);

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRouteStandaloneTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRouteStandaloneTest.java
@@ -1,34 +1,23 @@
 package org.broadinstitute.ddp.route;
 
-import static io.restassured.RestAssured.given;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.pubsub.v1.Publisher;
 import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
+import org.broadinstitute.ddp.cache.LanguageStore;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.DataExportDao;
 import org.broadinstitute.ddp.db.dao.JdbiUser;
 import org.broadinstitute.ddp.db.dao.JdbiUserStudyEnrollment;
+import org.broadinstitute.ddp.db.dao.StudyLanguageDao;
 import org.broadinstitute.ddp.db.dao.UserGovernanceDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.event.publish.pubsub.PubSubPublisherInitializer;
 import org.broadinstitute.ddp.json.GovernedUserRegistrationPayload;
 import org.broadinstitute.ddp.model.governance.Governance;
+import org.broadinstitute.ddp.model.user.UserProfile;
 import org.broadinstitute.ddp.util.ConfigManager;
 import org.broadinstitute.ddp.util.TestDataSetupUtil;
 import org.junit.After;
@@ -37,6 +26,20 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class GovernedParticipantRegistrationRouteStandaloneTest extends IntegrationTestSuite.TestCase {
 
@@ -51,6 +54,11 @@ public class GovernedParticipantRegistrationRouteStandaloneTest extends Integrat
         TransactionWrapper.useTxn(handle -> {
             testData = TestDataSetupUtil.generateBasicUserTestData(handle);
             token = testData.getTestingUser().getToken();
+            //insert study languages
+            StudyLanguageDao studyLanguageDao = handle.attach(StudyLanguageDao.class);
+            studyLanguageDao.insert(testData.getStudyGuid(), "en", "English");
+            studyLanguageDao.insert(testData.getStudyGuid(), "es", "Spanish");
+            studyLanguageDao.setAsDefaultLanguage(testData.getStudyId(), "en");
         });
 
         String endpoint = RouteConstants.API.USER_STUDY_PARTICIPANTS
@@ -105,20 +113,56 @@ public class GovernedParticipantRegistrationRouteStandaloneTest extends Integrat
 
     @Test
     public void createFew() {
-        GovernedUserRegistrationPayload payload1 = new GovernedUserRegistrationPayload("it", "John", "Doe",
+        GovernedUserRegistrationPayload payload1 = new GovernedUserRegistrationPayload("es", "John", "Doe",
                 "Europe/Amsterdam");
         GovernedUserRegistrationPayload payload2 = new GovernedUserRegistrationPayload("en", "Frank", "Johnson",
                 "Europe/Moscow");
+
+        //no payload
+        GovernedUserRegistrationPayload payload3 = new GovernedUserRegistrationPayload(null, null, null, null);
+
         List<String> governedUserGuids = new ArrayList<>();
-        governedUserGuids.add(postRequest(testData.getStudyGuid(), payload1)
+        String governedUser1Guid = postRequest(testData.getStudyGuid(), payload1)
                 .then().assertThat()
                 .statusCode(200)
-                .extract().path("ddpUserGuid"));
+                .extract().path("ddpUserGuid");
+        governedUserGuids.add(governedUser1Guid);
+        //check governed users preferred language
+        UserProfile child1Profile = TransactionWrapper.withTxn(handle ->
+                handle.attach(UserProfileDao.class).findProfileByUserGuid(governedUser1Guid).get());
+        assertTrue("Governed User preferred language does not match",
+                child1Profile.getPreferredLangCode().equals("es"));
 
         governedUserGuids.add(postRequest(testData.getStudyGuid(), payload2)
                 .then().assertThat()
                 .statusCode(200)
                 .extract().path("ddpUserGuid"));
+
+        //update parents preferred language to "es"
+        UserProfile parentProfile = testData.getProfile();
+        UserProfile newProfileES = UserProfile.builder()
+                .userId(parentProfile.getUserId())
+                .firstName(parentProfile.getFirstName())
+                .lastName(parentProfile.getLastName())
+                .birthDate(parentProfile.getBirthDate())
+                .doNotContact(parentProfile.getDoNotContact())
+                .preferredLangCode("es")
+                .preferredLangId(LanguageStore.get("es").getId())
+                .build();
+
+        parentProfile = TransactionWrapper.withTxn(handle ->
+                handle.attach(UserProfileDao.class).updateProfile(newProfileES));
+
+        String governedUserParentLanguageGuid = postRequest(testData.getStudyGuid(), payload3)
+                .then().assertThat()
+                .statusCode(200)
+                .extract().path("ddpUserGuid");
+
+        governedUserGuids.add(governedUserParentLanguageGuid);
+        UserProfile childProfile = TransactionWrapper.withTxn(handle ->
+                handle.attach(UserProfileDao.class).findProfileByUserGuid(governedUserParentLanguageGuid).get());
+        assertTrue("Governed User preferred language doesnt match parent preferred language",
+                childProfile.getPreferredLangCode().equals(parentProfile.getPreferredLangCode()));
 
         userGuidsToDelete.addAll(governedUserGuids);
         List<Governance> governances = TransactionWrapper.withTxn(handle -> handle.attach(UserGovernanceDao.class)

--- a/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRouteStandaloneTest.java
+++ b/pepper-apis/dss-core/src/test/java/org/broadinstitute/ddp/route/GovernedParticipantRegistrationRouteStandaloneTest.java
@@ -119,7 +119,7 @@ public class GovernedParticipantRegistrationRouteStandaloneTest extends Integrat
                 "Europe/Moscow");
 
         //no payload
-        GovernedUserRegistrationPayload payload3 = new GovernedUserRegistrationPayload(null, null, null, null);
+        GovernedUserRegistrationPayload payload3 = new GovernedUserRegistrationPayload(null, null, null, "Europe/Amsterdam");
 
         List<String> governedUserGuids = new ArrayList<>();
         String governedUser1Guid = postRequest(testData.getStudyGuid(), payload1)
@@ -174,7 +174,7 @@ public class GovernedParticipantRegistrationRouteStandaloneTest extends Integrat
         }
         assertTrue("Governed user is not found in the governances list", governedUserGuids.isEmpty());
 
-        verify(mockPublisher, times(2)).publish(any());
+        verify(mockPublisher, times(3)).publish(any());
     }
 
     private Response postRequest(String studyGuid, GovernedUserRegistrationPayload payload) {


### PR DESCRIPTION
## Context

pancan angular "Add Participant" doesn't seem to be setting preferred language and defaulting to study default language.
This PR tries to handle it on DSS backend in those scenarios.
If "Add Participant" request (GovernedParticipantRegistrationRoute) doesnt get payload with preferred language , try to get operator/proxy preferred language and set it. 
If operator doesnt have preferred language/profile, fall back to  study default language.
If front-end passes governed user preferred language, use it.


Alternate solution:
front-end / request caller can pass the preferred language of the governed user. ATCP is doing it

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [x] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

