### PR TITLE
Pepper-1241 pecgs pex fix

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PecgsPediatricPexUpdates.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PecgsPediatricPexUpdates.java
@@ -1,0 +1,57 @@
+package org.broadinstitute.ddp.studybuilder.task;
+
+import com.typesafe.config.Config;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.JdbiExpression;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+import java.nio.file.Path;
+import java.util.List;
+
+@Slf4j
+public class PecgsPediatricPexUpdates implements CustomTask {
+
+    public static String AGE_7_GT = "> 7";
+    public static String AGE_7_GTE = ">= 7";
+
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        ///not used
+    }
+
+    @Override
+    public void run(Handle handle) {
+
+        updatePediatricAgePex(handle);
+    }
+
+    public void updatePediatricAgePex(Handle handle) {
+
+        List<Long> matchedExprIds = handle.attach(PecgsPediatricPexUpdates.SqlHelper.class).getAge7Pex();
+        log.info("Matched {} pex expressions" , matchedExprIds.size());
+        JdbiExpression jdbiExpression = handle.attach(JdbiExpression.class);
+        int updatedPexCount = 0;
+        for (Long expressionId : matchedExprIds) {
+            String currentExpr = jdbiExpression.getExpressionById(expressionId);
+            String updatedExpr = currentExpr.replace(AGE_7_GT,  AGE_7_GTE);
+            int udpCount = jdbiExpression.updateById(expressionId, updatedExpr);
+            DBUtils.checkUpdate(1, udpCount);
+            updatedPexCount++;
+            log.info("Updated expressionId  {} with expr text {}. Old expr: {} ", expressionId, updatedExpr, currentExpr);
+        }
+        log.info("Updated {} pex expressions" , updatedPexCount);
+    }
+
+
+    private interface SqlHelper extends SqlObject {
+        @SqlQuery("select expression_id from expression where expression_text like '%> 7%' and "
+                + " (expression_text like '%cmi-lms%' OR expression_text like '%CMI-OSTEO%')")
+        List<Long> getAge7Pex();
+    }
+
+}
+

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PecgsPediatricPexUpdates.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/PecgsPediatricPexUpdates.java
@@ -32,7 +32,7 @@ public class PecgsPediatricPexUpdates implements CustomTask {
     public void updatePediatricAgePex(Handle handle) {
 
         List<Long> matchedExprIds = handle.attach(PecgsPediatricPexUpdates.SqlHelper.class).getAge7Pex();
-        log.info("Matched {} pex expressions" , matchedExprIds.size());
+        log.info("Matched {} pex expressions", matchedExprIds.size());
         JdbiExpression jdbiExpression = handle.attach(JdbiExpression.class);
         int updatedPexCount = 0;
         for (Long expressionId : matchedExprIds) {
@@ -43,7 +43,7 @@ public class PecgsPediatricPexUpdates implements CustomTask {
             updatedPexCount++;
             log.info("Updated expressionId  {} with expr text {}. Old expr: {} ", expressionId, updatedExpr, currentExpr);
         }
-        log.info("Updated {} pex expressions" , updatedPexCount);
+        log.info("Updated {} pex expressions", updatedPexCount);
     }
 
 

--- a/pepper-apis/studybuilder-cli/studies/lms/activities/germline-consent-form-pediatric.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/activities/germline-consent-form-pediatric.conf
@@ -251,7 +251,7 @@
           "blockType": "CONTENT",
           "shownExpr": null,
           "shownExpr": """ user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         },
         {
@@ -279,7 +279,7 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "shownExpr": """ user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         },
         {
@@ -307,7 +307,7 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "shownExpr": """ user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         }
       ]

--- a/pepper-apis/studybuilder-cli/studies/lms/patches/germline-consent-addendum-ped-v2.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/patches/germline-consent-addendum-ped-v2.conf
@@ -109,7 +109,7 @@
       },
       "blockType": "CONTENT",
       "shownExpr": """user.studies["cmi-lms"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
     }
 

--- a/pepper-apis/studybuilder-cli/studies/lms/snippets/somatic-assent-addendum.conf
+++ b/pepper-apis/studybuilder-cli/studies/lms/snippets/somatic-assent-addendum.conf
@@ -33,7 +33,7 @@
       "blockType": "CONTENT"
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -61,7 +61,7 @@
       "blockType": "CONTENT"
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -85,7 +85,7 @@
       "blockType": "CONTENT"
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -151,7 +151,7 @@
       "blockType": "CONTENT",
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -178,13 +178,13 @@
             "stableId": "SOMATIC_ASSENT_ADDENDUM"
           },
           "blockType": "QUESTION",
-          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7"""
+          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7"""
         }
       ],
       "blockType": "GROUP",
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -207,7 +207,7 @@
       "blockType": "CONTENT",
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -230,7 +230,7 @@
       "blockType": "CONTENT",
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
     },
     {
@@ -257,7 +257,7 @@
             "stableId": "ADDENDUM"
           },
           "blockType": "QUESTION",
-          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7"""
+          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7"""
         },
         {
           "titleTemplate": {
@@ -282,13 +282,13 @@
             "variables": []
           },
           "blockType": "CONTENT",
-          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7"""
+          "shownExpr": """operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7"""
         },
       ],
       "blockType": "GROUP",
       "shownExpr": """!(operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") ||
                    operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")) &&
-                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7 &&
+                   operator.studies["cmi-lms"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7 &&
                    user.studies["cmi-lms"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()"""
 
     }

--- a/pepper-apis/studybuilder-cli/studies/osteo/activities/germline-consent-form-pediatric.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/activities/germline-consent-form-pediatric.conf
@@ -251,7 +251,7 @@
           "blockType": "CONTENT",
           "shownExpr": null,
           "shownExpr": """ user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         },
         {
@@ -279,7 +279,7 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "shownExpr": """ user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         },
         {
@@ -307,7 +307,7 @@
           "blockType": "QUESTION",
           "shownExpr": null,
           "shownExpr": """ user.studies["CMI-OSTEO"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
         }
       ]

--- a/pepper-apis/studybuilder-cli/studies/osteo/patches/germline-consent-addendum-ped-v3.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/patches/germline-consent-addendum-ped-v3.conf
@@ -128,7 +128,7 @@
       },
       "blockType": "CONTENT",
       "shownExpr": """user.studies["cmi-osteo"].forms["GERMLINE_CONSENT_ADDENDUM_PEDIATRIC"].questions["ADDENDUM_CONSENT_BOOL_PEDIATRIC"].answers.hasTrue()
-                           && operator.studies["cmi-osteo"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+                           && operator.studies["cmi-osteo"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
                        """
     }
 

--- a/pepper-apis/studybuilder-cli/studies/osteo/snippets/somatic-assent-addendum.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/snippets/somatic-assent-addendum.conf
@@ -32,14 +32,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """

--- a/pepper-apis/studybuilder-cli/studies/osteo/snippets/somatic-assent-addendum.conf
+++ b/pepper-apis/studybuilder-cli/studies/osteo/snippets/somatic-assent-addendum.conf
@@ -75,14 +75,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -113,14 +113,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -192,14 +192,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -239,14 +239,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -276,14 +276,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -313,14 +313,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """
@@ -385,14 +385,14 @@
             operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && operator.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         ) || (
           user.studies["CMI-OSTEO"].forms["PREQUAL"].hasInstance()
           && !(
             user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_COUNTRY"].answers.hasOption("CA") 
             || user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_STATE"].answers.hasOption("NY")
           ) 
-          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() > 7
+          && user.studies["CMI-OSTEO"].forms["PREQUAL"].questions["CHILD_CURRENT_AGE"].answers.value() >= 7
         )) 
         && user.studies["CMI-OSTEO"].forms["CONSENT_ASSENT"].questions["CONSENT_ASSENT_TISSUE"].answers.hasTrue()
       """


### PR DESCRIPTION
update osteo and lms pediatric pex expressions to be >= 7 rather than > 7  related expressions will enable questions like pediatric participant signature in somatic-consent-addendum and germline-consent-addendum activities

osteo and lms study config files are NOT used by the patch, PecgsPediatricPexUpdates.java. 
They were updated just to keep in sync.

