### PR TITLE
PEPPER-655 Use VPC egress instead of docker

### DIFF
--- a/pepper-apis/config/DataDonationPlatform.yaml.ctmpl
+++ b/pepper-apis/config/DataDonationPlatform.yaml.ctmpl
@@ -22,7 +22,8 @@ basic_scaling:
 {{end}}
 
 vpc_access_connector:
-  name: "projects/broad-ddp-{{$environment}}/locations/us-central1/connectors/appengine-default-connect"
+  name: "projects/broad-ddp-{{$environment}}/locations/us-central1/connectors/appengine-connector"
+  egress_setting: all-traffic
 
 network:
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper

--- a/pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml
+++ b/pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml
@@ -6,7 +6,8 @@ manual_scaling:
   instances: 1
 
 vpc_access_connector:
-  name: "projects/{{project_id}}/locations/us-central1/connectors/appengine-default-connect"
+  name: "projects/broad-ddp-{{$environment}}/locations/us-central1/connectors/appengine-connector"
+  egress_setting: all-traffic
 
 network:
   instance_tag: study-manager


### PR DESCRIPTION
PEPPER-655 is all about replacing our error-prone docker-based egress proxy with off-the-shelf VPC.  The ticket has details for how we set up GCP for egress through a fixed IP.  This PR just changes the egress routing to use the new VPC for all outbound traffic.

My plan is to push this to dev, run the PW tests, monitor traffic into external systems like auth0, sendgrid, elastic to verify that the new egress IP is the source of traffic, and see what we've missed.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

