### PR TITLE
PEPPER-1209 fixing bug introduced when replacing strings with ints 

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/BSPDummyKitDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/BSPDummyKitDao.java
@@ -124,7 +124,7 @@ public class BSPDummyKitDao implements Dao<ClinicalKitDto> {
                 stmt.setString(1, ddpInstanceName);
                 ResultSet rs = stmt.executeQuery();
                 if (rs.next()) {
-                    dbVals.resultValue = rs.getString(DBConstants.ONC_HISTORY_DETAIL_ID);
+                    dbVals.resultValue = rs.getInt(DBConstants.ONC_HISTORY_DETAIL_ID);
                 } else {
                     throw new RuntimeException(
                             "Couldn't find a valid random onc history with accession number in realm " + ddpInstanceName);


### PR DESCRIPTION
In PEPPER-1209, I introduced a bug whereby the `String` returned from a query (which is for an `int` column) was cast into an `Integer`.  The fix is to query the column as an `int`.  This PR fixes the bug (stack trace below).

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
	at org.broadinstitute.dsm.db.dao.kit.BSPDummyKitDao.getRandomOncHistoryIdForStudy(BSPDummyKitDao.java:141)
	at org.broadinstitute.dsm.route.CreateClinicalDummyKitRoute.handle(CreateClinicalDummyKitRoute.java:170)
	at spark.ResponseTransformerRouteImpl$1.handle(ResponseTransformerRouteImpl.java:47)
	at spark.http.matching.Routes.execute(Routes.java:61)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at org.broadinstitute.dsm.jetty.JettyConfig$JettyCustomRemoteAddrHeaderHandler.doHandle(JettyConfig.java:94)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1568)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)
	at org.eclipse.jetty.server.Server.handle(Server.java:503)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:364)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:383)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:882)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1036)
	at java.base/java.lang.Thread.run(Thread.java:829)"
```
