### PR TITLE
PEPPER-526 failed lookups for tissue_id 0

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/MercuryOrderDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/MercuryOrderDao.java
@@ -317,7 +317,8 @@ public class MercuryOrderDao implements Dao<MercuryOrderDto> {
                                 .withStatusDate(rs.getLong(DBConstants.MERCURY_STATUS_DATE))
                                 .withOrderStatus(rs.getString(DBConstants.MERCURY_ORDER_STATUS))
                                 .withDdpParticipantId(rs.getString(DBConstants.DDP_PARTICIPANT_ID))
-                                .withTissueId(rs.getInt(DBConstants.TISSUE_ID))
+                                .withTissueId(rs.getObject(DBConstants.TISSUE_ID) != null
+                                        ? rs.getInt(DBConstants.TISSUE_ID) : null)
                                 .withDsmKitRequestId(rs.getInt(DBConstants.DSM_KIT_REQUEST_ID)).build();
                         ordersWithOrderId.add(mercurySequencingDto);
                     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/MercuryOrderDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/MercuryOrderDto.java
@@ -99,7 +99,7 @@ public class MercuryOrderDto {
             return this;
         }
 
-        public Builder withTissueId(int tissueId) {
+        public Builder withTissueId(Integer tissueId) {
             this.tissueId = tissueId;
             return this;
         }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/phimanifest/PhiManifestTest.java
@@ -291,6 +291,25 @@ public class PhiManifestTest extends DbAndElasticBaseTest {
             ddpInstanceDto.setStudyGuid(initialStudyGuid);
         }
 
+        // check that null tissue results in null values and not an exception
+        MercuryOrderDto orderWithoutTissue = orders.iterator().next();
+        Integer originalTissueId = orderWithoutTissue.getTissueId();
+        orderWithoutTissue.setTissueId(null);
+        try {
+            phiManifest = phiManifestService.generateDataForReport(participant, orders, ddpInstanceDto);
+            Assert.assertNull(phiManifest.getTumorCollaboratorSampleId());
+            Assert.assertNull(phiManifest.getBlockId());
+            Assert.assertNull(phiManifest.getTissueSite());
+            Assert.assertNull(phiManifest.getSequencingResults());
+            Assert.assertNull(phiManifest.getAccessionNumber());
+            Assert.assertNull(phiManifest.getDateOfPx());
+            Assert.assertNull(phiManifest.getHistology());
+            Assert.assertNull(phiManifest.getFacility());
+        } finally {
+            // reset value for proper deletion
+            orderWithoutTissue.setTissueId(originalTissueId);
+        }
+
         mercuryOrderDao.delete(mercuryOrderId);
         lmsOncHistoryTestUtil.deleteOncHistory(childReportGuid, participantDto.getParticipantId().get(), instanceName, userEmail,
                 oncHistoryDetail.getOncHistoryDetailId());


### PR DESCRIPTION
Bug in PEPPER-526.  rs.getInt() returns 0 when the value is null, and that was causing exceptions when trying to lookup nonexistent tissue with id 0.  PhiManifestService:L109 was expecting nulls and will filter them out properly already, but because getInt() uses 0 to represent null, that filter did not have the intended effect of removing the null tissue since 0 is not null.

PR to merge this into the current RC is: https://github.com/broadinstitute/ddp-study-server/pull/2790