### PR TITLE
[PEPPER-1353] Add ParticipantInitService to update missing RGP default data

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValues.java
@@ -57,7 +57,7 @@ public class ATDefaultValues extends BasicDefaultDataMaker {
 
     protected static synchronized boolean createGenomicId(String ddpParticipantId, String hruid, int instanceId) {
         List<ParticipantData> participantDataList =
-                participantDataDao.getParticipantDataByParticipantId(ddpParticipantId);
+                participantDataDao.getParticipantData(ddpParticipantId);
 
         boolean hasGenomeId = participantDataList.stream().anyMatch(
                 participantDataDto -> ATDefaultValues.GENOME_STUDY_FIELD_TYPE.equals(

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/RgpAutomaticProbandDataCreator.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/RgpAutomaticProbandDataCreator.java
@@ -1,10 +1,8 @@
 package org.broadinstitute.dsm.model.defaultvalues;
 
 import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
-import org.broadinstitute.dsm.model.bookmark.Bookmark;
 import org.broadinstitute.dsm.service.participantdata.RgpFamilyIdProvider;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
-
 
 public class RgpAutomaticProbandDataCreator extends BasicDefaultDataMaker {
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/data/ParticipantData.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/participant/data/ParticipantData.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.type.TypeReference;
-import liquibase.pro.packaged.D;
 import lombok.Data;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
@@ -103,7 +102,7 @@ public class ParticipantData {
             return Collections.emptyList();
         }
         ParticipantDataDao dataAccess = (ParticipantDataDao) setDataAccess(new ParticipantDataDao());
-        return dataAccess.getParticipantDataByParticipantId(ddpParticipantId);
+        return dataAccess.getParticipantData(ddpParticipantId);
     }
 
     private Dao setDataAccess(Dao dao) {
@@ -156,7 +155,7 @@ public class ParticipantData {
 
     public boolean isRelationshipIdExists() {
         List<String> participantRelationshipIds =
-                parseDtoList(((ParticipantDataDao) dataAccess).getParticipantDataByParticipantId(this.ddpParticipantId)).stream()
+                parseDtoList(((ParticipantDataDao) dataAccess).getParticipantData(this.ddpParticipantId)).stream()
                         .map(pData -> {
                             Map<String, String> familyMemberData = pData.getData();
                             boolean hasRelationshipId = familyMemberData.containsKey(FamilyMemberConstants.RELATIONSHIP_ID);
@@ -205,6 +204,4 @@ public class ParticipantData {
         String applicantEmail = StringUtils.defaultIfBlank(applicantProfile.getEmail(), StringUtils.EMPTY);
         return applicantEmail.equalsIgnoreCase(familyMemberEmail);
     }
-
-
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/BasePatch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/BasePatch.java
@@ -187,7 +187,7 @@ public abstract class BasePatch {
                 ElasticSearchUtil.writeWorkflow(
                         WorkflowForES.createInstance(ddpInstance, esParticipantId, action.getName(), action.getValue()), false);
             } else if (ParticipantUtil.matchesApplicantEmail(data.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID),
-                    participantDataDao.getParticipantDataByParticipantId(patch.getParentId()))) {
+                    participantDataDao.getParticipantData(patch.getParentId()))) {
                 ElasticSearchUtil.writeWorkflow(
                         WorkflowForES.createInstanceWithStudySpecificData(ddpInstance, esParticipantId, action.getName(),
                                 data.get(action.getName()),
@@ -199,7 +199,7 @@ public abstract class BasePatch {
                 ElasticSearchUtil.writeWorkflow(
                         WorkflowForES.createInstance(ddpInstance, esParticipantId, action.getName(), data.get(action.getName())), false);
             } else if (ParticipantUtil.matchesApplicantEmail(data.get(FamilyMemberConstants.COLLABORATOR_PARTICIPANT_ID),
-                    participantDataDao.getParticipantDataByParticipantId(patch.getParentId()))) {
+                    participantDataDao.getParticipantData(patch.getParentId()))) {
                 ElasticSearchUtil.writeWorkflow(
                         WorkflowForES.createInstanceWithStudySpecificData(ddpInstance, esParticipantId, action.getName(),
                                 data.get(action.getName()),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
@@ -104,7 +104,7 @@ public class WorkflowStatusUpdate {
                                              DDPInstance instance) {
         String instanceName = instance.getName();
         List<ParticipantData> participantDataList =
-                participantDataDao.getParticipantDataByParticipantId(ddpParticipantId);
+                participantDataDao.getParticipantData(ddpParticipantId);
         Optional<FieldSettingsDto> fieldSetting =
                 fieldSettingsDao.getFieldSettingByColumnNameAndInstanceId(instance.getDdpInstanceIdAsInt(), workflow);
         if (fieldSetting.isEmpty()) {
@@ -265,7 +265,7 @@ public class WorkflowStatusUpdate {
      */
     public static void updateEsParticipantData(String ddpParticipantId, DDPInstance instance) {
         updateEsParticipantData(ddpParticipantId,
-                participantDataDao.getParticipantDataByParticipantId(ddpParticipantId), instance);
+                participantDataDao.getParticipantData(ddpParticipantId), instance);
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/participant/GetParticipantDataRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/participant/GetParticipantDataRoute.java
@@ -33,6 +33,6 @@ public class GetParticipantDataRoute extends RequestHandler {
         String ddpParticipantId = queryParamsMap.get(ParticipantUtil.DDP_PARTICIPANT_ID).value();
         ParticipantDataDao participantDataDao = new ParticipantDataDao();
 
-        return ParticipantData.parseDtoList(participantDataDao.getParticipantDataByParticipantId(ddpParticipantId));
+        return ParticipantData.parseDtoList(participantDataDao.getParticipantData(ddpParticipantId));
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/admin/AdminOperationService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/admin/AdminOperationService.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.service.adminoperation.ElasticExportService;
 import org.broadinstitute.dsm.service.adminoperation.ParticipantDataFixupService;
+import org.broadinstitute.dsm.service.adminoperation.ParticipantInitService;
 import org.broadinstitute.dsm.service.adminoperation.ReferralSourceService;
 
 /**
@@ -20,7 +21,8 @@ public class AdminOperationService {
     public enum OperationTypeId {
         SYNC_REFERRAL_SOURCE,
         FIXUP_PARTICIPANT_DATA,
-        ELASTIC_EXPORT
+        ELASTIC_EXPORT,
+        PARTICIPANT_INIT
     }
 
     private final String userId;
@@ -45,6 +47,9 @@ public class AdminOperationService {
                 break;
             case ELASTIC_EXPORT:
                 adminOperation = new ElasticExportService();
+                break;
+            case PARTICIPANT_INIT:
+                adminOperation = new ParticipantInitService();
                 break;
             default:
                 throw new DSMBadRequestException("Invalid operation type ID: " + operationTypeId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupService.java
@@ -81,7 +81,7 @@ public class ParticipantDataFixupService implements AdminOperation {
             ParticipantListRequest req = ParticipantListRequest.fromJson(payload);
             List<String> participants = req.getParticipants();
             for (String participantId: participants) {
-                List<ParticipantData> ptpData = dataDao.getParticipantDataByParticipantId(participantId);
+                List<ParticipantData> ptpData = dataDao.getParticipantData(participantId);
                 if (ptpData.isEmpty()) {
                     throw new DSMBadRequestException("Invalid participant ID: " + participantId);
                 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupService.java
@@ -27,14 +27,6 @@ import org.broadinstitute.dsm.service.admin.AdminOperationRecord;
  */
 @Slf4j
 public class ParticipantDataFixupService implements AdminOperation {
-
-    protected enum UpdateStatus {
-        UPDATED,
-        NOT_UPDATED,
-        ERROR,
-        NO_PARTICIPANT_DATA
-    }
-
     private static final Gson gson = new Gson();
     protected List<String> validRealms = List.of("atcp");
     private boolean forceFlag = false;
@@ -134,11 +126,11 @@ public class ParticipantDataFixupService implements AdminOperation {
 
     protected UpdateLog updateParticipant(String ddpParticipantId, List<ParticipantData> participantDataList) {
         if (participantDataList.isEmpty()) {
-            return new UpdateLog(ddpParticipantId, UpdateStatus.NO_PARTICIPANT_DATA.name());
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA.name());
         }
         // no duplicates
         if (participantDataList.size() == 1) {
-            return new UpdateLog(ddpParticipantId, UpdateStatus.NOT_UPDATED.name());
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NOT_UPDATED.name());
         }
 
         try {
@@ -150,7 +142,7 @@ public class ParticipantDataFixupService implements AdminOperation {
                     genomeIdToDelete.size(), exitToDelete.size(), ddpParticipantId);
 
             if (genomeIdToDelete.isEmpty() && exitToDelete.isEmpty()) {
-                return new UpdateLog(ddpParticipantId, UpdateStatus.NOT_UPDATED.name());
+                return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NOT_UPDATED.name());
             }
 
             // remove records from DB
@@ -169,15 +161,15 @@ public class ParticipantDataFixupService implements AdminOperation {
                     ddpParticipantId, e);
             // many of these exceptions will require investigation, but conservatively we will just log
             // at error level for those that are definitely concerning
-            if (e instanceof DsmInternalError || e instanceof RuntimeException) {
+            if (e instanceof DsmInternalError) {
                 log.error(msg);
                 e.printStackTrace();
             } else {
                 log.warn(msg);
             }
-            return new UpdateLog(ddpParticipantId, UpdateStatus.ERROR.name(), e.toString());
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(), e.toString());
         }
-        return new UpdateLog(ddpParticipantId, UpdateStatus.UPDATED.name());
+        return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.UPDATED.name());
     }
 
     private Set<Integer> getRecordsToDelete(List<ParticipantData> participantDataList, String fieldTypeId) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
@@ -28,6 +28,16 @@ import org.broadinstitute.dsm.service.participantdata.RgpFamilyIdProvider;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 
+/**
+ * Service to initialize RGP participant data for participants that have not yet been initialized.
+ * The service also detects errors in participant data, fixes those that have a direct fix,
+ * and logs errors for those that require investigation. The 'logging' is part of the operation result which is
+ * stored in the DB. See AdminOperationRecord for details.
+ * </p>
+ * This service has a dry-run mode that logs changes that would be made without actually making them,
+ * including logging errors. Dry-run mode should always be run first to ensure the operation will yield the expected
+ * results.
+ */
 @Slf4j
 public class ParticipantInitService implements AdminOperation {
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
@@ -1,0 +1,110 @@
+package org.broadinstitute.dsm.service.adminoperation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.model.elastic.Dsm;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearch;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.admin.AdminOperation;
+import org.broadinstitute.dsm.service.admin.AdminOperationRecord;
+import org.broadinstitute.dsm.service.participantdata.RgpFamilyIdProvider;
+import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+
+@Slf4j
+public class ParticipantInitService implements AdminOperation {
+
+    private static final Gson gson = new Gson();
+    protected List<String> validRealms = List.of("rgp");
+    private DDPInstance ddpInstance;
+    private Map<String, Map<String, Object>> esParticipants;
+
+    /**
+     * Validate input and retrieve participant data, during synchronous part of operation handling
+     *
+     * @param userId     ID of user performing operation
+     * @param realm      realm for fixup
+     * @param attributes unused
+     * @param payload    request body, if any, as ParticipantDataFixupRequest
+     */
+    public void initialize(String userId, String realm, Map<String, String> attributes, String payload) {
+        if (!validRealms.contains(realm.toLowerCase())) {
+            throw new DsmInternalError("Invalid realm for ParticipantInitService: " + realm);
+        }
+
+        ddpInstance = DDPInstance.getDDPInstance(realm);
+        if (ddpInstance == null) {
+            throw new DsmInternalError("Invalid realm: " + realm);
+        }
+
+        String esIndex = ddpInstance.getParticipantIndexES();
+        if (StringUtils.isEmpty(esIndex)) {
+            throw new DsmInternalError("No ES participant index for study " + realm);
+        }
+
+        esParticipants =
+                ElasticSearchUtil.getDDPParticipantsFromES(ddpInstance.getName(), esIndex);
+        log.info("Found {} participants in ES for instance {}", esParticipants.size(), ddpInstance.getName());
+    }
+
+    /**
+     * Run the asynchronous part of the operation, updating the AdminRecord with the operation results
+     *
+     * @param operationId ID for reporting results
+     */
+    public void run(int operationId) {
+        List<UpdateLog> updateLog = new ArrayList<>();
+
+        ElasticSearch elasticSearch = new ElasticSearch();
+        // for each participant attempt an update and log results
+        for (var entry: esParticipants.entrySet()) {
+            updateLog.add(initParticipant(entry.getKey(),
+                    elasticSearch.parseSourceMap(entry.getValue(), entry.getKey()), ddpInstance));
+        }
+
+        // update job log record
+        try {
+            String json = gson.toJson(updateLog);
+            AdminOperationRecord.updateOperationRecord(operationId, AdminOperationRecord.OperationStatus.COMPLETED, json);
+        } catch (Exception e) {
+            log.error("Error writing operation log: {}", e.toString());
+        }
+    }
+
+    protected static UpdateLog initParticipant(String ddpParticipantId, ElasticSearchParticipantDto esParticipant,
+                                               DDPInstance ddpInstance) {
+        Optional<Dsm> dsm = esParticipant.getDsm();
+        if (dsm.isEmpty()) {
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA.name());
+        }
+        if (StringUtils.isNotBlank(dsm.get().getFamilyId())) {
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NOT_UPDATED.name());
+        }
+
+        try {
+            RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipant, ddpInstance,
+                    new RgpFamilyIdProvider());
+        } catch (Exception e) {
+            String msg = String.format("Exception in ParticipantInitService.run for participant %s: %s",
+                    ddpParticipantId, e);
+            // many of these exceptions will require investigation, but conservatively we will just log
+            // at error level for those that are definitely concerning
+            if (e instanceof DsmInternalError) {
+                log.error(msg);
+                e.printStackTrace();
+            } else {
+                log.warn(msg);
+            }
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(), e.toString());
+        }
+        return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.UPDATED.name());
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitService.java
@@ -1,5 +1,9 @@
 package org.broadinstitute.dsm.service.adminoperation;
 
+import static org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants.FAMILY_ID;
+import static org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants.MEMBER_TYPE;
+import static org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants.MEMBER_TYPE_SELF;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -9,12 +13,16 @@ import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearch;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.admin.AdminOperation;
 import org.broadinstitute.dsm.service.admin.AdminOperationRecord;
+import org.broadinstitute.dsm.service.participantdata.FamilyIdProvider;
 import org.broadinstitute.dsm.service.participantdata.RgpFamilyIdProvider;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
@@ -26,6 +34,7 @@ public class ParticipantInitService implements AdminOperation {
     protected List<String> validRealms = List.of("rgp");
     private DDPInstance ddpInstance;
     private Map<String, Map<String, Object>> esParticipants;
+    private boolean isDryRun = true;
 
     /**
      * Validate input and retrieve participant data, during synchronous part of operation handling
@@ -50,6 +59,17 @@ public class ParticipantInitService implements AdminOperation {
             throw new DsmInternalError("No ES participant index for study " + realm);
         }
 
+        // require dryRun since the user cannot specify a participant list
+        String dryRun = attributes.get("dryRun");
+        if (StringUtils.isBlank(dryRun)) {
+            throw new DSMBadRequestException("Missing required attribute 'dryRun'");
+        }
+
+        if (!dryRun.equalsIgnoreCase("true") && !dryRun.equalsIgnoreCase("false")) {
+            throw new DSMBadRequestException("Invalid dryRun parameter ('true' or 'false' accepted): " + dryRun);
+        }
+        isDryRun = Boolean.parseBoolean(dryRun);
+
         esParticipants =
                 ElasticSearchUtil.getDDPParticipantsFromES(ddpInstance.getName(), esIndex);
         log.info("Found {} participants in ES for instance {}", esParticipants.size(), ddpInstance.getName());
@@ -67,7 +87,8 @@ public class ParticipantInitService implements AdminOperation {
         // for each participant attempt an update and log results
         for (var entry: esParticipants.entrySet()) {
             updateLog.add(initParticipant(entry.getKey(),
-                    elasticSearch.parseSourceMap(entry.getValue(), entry.getKey()), ddpInstance));
+                    elasticSearch.parseSourceMap(entry.getValue(), entry.getKey()),
+                    ddpInstance, new RgpFamilyIdProvider(), isDryRun));
         }
 
         // update job log record
@@ -80,18 +101,29 @@ public class ParticipantInitService implements AdminOperation {
     }
 
     protected static UpdateLog initParticipant(String ddpParticipantId, ElasticSearchParticipantDto esParticipant,
-                                               DDPInstance ddpInstance) {
+                                               DDPInstance ddpInstance, FamilyIdProvider familyIdProvider,
+                                               boolean isDryRun) {
+        List<ParticipantData> ptpData = RgpParticipantDataService.getRgpParticipantData(ddpParticipantId);
+
         Optional<Dsm> dsm = esParticipant.getDsm();
-        if (dsm.isEmpty()) {
-            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA.name());
-        }
-        if (StringUtils.isNotBlank(dsm.get().getFamilyId())) {
+        if (dsm.isPresent() && StringUtils.isNotBlank(dsm.get().getFamilyId())) {
+            if (ptpData.isEmpty()) {
+                return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(),
+                        "Participant has family ID in ES but no RGP data");
+            }
             return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NOT_UPDATED.name());
         }
 
+        // participant has no family ID in ES
         try {
-            RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipant, ddpInstance,
-                    new RgpFamilyIdProvider());
+            // ptp does not have a family ID in ES, but does have RGP participant data
+            if (!ptpData.isEmpty()) {
+                return updateESFamilyId(ptpData, ddpParticipantId, ddpInstance.getParticipantIndexES(), isDryRun);
+            }
+            return createDefaultData(ddpParticipantId, esParticipant, ddpInstance, familyIdProvider, isDryRun);
+        } catch (ESMissingParticipantDataException e) {
+            // no profile
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA.name());
         } catch (Exception e) {
             String msg = String.format("Exception in ParticipantInitService.run for participant %s: %s",
                     ddpParticipantId, e);
@@ -105,6 +137,42 @@ public class ParticipantInitService implements AdminOperation {
             }
             return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(), e.toString());
         }
+    }
+
+    protected static UpdateLog createDefaultData(String ddpParticipantId, ElasticSearchParticipantDto esParticipant,
+                                                 DDPInstance ddpInstance, FamilyIdProvider familyIdProvider,
+                                                 boolean isDryRun) {
+        if (isDryRun) {
+            if (esParticipant.getProfile().isEmpty()) {
+                throw new ESMissingParticipantDataException("Participant does not yet have profile in ES");
+            }
+        } else {
+            RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipant, ddpInstance, familyIdProvider);
+        }
         return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.UPDATED.name());
+    }
+
+    /**
+     * Handle case where participant has RGP data but no family ID in ES
+     */
+    protected static UpdateLog updateESFamilyId(List<ParticipantData> ptpData, String ddpParticipantId, String esIndex,
+                                                boolean isDryRun) {
+        Optional<ParticipantData> probandData = ptpData.stream()
+                .filter(data -> MEMBER_TYPE_SELF.equals(data.getDataMap().get(MEMBER_TYPE)))
+                .findFirst();
+        if (probandData.isEmpty()) {
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(),
+                    "Participant has RGP data but no proband record");
+        }
+
+        String familyId = probandData.get().getDataMap().get(FAMILY_ID);
+        if (StringUtils.isBlank(familyId)) {
+            return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(),
+                    "Participant has proband RGP data but no family ID");
+        }
+        if (!isDryRun) {
+            RgpParticipantDataService.insertEsFamilyId(esIndex, ddpParticipantId, Long.parseLong(familyId));
+        }
+        return new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ES_UPDATED.name());
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
@@ -81,7 +81,7 @@ public class ReferralSourceService implements AdminOperation {
         if (!StringUtils.isBlank(payload)) {
             List<String> participants = getParticipantList(payload);
             for (String participantId: participants) {
-                List<ParticipantData> ptpData = dataDao.getParticipantDataByParticipantId(participantId);
+                List<ParticipantData> ptpData = dataDao.getParticipantData(participantId);
                 if (ptpData.isEmpty()) {
                     throw new DSMBadRequestException("Invalid participant ID: " + participantId);
                 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
@@ -16,8 +16,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.gson.Gson;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
@@ -42,17 +40,6 @@ import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
  */
 @Slf4j
 public class ReferralSourceService implements AdminOperation {
-
-    // the outcome of referral source update for each participant
-    public enum UpdateStatus {
-        UPDATED,
-        NOT_UPDATED,
-        NA_REFERRAL_SOURCE,
-        ERROR,
-        NO_ACTIVITIES,
-        NO_REFERRAL_SOURCE_IN_ACTIVITY,
-        NO_PARTICIPANT_DATA
-    }
 
     private static final String RGP_REALM = "RGP";
     protected static final String NA_REF_SOURCE = "NA";
@@ -123,11 +110,11 @@ public class ReferralSourceService implements AdminOperation {
         for (var entry: participantDataByPtpId.entrySet()) {
             String ddpParticipantId = entry.getKey();
             try {
-                UpdateStatus status = updateReferralSource(ddpParticipantId, entry.getValue(),
+                UpdateLog.UpdateStatus status = updateReferralSource(ddpParticipantId, entry.getValue(),
                         getParticipantActivities(ddpParticipantId, esIndex));
                 updateLog.add(new UpdateLog(ddpParticipantId, status.name()));
             } catch (Exception e) {
-                updateLog.add(new UpdateLog(ddpParticipantId, UpdateStatus.ERROR.name(), e.toString()));
+                updateLog.add(new UpdateLog(ddpParticipantId, UpdateLog.UpdateStatus.ERROR.name(), e.toString()));
 
                 String msg = String.format("Exception in ReferralSourceService.run for participant %s: %s", ddpParticipantId, e);
                 // many of these exceptions will require investigation, but conservatively we will just log
@@ -151,12 +138,7 @@ public class ReferralSourceService implements AdminOperation {
     }
 
     private static List<String> getParticipantList(String payload) {
-        ReferralSourceRequest req;
-        try {
-            req = new Gson().fromJson(payload, ReferralSourceRequest.class);
-        } catch (Exception e) {
-            throw new DSMBadRequestException("Invalid request format. Payload: " + payload);
-        }
+        ParticipantListRequest req = ParticipantListRequest.fromJson(payload);
         List<String> participants = req.getParticipants();
         if (participants.isEmpty()) {
             throw new DSMBadRequestException("Invalid request format. Empty participant list");
@@ -164,21 +146,22 @@ public class ReferralSourceService implements AdminOperation {
         return participants;
     }
 
-    protected UpdateStatus updateReferralSource(String ddpParticipantId, List<ParticipantData> dataList, List<Activities> activities) {
+    protected UpdateLog.UpdateStatus updateReferralSource(String ddpParticipantId, List<ParticipantData> dataList,
+                                                          List<Activities> activities) {
         if (dataList.isEmpty()) {
-            return UpdateStatus.NO_PARTICIPANT_DATA;
+            return UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA;
         }
         if (activities.isEmpty()) {
-            return UpdateStatus.NO_ACTIVITIES;
+            return UpdateLog.UpdateStatus.NO_ACTIVITIES;
         }
         List<String> refSources = getReferralSources(activities);
         if (refSources.isEmpty()) {
-            return UpdateStatus.NO_REFERRAL_SOURCE_IN_ACTIVITY;
+            return UpdateLog.UpdateStatus.NO_REFERRAL_SOURCE_IN_ACTIVITY;
         }
 
         String refSourceId = convertReferralSources(refSources);
         if (refSourceId.equals(NA_REF_SOURCE)) {
-            return UpdateStatus.NA_REFERRAL_SOURCE;
+            return UpdateLog.UpdateStatus.NA_REFERRAL_SOURCE;
         }
 
         // only need the RGP_PARTICIPANT_DATA type ParticipantData
@@ -187,7 +170,7 @@ public class ReferralSourceService implements AdminOperation {
         ).collect(Collectors.toList());
 
         if (rgpData.isEmpty()) {
-            return UpdateStatus.NO_PARTICIPANT_DATA;
+            return UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA;
         }
 
         // There may be multiple participant data records due to prior update errors
@@ -203,7 +186,7 @@ public class ReferralSourceService implements AdminOperation {
             log.warn(String.format("Multiple records found for field type %s, participant %s in realm %s",
                     RgpParticipantDataService.RGP_PARTICIPANTS_FIELD_TYPE, ddpParticipantId, RGP_REALM));
         }
-        return updateCount > 0 ? UpdateStatus.UPDATED : UpdateStatus.NOT_UPDATED;
+        return updateCount > 0 ? UpdateLog.UpdateStatus.UPDATED : UpdateLog.UpdateStatus.NOT_UPDATED;
     }
 
     private boolean updateParticipantData(ParticipantData participantData, String ddpParticipantId, String refSourceId) {
@@ -380,23 +363,5 @@ public class ReferralSourceService implements AdminOperation {
                     + "source %s: %s", sources.get(0), refSource));
         }
         return refSource;
-    }
-
-    // the format of each participant results
-    @AllArgsConstructor
-    private static class UpdateLog {
-        private final String ddpParticipantId;
-        private final String status;
-        private String message;
-
-        public UpdateLog(String ddpParticipantId, String status) {
-            this.ddpParticipantId = ddpParticipantId;
-            this.status = status;
-        }
-    }
-
-    @Data
-    private static class ReferralSourceRequest {
-        private List<String> participants;
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
@@ -17,7 +17,8 @@ public class UpdateLog {
         ERROR,
         NO_ACTIVITIES,
         NO_REFERRAL_SOURCE_IN_ACTIVITY,
-        NO_PARTICIPANT_DATA
+        NO_PARTICIPANT_DATA,
+        ES_UPDATED
     }
 
     private final String ddpParticipantId;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
@@ -9,6 +9,17 @@ import lombok.Data;
 @AllArgsConstructor
 @Data
 public class UpdateLog {
+
+    public enum UpdateStatus {
+        UPDATED,
+        NOT_UPDATED,
+        NA_REFERRAL_SOURCE,
+        ERROR,
+        NO_ACTIVITIES,
+        NO_REFERRAL_SOURCE_IN_ACTIVITY,
+        NO_PARTICIPANT_DATA
+    }
+
     private final String ddpParticipantId;
     private final String status;
     private String message;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/UpdateLog.java
@@ -22,11 +22,16 @@ public class UpdateLog {
     }
 
     private final String ddpParticipantId;
-    private final String status;
+    private String status;
     private String message;
 
     public UpdateLog(String ddpParticipantId, String status) {
         this.ddpParticipantId = ddpParticipantId;
         this.status = status;
+    }
+
+    public void setError(String message) {
+        this.message = message;
+        this.status = UpdateStatus.ERROR.name();
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
@@ -180,6 +180,9 @@ public class RgpParticipantDataService {
         });
     }
 
+    /**
+     * Return RGP participant data (records with field type RGP_PARTICIPANTS), or empty list if none found
+     */
     public static List<ParticipantData> getRgpParticipantData(String ddpParticipantId) {
         List<ParticipantData> participantDataList = participantDataDao.getParticipantData(ddpParticipantId);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
@@ -53,8 +54,8 @@ public class RgpParticipantDataService {
         log.info("Got ES profile of participant: {}", esProfile.getGuid());
         int ddpInstanceId = Integer.parseInt(instance.getDdpInstanceId());
 
-        Optional<ParticipantData> ptpData = getRgpParticipantData(ddpParticipantId);
-        if (ptpData.isPresent()) {
+        List<ParticipantData> ptpData = getRgpParticipantData(ddpParticipantId);
+        if (!ptpData.isEmpty()) {
             throw new DsmInternalError(String.format("Existing %s data found for participant %s",
                     RGP_PARTICIPANTS_FIELD_TYPE, ddpParticipantId));
         }
@@ -124,7 +125,7 @@ public class RgpParticipantDataService {
         return String.format("RGP_%d_%d", familyId, FamilyMemberConstants.PROBAND_RELATIONSHIP_ID);
     }
 
-    protected static void insertEsFamilyId(String esIndex, String ddpParticipantId, long familyId) {
+    public static void insertEsFamilyId(String esIndex, String ddpParticipantId, long familyId) {
         try {
             Map<String, Object> esMap =
                     ElasticSearchUtil.getObjectsMap(esIndex, ddpParticipantId, ESObjectConstants.DSM);
@@ -163,26 +164,28 @@ public class RgpParticipantDataService {
         Profile esProfile = esParticipantDto.getProfile().orElseThrow();
 
         // get existing ptp data
-        Optional<ParticipantData> ptpData = getRgpParticipantData(ddpParticipantId);
+        List<ParticipantData> ptpData = getRgpParticipantData(ddpParticipantId);
         if (ptpData.isEmpty()) {
             throw new DsmInternalError(String.format("No %s data found for participant %s", RGP_PARTICIPANTS_FIELD_TYPE,
                     ddpParticipantId));
         }
-        ParticipantData participantData = ptpData.get();
 
-        Map<String, String> dataMap = new HashMap<>(participantData.getDataMap());
+        // TODO should all family members be updated with the same data or just proband? -DC
+        ptpData.forEach(participantData -> {
+            Map<String, String> dataMap = new HashMap<>(participantData.getDataMap());
 
-        // update data with new data from ES profile and activities
-        updateDataMap(ddpParticipantId, dataMap, esParticipantDto.getActivities(), esProfile);
-        updateParticipantData(ddpParticipantId, participantData, dataMap, ddpInstance);
+            // update with new data from ES profile and activities
+            updateDataMap(ddpParticipantId, dataMap, esParticipantDto.getActivities(), esProfile);
+            updateParticipantData(ddpParticipantId, participantData, dataMap, ddpInstance);
+        });
     }
 
-    protected static Optional<ParticipantData> getRgpParticipantData(String ddpParticipantId) {
-        List<ParticipantData> participantDataList =
-                participantDataDao.getParticipantDataByParticipantId(ddpParticipantId);
+    public static List<ParticipantData> getRgpParticipantData(String ddpParticipantId) {
+        List<ParticipantData> participantDataList = participantDataDao.getParticipantData(ddpParticipantId);
 
         return participantDataList.stream().filter(participantDataDto ->
-                RGP_PARTICIPANTS_FIELD_TYPE.equals(participantDataDto.getRequiredFieldTypeId())).findFirst();
+                RGP_PARTICIPANTS_FIELD_TYPE.equals(participantDataDto.getRequiredFieldTypeId()))
+                .collect(Collectors.toList());
     }
 
     protected static void updateParticipantData(String ddpParticipantId, ParticipantData participantData,

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
@@ -169,7 +169,7 @@ public class ReceiveKitRequestTest extends DbAndElasticBaseTest {
 
     private void verifyParticipantData(String ddpParticipantId, boolean hasReceiveDate) {
         ParticipantDataDao dataDao = new ParticipantDataDao();
-        List<ParticipantData> ptpDataList = dataDao.getParticipantDataByParticipantId(ddpParticipantId);
+        List<ParticipantData> ptpDataList = dataDao.getParticipantData(ddpParticipantId);
         Assert.assertEquals(3, ptpDataList.size());
 
         Optional<ParticipantData> participantData = ptpDataList.stream()

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValuesTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/defaultvalues/ATDefaultValuesTest.java
@@ -187,7 +187,7 @@ public class ATDefaultValuesTest extends DbAndElasticBaseTest {
 
     private void verifyDefaultParticipantData(String ddpParticipantId) {
         ParticipantDataDao dataDao = new ParticipantDataDao();
-        List<ParticipantData> ptpDataList = dataDao.getParticipantDataByParticipantId(ddpParticipantId);
+        List<ParticipantData> ptpDataList = dataDao.getParticipantData(ddpParticipantId);
         Assert.assertEquals(2, ptpDataList.size()); // 1 for exit status, 1 for genomic id
         ptpDataList.forEach(ptpData -> {
             String fieldType = ptpData.getRequiredFieldTypeId();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
@@ -92,8 +92,7 @@ public class OncHistoryDetailPatchTest extends DbAndElasticBaseTest {
 
             // TODO: ElasticDataExportAdapter should probably force a refresh, but for now...
             Thread.sleep(1000);
-            //!! TEMP: update to debug level
-            log.info("Participant document with oncHistory patch: {}",
+            log.debug("Participant document with oncHistory patch: {}",
                     ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
 
             ElasticSearchParticipantDto esParticipant =

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
@@ -24,7 +24,6 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.db.dto.settings.FieldSettingsDto;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
 import org.broadinstitute.dsm.model.defaultvalues.ATDefaultValues;
-import org.broadinstitute.dsm.service.adminoperation.ReferralSourceServiceTest;
 import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
@@ -229,7 +228,7 @@ public class UpdateWorkflowStatusTest extends DbAndElasticBaseTest {
     private void verifyWorkflowParticipantData(String ddpParticipantId, String registrationFieldTypeId,
                                                String registrationStatus, List<String> otherFieldTypes) {
         ParticipantDataDao dataDao = new ParticipantDataDao();
-        List<ParticipantData> ptpDataList = dataDao.getParticipantDataByParticipantId(ddpParticipantId);
+        List<ParticipantData> ptpDataList = dataDao.getParticipantData(ddpParticipantId);
         Assert.assertEquals(otherFieldTypes.size() + 1, ptpDataList.size());
 
         ptpDataList.forEach(ptpData -> {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
@@ -104,7 +104,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
             // TODO: need to wait for the export to complete. Fussing with the refresh policy did not resolve this.
             TimeUnit.SECONDS.sleep(1);
         } catch (InterruptedException e) {
-            log.error("Interrupted while waiting for ES refresh", e);
+            Assert.fail("Interrupted while waiting for ES refresh");
         }
 
         // verify the data was exported properly

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupServiceTest.java
@@ -106,7 +106,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
         fixupService.validRealms = List.of(instanceName);
         fixupService.initialize(TEST_USER, instanceName, attributes, reqJson);
         UpdateLog updateLog = fixupService.updateParticipant(ddpParticipantId, ptpData);
-        Assert.assertEquals(ParticipantDataFixupService.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
+        Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
 
         ATDefaultValues.insertGenomicIdForParticipant(ddpParticipantId, "GUID_1", instanceId);
         ATDefaultValues.insertExitStatusForParticipant(ddpParticipantId, instanceId);
@@ -114,7 +114,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
         // now have the correct number of genomic IDs and exit statuses
         updateLog = fixupService.updateParticipant(ddpParticipantId,
                 dataDao.getParticipantDataByParticipantId(ddpParticipantId));
-        Assert.assertEquals(ParticipantDataFixupService.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
+        Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
         verifyParticipantData(ddpParticipantId);
 
         ATDefaultValues.insertGenomicIdForParticipant(ddpParticipantId, "GUID_2", instanceId);
@@ -123,7 +123,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
         // now have extra genomic IDs and exit statuses
         updateLog = fixupService.updateParticipant(ddpParticipantId,
                 dataDao.getParticipantDataByParticipantId(ddpParticipantId));
-        Assert.assertEquals(ParticipantDataFixupService.UpdateStatus.UPDATED.name(), updateLog.getStatus());
+        Assert.assertEquals(UpdateLog.UpdateStatus.UPDATED.name(), updateLog.getStatus());
         verifyParticipantData(ddpParticipantId);
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantDataFixupServiceTest.java
@@ -91,7 +91,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
         ParticipantDataTestUtil.createParticipantData(ddpParticipantId,
                 dataMap, "AT_GROUP_ELIGIBILITY", instanceId, TEST_USER);
 
-        List<ParticipantData> ptpData = dataDao.getParticipantDataByParticipantId(ddpParticipantId);
+        List<ParticipantData> ptpData = dataDao.getParticipantData(ddpParticipantId);
         Assert.assertEquals(2, ptpData.size());
         WorkflowStatusUpdate.updateEsParticipantData(ddpParticipantId, ptpData, ddpInstance);
 
@@ -113,7 +113,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
 
         // now have the correct number of genomic IDs and exit statuses
         updateLog = fixupService.updateParticipant(ddpParticipantId,
-                dataDao.getParticipantDataByParticipantId(ddpParticipantId));
+                dataDao.getParticipantData(ddpParticipantId));
         Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
         verifyParticipantData(ddpParticipantId);
 
@@ -122,7 +122,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
 
         // now have extra genomic IDs and exit statuses
         updateLog = fixupService.updateParticipant(ddpParticipantId,
-                dataDao.getParticipantDataByParticipantId(ddpParticipantId));
+                dataDao.getParticipantData(ddpParticipantId));
         Assert.assertEquals(UpdateLog.UpdateStatus.UPDATED.name(), updateLog.getStatus());
         verifyParticipantData(ddpParticipantId);
     }
@@ -136,7 +136,7 @@ public class ParticipantDataFixupServiceTest extends DbAndElasticBaseTest {
 
     private void verifyParticipantData(String ddpParticipantId) {
         ParticipantDataDao dataDao = new ParticipantDataDao();
-        List<ParticipantData> ptpDataList = dataDao.getParticipantDataByParticipantId(ddpParticipantId);
+        List<ParticipantData> ptpDataList = dataDao.getParticipantData(ddpParticipantId);
         // 1 for exit status, 1 for genomic id, 2 for other data
         Assert.assertEquals(4, ptpDataList.size());
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
@@ -1,37 +1,42 @@
 package org.broadinstitute.dsm.service.adminoperation;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
-import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.DbAndElasticBaseTest;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
-import org.broadinstitute.dsm.model.elastic.Activities;
+import org.broadinstitute.dsm.model.elastic.Dsm;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
+import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataTestUtil;
+import org.broadinstitute.dsm.service.participantdata.TestFamilyIdProvider;
+import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
-import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
-import org.broadinstitute.dsm.util.ParticipantDataTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+@Slf4j
 public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
-    private static final String TEST_USER = "TEST_USER";
     private static final String instanceName = "rgpinit";
     private static String esIndex;
     private static DDPInstanceDto ddpInstanceDto;
     private static DDPInstance ddpInstance;
-    private static final ParticipantDataDao dataDao = new ParticipantDataDao();
     private static final List<ParticipantDto> participants = new ArrayList<>();
     private static int participantCounter = 0;
-    private static final List<Integer> fieldSettingsIds = new ArrayList<>();
-    private static final Gson gson = new Gson();
+    private static RgpParticipantDataTestUtil rgpParticipantDataTestUtil;
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -39,6 +44,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
                 "elastic/atcpSettings.json");
         ddpInstanceDto = DdpInstanceGroupTestUtil.createTestDdpInstance(instanceName, esIndex);
         ddpInstance = DDPInstance.getDDPInstanceById(ddpInstanceDto.getDdpInstanceId());
+        rgpParticipantDataTestUtil = new RgpParticipantDataTestUtil(esIndex);
     }
 
     @AfterClass
@@ -58,17 +64,101 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         participants.forEach(participantDto ->
                 TestParticipantUtil.deleteParticipant(participantDto.getParticipantId().orElseThrow()));
         participants.clear();
-        fieldSettingsIds.forEach(FieldSettingsTestUtil::deleteFieldSettings);
-        fieldSettingsIds.clear();
+        rgpParticipantDataTestUtil.tearDown();
     }
 
     @Test
     public void testInitParticipant() {
+        // make ptp with some ES DSM data
+        ParticipantDto participant = createParticipant();
+        initParticipant(participant.getRequiredDdpParticipantId());
+    }
+
+    @Test
+    public void testInitParticipantOnlyProfile() {
+        // make ptp with ES profile and no participant ES DSM data
+        initParticipant(createMinimalParticipant());
+    }
+
+    @Test
+    public void testInitParticipantWithFamilyIdAndRgpData() {
+        // make ptp with family ID and RGP data
         ParticipantDto participant = createParticipant();
         String ddpParticipantId = participant.getRequiredDdpParticipantId();
-        ElasticTestUtil.addParticipantActivities(esIndex, ParticipantDataTestUtil.getRgpActivities(), ddpParticipantId);
 
-        ParticipantInitService.initParticipant()
+        // this dictates which default values and workflows are set
+        rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
+
+        ElasticSearchParticipantDto esParticipantDto =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+
+        // create RGP participant data
+        int familyId = 100;
+        RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(familyId));
+
+        esParticipantDto = ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(100), false);
+        Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED.name(), updateLog.getStatus());
+    }
+
+    @Test
+    public void testInitParticipantWithFamilyId() {
+        // make ptp with family ID and no RGP data
+        ParticipantDto participant = createParticipant();
+        String ddpParticipantId = participant.getRequiredDdpParticipantId();
+        Dsm dsm = new Dsm();
+        dsm.setFamilyId("100");
+        ElasticTestUtil.addParticipantDsm(esIndex, dsm, ddpParticipantId);
+
+        ElasticSearchParticipantDto esParticipantDto =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+
+        UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(100), false);
+
+        Assert.assertEquals(UpdateLog.UpdateStatus.ERROR.name(), updateLog.getStatus());
+        Assert.assertTrue(updateLog.getMessage().contains("Participant has family ID in ES but no RGP data"));
+    }
+
+    @Test
+    public void testInitParticipantWithRgpData() {
+        // make ptp with RGP data but no family id in ES
+        ParticipantDto participant = createParticipant();
+        String ddpParticipantId = participant.getRequiredDdpParticipantId();
+
+        // this dictates which default values and workflows are set
+        rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
+
+        ElasticSearchParticipantDto esParticipantDto =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+
+        // create RGP participant data
+        int familyId = 1000;
+        RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(familyId));
+        removeEsFamilyId(esIndex, ddpParticipantId);
+
+        esParticipantDto = ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(familyId), false);
+        Assert.assertEquals(UpdateLog.UpdateStatus.ES_UPDATED.name(), updateLog.getStatus());
+        rgpParticipantDataTestUtil.verifyDefaultElasticData(ddpParticipantId, familyId, Collections.emptyMap());
+    }
+
+    private void initParticipant(String ddpParticipantId) {
+        // this dictates which default values and workflows are set
+        rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
+
+        ElasticSearchParticipantDto esParticipantDto =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+
+        int familyId = 100;
+        UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
+                new TestFamilyIdProvider(familyId), false);
+        Assert.assertEquals(UpdateLog.UpdateStatus.UPDATED.name(), updateLog.getStatus());
+        rgpParticipantDataTestUtil.verifyDefaultData(ddpParticipantId, familyId);
     }
 
     private ParticipantDto createParticipant() {
@@ -79,4 +169,27 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         return participant;
     }
 
+    /**
+     * Create a participant with only an ES profile and no participant data in DSM
+     */
+    private String createMinimalParticipant() {
+        String baseName = String.format("%s_%d", instanceName, participantCounter++);
+        String ddpParticipantId = TestParticipantUtil.genDDPParticipantId(baseName);
+        ElasticTestUtil.addParticipantProfileFromFile(esIndex, "elastic/participantProfile.json",
+                ddpParticipantId);
+        return ddpParticipantId;
+    }
+
+    private static void removeEsFamilyId(String esIndex, String ddpParticipantId) {
+        try {
+            Map<String, Object> esMap =
+                    ElasticSearchUtil.getObjectsMap(esIndex, ddpParticipantId, ESObjectConstants.DSM);
+            Map<String, Object> dsmMap = (Map<String, Object>) esMap.get(ESObjectConstants.DSM);
+            dsmMap.put(ESObjectConstants.FAMILY_ID, null);
+            ElasticSearchUtil.updateRequest(ddpParticipantId, esIndex, esMap);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Error removing family ID from ES: " + e.toString());
+        }
+    }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
@@ -1,0 +1,82 @@
+package org.broadinstitute.dsm.service.adminoperation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.gson.Gson;
+import org.broadinstitute.dsm.DbAndElasticBaseTest;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
+import org.broadinstitute.dsm.model.elastic.Activities;
+import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
+import org.broadinstitute.dsm.util.ElasticTestUtil;
+import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
+import org.broadinstitute.dsm.util.ParticipantDataTestUtil;
+import org.broadinstitute.dsm.util.TestParticipantUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
+    private static final String TEST_USER = "TEST_USER";
+    private static final String instanceName = "rgpinit";
+    private static String esIndex;
+    private static DDPInstanceDto ddpInstanceDto;
+    private static DDPInstance ddpInstance;
+    private static final ParticipantDataDao dataDao = new ParticipantDataDao();
+    private static final List<ParticipantDto> participants = new ArrayList<>();
+    private static int participantCounter = 0;
+    private static final List<Integer> fieldSettingsIds = new ArrayList<>();
+    private static final Gson gson = new Gson();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        esIndex = ElasticTestUtil.createIndex(instanceName, "elastic/atcpMappings.json",
+                "elastic/atcpSettings.json");
+        ddpInstanceDto = DdpInstanceGroupTestUtil.createTestDdpInstance(instanceName, esIndex);
+        ddpInstance = DDPInstance.getDDPInstanceById(ddpInstanceDto.getDdpInstanceId());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        DdpInstanceGroupTestUtil.deleteInstance(ddpInstanceDto);
+        ElasticTestUtil.deleteIndex(esIndex);
+    }
+
+    @After
+    public void deleteParticipantData() {
+        ParticipantDataDao participantDataDao = new ParticipantDataDao();
+        List<ParticipantData> participantDataList =
+                participantDataDao.getParticipantDataByInstanceId(ddpInstanceDto.getDdpInstanceId());
+        participantDataList.forEach(participantData ->
+                participantDataDao.delete(participantData.getParticipantDataId()));
+
+        participants.forEach(participantDto ->
+                TestParticipantUtil.deleteParticipant(participantDto.getParticipantId().orElseThrow()));
+        participants.clear();
+        fieldSettingsIds.forEach(FieldSettingsTestUtil::deleteFieldSettings);
+        fieldSettingsIds.clear();
+    }
+
+    @Test
+    public void testInitParticipant() {
+        ParticipantDto participant = createParticipant();
+        String ddpParticipantId = participant.getRequiredDdpParticipantId();
+        ElasticTestUtil.addParticipantActivities(esIndex, ParticipantDataTestUtil.getRgpActivities(), ddpParticipantId);
+
+        ParticipantInitService.initParticipant()
+    }
+
+    private ParticipantDto createParticipant() {
+        String baseName = String.format("%s_%d", instanceName, participantCounter++);
+        ParticipantDto participant =
+                TestParticipantUtil.createParticipantWithEsProfile(baseName, ddpInstanceDto, esIndex);
+        participants.add(participant);
+        return participant;
+    }
+
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceServiceTest.java
@@ -89,7 +89,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
     public void getRefSourceOneProvided() {
         List<String> answer = List.of("TWITTER");
         applyFoundOutAnswer(activities, answer);
-        String refSourceId = ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
+        String refSourceId =
+                ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
         Assert.assertEquals("TWITTER", refSourceId);
     }
 
@@ -97,7 +98,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
     public void getRefSourceMultipleProvided() {
         List<String> answer = Arrays.asList("TWITTER", "FACEBOOK", "FAMILY");
         applyFoundOutAnswer(activities, answer);
-        String refSourceId = ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
+        String refSourceId =
+                ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
         Assert.assertEquals("MORE_THAN_ONE", refSourceId);
     }
 
@@ -105,7 +107,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
     public void getRefSourceNoneProvided() {
         List<String> answer = new ArrayList<>();
         applyFoundOutAnswer(activities, answer);
-        String refSourceId = ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
+        String refSourceId =
+                ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
         Assert.assertEquals("NA", refSourceId);
     }
 
@@ -137,7 +140,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         enrollment.setQuestionsAnswers(qa);
         log.info("Enrollment: " + enrollment);
 
-        String refSourceId = ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(lessActivities));
+        String refSourceId =
+                ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(lessActivities));
         Assert.assertEquals("NA", refSourceId);
     }
 
@@ -148,7 +152,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         // this possible value is still intact
         List<String> answer = List.of("FACEBOOK");
         applyFoundOutAnswer(activities, answer);
-        String refSourceId = ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
+        String refSourceId =
+                ReferralSourceService.convertReferralSources(ReferralSourceService.getReferralSources(activities));
         Assert.assertEquals("FACEBOOK", refSourceId);
 
         // the NA is removed
@@ -201,9 +206,9 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
 
         // already has a REFERRAL_SOURCE
         try {
-            ReferralSourceService.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
+            UpdateLog.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
                     List.of(testParticipantData), activities);
-            Assert.assertEquals(ReferralSourceService.UpdateStatus.NOT_UPDATED, res);
+            Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, res);
         } catch (Exception e) {
             Assert.fail("Exception from updateReferralSource: " + e);
         }
@@ -215,9 +220,9 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         testParticipantData.setData(gson.toJson(dataMap));
         updateParticipantData(testParticipantData);
         try {
-            ReferralSourceService.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
+            UpdateLog.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
                     List.of(testParticipantData), activities);
-            Assert.assertEquals(ReferralSourceService.UpdateStatus.NOT_UPDATED, res);
+            Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, res);
         } catch (Exception e) {
             Assert.fail("Exception from updateReferralSource: " + e);
         }
@@ -228,9 +233,9 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         testParticipantData.setData(gson.toJson(dataMap));
         updateParticipantData(testParticipantData);
         try {
-            ReferralSourceService.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
+            UpdateLog.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
                     List.of(testParticipantData), activities);
-            Assert.assertEquals(ReferralSourceService.UpdateStatus.NOT_UPDATED, res);
+            Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, res);
         } catch (Exception e) {
             Assert.fail("Exception from updateReferralSource: " + e);
         }
@@ -240,9 +245,9 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         testParticipantData.setData(gson.toJson(dataMap));
         updateParticipantData(testParticipantData);
         try {
-            ReferralSourceService.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
+            UpdateLog.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
                     List.of(testParticipantData), activities);
-            Assert.assertEquals(ReferralSourceService.UpdateStatus.UPDATED, res);
+            Assert.assertEquals(UpdateLog.UpdateStatus.UPDATED, res);
             verifyReferralSource(testParticipantData.getParticipantDataId(), "TWITTER");
         } catch (Exception e) {
             Assert.fail("Exception from updateReferralSource: " + e);
@@ -255,9 +260,9 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         secondRecord.setData(gson.toJson(dataMap));
         updateParticipantData(secondRecord);
         try {
-            ReferralSourceService.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
+            UpdateLog.UpdateStatus res = service.updateReferralSource(ddpParticipantId,
                     List.of(testParticipantData, secondRecord), activities);
-            Assert.assertEquals(ReferralSourceService.UpdateStatus.UPDATED, res);
+            Assert.assertEquals(UpdateLog.UpdateStatus.UPDATED, res);
             verifyReferralSource(testParticipantData.getParticipantDataId(), "TWITTER");
             verifyReferralSource(secondRecord.getParticipantDataId(), "TWITTER");
         } catch (Exception e) {
@@ -284,7 +289,8 @@ public class ReferralSourceServiceTest extends DbTxnBaseTest {
         refSourceQA.put(DDPActivityConstants.ACTIVITY_QUESTION_ANSWER, answer);
     }
 
-    private ParticipantData createParticipantData(String ddpParticipantId, DDPInstanceDto instance, List<Activities> activities) {
+    private ParticipantData createParticipantData(String ddpParticipantId, DDPInstanceDto instance,
+                                                  List<Activities> activities) {
         Profile esProfile = new Profile();
         esProfile.setGuid(ddpParticipantId);
         esProfile.setEmail("test_ptp@gmail.com");

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
@@ -1,0 +1,133 @@
+package org.broadinstitute.dsm.service.participantdata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
+import org.broadinstitute.dsm.model.elastic.Dsm;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
+import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.broadinstitute.dsm.util.ElasticTestUtil;
+import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
+import org.junit.Assert;
+
+@Slf4j
+public class RgpParticipantDataTestUtil {
+    private final String esIndex;
+    private static final List<Integer> fieldSettingsIds = new ArrayList<>();
+
+    public RgpParticipantDataTestUtil(String esIndex) {
+        this.esIndex = esIndex;
+    }
+
+    /**
+     * Clean up the records created by the methods in this class
+     * Call this on test tearDown.
+     */
+    public void tearDown() {
+        try {
+            fieldSettingsIds.forEach(FieldSettingsTestUtil::deleteFieldSettings);
+            fieldSettingsIds.clear();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Error in tearDown " + e.toString());
+        }
+    }
+
+    public void loadFieldSettings(int ddpInstanceId) {
+        int id = FieldSettingsTestUtil.loadOptionsFromFile("fieldsettings/active.json", "RGP_STUDY_STATUS_GROUP",
+                "ACTIVE", ddpInstanceId);
+        fieldSettingsIds.add(id);
+        id = FieldSettingsTestUtil.loadOptionsFromFile("fieldsettings/dataSharing.json", "RGP_STUDY_STATUS_GROUP",
+                "DATA_SHARING", ddpInstanceId);
+        fieldSettingsIds.add(id);
+        id = FieldSettingsTestUtil.loadOptionsAndActionsFromFile("fieldsettings/acceptanceStatus.json",
+                "fieldsettings/acceptanceStatusAction.json", "RGP_STUDY_STATUS_GROUP",
+                "ACCEPTANCE_STATUS", ddpInstanceId);
+        fieldSettingsIds.add(id);
+        id = FieldSettingsTestUtil.loadOptionsAndActionsFromFile("fieldsettings/redcapSurveyTaker.json",
+                "fieldsettings/redcapSurveyTakerAction.json", "RGP_SURVEY_GROUP",
+                "REDCAP_SURVEY_TAKER", ddpInstanceId);
+        fieldSettingsIds.add(id);
+    }
+
+    /**
+     * Verify initial data for a participant (based on the loaded field settings)
+     *
+     * @return names of workflows that were created
+     */
+    public Set<String> verifyDefaultData(String ddpParticipantId, int familyId) {
+        Map<String, String> expectedDataMap = new HashMap<>();
+        expectedDataMap.put("COLLABORATOR_PARTICIPANT_ID",
+                RgpParticipantDataService.createCollaboratorParticipantId(familyId));
+        // default values per field settings
+        expectedDataMap.put("ACTIVE", "ACTIVE");
+        expectedDataMap.put("DATA_SHARING", "UNKNOWN");
+        expectedDataMap.put("ACCEPTANCE_STATUS", "PRE_REVIEW");
+        expectedDataMap.put("REDCAP_SURVEY_TAKER", "NA");
+        expectedDataMap.put("FAMILY_ID", Integer.toString(familyId));
+        // from profile file
+        expectedDataMap.put(FamilyMemberConstants.EMAIL, "SpinkaNortheast@broad.org");
+
+        verifyParticipantData(ddpParticipantId, expectedDataMap);
+        verifyDefaultElasticData(ddpParticipantId, familyId, expectedDataMap);
+        Set<String> workflowNames = Set.of("REDCAP_SURVEY_TAKER", "ACCEPTANCE_STATUS");
+        verifyWorkflows(ddpParticipantId, workflowNames);
+        return workflowNames;
+    }
+
+    public void verifyDefaultElasticData(String ddpParticipantId, int familyId,
+                                         Map<String, String> expectedDataMap) {
+        ElasticSearchParticipantDto esParticipant =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
+                ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
+        Dsm dsm = esParticipant.getDsm().orElseThrow();
+
+        String esFamilyId = dsm.getFamilyId();
+        Assert.assertEquals(Integer.toString(familyId), esFamilyId);
+
+        if (!expectedDataMap.isEmpty()) {
+            List<ParticipantData> esParticipantData = dsm.getParticipantData();
+            Assert.assertEquals(1, esParticipantData.size());
+            ParticipantData participantData = esParticipantData.get(0);
+            Assert.assertEquals(RgpParticipantDataService.RGP_PARTICIPANTS_FIELD_TYPE,
+                    participantData.getRequiredFieldTypeId());
+            Map<String, String> dataMap = participantData.getDataMap();
+            expectedDataMap.forEach((key, value) -> Assert.assertEquals(value, dataMap.get(key)));
+        }
+    }
+
+    public void verifyWorkflows(String ddpParticipantId, Set<String> workflowNames) {
+        ElasticSearchParticipantDto esParticipant =
+                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
+                ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
+
+        List<Map<String, Object>> workflows = esParticipant.getWorkflows();
+        Assert.assertEquals(workflowNames.size(), workflows.size());
+
+        Set<Object> foundWorkflowNames = workflows.stream()
+                .map(m -> m.get("workflow")).collect(Collectors.toSet());
+        Assert.assertEquals(workflowNames, foundWorkflowNames);
+    }
+
+    public static void verifyParticipantData(String ddpParticipantId, Map<String, String> expectedDataMap) {
+        ParticipantDataDao dataDao = new ParticipantDataDao();
+        List<ParticipantData> ptpDataList = dataDao.getParticipantData(ddpParticipantId);
+        Assert.assertEquals(1, ptpDataList.size());
+
+        ParticipantData participantData = ptpDataList.get(0);
+        Assert.assertEquals(RgpParticipantDataService.RGP_PARTICIPANTS_FIELD_TYPE,
+                participantData.getRequiredFieldTypeId());
+        Map<String, String> dataMap = participantData.getDataMap();
+        expectedDataMap.forEach((key, value) -> Assert.assertEquals(value, dataMap.get(key)));
+    }
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsm.util;
 
-import static org.broadinstitute.ddp.db.TransactionWrapper.inTransaction;
 import static org.broadinstitute.dsm.statics.ESObjectConstants.ONC_HISTORY_DETAIL;
 
 import java.util.HashMap;
@@ -21,8 +20,6 @@ import org.broadinstitute.dsm.model.elastic.Profile;
 import org.broadinstitute.dsm.model.elastic.export.painless.UpsertPainless;
 import org.broadinstitute.dsm.util.export.ElasticSearchParticipantExporterFactory;
 import org.broadinstitute.dsm.util.export.ParticipantExportPayload;
-import org.broadinstitute.lddp.handlers.util.Institution;
-import org.broadinstitute.lddp.handlers.util.InstitutionRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.get.GetRequest;
@@ -155,8 +152,8 @@ public class ElasticTestUtil {
     public static void addDsmParticipant(ParticipantDto participantDto, DDPInstanceDto ddpInstanceDto) {
         ElasticSearchParticipantExporterFactory.fromPayload(
                 new ParticipantExportPayload(
-                        participantDto.getParticipantIdOrThrow(),
-                        participantDto.getDdpParticipantId().orElseThrow(),
+                        participantDto.getRequiredParticipantId(),
+                        participantDto.getRequiredDdpParticipantId(),
                         ddpInstanceDto.getDdpInstanceId().toString(),
                         ddpInstanceDto.getInstanceName(),
                         ddpInstanceDto
@@ -165,11 +162,11 @@ public class ElasticTestUtil {
     }
 
     public static void createParticipant(String esIndex, ParticipantDto participantDto) {
-        String ddpParticipantId = participantDto.getDdpParticipantIdOrThrow();
+        String ddpParticipantId = participantDto.getRequiredDdpParticipantId();
         try {
             Map<String, Object> props = new HashMap<>();
             props.put("ddpParticipantId", ddpParticipantId);
-            props.put("participantId", participantDto.getParticipantIdOrThrow());
+            props.put("participantId", participantDto.getRequiredParticipantId());
             props.put("created", participantDto.getLastChanged());
             Map<String, Object> parent = new HashMap<>();
             parent.put("participant", props);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/FieldSettingsTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/FieldSettingsTestUtil.java
@@ -34,7 +34,7 @@ public class FieldSettingsTestUtil {
         builder.withFieldType(AT_PARTICIPANT_EXIT)
                 .withColumnName(EXIT_STATUS)
                 .withPossibleValues("[{\"value\":\"0\",\"name\":\"Not Exited\",\"default\":true},"
-                + "{\"value\":\"1\",\"name\":\"Exited\"}]");
+                    + "{\"value\":\"1\",\"name\":\"Exited\"}]");
         return FieldSettingsTestUtil.createRadioFieldSetting(builder);
     }
 


### PR DESCRIPTION
## Context
[PEPPER-1353]

With PEPPER-1161 we changed the way RGP participant data gets created (see https://docs.google.com/document/d/1KMP-5oWFRNKktmVbzgaAbeZBMmOOp9TfEa39yNz3vzE/edit). That ensured there will be no new RGP participants without family IDs, but it left a gap for the existing RGP participants who have not yet completed enrollment: they will be missing a family ID until they complete enrollment.

This PR adds an AdminOperation, ParticipantInitService, to add family IDs and default data for those participants. It also handles a few edge cases -- essentially bad data -- by either fixing the data, or noting the problem in the operation log. ParticipantInitService has a dry run mode, since the operation considers all RGP participants, not just a list of participants. Dry run mode can also be used to simply identify bad/inconsistent data issues, so it might be something we expand in the future.

I ran ParticipantInitService locally against Dev data, to ensure it worked properly.

RgpParticipantDataTestUtil contains a set of test utility methods, culled from RgpParticipantDataServiceTest. These methods are now needed by more than one test, and the class adds the benefit of automatic resource management. 

UpdateStatus was moved from individual AdminOperation implementing classes to UpdateLog, where it can be shared.

The PR includes a handful of code cleanups:

1. Renamed and refactored ParticipantDataDao.getParticipantData. The prior name was inaccurate. Unfortunately this had a ripple effect into several files.
2. Removed unused imports and fixed checkstyle issues from a handful of files I recently edited. (IOW, I overlooked the issues after making changes.)
3. Cleaned up ElasticSearchUtil. getDDPParticipantsFromES. The log messages were ambiguous, since the same log message is used for more than one method, and there was unnecessary code. There is a lot of work to do in this file, and I chip away as methods are brought under test.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-1353]: https://broadworkbench.atlassian.net/browse/PEPPER-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ