### PR TITLE
Reverting java17 changes--too soon for develop.

### DIFF
--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -48,7 +48,7 @@ references:
 executors:
   test-executor:
     docker:
-      - image: broadinstitute/study-server-build:java-2023-03-28C
+      - image: broadinstitute/study-server-build:java-2022-06-01A
       # start pubsub emulator
       - image: broadinstitute/study-server-build:pubsub-1
       - image: cimg/redis:5.0

--- a/pepper-apis/build-utils/build-support-images/Dockerfile-build
+++ b/pepper-apis/build-utils/build-support-images/Dockerfile-build
@@ -1,11 +1,9 @@
 # To make our config generation "compatible" with official dsdetoolbox, extract what is needed from it (this is not the base image)
 FROM broadinstitute/dsde-toolbox:DDO-1934 AS dsdetoolbox
 
-FROM alpine:3.15.0
+FROM maven:3.6.3-jdk-11 AS maven
 
-FROM maven:3-openjdk-17-slim AS maven
-
-FROM google/cloud-sdk:400.0.0-alpine
+FROM google/cloud-sdk:alpine
 
 #Essentials for Maven
 COPY --from=maven /usr/share/maven /usr/share/maven
@@ -35,7 +33,7 @@ RUN case "${TARGETARCH:-amd64}" in \
     mysql-client \
     netcat-openbsd \
     git \
-    openjdk17 \
+    openjdk11 \
     # to support configure.rb
     ruby \
     ruby-json  \

--- a/pepper-apis/build-utils/build-support-images/Dockerfile-java-build
+++ b/pepper-apis/build-utils/build-support-images/Dockerfile-java-build
@@ -35,7 +35,7 @@ RUN case "${TARGETARCH:-amd64}" in \
     # base alpine image does not have ssh
     openssh-client \
     git \
-    openjdk17 \
+    openjdk11 \
     # to support configure.rb
     ruby \
     ruby-json \

--- a/pepper-apis/build-utils/build-support-images/Dockerfile-java-build
+++ b/pepper-apis/build-utils/build-support-images/Dockerfile-java-build
@@ -1,10 +1,9 @@
 # To make our config generation "compatible" with official dsdetoolbox, extract what is needed from it (this is not the base image)
 FROM broadinstitute/dsde-toolbox:DDO-1934 AS dsdetoolbox
 
-# upgrade https://github.com/netty/netty-tcnative/issues/649
-FROM maven:3-openjdk-17-slim AS maven
+FROM maven:3.6.3-jdk-11 AS maven
 
-FROM alpine:3.15.0
+FROM alpine:3.15
 
 #Essentials for Maven
 COPY --from=maven /usr/share/maven /usr/share/maven

--- a/pepper-apis/build-utils/build-support-images/README.md
+++ b/pepper-apis/build-utils/build-support-images/README.md
@@ -1,7 +1,8 @@
 # Creating build and deployment-support Docker images
 
 ## Overview
-Our builds and deploys are executed via CircleCi.
+Our builds and deplo
+ys are executed via CircleCi.
 
 We have two images used in our CircleCi configuration.
 
@@ -18,10 +19,10 @@ On Mac computer we are using:
 
 ## Procedure
 
-``docker buildx build --platform linux/amd64,linux/arm64 -t broadinstitute/study-server-build:java-2023-03-28C  --build-arg GIT_SHA=`git rev-parse --verify HEAD` -f ./Dockerfile-build --push .
+``docker buildx build --platform linux/amd64,linux/arm64 -t broadinstitute/study-server-build:java-2022-06-01A  --build-arg GIT_SHA=`git rev-parse --verify HEAD` -f ./Dockerfile-build --push .
 ``
 
-``docker buildx build --platform linux/amd64,linux/arm64 -t broadinstitute/study-server-build:java-2023-03-28C  --build-arg GIT_SHA=`git rev-parse --verify HEAD` -f ./Dockerfile-java-build --push .``
+``docker buildx build --platform linux/amd64,linux/arm64 -t broadinstitute/study-server-build:java-2022-06-01A  --build-arg GIT_SHA=`git rev-parse --verify HEAD` -f ./Dockerfile-java-build --push .``
 
 ## Additional Notes
 We are using multi-platform builds (amd64 and arm64) to create separate versions of images that can run on Intel 

--- a/pepper-apis/config/DataDonationPlatform.yaml.ctmpl
+++ b/pepper-apis/config/DataDonationPlatform.yaml.ctmpl
@@ -29,9 +29,9 @@ network:
   name: managed
   instance_tag: study-server # necessary for firewall rules so that DSM will accept https requests from pepper
 {{if and (or (eq $environment "prod") (eq $environment "staging") (eq $environment "dev") (eq $environment "test")) (eq $gae "true") }}
-entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=pepper-backend,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1640m -Dio.grpc.netty.shaded.io.netty.transport.noNative=false -jar DataDonationPlatform.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=pepper-backend,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1640m -jar DataDonationPlatform.jar
 {{else}}
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xmx1640m -Dio.grpc.netty.shaded.io.netty.transport.noNative=false-jar DataDonationPlatform.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xmx1640m -jar DataDonationPlatform.jar
 {{end}}
 # GAE does not like the "=" character in entrypoint and does not support "." in environment variables
 env_variables:

--- a/pepper-apis/config/Housekeeping.yaml.ctmpl
+++ b/pepper-apis/config/Housekeeping.yaml.ctmpl
@@ -16,9 +16,9 @@ manual_scaling:
 # todo arz give housekeeping and backends different app names for tcell
 
 {{if and (or (eq $environment "prod") (eq $environment "staging") (eq $environment "dev") (eq $environment "test")) (eq $gae "true") }}
-entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1340m -Dio.grpc.netty.shaded.io.netty.transport.noNative=false -jar Housekeeping.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=housekeeping,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1340m -jar Housekeeping.jar
 {{else}}
-entrypoint: java -javaagent:tcell/tcellagent.jar -Xmx1640m -Dio.grpc.netty.shaded.io.netty.transport.noNative=false -jar Housekeeping.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -Xmx1640m -jar Housekeeping.jar
 {{end}}
 
 # GAE does not like the "=" character in entrypoint and does not support "." in environment variables

--- a/pepper-apis/configure.rb
+++ b/pepper-apis/configure.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/ruby -w
 # Docker Image used to call out to generate config files
 
-$dsde_toolbox_image_name = "broadinstitute/study-server-build:java-2023-03-28C"
+$dsde_toolbox_image_name = "broadinstitute/study-server-build:java-2022-06-01A"
 # If USE_DOCKER evaluates to false, script will try to call consul-template directly
 # instead of using Docker image built in scripts
 $use_docker = ENV.fetch("USE_DOCKER", "true") == "true"

--- a/pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml
+++ b/pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml
@@ -13,7 +13,7 @@ network:
   name: managed
   instance_tag: study-manager
 
-entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=study-manager,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1640m -Dlog4j.configurationFile=log4j.xml -Dio.grpc.netty.shaded.io.netty.transport.noNative=false -jar DSMServer.jar
+entrypoint: java -javaagent:tcell/tcellagent.jar -agentpath:/opt/cprof/profiler_java_agent.so=-cprof_enable_heap_sampling=true,-cprof_service=study-manager,-cprof_cpu_use_per_thread_timers=true,-logtostderr -Xmx1640m -Dlog4j.configurationFile=log4j.xml -jar DSMServer.jar
 
 env_variables:
   TCELL_AGENT_HOST_IDENTIFIER: study-manager


### PR DESCRIPTION
Reverting changes to java17.  Too soon to put this on develop.  Instead, we'll continue on a separate branch.  These changes should be a complete undo of [this PR](https://github.com/broadinstitute/ddp-study-server/pull/2786).