### PR TITLE
PEPPER-526 prevent downloading manifest if consent is not complete

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -227,6 +227,30 @@ public class ElasticSearchParticipantDto {
         }).orElse("U");
     }
 
+    public boolean hasCompletedActivity(String activityCode) {
+        boolean isComplete = false;
+        for (Activities activity : getActivities()) {
+            if (activityCode.equals(activity.getActivityCode())) {
+                isComplete = "COMPLETE".equals(activity.getStatus());
+            }
+        }
+        return isComplete;
+    }
+
+    /**
+     * Changes the status of the given activity, returning true
+     * if the activity was found, and false otherwise.
+     */
+    public boolean changeActivityStatus(String activityCode, String activityStatusCode) {
+        for (Activities activity : getActivities()) {
+            if (activityCode.equals(activity.getActivityCode())) {
+                activity.setStatus(activityStatusCode);
+                return true;
+            }
+        }
+        return false;
+    }
+
     public static class Builder {
         private Address address;
         private List<Object> medicalProviders;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/search/ElasticSearchParticipantDto.java
@@ -241,6 +241,7 @@ public class ElasticSearchParticipantDto {
      * Changes the status of the given activity, returning true
      * if the activity was found, and false otherwise.
      */
+    @VisibleForTesting
     public boolean changeActivityStatus(String activityCode, String activityStatusCode) {
         for (Activities activity : getActivities()) {
             if (activityCode.equals(activity.getActivityCode())) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
@@ -190,7 +190,7 @@ public class PhiManifestService {
     }
 
     public boolean isParticipantConsented(@NonNull ElasticSearchParticipantDto participant, @NonNull DDPInstanceDto ddpInstanceDto) {
-        return (hasParticipantConsentedToSharedLearning(participant, ddpInstanceDto)) && hasParticipantConsentedToTumor(participant);
+        return hasParticipantConsentedToSharedLearning(participant, ddpInstanceDto) && hasParticipantConsentedToTumor(participant);
     }
 
     private boolean hasParticipantConsentedToTumor(ElasticSearchParticipantDto participant) {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
@@ -237,12 +237,18 @@ public class ElasticTestUtil {
         }
     }
 
-    public static Dsm addDsmObjectToParticipantFromFile(String esIndex, String fileName, String ddpParticipantId, String dob) {
+    public static Dsm addDsmObjectToParticipantFromFile(String esIndex, String fileName, String ddpParticipantId,
+                                                        String dob, String dateOfMajority) {
         Gson gson = new Gson();
         String json = null;
         try {
             json = TestUtil.readFile(fileName);
             json = json.replace("<dateOfBirth>", dob);
+            if (StringUtils.isNotBlank(dateOfMajority)) {
+                json = json.replace("<dateOfMajority>", dateOfMajority);
+            } else {
+                json = json.replace("\"dateOfMajority\" : \"<dateOfMajority>\",", "");
+            }
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail("Unexpected exception creating dsm for participant " + ddpParticipantId);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
@@ -68,29 +68,32 @@ public class TestParticipantUtil {
         }
     }
 
-    public static ParticipantDto createSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto, String dob,
-                                                                 String dateOfMajority, String esIndex) {
+    private static ParticipantDto createParticipantFromConfigFiles(String guid, DDPInstanceDto ddpInstanceDto, String dob,
+                                                            String dateOfMajority, String esIndex,
+                                                            String pathToParticipantProfileJson,
+                                                            String pathToDsmDataJson,
+                                                            String pathToActivitiesJson) {
         String ddpParticipantId = genDDPParticipantId(guid);
         ParticipantDto testParticipant = createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
         ElasticTestUtil.createParticipant(esIndex, testParticipant);
-        ElasticTestUtil.addParticipantProfileFromFile(esIndex, "elastic/participantProfile.json", ddpParticipantId);
-        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId,
+        ElasticTestUtil.addParticipantProfileFromFile(esIndex, pathToParticipantProfileJson, ddpParticipantId);
+        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, pathToDsmDataJson, ddpParticipantId,
                 dob, dateOfMajority);
-        ElasticTestUtil.addActivitiesFromFile(esIndex, "elastic/lmsActivitiesSharedLearningEligible.json", ddpParticipantId);
+        ElasticTestUtil.addActivitiesFromFile(esIndex, pathToActivitiesJson, ddpParticipantId);
         log.debug("ES participant record with dob {} for {}: {}", dob, ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         return testParticipant;
     }
 
-    public static ParticipantDto createIneligibleSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto, String dob, String esIndex) {
-        String ddpParticipantId = genDDPParticipantId(guid);
-        ParticipantDto testParticipant = createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
-        ElasticTestUtil.createParticipant(esIndex, testParticipant);
-        ElasticTestUtil.addParticipantProfileFromFile(esIndex, "elastic/participantProfile.json", ddpParticipantId);
-        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId, dob, null);
-        ElasticTestUtil.addActivitiesFromFile(esIndex, "elastic/lmsActivitiesSharedLearningIneligible.json", ddpParticipantId);
-        log.debug("ES participant record with dob {} for {}: {}", dob, ddpParticipantId,
-                ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
-        return testParticipant;
+    public static ParticipantDto createSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto, String dob,
+                                                                 String dateOfMajority, String esIndex) {
+        return createParticipantFromConfigFiles(guid, ddpInstanceDto, dob, dateOfMajority, esIndex,
+               "elastic/participantProfile.json", "elastic/participantDsm.json", "elastic/lmsActivitiesSharedLearningEligible.json");
+    }
+
+    public static ParticipantDto createIneligibleSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto,
+                                                                           String dob, String esIndex) {
+        return createParticipantFromConfigFiles(guid, ddpInstanceDto, dob, null, esIndex,
+                "elastic/participantProfile.json", "elastic/participantDsm.json", "elastic/lmsActivitiesSharedLearningIneligible.json");
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
@@ -68,12 +68,14 @@ public class TestParticipantUtil {
         }
     }
 
-    public static ParticipantDto createSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto, String dob, String esIndex) {
+    public static ParticipantDto createSharedLearningParticipant(String guid, DDPInstanceDto ddpInstanceDto, String dob,
+                                                                 String dateOfMajority, String esIndex) {
         String ddpParticipantId = genDDPParticipantId(guid);
         ParticipantDto testParticipant = createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
         ElasticTestUtil.createParticipant(esIndex, testParticipant);
         ElasticTestUtil.addParticipantProfileFromFile(esIndex, "elastic/participantProfile.json", ddpParticipantId);
-        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId, dob);
+        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId,
+                dob, dateOfMajority);
         ElasticTestUtil.addActivitiesFromFile(esIndex, "elastic/lmsActivitiesSharedLearningEligible.json", ddpParticipantId);
         log.debug("ES participant record with dob {} for {}: {}", dob, ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
@@ -85,7 +87,7 @@ public class TestParticipantUtil {
         ParticipantDto testParticipant = createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
         ElasticTestUtil.createParticipant(esIndex, testParticipant);
         ElasticTestUtil.addParticipantProfileFromFile(esIndex, "elastic/participantProfile.json", ddpParticipantId);
-        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId, dob);
+        ElasticTestUtil.addDsmObjectToParticipantFromFile(esIndex, "elastic/participantDsm.json", ddpParticipantId, dob, null);
         ElasticTestUtil.addActivitiesFromFile(esIndex, "elastic/lmsActivitiesSharedLearningIneligible.json", ddpParticipantId);
         log.debug("ES participant record with dob {} for {}: {}", dob, ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));

--- a/pepper-apis/dsm-core/src/test/resources/elastic/participantDsm.json
+++ b/pepper-apis/dsm-core/src/test/resources/elastic/participantDsm.json
@@ -1,4 +1,5 @@
 {
   "dateOfBirth" : "<dateOfBirth>",
+  "dateOfMajority" : "<dateOfMajority>",
   "hasConsentedToTissueSample" : true
 }


### PR DESCRIPTION
Continuation of the https://github.com/broadinstitute/ddp-study-server/pull/2777.  In this episode, we prevent displaying the PHI manifest if the relevant consent/assent have not been completed.  Previously, we would allow CRCs to see the manifest.  There was already logic that would prevent the download, but it needed to be augmented to take into account not just the fields in the surveys, but the status of said surveys.

These changes required adding some stubs to the .json that we use for the `dsm` object in ES so that we could exercise some different AOM scenarios.