### PR TITLE
[PEPPER-729] Fix osteo tags for re-consent case

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/tag/cohort/CohortTagDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/tag/cohort/CohortTagDao.java
@@ -9,6 +9,8 @@ import org.broadinstitute.dsm.db.dto.tag.cohort.CohortTag;
 public interface CohortTagDao extends Dao<CohortTag> {
     Map<String, List<CohortTag>> getCohortTagsByInstanceName(String instanceName);
 
+    public List<CohortTag> getParticipantCohortTags(String ddpParticipantId, int ddpInstanceId);
+
     List<Integer> bulkCohortCreate(List<CohortTag> cohortTags);
 
     int removeCohortByCohortTagNameAndGuid(String cohortTagName, String ddpParticipantId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/tag/cohort/CohortTagDaoImpl.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/tag/cohort/CohortTagDaoImpl.java
@@ -27,6 +27,9 @@ public class CohortTagDaoImpl implements CohortTagDao {
     private static final String SQL_GET_TAGS_BY_INSTANCE_NAME = "SELECT * FROM cohort_tag WHERE ddp_instance_id = "
             + "(SELECT ddp_instance_id FROM ddp_instance WHERE instance_name = ?)";
 
+    private static final String SQL_GET_PARTICIPANT_TAGS_BY_INSTANCE =
+            "SELECT * FROM cohort_tag WHERE ddp_participant_id = ? AND ddp_instance_id = ?";
+
     public static final String SQL_DELETE_BY_NAME_AND_GUID = "DELETE FROM cohort_tag WHERE cohort_tag_name = ? AND ddp_participant_id = ?";
 
     public static final String SQL_SELECT_BY_NAME_AND_GUID = "SELECT * FROM cohort_tag WHERE cohort_tag_name = ? "
@@ -119,6 +122,23 @@ public class CohortTagDaoImpl implements CohortTagDao {
                     simpleResult.resultException);
         }
         return result;
+    }
+
+    public List<CohortTag> getParticipantCohortTags(String dppParticipantId, int ddpInstanceId) {
+        return inTransaction(conn -> {
+            List<CohortTag> cohortTags = new ArrayList<>();
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_GET_PARTICIPANT_TAGS_BY_INSTANCE)) {
+                stmt.setString(1, dppParticipantId);
+                stmt.setInt(2, ddpInstanceId);
+                ResultSet resultSet = stmt.executeQuery();
+                while (resultSet.next()) {
+                    cohortTags.add(buildCohortTagFrom(resultSet));
+                }
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error getting cohort tags for instance, id=" + ddpInstanceId, e);
+            }
+            return cohortTags;
+        });
     }
 
     @Override

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/CohortTagMigrator.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/migration/CohortTagMigrator.java
@@ -21,8 +21,9 @@ public class CohortTagMigrator extends BaseCollectionMigrator {
     protected Map<String, Object> getDataByRealm() {
         Map<String, List<CohortTag>> cohortTags = cohortTagDao.getCohortTagsByInstanceName(realm);
         int tagsFromRealm = cohortTags.size();
-        AdditionalCohortTagsRetriever.fromRealm(realm)
-                .ifPresent(retriever -> retriever.mergeRecords(cohortTags));
+        // TODO: Remove this via PEPPER-1339. -DC
+        //AdditionalCohortTagsRetriever.fromRealm(realm)
+        //        .ifPresent(retriever -> retriever.mergeRecords(cohortTags));
         log.info("Migrator retrieved {} cohort tags from realm {}, and {} additional tags",
                 tagsFromRealm, realm, cohortTags.size() - tagsFromRealm);
         return (Map) cohortTags;


### PR DESCRIPTION
## Context
PEPPER-729

This PR fixes a bug where DSM was not adding an osteo2 tag to the osteo1 participant when an osteo1 ptp consents into osteo2. It also now copies all tags from osteo1 to osteo2 for the re-consent case. In the prior code (prior to the rewrite), all tags were only copied if the osteo1 participant had medical records, which is sort of bug. In most cases this new behavior is not a change, since typically the only osteo1 tag is present.

Also eliminated the double export of cohort tags. This was covering some of the cases addressed in this PR, so it is no longer needed. (Keeping the code around until I can finish PEPPER-1339 since a bunch of infra can now be retired.)

## Checklist

- [x] I have labeled the type of changes involved using the `C-*` labels.
- [x] I have assessed potential risks and labeled using the `R-*` labels.
- [x] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

