### PR TITLE
[PEPPER-1390] Improve handling of missing ES participant document

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/MedicalRecord.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import lombok.Data;
@@ -320,7 +319,6 @@ public class MedicalRecord implements HasDdpInstanceId {
         });
     }
 
-    @VisibleForTesting
     public static List<MedicalRecord> getMedicalRecordsForParticipant(int participantId) {
         return inTransaction(conn -> {
             List<MedicalRecord> medicalRecords = new ArrayList<>();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/BasicDefaultDataMaker.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/BasicDefaultDataMaker.java
@@ -30,7 +30,7 @@ public abstract class BasicDefaultDataMaker implements Defaultable {
         }
 
         Optional<ElasticSearchParticipantDto> esParticipant =
-                elasticSearchService.getParticipantDocumentById(participantId, esIndex);
+                elasticSearchService.getParticipantDocument(participantId, esIndex);
         if (esParticipant.isEmpty()) {
             throw new ESMissingParticipantDataException("Participant %s does not have an ES document"
                     .formatted(participantId));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/BasicDefaultDataMaker.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/BasicDefaultDataMaker.java
@@ -1,32 +1,22 @@
 package org.broadinstitute.dsm.model.defaultvalues;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
-import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
-import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
-import org.broadinstitute.dsm.model.bookmark.Bookmark;
+import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
-import org.broadinstitute.dsm.model.settings.field.FieldSettings;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 
 @Slf4j
 public abstract class BasicDefaultDataMaker implements Defaultable {
-    protected static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
-    protected final FieldSettings fieldSettings = new FieldSettings();
-    protected final Bookmark bookmark = new Bookmark();
-    protected final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
+    protected static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     protected DDPInstance instance;
-    protected int instanceId;
-    protected ElasticSearchParticipantDto elasticSearchParticipantDto;
 
-
-    @VisibleForTesting
-    protected abstract boolean setDefaultData(String ddpParticipantId);
+    protected abstract boolean setDefaultData(String ddpParticipantId, ElasticSearchParticipantDto esParticipant);
 
     @Override
     public boolean generateDefaults(String studyGuid, String participantId) {
@@ -34,14 +24,18 @@ public abstract class BasicDefaultDataMaker implements Defaultable {
         if (instance == null) {
             throw new DSMBadRequestException("Invalid study GUID: " + studyGuid);
         }
-        instanceId = Integer.parseInt(instance.getDdpInstanceId());
         String esIndex = instance.getParticipantIndexES();
         if (StringUtils.isEmpty(esIndex)) {
             throw new DsmInternalError("No ES participant index for study " + studyGuid);
         }
 
-        elasticSearchParticipantDto = ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, participantId);
+        Optional<ElasticSearchParticipantDto> esParticipant =
+                elasticSearchService.getParticipantDocumentById(participantId, esIndex);
+        if (esParticipant.isEmpty()) {
+            throw new ESMissingParticipantDataException("Participant %s does not have an ES document"
+                    .formatted(participantId));
+        }
         log.info("Calling setDefaultData for ES index {} and participant ID {}", esIndex, participantId);
-        return setDefaultData(participantId);
+        return setDefaultData(participantId, esParticipant.get());
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/NewOsteoDefaultValues.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/NewOsteoDefaultValues.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.model.defaultvalues;
 
 import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.participant.OsteoParticipantService;
 
 /**
@@ -9,13 +10,13 @@ import org.broadinstitute.dsm.service.participant.OsteoParticipantService;
 public class NewOsteoDefaultValues extends BasicDefaultDataMaker {
 
     @Override
-    protected boolean setDefaultData(String ddpParticipantId) {
-        if (elasticSearchParticipantDto.getDsm().isEmpty() || elasticSearchParticipantDto.getActivities().isEmpty()) {
+    protected boolean setDefaultData(String ddpParticipantId, ElasticSearchParticipantDto esParticipant) {
+        if (esParticipant.getDsm().isEmpty() || esParticipant.getActivities().isEmpty()) {
             throw new ESMissingParticipantDataException(String.format("Participant %s does not yet have DSM data and "
                     + "activities in ES", ddpParticipantId));
         }
         OsteoParticipantService osteoParticipantService = new OsteoParticipantService();
-        osteoParticipantService.setOsteoDefaultData(ddpParticipantId, elasticSearchParticipantDto);
+        osteoParticipantService.setOsteoDefaultData(ddpParticipantId, esParticipant);
         return true;
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/RgpAutomaticProbandDataCreator.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/defaultvalues/RgpAutomaticProbandDataCreator.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.model.defaultvalues;
 
 import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.participantdata.RgpFamilyIdProvider;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
 
@@ -13,8 +14,8 @@ public class RgpAutomaticProbandDataCreator extends BasicDefaultDataMaker {
      *                                         callers to retry after waiting for the ES profile to be created.
      */
     @Override
-    protected boolean setDefaultData(String ddpParticipantId) {
-        RgpParticipantDataService.createDefaultData(ddpParticipantId, elasticSearchParticipantDto, instance,
+    protected boolean setDefaultData(String ddpParticipantId, ElasticSearchParticipantDto esParticipant) {
+        RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipant, instance,
                 new RgpFamilyIdProvider());
         return true;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
@@ -130,7 +130,7 @@ public class DSMtasksSubscription {
             retryPerParticipant.merge(participantGuid, 1, Integer::sum);
             int tryNum = retryPerParticipant.get(participantGuid);
             if (tryNum == MAX_RETRY) {
-                logger.warn("Exhausted retries waiting for missing ES data for participant {}: {}", participantGuid, e);
+                logger.warn("Exhausted retries waiting for missing ES data for participant {}", participantGuid, e);
                 retryPerParticipant.remove(participantGuid);
                 consumer.ack();
                 throw e;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/DSMtasksSubscription.java
@@ -130,11 +130,13 @@ public class DSMtasksSubscription {
             retryPerParticipant.merge(participantGuid, 1, Integer::sum);
             int tryNum = retryPerParticipant.get(participantGuid);
             if (tryNum == MAX_RETRY) {
+                logger.warn("Exhausted retries waiting for missing ES data for participant {}: {}", participantGuid, e);
                 retryPerParticipant.remove(participantGuid);
                 consumer.ack();
                 throw e;
             } else {
-                logger.info("Waiting for missing ES data, try number {}: {}", tryNum, e.toString());
+                logger.info("Waiting for missing ES data for participant {}: {}. Try number {}",
+                        participantGuid, e, tryNum);
                 consumer.nack();
             }
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/pubsub/WorkflowStatusUpdate.java
@@ -77,9 +77,9 @@ public class WorkflowStatusUpdate {
         }
 
         if (isRGPEnrollment(studyGuid, workflow, status)) {
-            log.info("Creating participant data for participant {} in study {} via workflow {} with status {}",
+            log.info("Updating participant data for participant {} in study {} via workflow {} with status {}",
                     ddpParticipantId, studyGuid, workflow, status);
-            updateRGP(ddpParticipantId, studyGuid);
+            RgpParticipantDataService.updateWithExtractedData(ddpParticipantId, studyGuid);
             return;
         }
 
@@ -240,15 +240,6 @@ public class WorkflowStatusUpdate {
 
     public static boolean isProband(Map<String, String> dataMap) {
         return dataMap.containsKey(MEMBER_TYPE) && dataMap.get(MEMBER_TYPE).equals(MEMBER_TYPE_SELF);
-    }
-
-    protected static void updateRGP(String participantId, String studyGuid) {
-        try {
-            RgpParticipantDataService.updateWithExtractedData(participantId, studyGuid);
-        } catch (Exception e) {
-            throw new DsmInternalError(String.format("Error updating participant data for participant %s in study %s",
-                    participantId, studyGuid), e);
-        }
     }
 
     private static class WorkflowPayload {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
@@ -231,7 +231,7 @@ public class ReferralSourceService implements AdminOperation {
     }
 
     private List<Activities> getParticipantActivities(String ddpParticipantId, String esIndex) {
-        return elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex).getActivities();
+        return elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex).getActivities();
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/adminoperation/ReferralSourceService.java
@@ -26,9 +26,9 @@ import org.broadinstitute.dsm.model.ddp.DDPActivityConstants;
 import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.service.admin.AdminOperation;
 import org.broadinstitute.dsm.service.admin.AdminOperationRecord;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
 import org.broadinstitute.dsm.statics.DBConstants;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.proxy.jackson.JsonParseException;
 import org.broadinstitute.dsm.util.proxy.jackson.JsonProcessingException;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
@@ -39,7 +39,7 @@ import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
  */
 @Slf4j
 public class ReferralSourceService implements AdminOperation {
-
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String RGP_REALM = "RGP";
     protected static final String NA_REF_SOURCE = "NA";
     private String userId;
@@ -165,7 +165,7 @@ public class ReferralSourceService implements AdminOperation {
         // only need the RGP_PARTICIPANT_DATA type ParticipantData
         List<ParticipantData> rgpData = dataList.stream().filter(participantDataDto ->
                 participantDataDto.getRequiredFieldTypeId().equals(RgpParticipantDataService.RGP_PARTICIPANTS_FIELD_TYPE)
-        ).collect(Collectors.toList());
+        ).toList();
 
         if (rgpData.isEmpty()) {
             return UpdateLog.UpdateStatus.NO_PARTICIPANT_DATA;
@@ -231,7 +231,7 @@ public class ReferralSourceService implements AdminOperation {
     }
 
     private List<Activities> getParticipantActivities(String ddpParticipantId, String esIndex) {
-        return ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId).getActivities();
+        return elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex).getActivities();
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
@@ -79,8 +79,8 @@ public class ElasticSearchService {
     /**
      * Get a single participant document based on participant GUID. Throw an exception if document is not found.
      */
-    public ElasticSearchParticipantDto getRequiredParticipantDocumentById(String ddpParticipantId, String index) {
-        return getParticipantDocumentById(ddpParticipantId, index)
+    public ElasticSearchParticipantDto getRequiredParticipantDocument(String ddpParticipantId, String index) {
+        return getParticipantDocument(ddpParticipantId, index)
                 .orElseThrow(() -> new ESMissingParticipantDataException("Participant document %s not found in index %s"
                         .formatted(ddpParticipantId, index)));
     }
@@ -88,19 +88,8 @@ public class ElasticSearchService {
     /**
      * Get a single participant document based on participant GUID
      */
-    public Optional<ElasticSearchParticipantDto> getParticipantDocumentById(String ddpParticipantId, String index) {
+    public Optional<ElasticSearchParticipantDto> getParticipantDocument(String ddpParticipantId, String index) {
         return getSingleParticipantDocument(ddpParticipantId, ElasticSearchUtil.PROFILE_GUID, index);
-    }
-
-    /**
-     * Get a single participant document based on a field value match
-     *
-     * @param id value to match
-     * @param matchField field to match against
-     */
-    public Optional<ElasticSearchParticipantDto> getSingleParticipantDocument(String id, String matchField,
-                                                                              String index) {
-        return getSingleParticipantDocument(id, matchField, null, index);
     }
 
     public boolean participantDocumentExists(String ddpParticipantId, String index) {
@@ -113,6 +102,17 @@ public class ElasticSearchService {
             throw new DsmInternalError("Error checking if participant document exists for %s, index: %s"
                     .formatted(ddpParticipantId, index), e);
         }
+    }
+
+    /**
+     * Get a single participant document based on a field value match
+     *
+     * @param id value to match
+     * @param matchField field to match against
+     */
+    public Optional<ElasticSearchParticipantDto> getSingleParticipantDocument(String id, String matchField,
+                                                                              String index) {
+        return getSingleParticipantDocument(id, matchField, null, index);
     }
 
     /**
@@ -304,7 +304,7 @@ public class ElasticSearchService {
     /**
      * Get participant document as an object map
      */
-    public static Map<String, Object> getParticipantDocument(String ddpParticipantId, String index) {
+    public static Map<String, Object> getParticipantDocumentAsMap(String ddpParticipantId, String index) {
         GetResponse res = _getParticipantDocument(index, ddpParticipantId);
         if (!res.isExists()) {
             throw new DsmInternalError("Participant document %s not found in index %s".formatted(ddpParticipantId, index));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/elastic/ElasticSearchService.java
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsm.service.elastic;
 
+import static org.broadinstitute.dsm.util.ElasticSearchUtil.PROFILE_GUID;
+import static org.broadinstitute.dsm.util.ElasticSearchUtil.PROFILE_LEGACYALTPID;
 import static org.broadinstitute.dsm.util.ElasticSearchUtil.search;
 
 import java.io.IOException;
@@ -23,6 +25,7 @@ import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.model.elastic.search.SourceMapDeserializer;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.broadinstitute.dsm.util.ParticipantUtil;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -89,7 +92,8 @@ public class ElasticSearchService {
      * Get a single participant document based on participant GUID
      */
     public Optional<ElasticSearchParticipantDto> getParticipantDocument(String ddpParticipantId, String index) {
-        return getSingleParticipantDocument(ddpParticipantId, ElasticSearchUtil.PROFILE_GUID, index);
+        String matchField = ParticipantUtil.isGuid(ddpParticipantId) ? PROFILE_GUID : PROFILE_LEGACYALTPID;
+        return getSingleParticipantDocument(ddpParticipantId, matchField, index);
     }
 
     public boolean participantDocumentExists(String ddpParticipantId, String index) {
@@ -158,7 +162,7 @@ public class ElasticSearchService {
         SearchRequest searchRequest = new SearchRequest(esIndex);
         try {
             SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-            sourceBuilder.query(QueryBuilders.existsQuery(ElasticSearchUtil.PROFILE_LEGACYALTPID));
+            sourceBuilder.query(QueryBuilders.existsQuery(PROFILE_LEGACYALTPID));
             searchRequest.source(sourceBuilder);
 
             int batchSize = 1000;
@@ -283,7 +287,7 @@ public class ElasticSearchService {
                     .formatted(ddpParticipantId, index));
         }
         Optional<ElasticSearchParticipantDto> esParticipant =
-                getSingleParticipantDocument(ddpParticipantId, ElasticSearchUtil.PROFILE_GUID, "dsm.*", index);
+                getSingleParticipantDocument(ddpParticipantId, PROFILE_GUID, "dsm.*", index);
         if (esParticipant.isEmpty()) {
             return Optional.empty();
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordService.java
@@ -95,6 +95,7 @@ public class MedicalRecordService {
                         ddpInstanceProvider.getEffectiveInstance(ddpInstance, req.getParticipantId()));
                 // Note: we could update the sequence number once at the end, but that makes the error handling
                 // more complex, so we update it for each request. The updates should be fast.
+                log.info("Updating instance sequence number to {}. Sequence start was {}", seqNumber, seqStart);
                 ddpInstanceProvider.updateInstanceSequenceNumber(ddpInstance, seqNumber, conn);
             }
             return true;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
@@ -158,7 +158,7 @@ public class OsteoParticipantService {
         // there *should* be ES DSM data for osteo2, but make it if not
         String osteo2Index = osteo2Instance.getParticipantIndexES();
         ElasticSearchParticipantDto osteo2EsParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo2Index);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, osteo2Index);
         Optional<Dsm> dsm = osteo2EsParticipant.getDsm();
         Dsm osteo2Dsm = dsm.orElseGet(Dsm::new);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
@@ -27,7 +27,6 @@ import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.onchistory.OncHistoryService;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.SystemUtil;
 
 
@@ -157,9 +156,9 @@ public class OsteoParticipantService {
                 new DsmInternalError("ES Participant data missing for participant %s".formatted(ddpParticipantId)));
 
         // there *should* be ES DSM data for osteo2, but make it if not
+        String osteo2Index = osteo2Instance.getParticipantIndexES();
         ElasticSearchParticipantDto osteo2EsParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(osteo2Instance.getParticipantIndexES(),
-                        ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo2Index);
         Optional<Dsm> dsm = osteo2EsParticipant.getDsm();
         Dsm osteo2Dsm = dsm.orElseGet(Dsm::new);
 
@@ -202,7 +201,7 @@ public class OsteoParticipantService {
         cohortTags.add(cohortTag);
         osteo2Dsm.setCohortTag(cohortTags);
 
-        ElasticSearchService.updateDsm(ddpParticipantId, osteo2Dsm, osteo2Instance.getParticipantIndexES());
+        ElasticSearchService.updateDsm(ddpParticipantId, osteo2Dsm, osteo2Index);
         OncHistoryService.createEmptyOncHistory(osteo2ParticipantId, ddpParticipantId, osteo2Instance);
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataService.java
@@ -46,7 +46,7 @@ public class ATParticipantDataService {
         }
 
         return createDefaultData(ddpParticipantId,
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex), instance);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex), instance);
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataService.java
@@ -20,7 +20,7 @@ import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Profile;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.model.settings.field.FieldSettings;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 
 @Slf4j
 public class ATParticipantDataService {
@@ -33,6 +33,7 @@ public class ATParticipantDataService {
     public static final String AT_GROUP_GENOME_STUDY = "AT_GROUP_GENOME_STUDY";
     public static final String EXIT_STATUS = "EXITSTATUS";
     protected static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
 
     public static boolean generateDefaultData(String studyGuid, String ddpParticipantId) {
         DDPInstance instance = DDPInstance.getDDPInstanceByGuid(studyGuid);
@@ -45,7 +46,7 @@ public class ATParticipantDataService {
         }
 
         return createDefaultData(ddpParticipantId,
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId), instance);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex), instance);
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataService.java
@@ -151,7 +151,7 @@ public class RgpParticipantDataService {
         }
 
         Optional<ElasticSearchParticipantDto> esParticipant =
-                elasticSearchService.getParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getParticipantDocument(ddpParticipantId, esIndex);
         ElasticSearchParticipantDto esParticipantDto = esParticipant.orElseThrow(() ->
                 new ESMissingParticipantDataException("Participant %s does not have an ES document"
                     .formatted(ddpParticipantId)));

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/ElasticSearchUtil.java
@@ -807,11 +807,12 @@ public class ElasticSearchUtil {
         }
     }
 
-    public static Map<String, Object> getObjectsMap(RestHighLevelClient client, String index, String id, String object) throws Exception {
+    public static Map<String, Object> getObjectsMap(RestHighLevelClient client, String index, String id, String object)
+            throws IOException {
         String[] includes = new String[] {object};
         String[] excludes = Strings.EMPTY_ARRAY;
         FetchSourceContext fetchSourceContext = new FetchSourceContext(true, includes, excludes);
-        GetRequest getRequest = new GetRequest().index(index).type("_doc").id(id).fetchSourceContext(fetchSourceContext);
+        GetRequest getRequest = new GetRequest().index(index).id(id).fetchSourceContext(fetchSourceContext);
 
         GetResponse getResponse = null;
         if (client.exists(getRequest, RequestOptions.DEFAULT)) {
@@ -820,7 +821,7 @@ public class ElasticSearchUtil {
         return getResponse != null ? getResponse.getSourceAsMap() : Collections.emptyMap();
     }
 
-    public static Map<String, Object> getObjectsMap(String index, String id, String object) throws Exception {
+    public static Map<String, Object> getObjectsMap(String index, String id, String object) throws IOException {
         initialize();
         return getObjectsMap(client, index, id, object);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -11,8 +11,8 @@ import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
@@ -24,7 +24,7 @@ import org.junit.Test;
 
 @Slf4j
 public class OncHistoryDetailTest extends DbAndElasticBaseTest {
-
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String TEST_USER = "TEST_USER";
     private static DDPInstanceDto ddpInstanceDto;
     private static String instanceName;
@@ -103,7 +103,7 @@ public class OncHistoryDetailTest extends DbAndElasticBaseTest {
             Assert.assertEquals("3", updateRec3.getColumnValues().get("destruction_policy"));
 
             ElasticSearchParticipantDto esParticipant =
-                    ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                    elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
             Dsm dsm = esParticipant.getDsm().orElseThrow();
 
             List<OncHistoryDetail> oncHistoryDetailList = dsm.getOncHistoryDetail();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/OncHistoryDetailTest.java
@@ -103,7 +103,7 @@ public class OncHistoryDetailTest extends DbAndElasticBaseTest {
             Assert.assertEquals("3", updateRec3.getColumnValues().get("destruction_policy"));
 
             ElasticSearchParticipantDto esParticipant =
-                    elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                    elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
             Dsm dsm = esParticipant.getDsm().orElseThrow();
 
             List<OncHistoryDetail> oncHistoryDetailList = dsm.getOncHistoryDetail();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
@@ -194,7 +194,7 @@ public class ReceiveKitRequestTest extends DbAndElasticBaseTest {
 
     private void verifyElasticData(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/at/ReceiveKitRequestTest.java
@@ -20,9 +20,9 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participantdata.ParticipantDataService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
 import org.broadinstitute.dsm.util.NotificationUtil;
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 
 @Slf4j
 public class ReceiveKitRequestTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String TEST_USER = "TEST_USER";
     private static final String KIT_BARCODE = "SM-ABC123";
     private static final String instanceName = "atkit";
@@ -193,7 +194,7 @@ public class ReceiveKitRequestTest extends DbAndElasticBaseTest {
 
     private void verifyElasticData(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
@@ -286,7 +286,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
 
     private void verifyOncHistory(String ddpParticipantId, List<Integer> participantIds) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -331,7 +331,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
     }
 
     private List<CohortTag> getCohortTagsFromDoc(String ddpParticipantId) {
-        Map<String, Object> sourceMap = ElasticSearchService.getParticipantDocument(ddpParticipantId, esIndex);
+        Map<String, Object> sourceMap = ElasticSearchService.getParticipantDocumentAsMap(ddpParticipantId, esIndex);
         Assert.assertNotNull(sourceMap);
         Map<String, Object> dsmProp = (Map<String, Object>) sourceMap.get(ESObjectConstants.DSM);
         Assert.assertNotNull(dsmProp);
@@ -343,7 +343,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
 
     private void verifyKitShipping(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/elastic/migration/OsteoMigratorTest.java
@@ -15,7 +15,6 @@ import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.MedicalRecord;
 import org.broadinstitute.dsm.db.OncHistoryDetail;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
-import org.broadinstitute.dsm.db.dao.ddp.onchistory.OncHistoryDetailDaoImpl;
 import org.broadinstitute.dsm.db.dao.tag.cohort.CohortTagDaoImpl;
 import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
@@ -27,7 +26,6 @@ import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.CohortTagTestUtil;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.KitShippingTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
@@ -47,7 +45,7 @@ import org.junit.Test;
 public class OsteoMigratorTest extends DbAndElasticBaseTest {
     private static final String TEST_USER = "TEST_USER";
     private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
-    private static final OncHistoryDetailDaoImpl oncHistoryDetailDao = new OncHistoryDetailDaoImpl();
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static DDPInstanceDto os1DdpInstanceDto;
     private static DDPInstanceDto os2DdpInstanceDto;
     private static String os1InstanceName;
@@ -288,7 +286,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
 
     private void verifyOncHistory(String ddpParticipantId, List<Integer> participantIds) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -345,7 +343,7 @@ public class OsteoMigratorTest extends DbAndElasticBaseTest {
 
     private void verifyKitShipping(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
@@ -17,8 +17,8 @@ import org.broadinstitute.dsm.model.NameValue;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.Profile;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 @Slf4j
 public class OncHistoryDetailPatchTest extends DbAndElasticBaseTest {
-
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
     private static final String instanceName = "ohdetailpatch";
     private static String esIndex;
@@ -106,7 +106,7 @@ public class OncHistoryDetailPatchTest extends DbAndElasticBaseTest {
                     ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
 
             ElasticSearchParticipantDto esParticipant =
-                     ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                    elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
             Profile esProfile = esParticipant.getProfile().orElseThrow();
             Assert.assertEquals(profile.getHruid(), esProfile.getHruid());
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/patch/OncHistoryDetailPatchTest.java
@@ -106,7 +106,7 @@ public class OncHistoryDetailPatchTest extends DbAndElasticBaseTest {
                     ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
 
             ElasticSearchParticipantDto esParticipant =
-                    elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                    elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
             Profile esProfile = esParticipant.getProfile().orElseThrow();
             Assert.assertEquals(profile.getHruid(), esProfile.getHruid());
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
@@ -245,7 +245,7 @@ public class UpdateWorkflowStatusTest extends DbAndElasticBaseTest {
     private void verifyDefaultElasticData(String ddpParticipantId, String registrationFieldTypeId,
                                           String registrationStatus, List<String> otherFieldTypes) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/pubsub/UpdateWorkflowStatusTest.java
@@ -27,10 +27,10 @@ import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.route.EditParticipantPublisherRoute;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participantdata.ATParticipantDataService;
 import org.broadinstitute.dsm.util.DBTestUtil;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
 import org.broadinstitute.dsm.util.ParticipantDataTestUtil;
@@ -47,6 +47,7 @@ public class UpdateWorkflowStatusTest extends DbAndElasticBaseTest {
     public static final String memberTypeFieldTypeId = basename;
     private static final UserDao userDao = new UserDao();
     private static final ParticipantDataDao participantDataDao = new ParticipantDataDao();
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static Gson gson;
     private static UserDto userDto;
     private static DDPInstanceDto ddpInstanceDto;
@@ -244,7 +245,8 @@ public class UpdateWorkflowStatusTest extends DbAndElasticBaseTest {
     private void verifyDefaultElasticData(String ddpParticipantId, String registrationFieldTypeId,
                                           String registrationStatus, List<String> otherFieldTypes) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
@@ -89,13 +89,13 @@ public class ElasticSearchServiceTest extends DbAndElasticBaseTest {
         ElasticSearchService elasticSearchService = new ElasticSearchService();
 
         Optional<ElasticSearchParticipantDto> esPtp =
-                elasticSearchService.getParticipantDocumentById(ddpParticipantId1, esIndex);
+                elasticSearchService.getParticipantDocument(ddpParticipantId1, esIndex);
         Assert.assertTrue(esPtp.isPresent());
         ElasticSearchParticipantDto esParticipant = esPtp.get();
         Assert.assertEquals(ddpParticipantId1, esParticipant.getProfile().get().getGuid());
         Assert.assertTrue(esParticipant.getDsm().isPresent());
 
-        Assert.assertTrue(elasticSearchService.getParticipantDocumentById("bogus", esIndex).isEmpty());
+        Assert.assertTrue(elasticSearchService.getParticipantDocument("bogus", esIndex).isEmpty());
     }
 
     @Test

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
@@ -95,7 +95,8 @@ public class ElasticSearchServiceTest extends DbAndElasticBaseTest {
         Assert.assertEquals(ddpParticipantId1, esParticipant.getProfile().get().getGuid());
         Assert.assertTrue(esParticipant.getDsm().isPresent());
 
-        Assert.assertTrue(elasticSearchService.getParticipantDocument("bogus", esIndex).isEmpty());
+        Assert.assertTrue(elasticSearchService.getParticipantDocument(TestParticipantUtil.genDDPParticipantId("bogus"), esIndex)
+                .isEmpty());
     }
 
     @Test

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/ElasticSearchServiceTest.java
@@ -16,6 +16,7 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Dsm;
+import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participantdata.ATParticipantDataTestUtil;
 import org.broadinstitute.dsm.service.participantdata.ParticipantDataService;
@@ -69,6 +70,32 @@ public class ElasticSearchServiceTest extends DbAndElasticBaseTest {
         participants.forEach(participantDto ->
                 TestParticipantUtil.deleteParticipant(participantDto.getParticipantId().orElseThrow()));
         participants.clear();
+    }
+
+    @Test
+    public void testGetParticipantDocumentById() {
+        // create a couple of participants with some DSM data
+        ParticipantDto participant = createParticipant();
+        String ddpParticipantId1 = participant.getRequiredDdpParticipantId();
+
+        createParticipantData(ddpParticipantId1);
+        createMedicalRecordAndOncHistory(participant);
+
+        participant = createParticipant();
+        String ddpParticipantId2 = participant.getRequiredDdpParticipantId();
+
+        createParticipantData(ddpParticipantId2);
+
+        ElasticSearchService elasticSearchService = new ElasticSearchService();
+
+        Optional<ElasticSearchParticipantDto> esPtp =
+                elasticSearchService.getParticipantDocumentById(ddpParticipantId1, esIndex);
+        Assert.assertTrue(esPtp.isPresent());
+        ElasticSearchParticipantDto esParticipant = esPtp.get();
+        Assert.assertEquals(ddpParticipantId1, esParticipant.getProfile().get().getGuid());
+        Assert.assertTrue(esParticipant.getDsm().isPresent());
+
+        Assert.assertTrue(elasticSearchService.getParticipantDocumentById("bogus", esIndex).isEmpty());
     }
 
     @Test

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
@@ -321,7 +321,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
     private void verifyMedicalRecordAndOncHistory(ParticipantDto participant) {
         String ddpParticipantId = participant.getRequiredDdpParticipantId();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -363,7 +363,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
     private void verifyMedicalRecordNotSpecified(ParticipantDto participant) {
         String ddpParticipantId = participant.getRequiredDdpParticipantId();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -389,7 +389,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
 
     private void verifyKitShipping(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -402,7 +402,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
 
     private void verifyParticipant(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ElasticExportServiceTest.java
@@ -34,7 +34,6 @@ import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.statics.ESObjectConstants;
 import org.broadinstitute.dsm.util.CohortTagTestUtil;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.KitShippingTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
@@ -47,6 +46,7 @@ import org.junit.Test;
 
 @Slf4j
 public class ElasticExportServiceTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String TEST_USER = "TEST_USER";
     private static final String OS1_TAG = "OS1";
     private static final String instanceName = "elasticexport";
@@ -321,7 +321,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
     private void verifyMedicalRecordAndOncHistory(ParticipantDto participant) {
         String ddpParticipantId = participant.getRequiredDdpParticipantId();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -363,7 +363,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
     private void verifyMedicalRecordNotSpecified(ParticipantDto participant) {
         String ddpParticipantId = participant.getRequiredDdpParticipantId();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -389,7 +389,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
 
     private void verifyKitShipping(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -402,7 +402,7 @@ public class ElasticExportServiceTest extends DbAndElasticBaseTest {
 
     private void verifyParticipant(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/MedicalRecordInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/MedicalRecordInitServiceTest.java
@@ -17,8 +17,8 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantRecordDto;
 import org.broadinstitute.dsm.db.dto.onchistory.OncHistoryDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
@@ -38,6 +38,7 @@ public class MedicalRecordInitServiceTest extends DbAndElasticBaseTest {
     private static DDPInstance ddpInstance;
     private static int participantCounter = 0;
     private static final ParticipantDao participantDao = new ParticipantDao();
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -111,7 +112,7 @@ public class MedicalRecordInitServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -144,7 +145,7 @@ public class MedicalRecordInitServiceTest extends DbAndElasticBaseTest {
 
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/MedicalRecordInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/MedicalRecordInitServiceTest.java
@@ -112,7 +112,7 @@ public class MedicalRecordInitServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -145,7 +145,7 @@ public class MedicalRecordInitServiceTest extends DbAndElasticBaseTest {
 
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
@@ -14,6 +14,7 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataService;
 import org.broadinstitute.dsm.service.participantdata.RgpParticipantDataTestUtil;
 import org.broadinstitute.dsm.service.participantdata.TestFamilyIdProvider;
@@ -30,6 +31,7 @@ import org.junit.Test;
 
 @Slf4j
 public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String instanceName = "rgpinit";
     private static String esIndex;
     private static DDPInstanceDto ddpInstanceDto;
@@ -90,14 +92,14 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
 
         // create RGP participant data
         int familyId = 100;
         RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(familyId));
 
-        esParticipantDto = ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        esParticipantDto = elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(100), false);
         Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, updateLog.getStatus());
@@ -113,7 +115,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addParticipantDsm(esIndex, dsm, ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
 
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(100), false);
@@ -132,7 +134,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
 
         // create RGP participant data
         int familyId = 1000;
@@ -140,7 +142,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
                 new TestFamilyIdProvider(familyId));
         removeEsFamilyId(esIndex, ddpParticipantId);
 
-        esParticipantDto = ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+        esParticipantDto = elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(familyId), false);
         Assert.assertEquals(UpdateLog.UpdateStatus.ES_UPDATED, updateLog.getStatus());
@@ -152,7 +154,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
 
         int familyId = 100;
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
@@ -178,7 +180,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
             ElasticSearchUtil.updateRequest(ddpParticipantId, esIndex, esMap);
         } catch (Exception e) {
             e.printStackTrace();
-            Assert.fail("Error removing family ID from ES: " + e.toString());
+            Assert.fail("Error removing family ID from ES: " + e);
         }
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/adminoperation/ParticipantInitServiceTest.java
@@ -93,14 +93,14 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         // create RGP participant data
         int familyId = 100;
         RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(familyId));
 
-        esParticipantDto = elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+        esParticipantDto = elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(100), false);
         Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, updateLog.getStatus());
@@ -116,7 +116,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addParticipantDsm(esIndex, dsm, ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(100), false);
@@ -135,7 +135,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         // create RGP participant data
         int familyId = 1000;
@@ -143,7 +143,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
                 new TestFamilyIdProvider(familyId));
         removeEsFamilyId(esIndex, ddpParticipantId);
 
-        esParticipantDto = elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+        esParticipantDto = elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(familyId), false);
         Assert.assertEquals(UpdateLog.UpdateStatus.ES_UPDATED, updateLog.getStatus());
@@ -159,7 +159,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         String legacyPid = ptpToLegacyId.getRight();
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         UpdateLog updateLog = ParticipantInitService.initParticipant(legacyPid, esParticipantDto, ddpInstance,
                 new TestFamilyIdProvider(100), false);
         Assert.assertEquals(UpdateLog.UpdateStatus.NOT_UPDATED, updateLog.getStatus());
@@ -171,7 +171,7 @@ public class ParticipantInitServiceTest extends DbAndElasticBaseTest {
         rgpParticipantDataTestUtil.loadFieldSettings(ddpInstanceDto.getDdpInstanceId());
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         int familyId = 100;
         UpdateLog updateLog = ParticipantInitService.initParticipant(ddpParticipantId, esParticipantDto, ddpInstance,

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordServiceTest.java
@@ -125,7 +125,7 @@ public class MedicalRecordServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/medicalrecord/MedicalRecordServiceTest.java
@@ -16,9 +16,9 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.db.dto.onchistory.OncHistoryDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.service.participant.OsteoParticipantService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
 import org.broadinstitute.dsm.util.SystemUtil;
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 @Slf4j
 public class MedicalRecordServiceTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     public static final String osteo1InstanceName = "osteo1test";
     public static final String osteo2InstanceName = "osteo2test";
     private static DDPInstanceDto osteo1InstanceDto;
@@ -124,7 +125,7 @@ public class MedicalRecordServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);;
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
@@ -25,9 +25,9 @@ import org.broadinstitute.dsm.db.dto.onchistory.OncHistoryDto;
 import org.broadinstitute.dsm.db.dto.tag.cohort.CohortTag;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.CohortTagTestUtil;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.MedicalRecordTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
@@ -52,7 +52,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
     private static CohortTagTestUtil cohortTagTestUtil;
     private static final ParticipantRecordDao participantRecordDao = new ParticipantRecordDao();
     private static final ParticipantDao participantDao = new ParticipantDao();
-
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
 
 
     @BeforeClass
@@ -97,7 +97,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo2EsIndex, "elastic/osteo2Activities.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(osteo2EsIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo2EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -113,7 +113,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo1EsIndex, "elastic/osteo1Activities.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(osteo1EsIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo1EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -129,7 +129,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo1EsIndex, "elastic/osteoActivitiesNoConsent.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(osteo1EsIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo1EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -248,7 +248,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
     private void verifyParticipant(String ddpParticipantId, DDPInstanceDto ddpInstanceDto) {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -264,7 +264,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
     private void verifyCohortTag(String ddpParticipantId, String tag, DDPInstanceDto ddpInstanceDto) {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -279,7 +279,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
@@ -97,7 +97,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo2EsIndex, "elastic/osteo2Activities.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo2EsIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, osteo2EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -113,7 +113,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo1EsIndex, "elastic/osteo1Activities.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo1EsIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, osteo1EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -129,7 +129,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         ElasticTestUtil.addActivitiesFromFile(osteo1EsIndex, "elastic/osteoActivitiesNoConsent.json", ddpParticipantId);
 
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, osteo1EsIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, osteo1EsIndex);
 
         OsteoParticipantService osteoParticipantService =
                 new OsteoParticipantService(osteo1InstanceName, osteo2InstanceName);
@@ -248,7 +248,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
     private void verifyParticipant(String ddpParticipantId, DDPInstanceDto ddpInstanceDto) {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -264,7 +264,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
     private void verifyCohortTag(String ddpParticipantId, String tag, DDPInstanceDto ddpInstanceDto) {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -279,7 +279,7 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
 
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/ParticipantServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/ParticipantServiceTest.java
@@ -80,7 +80,7 @@ public class ParticipantServiceTest extends DbAndElasticBaseTest {
         String ddpParticipantId = participantDto.getRequiredDdpParticipantId();
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/ParticipantServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/ParticipantServiceTest.java
@@ -11,8 +11,8 @@ import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.TestParticipantUtil;
 import org.junit.After;
@@ -29,6 +29,7 @@ public class ParticipantServiceTest extends DbAndElasticBaseTest {
     private static DDPInstance ddpInstance;
     private static int participantCounter = 0;
     private static final ParticipantDao participantDao = new ParticipantDao();
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
 
     @BeforeClass
     public static void setup() throws Exception {
@@ -79,7 +80,7 @@ public class ParticipantServiceTest extends DbAndElasticBaseTest {
         String ddpParticipantId = participantDto.getRequiredDdpParticipantId();
         String esIndex = ddpInstanceDto.getEsParticipantIndex();
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
@@ -20,8 +20,8 @@ import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
 import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
 import org.broadinstitute.dsm.util.ParticipantDataTestUtil;
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 @Slf4j
 public class ATParticipantDataServiceTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String instanceName = "atdefault";
     private static String esIndex;
     private static DDPInstanceDto ddpInstanceDto;
@@ -196,7 +197,7 @@ public class ATParticipantDataServiceTest extends DbAndElasticBaseTest {
 
     private void verifyDefaultElasticData(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
@@ -197,7 +197,7 @@ public class ATParticipantDataServiceTest extends DbAndElasticBaseTest {
 
     private void verifyDefaultElasticData(String ddpParticipantId) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/ATParticipantDataServiceTest.java
@@ -96,7 +96,7 @@ public class ATParticipantDataServiceTest extends DbAndElasticBaseTest {
         } catch (ESMissingParticipantDataException e) {
             Assert.assertTrue(String.format("Error message should include the queried participant id %s.  The "
                             + "message given is %s", nonexistentParticipantId, e.getMessage()),
-                    e.getMessage().toUpperCase().contains("PARTICIPANT " + nonexistentParticipantId));
+                    e.getMessage().contains("Participant document %s not found".formatted(nonexistentParticipantId)));
         }
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
@@ -22,9 +22,9 @@ import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Profile;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
 import org.broadinstitute.dsm.util.ParticipantDataTestUtil;
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 @Slf4j
 public class RgpParticipantDataServiceTest extends DbAndElasticBaseTest {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private static final String instanceName = "rgpservice";
     private static String esIndex;
     private static DDPInstanceDto ddpInstanceDto;
@@ -114,7 +115,7 @@ public class RgpParticipantDataServiceTest extends DbAndElasticBaseTest {
 
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceByGuid(instanceName);
         ElasticSearchParticipantDto esParticipantDto =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
 
         int familyId = 1000;
         RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,
@@ -135,7 +136,7 @@ public class RgpParticipantDataServiceTest extends DbAndElasticBaseTest {
         expectedDataMap.put(FamilyMemberConstants.PHONE, "6177147395");
         expectedDataMap.put(DBConstants.REFERRAL_SOURCE_ID, "MORE_THAN_ONE");
 
-        rgpParticipantDataTestUtil.verifyParticipantData(ddpParticipantId, expectedDataMap);
+        RgpParticipantDataTestUtil.verifyParticipantData(ddpParticipantId, expectedDataMap);
         rgpParticipantDataTestUtil.verifyDefaultElasticData(ddpParticipantId, familyId, expectedDataMap);
         rgpParticipantDataTestUtil.verifyWorkflows(ddpParticipantId, workflowNames);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
@@ -116,7 +116,7 @@ public class RgpParticipantDataServiceTest extends DbAndElasticBaseTest {
 
         DDPInstance ddpInstance = DDPInstance.getDDPInstanceByGuid(instanceName);
         ElasticSearchParticipantDto esParticipantDto =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
 
         int familyId = 1000;
         RgpParticipantDataService.createDefaultData(ddpParticipantId, esParticipantDto, ddpInstance,

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataServiceTest.java
@@ -17,6 +17,7 @@ import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDataDao;
 import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
+import org.broadinstitute.dsm.exception.ESMissingParticipantDataException;
 import org.broadinstitute.dsm.model.bookmark.Bookmark;
 import org.broadinstitute.dsm.model.elastic.Activities;
 import org.broadinstitute.dsm.model.elastic.Profile;
@@ -156,6 +157,15 @@ public class RgpParticipantDataServiceTest extends DbAndElasticBaseTest {
 
         RgpParticipantDataService.insertEsFamilyId(esIndex, ddpParticipantId, familyId);
         rgpParticipantDataTestUtil.verifyDefaultElasticData(ddpParticipantId, familyId, Collections.emptyMap());
+
+        try {
+            // ptp who does not have an ES document
+            RgpParticipantDataService.insertEsFamilyId(esIndex, "bogus", familyId);
+            Assert.fail("Expected exception not thrown");
+        } catch (Exception e) {
+            Assert.assertEquals(ESMissingParticipantDataException.class, e.getClass());
+            Assert.assertTrue(e.getMessage().contains("Participant document"));
+        }
     }
 
     private String createParticipant() {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
@@ -13,13 +13,14 @@ import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantData;
 import org.broadinstitute.dsm.model.elastic.Dsm;
 import org.broadinstitute.dsm.model.elastic.search.ElasticSearchParticipantDto;
 import org.broadinstitute.dsm.model.participant.data.FamilyMemberConstants;
-import org.broadinstitute.dsm.util.ElasticSearchUtil;
+import org.broadinstitute.dsm.service.elastic.ElasticSearchService;
 import org.broadinstitute.dsm.util.ElasticTestUtil;
 import org.broadinstitute.dsm.util.FieldSettingsTestUtil;
 import org.junit.Assert;
 
 @Slf4j
 public class RgpParticipantDataTestUtil {
+    private static final ElasticSearchService elasticSearchService = new ElasticSearchService();
     private final String esIndex;
     private static final List<Integer> fieldSettingsIds = new ArrayList<>();
 
@@ -37,7 +38,7 @@ public class RgpParticipantDataTestUtil {
             fieldSettingsIds.clear();
         } catch (Exception e) {
             e.printStackTrace();
-            Assert.fail("Error in tearDown " + e.toString());
+            Assert.fail("Error in tearDown " + e);
         }
     }
 
@@ -86,7 +87,7 @@ public class RgpParticipantDataTestUtil {
     public void verifyDefaultElasticData(String ddpParticipantId, int familyId,
                                          Map<String, String> expectedDataMap) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -107,7 +108,7 @@ public class RgpParticipantDataTestUtil {
 
     public void verifyWorkflows(String ddpParticipantId, Set<String> workflowNames) {
         ElasticSearchParticipantDto esParticipant =
-                ElasticSearchUtil.getParticipantESDataByParticipantId(esIndex, ddpParticipantId);
+                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participantdata/RgpParticipantDataTestUtil.java
@@ -87,7 +87,7 @@ public class RgpParticipantDataTestUtil {
     public void verifyDefaultElasticData(String ddpParticipantId, int familyId,
                                          Map<String, String> expectedDataMap) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
         Dsm dsm = esParticipant.getDsm().orElseThrow();
@@ -108,7 +108,7 @@ public class RgpParticipantDataTestUtil {
 
     public void verifyWorkflows(String ddpParticipantId, Set<String> workflowNames) {
         ElasticSearchParticipantDto esParticipant =
-                elasticSearchService.getRequiredParticipantDocumentById(ddpParticipantId, esIndex);
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
         log.debug("Verifying ES participant record for {}: {}", ddpParticipantId,
                 ElasticTestUtil.getParticipantDocumentAsString(esIndex, ddpParticipantId));
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/TestParticipantUtil.java
@@ -3,6 +3,8 @@ package org.broadinstitute.dsm.util;
 import java.time.Instant;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.broadinstitute.dsm.db.Participant;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDao;
 import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
@@ -86,6 +88,25 @@ public class TestParticipantUtil {
         ElasticTestUtil.addParticipantProfileFromFile(ddpInstanceDto.getEsParticipantIndex(),
                 "elastic/participantProfile.json", ddpParticipantId);
         return ddpParticipantId;
+    }
+
+    /**
+     * Create a participant with a legacy PID profile in ES
+     *
+     * @param baseName base name for the participant and legacy PID
+     * @param participantOrdinal ordinal for the participant ID and legacy PID
+     * @return a pair of the participant DTO and the legacy PID
+     */
+    public static Pair<ParticipantDto, String> createLegacyParticipant(String baseName, int participantOrdinal,
+                                                                        DDPInstanceDto ddpInstanceDto) {
+        String ptpBase = String.format("%s_%d", baseName, participantOrdinal);
+        Profile profile = TestParticipantUtil.createProfile("Joe", "Participant%d".formatted(participantOrdinal),
+                participantOrdinal);
+        String legacyPid = "PID_%s_%d".formatted(baseName, participantOrdinal);
+        profile.setLegacyAltPid(legacyPid);
+        ParticipantDto participant =
+                TestParticipantUtil.createParticipantWithEsProfile(ptpBase, profile, ddpInstanceDto);
+        return new ImmutablePair<>(participant, legacyPid);
     }
 
     public static void deleteParticipant(int participantId) {


### PR DESCRIPTION
## Context
PEPPER-1390

The  essential issue for the problems described in PEPPER-1390 is elsewhere, but this PR fixes an issue with how WorkflowStatusUpdate was handling ESMissingParticipantDataException. Along the way I made the following improvements:

1.  Added ElasticSearchService.getParticipantDocumentById (and related) to replace use of ElasticSearchUtil.getParticipantESDataByParticipantId. The latter did not provide a way for callers to detect a missing participant document, and was overly complex. Also added a corresponding test in ElasticSearchServiceTest.
2. Refactored BasicDefaultDataMaker.SetDefaultData. Since this method is used differently now it could be simplified. Also now checking for a valid ES participant document here.
3. Added logging for the retry exhausted case in DMtasksSubscription.generateStudyDefaultValues.
4. Removed temporary logging in RgpParticipantDataService since we now know what the underlying problem is.
5. Rewrote and simplified RgpParticipantDataService.insertEsFamilyId, since it was not handling missing participant documents correctly. Updated the corresponding test, and added support in ElasticSearchService.
6. Stopped handling participants with legacy PIDs in ParticipantInitService. These participants do not need initialization, and the current code does not handle them correctly. Added a test  for that. 
7. The rest of the changes are converting from ElasticSearchUtil.getParticipantESDataByParticipantId to ElasticSearchService.getParticipantDocumentById (and related) in files I recently created. 

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

