### PR TITLE
PEPPER-1301 disable sonar from circleci pipeline

### DIFF
--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -891,7 +891,7 @@ jobs:
                 restore_m2_cache: false
                 save_m2_cache: false    #REMOVE WHEN DONE
                 coverage_report: true
-                sonar_scan: true
+                sonar_scan: false
                 sonar_additional_module: 'ddp-common'
             - save-ddp-cache
             - persist_to_workspace:
@@ -936,7 +936,7 @@ jobs:
                 additional_options: '-PDefaultBuild,coverage -Dtest=ServerInSameProcessIntegrationTestSuite'
                 restore_m2_cache: false
                 coverage_report: true
-                sonar_scan: true
+                sonar_scan: false
             - save-ddp-cache
 
   dss-parallel-compile-and-test-job:
@@ -983,7 +983,7 @@ jobs:
                 additional_options: '-PCircleciParallelBuild,coverage -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH -DcachingDisabled=true'
                 save_m2_cache: true
                 coverage_report: true
-                sonar_scan: true
+                sonar_scan: false
             - save-ddp-cache
             - run:
                 name: 'Check node index to save workspace only once'

--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -890,7 +890,7 @@ jobs:
                 additional_options: -PDefaultBuild,coverage -Ddsm.test.excludes='${dsm.test.ci.excludes}'
                 restore_m2_cache: false
                 save_m2_cache: false    #REMOVE WHEN DONE
-                coverage_report: false
+                coverage_report: true
                 sonar_scan: false
                 sonar_additional_module: 'ddp-common'
             - save-ddp-cache
@@ -935,7 +935,7 @@ jobs:
                 skip_checkstyle: true
                 additional_options: '-PDefaultBuild,coverage -Dtest=ServerInSameProcessIntegrationTestSuite'
                 restore_m2_cache: false
-                coverage_report: false
+                coverage_report: true
                 sonar_scan: false
             - save-ddp-cache
 
@@ -982,7 +982,7 @@ jobs:
                 module: dss-core
                 additional_options: '-PCircleciParallelBuild,coverage -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH -DcachingDisabled=true'
                 save_m2_cache: true
-                coverage_report: false
+                coverage_report: true
                 sonar_scan: false
             - save-ddp-cache
             - run:

--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -890,7 +890,7 @@ jobs:
                 additional_options: -PDefaultBuild,coverage -Ddsm.test.excludes='${dsm.test.ci.excludes}'
                 restore_m2_cache: false
                 save_m2_cache: false    #REMOVE WHEN DONE
-                coverage_report: true
+                coverage_report: false
                 sonar_scan: false
                 sonar_additional_module: 'ddp-common'
             - save-ddp-cache
@@ -935,7 +935,7 @@ jobs:
                 skip_checkstyle: true
                 additional_options: '-PDefaultBuild,coverage -Dtest=ServerInSameProcessIntegrationTestSuite'
                 restore_m2_cache: false
-                coverage_report: true
+                coverage_report: false
                 sonar_scan: false
             - save-ddp-cache
 
@@ -982,7 +982,7 @@ jobs:
                 module: dss-core
                 additional_options: '-PCircleciParallelBuild,coverage -Dsurefire.excludesFile=$IGNORE_CLASS_LIST_PATH -DcachingDisabled=true'
                 save_m2_cache: true
-                coverage_report: true
+                coverage_report: false
                 sonar_scan: false
             - save-ddp-cache
             - run:

--- a/pepper-apis/config/pepper-apis-settings.xml
+++ b/pepper-apis/config/pepper-apis-settings.xml
@@ -12,7 +12,6 @@
                 <sonar.projectName>ddp-study-server</sonar.projectName>
                 <sonar.projectKey>broadinstitute_ddp-study-server</sonar.projectKey>
                 <sonar.organization>dsp-appsec</sonar.organization>
-                <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
             </properties>
         </profile>
     </profiles>

--- a/pepper-apis/ddp-common/pom.xml
+++ b/pepper-apis/ddp-common/pom.xml
@@ -16,7 +16,6 @@
         <sonar.sources>src/main/java</sonar.sources>
         <sonar.java.binaries>target/classes</sonar.java.binaries>
         <liquibase.version>4.8.0</liquibase.version>
-        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
     </properties>
 
     <dependencies>

--- a/pepper-apis/dsm-core/pom.xml
+++ b/pepper-apis/dsm-core/pom.xml
@@ -300,6 +300,5 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             target/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
     </properties>
 </project>

--- a/pepper-apis/dss-core/pom.xml
+++ b/pepper-apis/dss-core/pom.xml
@@ -18,7 +18,6 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             target/site/jacoco/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.scanner.force-deprecated-java-version>true</sonar.scanner.force-deprecated-java-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Disable Sonar scan on CircleCI until project Java ver 11 is upgraded because Sonar will stop accepting Java ver 11 soon.

Sonar warning:

```
[WARNING] The version of Java (11.0.15) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17.
```
Ran CI pipeline against this PR branch. No error or warning is found.
https://app.circleci.com/pipelines/github/broadinstitute/ddp-study-server?branch=PEPPER-1301-disable-sonar-circleci

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous


