### PR TITLE
[PEPPER-1335] Fix Osteo1 participant init when no consent

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/ExportLogger.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/ExportLogger.java
@@ -1,0 +1,59 @@
+package org.broadinstitute.dsm.model.elastic.migration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+import org.broadinstitute.dsm.service.adminoperation.ExportLog;
+
+public class ExportLogger {
+    @Getter
+    private final List<ExportLog> exportLogs;
+    @Getter
+    private final String entity;
+    private final boolean recordSuccessIds;
+    private final boolean useExportLog;
+
+    public ExportLogger(String entity) {
+        this(new ArrayList<>(), entity, false, false);
+    }
+
+    public ExportLogger(List<ExportLog> exportLogs, String entity, boolean recordSuccessIds, boolean useExportLog) {
+        this.exportLogs = exportLogs;
+        this.entity = entity;
+        this.recordSuccessIds = recordSuccessIds;
+        this.useExportLog = useExportLog;
+    }
+
+    public ExportLogger(List<ExportLog> exportLogs, String entity, boolean recordSuccessIds) {
+        this(exportLogs, entity, recordSuccessIds, true);
+    }
+
+    public ExportLogger(List<ExportLog> exportLogs, String entity) {
+        this(exportLogs, entity, false, true);
+    }
+
+    public void addLog(ExportLog log) {
+        exportLogs.add(log);
+    }
+
+    public boolean recordSuccessIds() {
+        return recordSuccessIds;
+    }
+
+    public boolean useExportLog() {
+        return useExportLog;
+    }
+
+    public void setEntityStatus(ExportLog.Status status) {
+        ExportLog exportLog = new ExportLog(entity);
+        exportLog.setStatus(status);
+        addLog(exportLog);
+    }
+
+    public void setEntityError(String message) {
+        ExportLog exportLog = new ExportLog(entity);
+        exportLog.setError(message);
+        addLog(exportLog);
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/VerificationLog.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/VerificationLog.java
@@ -21,6 +21,7 @@ public class VerificationLog {
         VERIFIED,
         ES_DATA_MISMATCH,
         ES_ENTITY_MISMATCH,
+        NO_ES_DOCUMENT,
         ERROR
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
@@ -81,7 +81,12 @@ public class OsteoParticipantService {
     }
 
     /**
-     * Return true if new participant registration is for OS1
+     * Return true if new participant registration is for OS1.
+     * The criteria for OS1 participant is:
+     * 1. Has consent activity
+     * 2. Does not have any consent activity with version > v1
+     * So if a participant has no consent activities when this code is called,
+     * they are considered OS2 participant.
      */
     protected boolean isOsteo1Participant(ElasticSearchParticipantDto participantDto) {
         List<Activities> activities = participantDto.getActivities();

--- a/pepper-apis/dsm-core/src/test/resources/elastic/osteoActivitiesNoConsent.json
+++ b/pepper-apis/dsm-core/src/test/resources/elastic/osteoActivitiesNoConsent.json
@@ -1,0 +1,57 @@
+[
+  {
+    "activityCode": "PREQUAL",
+    "activityVersion": "v1",
+    "guid": "I9MORP2IUP",
+    "parentInstanceGuid": null,
+    "status": "COMPLETE",
+    "questionsAnswers": [
+      {
+        "answer": [
+          "CHILD_DIAGNOSED"
+        ],
+        "optionDetails": [],
+        "groupedOptions": {},
+        "nestedOptions": {},
+        "questionType": "PICKLIST",
+        "stableId": "PREQUAL_SELF_DESCRIBE",
+        "PREQUAL_SELF_DESCRIBE": [
+          "CHILD_DIAGNOSED"
+        ]
+      },
+      {
+        "answer": 14,
+        "questionType": "NUMERIC",
+        "stableId": "CHILD_CURRENT_AGE",
+        "CHILD_CURRENT_AGE": 14
+      },
+      {
+        "answer": [
+          "US"
+        ],
+        "optionDetails": [],
+        "groupedOptions": {},
+        "nestedOptions": {},
+        "questionType": "PICKLIST",
+        "stableId": "CHILD_COUNTRY",
+        "CHILD_COUNTRY": [
+          "US"
+        ]
+      },
+      {
+        "answer": [
+          "CA"
+        ],
+        "optionDetails": [],
+        "groupedOptions": {},
+        "nestedOptions": {},
+        "questionType": "PICKLIST",
+        "stableId": "CHILD_STATE",
+        "CHILD_STATE": [
+          "CA"
+        ]
+      }
+    ],
+    "attributes": {}
+  }
+]


### PR DESCRIPTION
## Context
PEPPER-1335

This PR includes a few changes to better support moving to separate OS1 and OS2 ES indexes:

- Bug fix: When DSM receives a new osteo ptp registration message, it will create an OS2 cohort tag if there is no consent activity.
- Improved export logging: Created `ExportLogger` to more cleanly express what should appear in the export logs, and to make export logs easier to assemble. (The addition of one more toggle, `recordSuccessIds`, provoked this.)
- Improved verification logging: In the Dev environment (at least) there are many instances where no ES document exists for a participant. Apparently the DSM DB has old study information that was never erased. To make these cases clearer, now reporting these cases as 'NO_ES_DOCUMENT' status.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

