### PR TITLE
PEPPER-526 Adult Consent

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -68,22 +68,23 @@ public class ElasticSearchParticipantDto {
     /**
      * Changes the value for the given question's answer.
      * Does not make any modification to underlying elastic data.
+     * @return true if the value was changed, false if the activity
+     * and question do not exist.
      */
     @VisibleForTesting
-    public void changeQuestionAnswer(String activityCode, String questionStableId, String value) {
+    public boolean changeQuestionAnswer(String activityCode, String questionStableId, String value) {
         for (Activities activity : getActivities()) {
             if (activity.getActivityCode().equals(activityCode)) {
                 for (Map<String, Object> questionAnswer : activity.getQuestionsAnswers()) {
                     if (questionAnswer.containsKey(questionStableId)) {
                         questionAnswer.replace(ESObjectConstants.ANSWER, value);
                         questionAnswer.replace(questionStableId, value);
-                        return;
+                        return true;
                     }
                 }
             }
         }
-        throw new DsmInternalError(String.format("Could not change answer to %s.%s because question %s was not found "
-                + "in any activities.", activityCode, questionStableId, questionStableId));
+        return false;
     }
 
     public Optional<Address> getAddress() {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
@@ -131,7 +131,6 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         Assert.assertFalse(phiManifestService.isParticipantConsented(ineligibleAdult.getDdpParticipantIdOrThrow(), ddpInstanceDto));
     }
 
-
     @Test
     public void phiReportTest() throws Exception {
         String pdo = "child-report-PDO";
@@ -195,11 +194,26 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
         assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
 
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, "");
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
         mercuryOrderDao.delete(mercuryOrderId);
         lmsOncHistoryTestUtil.deleteOncHistory(childReportGuid, participantDto.getParticipantId().get(), instanceName, userEmail,
                 oncHistoryDetail.getOncHistoryDetailId());
     }
-
 
     private void assertPhiManifest(PhiManifest phiManifest, List<MercuryOrderDto> orders, Tissue tissue,
                                    OncHistoryDetail oncHistoryDetail, ElasticSearchParticipantDto participant) {
@@ -235,5 +249,19 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
                         SOMATIC_ASSENT_ADDENDUM_QUESTION_STABLE_ID));
         Assert.assertTrue(
                 StringUtils.equals(somaticAssentAddendumReportValue, phiManifest.getSomaticAssentAddendumResponse()));
+
+        String os2SomaticConsent = PhiManifestService.convertBooleanActivityAnswerToString(
+                participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
+                        OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
+
+        String lmsConsentTumor = PhiManifestService.convertBooleanActivityAnswerToString(
+                participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
+                        LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
+
+        boolean lmsOrOsConsentForTumorTrue =
+                StringUtils.equals(lmsConsentTumor, phiManifest.getSomaticConsentTumorResponse())
+                || StringUtils.equals(os2SomaticConsent, phiManifest.getSomaticConsentTumorResponse());
+
+        Assert.assertTrue(lmsOrOsConsentForTumorTrue);
     }
 }

--- a/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
+++ b/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
@@ -17,6 +17,12 @@
       "questionType" : "BOOLEAN"
     },
     {
+      "stableId" : "SOMATIC_CONSENT_ADDENDUM_TUMOR",
+      "answer" : true,
+      "SOMATIC_CONSENT_ADDENDUM_TUMOR" : true,
+      "questionType" : "BOOLEAN"
+    },
+    {
     "stableId" : "SOMATIC_SINGATURE_PEDIATRIC",
     "SOMATIC_SINGATURE_PEDIATRIC" : "name",
     "answer" : "name",


### PR DESCRIPTION
Follow-on to https://github.com/broadinstitute/ddp-study-server/pull/2777.  The adult consent field was also being defaulted to "No" even when the participant did not answer the question.

The fix is similar to the other PR.