### PR TITLE
[PEPPER-1353] Add temporary logging for missing ES data

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
@@ -128,11 +128,13 @@ public class DSMtasksSubscription {
         } catch (ESMissingParticipantDataException e) {
             // retry until ES data shows up, or we reach max wait
             retryPerParticipant.merge(participantGuid, 1, Integer::sum);
-            if (retryPerParticipant.get(participantGuid) == MAX_RETRY) {
+            int tryNum = retryPerParticipant.get(participantGuid);
+            if (tryNum == MAX_RETRY) {
                 retryPerParticipant.remove(participantGuid);
                 consumer.ack();
                 throw e;
             } else {
+                logger.info("Waiting for missing ES data, try number {}: {}", tryNum, e.toString());
                 consumer.nack();
             }
         }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
@@ -23,6 +23,7 @@ import org.broadinstitute.dsm.db.dto.tag.cohort.CohortTag;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.adminoperation.ExportLog;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.CohortTagTestUtil;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
@@ -332,7 +333,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
     }
 
     private List<CohortTag> getCohortTagsFromDoc(String ddpParticipantId) {
-        Map<String, Object> sourceMap = ElasticTestUtil.getParticipantDocument(esIndex,  ddpParticipantId);
+        Map<String, Object> sourceMap = ElasticSearchService.getParticipantDocument(ddpParticipantId, esIndex);
         Assert.assertNotNull(sourceMap);
         Map<String, Object> dsmProp = (Map<String, Object>) sourceMap.get(ESObjectConstants.DSM);
         Assert.assertNotNull(dsmProp);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
@@ -3,6 +3,7 @@ package org.broadinstitute.dsm.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.DbAndElasticBaseTest;
@@ -108,6 +109,22 @@ public class ElasticSearchServiceTest extends DbAndElasticBaseTest {
             OncHistoryDetail oncHistoryDetail = oncHistoryDetailList.get(0);
             Assert.assertEquals(medicalRecord.getMedicalRecordId(), oncHistoryDetail.getMedicalRecordId());
         });
+    }
+
+    @Test
+    public void testGetParticipantDocumentAsString() {
+        ParticipantDto participant = createParticipant();
+        String ddpParticipantId = participant.getRequiredDdpParticipantId();
+
+        Optional<String> ptpDoc = ElasticSearchService.getParticipantDocumentAsString(ddpParticipantId, esIndex);
+        Assert.assertTrue(ptpDoc.isPresent());
+        String ptpDocStr = ptpDoc.get();
+        Assert.assertTrue(ptpDocStr.contains("\"profile\":{"));
+        Assert.assertTrue(ptpDocStr.contains(ddpParticipantId));
+
+        // bogus participant ID
+        ElasticSearchService.getParticipantDocumentAsString(TestParticipantUtil.genDDPParticipantId("bogus"),
+                esIndex).ifPresent(doc -> Assert.fail("Should not have found participant document"));
     }
 
     private ParticipantDto createParticipant() {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/ElasticTestUtil.java
@@ -18,12 +18,11 @@ import org.broadinstitute.dsm.model.elastic.Address;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.Profile;
 import org.broadinstitute.dsm.model.elastic.export.painless.UpsertPainless;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.export.ElasticSearchParticipantExporterFactory;
 import org.broadinstitute.dsm.util.export.ParticipantExportPayload;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RequestOptions;
@@ -128,25 +127,7 @@ public class ElasticTestUtil {
     }
 
     public static String getParticipantDocumentAsString(String index, String ddpParticipantId) {
-        return _getParticipantDocument(index, ddpParticipantId).getSourceAsString();
-    }
-
-    public static Map<String, Object> getParticipantDocument(String index, String ddpParticipantId) {
-        return _getParticipantDocument(index, ddpParticipantId).getSource();
-    }
-
-    private static GetResponse _getParticipantDocument(String index, String ddpParticipantId) {
-        GetResponse res = null;
-        try {
-            RestHighLevelClient client = ElasticSearchUtil.getClientInstance();
-
-            GetRequest getRequest = new GetRequest().index(index).id(ddpParticipantId);
-            res = client.get(getRequest, RequestOptions.DEFAULT);
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected exception getting document for participant " + ddpParticipantId);
-        }
-        return res;
+        return ElasticSearchService.getParticipantDocumentAsString(ddpParticipantId, index).orElseThrow();
     }
 
     public static void addDsmParticipant(ParticipantDto participantDto, DDPInstanceDto ddpInstanceDto) {


### PR DESCRIPTION
## Context
PEPPER-1353

This PR contains temporary logging to help debug a problem we observed on Prod. Specifically, we are seeing DSM fail to get profile information from participant ES documents. Based in the logging timestamps the profile should be in place, so it is unclear if DSM is just failing to read the ES document, or if the timestamps are misleading.

Included in this PR:

1. Added logging to retrieve the ptp document in cases where DSM cannot get the ptp profile (RgpParticipantDataService).
2. Added logging to indicate when we are retrying the PARTICIPANT_REGISTERED handling (we already have this for UPDATE_CUSTOM_WORKFLOW handling). 
3. Moved `getParticipantDocument` methods from ElasticTestUtil to ElasticSearchService. Get a document by ID is a fundamental service that we have not provided for non-test cases.


## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

