### PR TITLE
PEPPER-1420 removing openapi docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: false
   project:
     type: enum
-    enum: ["dss", "dsm", "nothing"]
+    enum: ["dss", "dsm","api-docs", "nothing"]
     default: "nothing"
   action:
     type: enum
@@ -28,7 +28,7 @@ workflows:
     jobs:
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"build-test-deploy","dss": true}'
+          parameters: '{"action":"build-test-deploy","dss": true,"api-docs": false}'
 
   build-test-workflow:
     description: |
@@ -47,6 +47,8 @@ workflows:
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* test_parallelism 15
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* dss true
             pepper-apis/((dsm-.*)|(ddp-.*))/.* dsm true
+            # don't bother keepign openapidocs up to date
+            # pepper-apis/docs/.* api-docs true
 
   branch-triggered-workflow:
     description: Will initiate workflows based on updates to branches
@@ -65,6 +67,8 @@ workflows:
             pepper-apis/pom.xml dss true
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* dss true
             pepper-apis/((dsm-.*)|(ddp-.*))/.* dsm true
+            # don't bother keeping openapi docs up to date
+            # pepper-apis/docs/.* api-docs true
             pepper-apis/config/.* dss true
             pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml dsm true
           filters:
@@ -77,7 +81,7 @@ workflows:
       # Only DSS projects and API docs affected!
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"build-test-store","dss": true}'
+          parameters: '{"action":"build-test-store","dss": true,"api-docs": false}'
           filters:
             branches:
               only:
@@ -92,7 +96,7 @@ workflows:
       # Only DSS is affected. DSM handled separately in workflows below
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"retrieve-deploy","dss": true}'
+          parameters: '{"action":"retrieve-deploy","dss": true,"api-docs": false}'
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
     default: false
   project:
     type: enum
-    enum: ["dss", "dsm","api-docs", "nothing"]
+    enum: ["dss", "dsm", "nothing"]
     default: "nothing"
   action:
     type: enum
@@ -28,7 +28,7 @@ workflows:
     jobs:
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"build-test-deploy","dss": true,"api-docs": false}'
+          parameters: '{"action":"build-test-deploy","dss": true}'
 
   build-test-workflow:
     description: |
@@ -47,7 +47,6 @@ workflows:
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* test_parallelism 15
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* dss true
             pepper-apis/((dsm-.*)|(ddp-.*))/.* dsm true
-            pepper-apis/docs/.* api-docs true
 
   branch-triggered-workflow:
     description: Will initiate workflows based on updates to branches
@@ -66,7 +65,6 @@ workflows:
             pepper-apis/pom.xml dss true
             pepper-apis/((dss-.*)|(ddp-.*)|(pex-antlr)|(housekeeping)|(studybuilder-cli))/.* dss true
             pepper-apis/((dsm-.*)|(ddp-.*))/.* dsm true
-            pepper-apis/docs/.* api-docs true
             pepper-apis/config/.* dss true
             pepper-apis/dsm-server/appengine/StudyManager.tmpl.yaml dsm true
           filters:
@@ -79,7 +77,7 @@ workflows:
       # Only DSS projects and API docs affected!
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"build-test-store","dss": true,"api-docs": true}'
+          parameters: '{"action":"build-test-store","dss": true}'
           filters:
             branches:
               only:
@@ -94,7 +92,7 @@ workflows:
       # Only DSS is affected. DSM handled separately in workflows below
       - continuation/continue:
           configuration_path: .circleci/main-config.yml
-          parameters: '{"action":"retrieve-deploy","dss": true,"api-docs": true}'
+          parameters: '{"action":"retrieve-deploy","dss": true}'
           filters:
             branches:
               only:

--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -26,8 +26,6 @@ references:
                       /home/circleci/repo/pepper-apis
   docs-path: &docs-path
                /home/circleci/repo/pepper-apis/docs
-  api-spec-path: &api-spec-path
-                   /home/circleci/repo/pepper-apis/docs/specification
   circleci_path: &circleci_path
                    /home/circleci/repo/.circleci
   builds_bucket: &builds_bucket
@@ -830,26 +828,6 @@ commands:
             fi
 
 jobs:
-  build-api-docs-job:
-    executor:
-      name: build-deploy-executor
-    working_directory: *repo_path
-    parameters:
-      spec_dir:
-        type: string
-        default: *api-spec-path
-    steps:
-      - run: echo "Doing build-api-docs-job << pipeline.parameters.api-docs >>"
-      - when:
-          condition: << pipeline.parameters.api-docs >>
-          steps:
-            - checkout
-            - run:
-                name: Build docs
-                command: |
-                  cd << parameters.spec_dir >>
-                  ./build.sh documentation
-
   dsm-compile-and-run-tests-job:
     executor:
       name: test-executor
@@ -1107,35 +1085,6 @@ jobs:
           module: dsm-server
       - deploy-dsm-jar
 
-  build-deploy-docs-job:
-    executor:
-      name: build-deploy-executor
-    working_directory: *api-spec-path
-    parameters:
-      pepper_apis_path:
-        type: string
-        default: *pepper_apis_path
-    steps:
-      - run:
-          name: Remove recursively << parameters.pepper_apis_path >>
-          command: |
-            rm -r << parameters.pepper_apis_path >>
-      - checkout:
-          path: *repo_path
-      - run:
-          name: Build docs
-          command: ./build.sh documentation
-      - setup-shared-env
-      - set-deployment-env
-      - auth-gcp-service-account
-      - run:
-          name: Deploy docs website
-          command: |
-            set -u
-            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --project "broad-ddp-${ENVIRONMENT}" deploy/app.yaml
-      - delete-old-service-versions:
-          deploy_dir: deploy
-
 parameters:
   on_demand:
     type: boolean
@@ -1143,7 +1092,7 @@ parameters:
 
   project:
     type: enum
-    enum: ["dss", "dsm","api-docs", "nothing"]
+    enum: ["dss", "dsm", "nothing"]
     default: "dss"
 
   action:
@@ -1158,10 +1107,6 @@ parameters:
   test_parallelism:
     type: integer
     default: 1
-
-  api-docs:
-    type: boolean
-    default: false
 
   dsm:
     type: boolean
@@ -1180,16 +1125,6 @@ workflows:
       - dss-parallel-compile-and-test-job:
           parallelism: << pipeline.parameters.test_parallelism >> # the caller of this workflow will tell us the parallelism
       - dsm-compile-and-run-tests-job
-      - build-api-docs-job
-
-  # Build and deploy API docs
-  api-docs-build-test-deploy-workflow:
-    when:
-      and:
-        - equal: ["build-test-deploy", << pipeline.parameters.action >>]
-        - << pipeline.parameters.api-docs >>
-    jobs:
-      - build-deploy-docs-job
 
   # Build , run all tests, and immediately deploy DSS. Currently used in develop branch and dev environment
   dss-build-test-deploy-workflow:
@@ -1241,7 +1176,6 @@ workflows:
         - << pipeline.parameters.dss >>
     jobs:
       - deploy-dss-stored-jar-job
-      - build-deploy-docs-job
 
   # DSM build and test and then store the jar in a bucket for later deployment
   dsm-build-test-store-workflow:

--- a/.circleci/main-config.yml
+++ b/.circleci/main-config.yml
@@ -26,6 +26,8 @@ references:
                       /home/circleci/repo/pepper-apis
   docs-path: &docs-path
                /home/circleci/repo/pepper-apis/docs
+  api-spec-path: &api-spec-path
+                   /home/circleci/repo/pepper-apis/docs/specification
   circleci_path: &circleci_path
                    /home/circleci/repo/.circleci
   builds_bucket: &builds_bucket
@@ -828,6 +830,26 @@ commands:
             fi
 
 jobs:
+  build-api-docs-job:
+    executor:
+      name: build-deploy-executor
+    working_directory: *repo_path
+    parameters:
+      spec_dir:
+        type: string
+        default: *api-spec-path
+    steps:
+      - run: echo "Doing build-api-docs-job << pipeline.parameters.api-docs >>"
+      - when:
+          condition: << pipeline.parameters.api-docs >>
+          steps:
+            - checkout
+            - run:
+                name: Build docs
+                command: |
+                  cd << parameters.spec_dir >>
+                  ./build.sh documentation
+
   dsm-compile-and-run-tests-job:
     executor:
       name: test-executor
@@ -1085,6 +1107,35 @@ jobs:
           module: dsm-server
       - deploy-dsm-jar
 
+  build-deploy-docs-job:
+    executor:
+      name: build-deploy-executor
+    working_directory: *api-spec-path
+    parameters:
+      pepper_apis_path:
+        type: string
+        default: *pepper_apis_path
+    steps:
+      - run:
+          name: Remove recursively << parameters.pepper_apis_path >>
+          command: |
+            rm -r << parameters.pepper_apis_path >>
+      - checkout:
+          path: *repo_path
+      - run:
+          name: Build docs
+          command: ./build.sh documentation
+      - setup-shared-env
+      - set-deployment-env
+      - auth-gcp-service-account
+      - run:
+          name: Deploy docs website
+          command: |
+            set -u
+            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --project "broad-ddp-${ENVIRONMENT}" deploy/app.yaml
+      - delete-old-service-versions:
+          deploy_dir: deploy
+
 parameters:
   on_demand:
     type: boolean
@@ -1092,7 +1143,7 @@ parameters:
 
   project:
     type: enum
-    enum: ["dss", "dsm", "nothing"]
+    enum: ["dss", "dsm","api-docs", "nothing"]
     default: "dss"
 
   action:
@@ -1107,6 +1158,10 @@ parameters:
   test_parallelism:
     type: integer
     default: 1
+
+  api-docs:
+    type: boolean
+    default: false
 
   dsm:
     type: boolean
@@ -1125,6 +1180,17 @@ workflows:
       - dss-parallel-compile-and-test-job:
           parallelism: << pipeline.parameters.test_parallelism >> # the caller of this workflow will tell us the parallelism
       - dsm-compile-and-run-tests-job
+      # don't build openapi docs
+      # - build-api-docs-job
+
+  # Build and deploy API docs
+  api-docs-build-test-deploy-workflow:
+    when:
+      and:
+        - equal: ["build-test-deploy", << pipeline.parameters.action >>]
+        - << pipeline.parameters.api-docs >>
+    jobs:
+      - build-deploy-docs-job
 
   # Build , run all tests, and immediately deploy DSS. Currently used in develop branch and dev environment
   dss-build-test-deploy-workflow:
@@ -1176,6 +1242,8 @@ workflows:
         - << pipeline.parameters.dss >>
     jobs:
       - deploy-dss-stored-jar-job
+      # don't build open API docs
+      # - build-deploy-docs-job
 
   # DSM build and test and then store the jar in a bucket for later deployment
   dsm-build-test-store-workflow:


### PR DESCRIPTION
PEPPER-1420 Since nobody is using the [pepper openAPI docs](https://pepper.datadonationplatform.org/docs), so we are going to stop generating them in our builds and stop hosting them in GAE.

The changes are limited to our circleci config.  Once these changes get up to `develop`, we can verify circleCI behavior and then remove the `pepper-api-spec` appengine service in each environment as the RC takes shape and moves to dev, test, staging, and prod.

We'll leave most of the code in place to generate the api docs so if we change our mind, it'll be easy to re-enable the docs.  These changes just eliminate the build from generating and deploying the docs.