### PR TITLE
PEPPER-1289 fix to handle user preferred language for AOM emails during Ageup process

### DIFF
--- a/pepper-apis/config/pepper-apis-settings.xml
+++ b/pepper-apis/config/pepper-apis-settings.xml
@@ -12,6 +12,7 @@
                 <sonar.projectName>ddp-study-server</sonar.projectName>
                 <sonar.projectKey>broadinstitute_ddp-study-server</sonar.projectKey>
                 <sonar.organization>dsp-appsec</sonar.organization>
+                <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
             </properties>
         </profile>
     </profiles>

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -15,7 +15,6 @@
         <logback.version>1.4.14</logback.version>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.java.binaries>target/classes</sonar.java.binaries>
-        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
         <liquibase.version>4.8.0</liquibase.version>
     </properties>
 

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -15,6 +15,7 @@
         <logback.version>1.4.14</logback.version>
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.java.binaries>target/classes</sonar.java.binaries>
+        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
         <liquibase.version>4.8.0</liquibase.version>
     </properties>
 

--- a/pepper-apis/dss-core/pom.xml
+++ b/pepper-apis/dss-core/pom.xml
@@ -18,6 +18,7 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             target/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
     </properties>
 
     <dependencies>

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/housekeeping/PubSubMessageBuilder.java
@@ -106,6 +106,14 @@ public class PubSubMessageBuilder {
                         if (jmlDtoOpt.isPresent()) {
                             userPreferredLangCode = jmlDtoOpt.get().getLanguageCode();
                         }
+                    } else if (queuedNotificationDto.getParticipantGuid() != null) {
+                        //handle the scenario where Agedup users email is passed in the message during Ageup prep
+                        //try to get user preferred language
+                        UserProfile profile = apisHandle.attach(UserProfileDao.class)
+                                .findProfileByUserGuid(queuedNotificationDto.getParticipantGuid()).orElse(null);
+                        userPreferredLangCode = profile != null ? profile.getPreferredLangCode() : null;
+                        log.info("looked up user preferred language using the participant guid. user preferred lang: {}",
+                                userPreferredLangCode);
                     }
                 } else {
                     // otherwise, lookup address information for the auth0 account
@@ -226,6 +234,9 @@ public class PubSubMessageBuilder {
                     }
                 }
 
+                log.info("Looking up notification template(s) for event configId: {} study: {} and user preferred language={} "
+                                + "for queued event {}", queuedNotificationDto.getEventConfigurationId(),
+                        queuedNotificationDto.getStudyGuid(), queuedNotificationDto.getQueuedEventId());
                 NotificationTemplate template = determineEmailTemplate(
                         apisHandle,
                         queuedNotificationDto.getEventConfigurationId(),


### PR DESCRIPTION
PEPPER-1289 
handle the scenario where Agedup users email is passed in the message during Ageup prep
If the message contains participantGuid, try to get user preferred language
