### PR TITLE
PEPPER-1240 Concurrency Bug in DSM Kit Scan Pages

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitFinalScanRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitFinalScanRoute.java
@@ -5,17 +5,19 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitFinalScanUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 
 public class KitFinalScanRoute extends KitStatusChangeRoute {
+
     public KitFinalScanRoute() {
         super(null);
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitFinalScanUseCase kitFinalScanUseCase = new KitFinalScanUseCase(kitPayload, new KitDao());
-        scanResultList.addAll(kitFinalScanUseCase.get());
+        return kitFinalScanUseCase.get();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitInitialScanRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitInitialScanRoute.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitInitialScanUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 
 public class KitInitialScanRoute extends KitStatusChangeRoute {
@@ -14,9 +15,9 @@ public class KitInitialScanRoute extends KitStatusChangeRoute {
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitInitialScanUseCase kitInitialScanUseCase = new KitInitialScanUseCase(kitPayload, new KitDao());
-        scanResultList.addAll(kitInitialScanUseCase.get());
+        return kitInitialScanUseCase.get();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitTrackingScanRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/KitTrackingScanRoute.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitTrackingScanUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 
 public class KitTrackingScanRoute extends KitStatusChangeRoute {
@@ -13,9 +14,9 @@ public class KitTrackingScanRoute extends KitStatusChangeRoute {
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitTrackingScanUseCase kitTrackingScanUseCase = new KitTrackingScanUseCase(kitPayload, new KitDao());
-        scanResultList.addAll(kitTrackingScanUseCase.get());
+        return kitTrackingScanUseCase.get();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/RGPKitFinalScanRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/RGPKitFinalScanRoute.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitFinalScanUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 
 
 public class RGPKitFinalScanRoute  extends KitStatusChangeRoute {
@@ -15,9 +16,9 @@ public class RGPKitFinalScanRoute  extends KitStatusChangeRoute {
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitFinalScanUseCase kitFinalScanUseCase = new KitFinalScanUseCase(kitPayload, new KitDao());
-        scanResultList.addAll(kitFinalScanUseCase.getRGPFinalScan());
+        return kitFinalScanUseCase.getRGPFinalScan();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/ReceivedKitsRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/ReceivedKitsRoute.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.NonNull;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitReceivedUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.util.NotificationUtil;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 
@@ -15,9 +16,9 @@ public class ReceivedKitsRoute extends KitStatusChangeRoute {
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitReceivedUseCase kitReceivedUseCase = new KitReceivedUseCase(kitPayload, new KitDao(), notificationUtil);
-        scanResultList.addAll(kitReceivedUseCase.get());
+        return kitReceivedUseCase.get();
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/SentKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/kit/SentKitRoute.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
 import org.broadinstitute.dsm.model.kit.KitSentUseCase;
+import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 
 public class SentKitRoute extends KitStatusChangeRoute {
@@ -14,9 +15,9 @@ public class SentKitRoute extends KitStatusChangeRoute {
     }
 
     @Override
-    protected void processRequest() {
+    protected List<ScanResult> processRequest(KitPayload kitPayload) {
         KitSentUseCase kitSentUseCase = new KitSentUseCase(kitPayload, new KitDao());
-        scanResultList.addAll(kitSentUseCase.get());
+        return kitSentUseCase.get();
     }
 
     @Override


### PR DESCRIPTION
In PEPPER-1240, we discovered an interesting case where the final scan page for kit "X" returns an error about kit "Y".

Our routes are generally singletons, and they are generally stateless with regard to http request/response values, but `KitStatusChangeRoute` and derived classes used instance variables `kitPayload` and `scanResultList`.  As a result, it was possible that concurrent calls into derived instances of `KitStatusChangeRoute` (which includes 6 kit-related routes) could result in payload and response being overwritten such that the http inputs into one instance would be mixed up with the http inputs to a different instance (and similar with the outputs).

The fix is straightforward: move the stateful instance variables that keep track of request/response information values KitStatusChangeRoute to method params and return values so that concurrent calls don't result in inputs/outputs being overwritten. [ Start your review here to see the primary change to the superclass](https://github.com/broadinstitute/ddp-study-server/pull/2756/files#r1415859897), and then look at changes to each derived class.

![image](https://github.com/broadinstitute/ddp-study-server/assets/1653048/a6b6350a-07e7-493d-aa0e-f7fe953785d5)

