### PR TITLE
Reducing chattiness of housekeeping logs.

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/AgeUpService.java
@@ -73,10 +73,10 @@ public class AgeUpService {
             String userGuid = candidate.getParticipantUserGuid();
             String operatorGuid = candidate.getOperatorUserGuid();
             if (candidate.getBirthDate() == null) {
-                log.info("Age-up candidate with guid {} in study {} does not have birth date, skipping", userGuid, studyGuid);
+                log.debug("Age-up candidate with guid {} in study {} does not have birth date, skipping", userGuid, studyGuid);
                 continue;
             } else if (candidate.getStatus().isExited()) {
-                log.info("Age-up candidate with guid {} has exited study {}, will be removed", userGuid, studyGuid);
+                log.debug("Age-up candidate with guid {} has exited study {}, will be removed", userGuid, studyGuid);
                 exitedCandidates.add(candidate.getId());
                 continue;
             }
@@ -89,7 +89,7 @@ public class AgeUpService {
                 continue;
             }
             if (rule == null) {
-                log.warn("No applicable age-of-majority rules found for participant {} in study {}", userGuid, studyGuid);
+                log.debug("No applicable age-of-majority rules found for participant {} in study {}", userGuid, studyGuid);
                 continue;
             }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -124,7 +124,7 @@ public class KitCheckService {
 
         if (candidate.getAddressValidationStatus() == null
                 || candidate.getAddressValidationStatus() == DSM_INVALID_ADDRESS_STATUS) {
-            log.warn("Participant {} has an invalid mailing address", userGuid);
+            log.debug("Participant {} has an invalid mailing address", userGuid);
             return null;
         }
 
@@ -338,7 +338,7 @@ public class KitCheckService {
         }
         if (pending.getAddressValidationStatus() == null
                 || pending.getAddressValidationStatus() == DSM_INVALID_ADDRESS_STATUS) {
-            log.warn("Participant {} has an invalid mailing address", userGuid);
+            log.debug("Participant {} has an invalid mailing address", userGuid);
             return;
         }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/KitCheckService.java
@@ -160,7 +160,7 @@ public class KitCheckService {
         if (wasSuccessful) {
             kitCheckResult.addQueuedParticipantForStudy(studyGuid, candidate.getUserId());
         } else {
-            log.warn("Participant {} was ineligible for a kit", userGuid);
+            log.debug("Participant {} was ineligible for a kit", userGuid);
         }
 
         return kitCheckResult;


### PR DESCRIPTION
## Context
Housekeeping logs are full of noisy entries that aren't useful and make it harder to find items of interest.  These log statements have been moved from `warn` or `info` to `debug`:

```
o.b.ddp.service.KitCheckService Participant ... was ineligible for a kit
 o.b.ddp.service.AgeUpService Age-up candidate with guid ... in study ... does not have birth date, skipping
o.b.ddp.service.KitCheckService Participant ... has an invalid mailing address
 o.b.ddp.service.AgeUpService No applicable age-of-majority rules found for participant .... in study ...
```
