### PR TITLE
PEPPER-1392 initialize spark and response to ah/start routes sooner

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -449,7 +449,7 @@ public class DSMServer {
         return true;
     }
 
-    private static void registerAppEngineStartupCallback() {
+    private static void registerAppEngineCallbacks() {
         get(RoutePath.GAE.START_ENDPOINT, (request, response) -> {
             logger.info("Received GAE start request [{}]", request.url());
             response.status(HttpStatus.SC_OK);
@@ -509,7 +509,7 @@ public class DSMServer {
         logger.info("Using port {}", port);
         port(port);
 
-        registerAppEngineStartupCallback();
+        registerAppEngineCallbacks();
 
         setupDB(config);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -449,7 +449,7 @@ public class DSMServer {
         return true;
     }
 
-    private static void registerAppEngineStartupCallback(long bootTimeoutSeconds) {
+    private static void registerAppEngineStartupCallback() {
         get(RoutePath.GAE.START_ENDPOINT, (request, response) -> {
             logger.info("Received GAE start request [{}]", request.url());
             response.status(HttpStatus.SC_OK);
@@ -505,15 +505,11 @@ public class DSMServer {
         if (appEnginePort != null) {
             port = Integer.parseInt(appEnginePort);
         }
-        long bootTimeoutSeconds = DEFAULT_BOOT_WAIT.getSeconds();
-        if (config.hasPath(ApplicationConfigConstants.BOOT_TIMEOUT)) {
-            bootTimeoutSeconds = config.getInt(ApplicationConfigConstants.BOOT_TIMEOUT);
-        }
 
         logger.info("Using port {}", port);
         port(port);
 
-        registerAppEngineStartupCallback(bootTimeoutSeconds);
+        registerAppEngineStartupCallback();
 
         setupDB(config);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/RoutePath.java
@@ -155,5 +155,6 @@ public class RoutePath {
 
     public static final class GAE {
         public static final String STOP_ENDPOINT = "/_ah/stop";
+        public static final String START_ENDPOINT = "/_ah/start";
     }
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/DataDonationPlatform.java
@@ -26,7 +26,6 @@ import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -298,6 +297,18 @@ public class DataDonationPlatform {
         Config sqlConfig = ConfigFactory.load(ConfigFile.SQL_CONFIG_FILE);
         initSqlCommands(sqlConfig);
 
+        // start responding to GAE _ah/start commands as soon as we can,
+        // even if that means we accept traffic before we've done
+        // cache cleanup and possibly lengthy liquibase updates
+        if (appEnginePort != null) {
+            port(Integer.parseInt(appEnginePort));
+        } else {
+            port(configFilePort);
+        }
+        threadPool(-1, -1, requestThreadTimeout);
+        JettyConfig.setupJetty(preferredSourceIPHeader);
+        registerAppEngineCallbacks();
+
         if (cfg.hasPath(ConfigFile.DO_LIQUIBASE_IN_STUDY_SERVER) && cfg.getBoolean(ConfigFile.DO_LIQUIBASE_IN_STUDY_SERVER)) {
             log.info("Running liquibase migrations in StudyServer against database");
             LiquibaseUtil.runLiquibase(dbUrl, TransactionWrapper.DB.APIS);
@@ -306,19 +317,6 @@ public class DataDonationPlatform {
         //@TODO figure out how to do this only at deployment time.
         CacheService.getInstance().resetAllCaches();
         TransactionWrapper.useTxn(TransactionWrapper.DB.APIS, LanguageStore::init);
-
-        if (appEnginePort != null) {
-            port(Integer.parseInt(appEnginePort));
-        } else {
-            port(configFilePort);
-        }
-        threadPool(-1, -1, requestThreadTimeout);
-        JettyConfig.setupJetty(preferredSourceIPHeader);
-
-        // The first route mapping call will also initialize the Spark server. Make that first call
-        // the GAE lifecycle hooks so we capture the GAE call as soon as possible, and respond
-        // only once server has fully booted.
-        registerAppEngineCallbacks(DEFAULT_BOOT_WAIT_SECS);
 
         ActivityInstanceDao activityInstanceDao = new ActivityInstanceDao();
 
@@ -625,31 +623,17 @@ public class DataDonationPlatform {
         }
     }
 
-    private static void registerAppEngineCallbacks(long bootWaitSecs) {
+    public static void registerAppEngineCallbacks() {
         get(RouteConstants.GAE.START_ENDPOINT, (request, response) -> {
-            log.info("Received GAE start request [{}]", RouteConstants.GAE.START_ENDPOINT);
-            long startedMillis = Instant.now().toEpochMilli();
-
-            var status = new AtomicInteger(HttpStatus.SC_SERVICE_UNAVAILABLE);
-            var waitForBoot = new Thread(() -> {
-                synchronized (isReady) {
-                    if (isReady.get()) {
-                        status.set(HttpStatus.SC_OK);
-                    }
-                }
-            });
-            waitForBoot.start();
-            waitForBoot.join(bootWaitSecs * 1000);
-
-            long elapsed = Instant.now().toEpochMilli() - startedMillis;
-            log.info("Responding to GAE start request with status {} after delay of {}ms", status, elapsed);
-            response.status(status.get());
+            log.info("Received GAE start request [{}]", request.url());
+            response.status(HttpStatus.SC_OK);
             return "";
         });
 
         get(RouteConstants.GAE.STOP_ENDPOINT, (request, response) -> {
-            log.info("Received GAE stop request [{}]", RouteConstants.GAE.STOP_ENDPOINT);
-
+            log.info("Received GAE stop request [{}]", request.url());
+            Spark.stop();
+            Spark.awaitStop();
             response.status(HttpStatus.SC_OK);
             return "";
         });


### PR DESCRIPTION
PEPPER-1392 initialize spark and response to ah/start routes sooner in the boot process so that gae does not keep trying to create instances due to slower than expected startup times.

For an as of yet unknown reason, GAE seems to be waiting for less time for `ah/start` routes to return a 200.  This PR changes housekeeping, DSS, and DSM boot processes so that spark initializes faster, leading to faster response to GAE start calls.  

** This does introduce the risk that the deployed service will accept traffic before it is truly ready, which is a particular hazard for long liquibase scripts. **  I think that risk is acceptable, given the problems we are currently experience in prod.
