### PR TITLE
PEPPER-526 Consent Part Deux

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -72,7 +72,7 @@ public class ElasticSearchParticipantDto {
      * and question do not exist.
      */
     @VisibleForTesting
-    public boolean changeQuestionAnswer(String activityCode, String questionStableId, String value) {
+    public boolean changeQuestionAnswer(String activityCode, String questionStableId, Object value) {
         for (Activities activity : getActivities()) {
             if (activity.getActivityCode().equals(activityCode)) {
                 for (Map<String, Object> questionAnswer : activity.getQuestionsAnswers()) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -68,22 +68,23 @@ public class ElasticSearchParticipantDto {
     /**
      * Changes the value for the given question's answer.
      * Does not make any modification to underlying elastic data.
+     * @return true if the value was changed, false if the activity
+     * and question do not exist.
      */
     @VisibleForTesting
-    public void changeQuestionAnswer(String activityCode, String questionStableId, String value) {
+    public boolean changeQuestionAnswer(String activityCode, String questionStableId, String value) {
         for (Activities activity : getActivities()) {
             if (activity.getActivityCode().equals(activityCode)) {
                 for (Map<String, Object> questionAnswer : activity.getQuestionsAnswers()) {
                     if (questionAnswer.containsKey(questionStableId)) {
                         questionAnswer.replace(ESObjectConstants.ANSWER, value);
                         questionAnswer.replace(questionStableId, value);
-                        return;
+                        return true;
                     }
                 }
             }
         }
-        throw new DsmInternalError(String.format("Could not change answer to %s.%s because question %s was not found "
-                + "in any activities.", activityCode, questionStableId, questionStableId));
+        return false;
     }
 
     public Optional<Address> getAddress() {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
@@ -161,14 +161,14 @@ public class PhiManifestService {
         Optional<Object> consentAnswer = getAdultParticipantConsentedToTumorAnswer(participant, ddpInstanceDto.getStudyGuid());
 
         if (consentAnswer.isPresent()) {
-            phiManifest.setSomaticConsentTumorResponse(convertBooleanToYesNo((Boolean)consentAnswer.get()));
+            phiManifest.setSomaticConsentTumorResponse(convertBooleanActivityAnswerToString(consentAnswer));
         } else {
             phiManifest.setSomaticConsentTumorResponse("");
         }
         return phiManifest;
     }
 
-    public static String convertBooleanToYesNo(boolean b) {
+    private static String convertBooleanToYesNo(boolean b) {
         return b ? "Yes" : "No";
     }
 
@@ -178,7 +178,7 @@ public class PhiManifestService {
      */
     public static String convertBooleanActivityAnswerToString(Optional<Object> answer) {
         if (answer.isPresent() && answer.get() instanceof Boolean) {
-            return convertBooleanToYesNo((Boolean) answer.get());
+            return convertBooleanToYesNo((Boolean)answer.get());
         } else {
             if (answer.isPresent()) {
                 return answer.get().toString();
@@ -204,11 +204,11 @@ public class PhiManifestService {
      * If the participant has answered the question, it will be returned
      * as a boolean.  If they have not, an empty optional will be returned.
      */
-    private static Optional<Object> getAdultParticipantConsentedToTumorAnswer(ElasticSearchParticipantDto participant, String studyGuid) {
+    public static Optional<Object> getAdultParticipantConsentedToTumorAnswer(ElasticSearchParticipantDto participant, String studyGuid) {
         if (DBConstants.LMS_STUDY_GUID.equals(studyGuid)) {
-            return participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID);
+            return participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID);
         } else if (DBConstants.OSTEO_STUDY_GUID.equals(studyGuid)) {
-            return participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID);
+            return participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID);
         }
         return Optional.empty();
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
@@ -131,7 +131,6 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         Assert.assertFalse(phiManifestService.isParticipantConsented(ineligibleAdult.getDdpParticipantIdOrThrow(), ddpInstanceDto));
     }
 
-
     @Test
     public void phiReportTest() throws Exception {
         String pdo = "child-report-PDO";
@@ -195,11 +194,26 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
         assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
 
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, "");
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_PEDIATRICS_ACTIVITY_CODE, LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+
         mercuryOrderDao.delete(mercuryOrderId);
         lmsOncHistoryTestUtil.deleteOncHistory(childReportGuid, participantDto.getParticipantId().get(), instanceName, userEmail,
                 oncHistoryDetail.getOncHistoryDetailId());
     }
-
 
     private void assertPhiManifest(PhiManifest phiManifest, List<MercuryOrderDto> orders, Tissue tissue,
                                    OncHistoryDetail oncHistoryDetail, ElasticSearchParticipantDto participant) {
@@ -235,5 +249,19 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
                         SOMATIC_ASSENT_ADDENDUM_QUESTION_STABLE_ID));
         Assert.assertTrue(
                 StringUtils.equals(somaticAssentAddendumReportValue, phiManifest.getSomaticAssentAddendumResponse()));
+
+        String os2SomaticConsent = PhiManifestService.convertBooleanActivityAnswerToString(
+                participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
+                        OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
+
+        String lmsConsentTumor = PhiManifestService.convertBooleanActivityAnswerToString(
+                participant.getParticipantAnswerInSurvey(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
+                        LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
+
+        boolean lmsOrOsConsentForTumorTrue =
+                StringUtils.equals(lmsConsentTumor, phiManifest.getSomaticConsentTumorResponse())
+                || StringUtils.equals(os2SomaticConsent, phiManifest.getSomaticConsentTumorResponse());
+
+        Assert.assertTrue(lmsOrOsConsentForTumorTrue);
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
@@ -201,6 +201,7 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
         assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
 
+        // change the LMS consent tumor to blank/true/false and verify
         participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                 LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
         phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
@@ -208,17 +209,20 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
         Assert.assertEquals("", phiManifest.getSomaticConsentTumorResponse());
 
         participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
-        participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                 LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, true);
         phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
         assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
         Assert.assertEquals("Yes", phiManifest.getSomaticConsentTumorResponse());
 
+        participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
+                LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, false);
+        phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+        assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
+        Assert.assertEquals("No", phiManifest.getSomaticConsentTumorResponse());
+
         try {
             // verify that consent tumor response strings in the report are correct
-            // for adult consent in both LMS and OS.  This requires changing the study guid
-            // in order to exercise the if-osteo, if-lms branching in the code under test.
+            // for adult consent in both OS.
 
             ddpInstanceDto.setStudyGuid(DBConstants.OSTEO_STUDY_GUID);
 
@@ -228,12 +232,6 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
                         CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                         OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
             }
-            if (!participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, "")) {
-                Assert.fail(String.format("%s.%s is missing from the participant's activities.  Is the test json correct?",
-                        CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                        LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID));
-            }
 
             phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
             assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
@@ -241,36 +239,21 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
 
             participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                     OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, false);
-            participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
             phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
             assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
             Assert.assertEquals("No", phiManifest.getSomaticConsentTumorResponse());
 
             participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                     OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, true);
-            participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
             phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
             assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
             Assert.assertEquals("Yes", phiManifest.getSomaticConsentTumorResponse());
 
             participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
                     OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
-            participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
             phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
             assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
             Assert.assertEquals("", phiManifest.getSomaticConsentTumorResponse());
-
-            ddpInstanceDto.setStudyGuid(DBConstants.LMS_STUDY_GUID);
-            participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    OS2_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, null);
-            participant.changeQuestionAnswer(CONSENT_ADDENDUM_ACTIVITY_ACTIVITY_CODE,
-                    LMS_QUESTION_SOMATIC_CONSENT_ADDENDUM_TUMOR_STABLE_ID, false);
-            phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
-            assertPhiManifest(phiManifest, orders, createdTissue, oncHistoryDetail, participant);
-            Assert.assertEquals("No", phiManifest.getSomaticConsentTumorResponse());
 
         } finally {
             // if there's an issue, always reset the study guid to LMS

--- a/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
+++ b/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
@@ -17,6 +17,12 @@
       "questionType" : "BOOLEAN"
     },
     {
+      "stableId" : "SOMATIC_CONSENT_ADDENDUM_TUMOR",
+      "answer" : true,
+      "SOMATIC_CONSENT_ADDENDUM_TUMOR" : true,
+      "questionType" : "BOOLEAN"
+    },
+    {
     "stableId" : "SOMATIC_SINGATURE_PEDIATRIC",
     "SOMATIC_SINGATURE_PEDIATRIC" : "name",
     "answer" : "name",

--- a/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
+++ b/pepper-apis/dsm-core/src/test/resources/elastic/lmsActivitiesSharedLearningEligible.json
@@ -45,6 +45,12 @@
     "questionType" : "BOOLEAN"
     },
     {
+      "stableId" : "SOMATIC_CONSENT_TUMOR",
+      "answer" : true,
+      "SOMATIC_CONSENT_TUMOR" : true,
+      "questionType" : "BOOLEAN"
+    },
+    {
     "stableId" : "SOMATIC_SINGATURE",
     "SOMATIC_SINGATURE" : "signature",
     "answer" : "name",


### PR DESCRIPTION
Continuation of the [original PR](https://github.com/broadinstitute/ddp-study-server/pull/2777).

The PHI manifest was returning "No" instead of blank when there is no value given for CONSENT_ADDENDUM.SOMATIC_CONSENT_ADDENDUM_TUMOR (LMS) or CONSENT_ADDENDUM.SOMATIC_CONSENT_TUMOR (OS).  For pediatrics, these values are not set, so the manifest must render them as blank instead of "No" when they are missing (which is the case when the participant is a pediatric case).