### PR TITLE
[DSM] PEPPER-1220 fix for RC and Clinical Orders page

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/ClinicalOrderDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/ClinicalOrderDto.java
@@ -13,28 +13,20 @@ import java.sql.SQLException;
 @Getter
 public class ClinicalOrderDto {
 
-    @SerializedName("shortId")
     String shortId;
 
-    @SerializedName("smId")
     String sample;
 
-    @SerializedName("orderId")
     String orderId;
 
-    @SerializedName("orderStatus")
     String orderStatus;
 
-    @SerializedName("orderedAtMillis")
     public long orderDate;
 
-    @SerializedName("statusDateMillis")
     long statusDate;
 
-    @SerializedName("statusDetail")
     String statusDetail;
 
-    @SerializedName("sampleType")
     String sampleType;
 
     int mercurySequencingId;


### PR DESCRIPTION
Because of changes in naming in the json the clinical orders page in frontend was not showing some values., Considering the tests that cover Clinical Orders do not have 100% coverage I am reverting the names of the values in json. 