### PR TITLE
[PEPPER-1267] Fix search scrolling in getLegacyPidsByGuid

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
@@ -79,37 +79,60 @@ public class ElasticSearchService {
      * for participants that have a legacy PID.
      */
     public Map<String, String> getLegacyPidsByGuid(String esIndex) {
+        Map<String, String> guidToPid = new HashMap<>();
+
         SearchRequest searchRequest = new SearchRequest(esIndex);
-        SearchResponse response;
         try {
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            searchSourceBuilder.query(QueryBuilders.existsQuery(ElasticSearchUtil.PROFILE_LEGACYALTPID));
-            searchRequest.source(searchSourceBuilder);
-            response = ElasticSearchUtil.getClientInstance().search(searchRequest, RequestOptions.DEFAULT);
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+            sourceBuilder.query(QueryBuilders.existsQuery(ElasticSearchUtil.PROFILE_LEGACYALTPID));
+            searchRequest.source(sourceBuilder);
+
+            int batchSize = 1000;
+            int batchNumber = 0;
+            while (true) {
+                sourceBuilder.size(batchSize);
+                sourceBuilder.from(batchNumber * batchSize);
+                searchRequest.source(sourceBuilder);
+                if (addLegacyPidHits(search(searchRequest), guidToPid, esIndex) == 0) {
+                    break;
+                }
+                batchNumber++;
+            }
         } catch (Exception e) {
             // this is likely due to a bad query, so log it
             log.error("Error getting ES participant legacy PIDs: index %s, query: %s"
                     .formatted(esIndex, searchRequest));
             throw new DsmInternalError("Error getting ES participants for instance " + esIndex, e);
         }
-        List<ElasticSearchParticipantDto> participants = elasticSearch.parseSourceMaps(response.getHits().getHits());
-        log.info("Got {} participants from ES index {} (getLegacyPidsByGuid)", participants.size(), esIndex);
+        log.info("Got {} participants from ES index {} (getLegacyPidsByGuid)", guidToPid.size(), esIndex);
+        return guidToPid;
+    }
 
-        Map<String, String> guidToPid = new HashMap<>();
-        participants.forEach(participant -> {
+    protected int addLegacyPidHits(SearchResponse response, Map<String, String> guidToPid, String esIndex) {
+        SearchHits hits = response.getHits();
+        int numHits = hits.getHits().length;
+        for (int i = 0; i < numHits; i++) {
+            SearchHit hit = hits.getAt(i);
+            String ddpParticipantId = hit.getId();
+            ElasticSearchParticipantDto participant =
+                    elasticSearch.parseSourceMap(hit.getSourceAsMap(), ddpParticipantId);
             if (participant.getProfile().isPresent()) {
                 Profile profile = participant.getProfile().get();
                 String participantGuid = profile.getGuid();
-                if (StringUtils.isNotBlank(participantGuid) && StringUtils.isNotBlank(profile.getLegacyAltPid())) {
-                    if (guidToPid.containsKey(participantGuid)) {
+                if (!participantGuid.equals(ddpParticipantId)) {
+                    throw new DsmInternalError("Participant GUID does not match document ID: %s, %s. Index: %s"
+                            .formatted(participantGuid, ddpParticipantId, esIndex));
+                }
+                if (StringUtils.isNotBlank(profile.getLegacyAltPid())) {
+                    if (guidToPid.containsKey(ddpParticipantId)) {
                         throw new DsmInternalError("Duplicate participant GUID in Profile: %s, index: %s"
                                 .formatted(participantGuid, esIndex));
                     }
-                    guidToPid.put(profile.getGuid(), profile.getLegacyAltPid());
+                    guidToPid.put(ddpParticipantId, profile.getLegacyAltPid());
                 }
             }
-        });
-        return guidToPid;
+        }
+        return numHits;
     }
 
     /**
@@ -133,7 +156,7 @@ public class ElasticSearchService {
                 sourceBuilder.size(batchSize);
                 sourceBuilder.from(batchNumber * batchSize);
                 searchRequest.source(sourceBuilder);
-                if (addHits(search(searchRequest), esData) == 0) {
+                if (addDsmHits(search(searchRequest), esData) == 0) {
                     break;
                 }
                 batchNumber++;
@@ -145,7 +168,7 @@ public class ElasticSearchService {
         return esData;
     }
 
-    protected int addHits(SearchResponse response, Map<String, Map<String, Object>> esData) {
+    protected int addDsmHits(SearchResponse response, Map<String, Map<String, Object>> esData) {
         SearchHits hits = response.getHits();
         int numHits = hits.getHits().length;
         for (int i = 0; i < numHits; i++) {


### PR DESCRIPTION
## Context
PEPPER-1267

This PR fixes a bug in `ElasticSearchService.getLegacyPidsByGuid`, which I wrote for `ParticipantDataFixupService.fixupLegacyPidData`. That method was using the default batch size (10) for returning search results, and the code was not managing multiple batches, so it was only returning the first 10 search hits. 

The test for this is indirect: `ParticipantDataFixupServiceTest.testFixupLegacyPidData`, and the test was passing since it uses less that 10 legacy IDs. It does not make sense to write a separate test that creates large batch sizes, so I left testing as is. It was just a poor implementation initially. Verified in Dev, where there are 11 legacy IDs for AT.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

