### PR TITLE
PEPPER-655 changing housekeeping to use new VPC for egress

### DIFF
--- a/pepper-apis/config/Housekeeping.yaml.ctmpl
+++ b/pepper-apis/config/Housekeeping.yaml.ctmpl
@@ -5,7 +5,11 @@ runtime: java11
 instance_class: B8
 
 vpc_access_connector:
-  name: "projects/broad-ddp-{{$environment}}/locations/us-central1/connectors/appengine-default-connect"
+  name: "projects/broad-ddp-{{$environment}}/locations/us-central1/connectors/appengine-connector"
+  egress_setting: all-traffic
+
+network:
+  name: managed
 
 manual_scaling:
   instances: 1


### PR DESCRIPTION
PEPPER-655 forgot to make the VPC change for housekeeping deployment.  This PR applies the same changes as DSM and DSS yamls to Housekeeping.