### PR TITLE
[PEPPER-1311] Add force flag for ParticipantDataFixupService

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
@@ -45,7 +45,7 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
 
         Profile profile = elasticSearchParticipantDto.getProfile().orElseThrow();
         try {
-            if (!createGenomicId(ddpParticipantId, profile.getHruid())) {
+            if (!createGenomicId(ddpParticipantId, profile.getHruid(), instanceId)) {
                 return false;
             }
             WorkflowStatusUpdate.updateEsParticipantData(ddpParticipantId, instance);
@@ -55,9 +55,7 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
         return true;
     }
 
-    protected synchronized boolean createGenomicId(String ddpParticipantId, String hruid) {
-        log.info("TEMP: Entering createGenomicId for {} and thread {}", ddpParticipantId,
-                Thread.currentThread().getId());
+    protected static synchronized boolean createGenomicId(String ddpParticipantId, String hruid, int instanceId) {
         List<ParticipantData> participantDataList =
                 participantDataDao.getParticipantDataByParticipantId(ddpParticipantId);
 
@@ -75,8 +73,6 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
             insertExitStatusForParticipant(ddpParticipantId, instanceId);
         }
 
-        log.info("TEMP: Exiting createGenomicId for {} and thread {}", ddpParticipantId,
-                Thread.currentThread().getId());
         if (hasGenomeId && hasExitStatus) {
             log.info("Participant {} already has AT default data", ddpParticipantId);
             return false;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
@@ -56,6 +56,8 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
     }
 
     protected synchronized boolean createGenomicId(String ddpParticipantId, String hruid) {
+        log.info("TEMP: Entering createGenomicId for {} and thread {}", ddpParticipantId,
+                Thread.currentThread().getId());
         List<ParticipantData> participantDataList =
                 participantDataDao.getParticipantDataByParticipantId(ddpParticipantId);
 
@@ -73,6 +75,8 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
             insertExitStatusForParticipant(ddpParticipantId, instanceId);
         }
 
+        log.info("TEMP: Exiting createGenomicId for {} and thread {}", ddpParticipantId,
+                Thread.currentThread().getId());
         if (hasGenomeId && hasExitStatus) {
             log.info("Participant {} already has AT default data", ddpParticipantId);
             return false;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/admin/AdminOperationService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/admin/AdminOperationService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.service.adminoperation.ElasticExportService;
 import org.broadinstitute.dsm.service.adminoperation.ParticipantDataFixupService;
 import org.broadinstitute.dsm.service.adminoperation.ReferralSourceService;
 
@@ -18,7 +19,8 @@ public class AdminOperationService {
     // supported operations
     public enum OperationTypeId {
         SYNC_REFERRAL_SOURCE,
-        FIXUP_PARTICIPANT_DATA
+        FIXUP_PARTICIPANT_DATA,
+        ELASTIC_EXPORT
     }
 
     private final String userId;
@@ -40,6 +42,9 @@ public class AdminOperationService {
                 break;
             case FIXUP_PARTICIPANT_DATA:
                 adminOperation = new ParticipantDataFixupService();
+                break;
+            case ELASTIC_EXPORT:
+                adminOperation = new ElasticExportService();
                 break;
             default:
                 throw new DSMBadRequestException("Invalid operation type ID: " + operationTypeId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ExportLog.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ExportLog.java
@@ -14,11 +14,13 @@ public class ExportLog {
     private String entity;
     private Status status;
     private int participantCount;
+    private int exportedCount;
     private String message;
 
     public ExportLog(String entity) {
         this.entity = entity;
         this.participantCount = 0;
+        this.exportedCount = 0;
     }
 
     public void setError(String message) {


### PR DESCRIPTION
## Context
[PEPPER-1311]
[PEPPER-1206]

There are three distinct changes in this PR:

1. Add a force flag for ParticipantDataFixupService. This is to cover a specific case for removing duplicate AT genomic IDs, but should be generally useful for ParticipantDataFixupService in the future. (Tested locally against Dev data.)
2. Complete the hookup to AdminOperation for ElasticExportService. This fell through the cracks when there were a couple of PRs in review with conflicting changes. Also improved the ExportLog use for ElasticExportService. (Tested locally against Dev data.)
3. Add diagnostic logging to ATDefaultValues to help troubleshoot an issue.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-1311]: https://broadworkbench.atlassian.net/browse/PEPPER-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PEPPER-1206]: https://broadworkbench.atlassian.net/browse/PEPPER-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ