### PR TITLE
bump sonar scanner version, fix includedModules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ output/
 target/
 output-config/
 output-build-config/
+.sonar-token

--- a/pepper-apis/config/pepper-apis-settings.xml
+++ b/pepper-apis/config/pepper-apis-settings.xml
@@ -1,18 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <profiles>
-        <profile>
-            <id>sonar</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-                <sonar.projectName>ddp-study-server</sonar.projectName>
-                <sonar.projectKey>broadinstitute_ddp-study-server</sonar.projectKey>
-                <sonar.organization>dsp-appsec</sonar.organization>
-            </properties>
-        </profile>
-    </profiles>
+  <pluginGroups>
+    <pluginGroup>
+      org.sonarsource.scanner.maven
+    </pluginGroup>
+  </pluginGroups>
 </settings>

--- a/pepper-apis/pom.xml
+++ b/pepper-apis/pom.xml
@@ -17,7 +17,7 @@
         <sonar.projectKey>broadinstitute_ddp-study-server</sonar.projectKey>
         <sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
         <sonar.junit.reportPaths>target/surefire-reports/</sonar.junit.reportPaths>
-        <sonar.includedModules>dpp-common,dsm-core,dss-core</sonar.includedModules>
+        <sonar.includedModules>ddp-common,dsm-core,dss-core</sonar.includedModules>
         <jdbi.version>3.39.1</jdbi.version>
         <itext.version>7.1.4</itext.version>
         <itext.licensekey.version>3.0.3</itext.licensekey.version>
@@ -815,7 +815,7 @@
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
-                <version>3.9.1.2184</version>
+                <version>3.10.0.2594</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This bumps the sonar scanner version and fixes a typo in the list of includedModules. This enables makes it so all the code is scanned in one scan:

```sh
cd pepper-apis
mvn sonar:sonar
```

This could be set up in CircleCI as a parallel workflow. Or if that's not fast enough, I can set up a second sonarcloud project and we can break it into two scans. 

There must be a one-to-one correspondence between scan runs in CI and sonar projects. Each scan run on the same project key replaces the prior scan results.