### PR TITLE
[PEPPER-729] Create OS2 cohort tag for re-consent with no OS1 participant data

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/Dsm.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/Dsm.java
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsm.model.elastic;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -156,7 +157,7 @@ public class Dsm {
 
     public List<CohortTag> getCohortTag() {
         if (cohortTag == null) {
-            cohortTag = Collections.emptyList();
+            cohortTag = new ArrayList<>();
         }
         return cohortTag;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
@@ -127,9 +127,6 @@ public class OsteoParticipantService {
         cohortTag.setCohortTagId(newCohortTagId);
 
         List<CohortTag> cohortTags = dsm.getCohortTag();
-        if (cohortTags.isEmpty()) {
-            cohortTags = new ArrayList<>();
-        }
         cohortTags.add(cohortTag);
         dsm.setCohortTag(cohortTags);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/OsteoParticipantService.java
@@ -69,7 +69,6 @@ public class OsteoParticipantService {
      */
     public void setOsteoDefaultData(String ddpParticipantId, ElasticSearchParticipantDto participantDto) {
         if (isOsteo1Participant(participantDto)) {
-            log.info("Creating an osteo1 cohort tag for participant {}", ddpParticipantId);
             createOsteoTag(participantDto, ddpParticipantId, osteo1Instance, OSTEO1_COHORT_TAG_NAME);
         } else {
             createOsteoTag(participantDto, ddpParticipantId, osteo2Instance, OSTEO2_COHORT_TAG_NAME);
@@ -118,49 +117,70 @@ public class OsteoParticipantService {
                                        DDPInstance osteoInstance, String tagName) {
         // invariant: participant should have a DSM entity
         Dsm dsm = participantDto.getDsm().orElseThrow();
+        createOteoTag(dsm, ddpParticipantId, osteoInstance, tagName);
+    }
 
-        CohortTag newCohortTag =
-                new CohortTag(tagName, ddpParticipantId, osteoInstance.getDdpInstanceIdAsInt());
-        int newCohortTagId = cohortTagDao.create(newCohortTag);
-        newCohortTag.setCohortTagId(newCohortTagId);
+    private static void createOteoTag(Dsm dsm, String ddpParticipantId, DDPInstance osteoInstance, String tagName) {
+        log.info("Creating {} cohort tag for participant {}", tagName, ddpParticipantId);
+        CohortTag cohortTag = new CohortTag(tagName, ddpParticipantId, osteoInstance.getDdpInstanceIdAsInt());
+        int newCohortTagId = cohortTagDao.create(cohortTag);
+        cohortTag.setCohortTagId(newCohortTagId);
 
-        // new participant so this is the first tag
-        dsm.setCohortTag(List.of(newCohortTag));
+        List<CohortTag> cohortTags = dsm.getCohortTag();
+        if (cohortTags.isEmpty()) {
+            cohortTags = new ArrayList<>();
+        }
+        cohortTags.add(cohortTag);
+        dsm.setCohortTag(cohortTags);
+
         ElasticSearchService.updateDsm(ddpParticipantId, dsm, osteoInstance.getParticipantIndexES());
     }
 
     /**
-     * Copy osteo1 participant data to osteo2 for osteo1 participant who consented to OS PE-CGS (OS2/osteo2)
+     * For osteo1 participant who consented to OS PE-CGS (OS2/osteo2), create a osteo2 cohort tag,
+     * and copy osteo1 participant data to osteo2
      */
     public void initializeReconsentedParticipant(String ddpParticipantId) {
         log.info("Initializing re-consented osteo participant {}", ddpParticipantId);
 
-        // ensure we can get what we need before committing anything
-        int osteo1InstanceId = osteo1Instance.getDdpInstanceIdAsInt();
+        String osteo2Index = osteo2Instance.getParticipantIndexES();
+        Dsm osteo2Dsm = getParticipantDsm(ddpParticipantId, osteo2Index);
+        createOteoTag(osteo2Dsm, ddpParticipantId, osteo2Instance, OSTEO2_COHORT_TAG_NAME);
+
         Optional<ParticipantDto> osteo1Ptp = participantDao
-                .getParticipantForInstance(ddpParticipantId, osteo1InstanceId);
+                .getParticipantForInstance(ddpParticipantId, osteo1Instance.getDdpInstanceIdAsInt());
         if (osteo1Ptp.isEmpty()) {
-            log.info("Participant {} record not found for instance {}. Skipping re-consent initialization.",
+            log.info("Participant {} record not found for instance {}. No re-consent participant data to copy.",
                     ddpParticipantId, osteo1Instance.getName());
             return;
         }
-        ParticipantDto osteo1Participant = osteo1Ptp.get();
-        int osteo1ParticipantId = osteo1Participant.getRequiredParticipantId();
-        log.info("Creating new {} participant data for existing {} participant {}",
-                osteo2Instance.getName(), osteo1Instance.getName(), ddpParticipantId);
+        copyOsteo1Data(osteo1Ptp.get(), ddpParticipantId, osteo2Dsm);
+    }
 
+    /**
+     * Get participant DSM ES data, or create it if missing
+     */
+    private Dsm getParticipantDsm(String ddpParticipantId, String esIndex) {
+        // there *should* be ES DSM data for osteo2, but make it if not
+        ElasticSearchParticipantDto esParticipant =
+                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, esIndex);
+        Optional<Dsm> dsm = esParticipant.getDsm();
+        return dsm.orElseGet(Dsm::new);
+    }
+
+    /**
+     * Copy osteo1 medical record bundle to osteo2 for existing osteo1 participant
+     */
+    private void copyOsteo1Data(ParticipantDto osteo1Participant, String ddpParticipantId, Dsm osteo2Dsm) {
+        log.info("Copying participant data for existing {} participant {} to {}",
+                osteo1Instance.getName(), ddpParticipantId, osteo2Instance.getName());
+
+        // ensure we can get what we need before copying and committing anything
         // there should already be ES DSM data in osteo1 index for this participant
         Dsm osteo1Dsm =
                 elasticSearchService.getRequiredDsmData(ddpParticipantId, osteo1Instance.getParticipantIndexES());
         Participant esParticipant = osteo1Dsm.getParticipant().orElseThrow(() ->
                 new DsmInternalError("ES Participant data missing for participant %s".formatted(ddpParticipantId)));
-
-        // there *should* be ES DSM data for osteo2, but make it if not
-        String osteo2Index = osteo2Instance.getParticipantIndexES();
-        ElasticSearchParticipantDto osteo2EsParticipant =
-                elasticSearchService.getRequiredParticipantDocument(ddpParticipantId, osteo2Index);
-        Optional<Dsm> dsm = osteo2EsParticipant.getDsm();
-        Dsm osteo2Dsm = dsm.orElseGet(Dsm::new);
 
         // there should not be osteo2 Participant, MedicalRecord or ParticipantRecord yet
         // if the Participant does not exist, the other data will not exist either
@@ -188,20 +208,9 @@ public class OsteoParticipantService {
                     participantRecordDao.create(clonedRecord);
                 });
 
-        osteo2Dsm.setMedicalRecord(copyMedicalRecords(osteo1ParticipantId, osteo2ParticipantId, osteo2InstanceId));
-
-        CohortTag cohortTag = new CohortTag(OSTEO2_COHORT_TAG_NAME, ddpParticipantId, osteo2InstanceId);
-        int newCohortTagId = cohortTagDao.create(cohortTag);
-        cohortTag.setCohortTagId(newCohortTagId);
-
-        List<CohortTag> cohortTags = osteo2Dsm.getCohortTag();
-        if (cohortTags.isEmpty()) {
-            cohortTags = new ArrayList<>();
-        }
-        cohortTags.add(cohortTag);
-        osteo2Dsm.setCohortTag(cohortTags);
-
-        ElasticSearchService.updateDsm(ddpParticipantId, osteo2Dsm, osteo2Index);
+        osteo2Dsm.setMedicalRecord(copyMedicalRecords(osteo1Participant.getRequiredParticipantId(),
+                osteo2ParticipantId, osteo2InstanceId));
+        ElasticSearchService.updateDsm(ddpParticipantId, osteo2Dsm, osteo2Instance.getParticipantIndexES());
         OncHistoryService.createEmptyOncHistory(osteo2ParticipantId, ddpParticipantId, osteo2Instance);
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/participant/OsteoParticipantServiceTest.java
@@ -213,7 +213,8 @@ public class OsteoParticipantServiceTest extends DbAndElasticBaseTest {
             Assert.fail("Failed to initialize reconsented participant: " + e.getMessage());
         }
 
-        // when no osteo1 Participant record, initializeReconsentedParticipant is a no-op
+        // when no osteo1 Participant record, initializeReconsentedParticipant only creates a cohort tag
+        verifyCohortTag(ddpParticipantId, OSTEO2_COHORT_TAG_NAME, osteo2InstanceDto);
         List<ParticipantDto> participants = participantDao.getParticipant(ddpParticipantId);
         Assert.assertTrue(participants.isEmpty());
     }


### PR DESCRIPTION
## Context
[PEPPER-729]

This handles the case where an osteo1 participant who consents into osteo2 but has no DSM participant record (or medical record bundle). We had been handling this as a no-op, but it requires a new osteo2 cohort tag.

A minor refactoring (the code in this file is relatively new) to move the cohort tag creation out of the middle of the participant data copy, and to consolidate the cohort tag creation code. Also broke out `OsteoParticipantService.copyOsteo1Data` and `OsteoParticipantService. getParticipantDsm` to improve readability.

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document



[PEPPER-729]: https://broadworkbench.atlassian.net/browse/PEPPER-729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ