### PR TITLE
PEPPER-332 It's okay to delete a somatic upload with no bytes

### DIFF
--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -214,7 +214,7 @@
       {{end}}
     }
     "somatic": {
-        "maxFileSize": 3000000,
+        "maxFileSize": 30000000,
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -214,7 +214,7 @@
       {{end}}
     }
     "somatic": {
-        "maxFileSize": 1000000000,
+        "maxFileSize": 3000000,
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -215,7 +215,7 @@
     }
     "somatic": {
         "maxFileSize": 30000000,
-        "mediaTypes": "application/pdf,application/json"
+        "mediaTypes": "application/pdf,application/json",
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -217,7 +217,7 @@
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},
-            {"realm": "somatic-upload-test", "uploadBucket":"cmi-lms-uploaded-files"}
+            {"realm": "somatic-upload-test", "uploadBucket":"cmi-lms-uploaded-files", "maxFileSize": 100000000L}
         ]
     }
 }

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -214,7 +214,6 @@
       {{end}}
     }
     "somatic": {
-        "maxFileSize": 30000000,
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -214,10 +214,11 @@
       {{end}}
     }
     "somatic": {
+        "maxFileSize": 1000000000,
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},
-            {"realm": "somatic-upload-test", "uploadBucket":"cmi-lms-uploaded-files", "maxFileSize": 100000000L}
+            {"realm": "somatic-upload-test", "uploadBucket":"cmi-lms-uploaded-files"}
         ]
     }
 }

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -215,6 +215,7 @@
     }
     "somatic": {
         "maxFileSize": 30000000,
+        "mediaTypes": "application/pdf"
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -215,7 +215,7 @@
     }
     "somatic": {
         "maxFileSize": 30000000,
-        "mediaTypes": "application/pdf"
+        "mediaTypes": "application/pdf,application/json"
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -216,7 +216,8 @@
     "somatic": {
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
-            {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"}
+            {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},
+            {"realm": "somatic-upload-test", "uploadBucket":"cmi-lms-uploaded-files"}
         ]
     }
 }

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -215,7 +215,6 @@
     }
     "somatic": {
         "maxFileSize": 30000000,
-        "mediaTypes": "application/pdf,application/json",
         "realmToBucketMappings": [
             {"realm": "osteo2", "uploadBucket":"cmi-osteo2-uploaded-files"},
             {"realm": "cmi-lms", "uploadBucket":"cmi-lms-uploaded-files"},

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/SomaticResultUpload.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/SomaticResultUpload.java
@@ -260,6 +260,9 @@ public class SomaticResultUpload implements HasDdpInstanceId {
         if (documents.isEmpty()) {
             throw new DSMBadRequestException("Bad request for document with id " + documentId);
         }
+        if (documents.get(0) == null) {
+            throw new DsmInternalError("somatic upload document is null for " + documentId);
+        }
         return documents.get(0);
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/SomaticResultUpload.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/SomaticResultUpload.java
@@ -126,7 +126,7 @@ public class SomaticResultUpload implements HasDdpInstanceId {
             + "LEFT JOIN ddp_instance as ddp ON (ddp.ddp_instance_id = p.ddp_instance_id) "
             + "WHERE p.ddp_participant_id = ? AND ddp.instance_name= ?)";
 
-    private static final String HARD_DELETE_SOMATIC_DOCUMENT = "delete from somatic_documents where id = ?";
+    private static final String SQL_HARD_DELETE_SOMATIC_DOCUMENT = "delete from somatic_documents where id = ?";
 
     public SomaticResultUpload() {}
 
@@ -325,7 +325,7 @@ public class SomaticResultUpload implements HasDdpInstanceId {
      */
     @VisibleForTesting
     public static void hardDeleteSomaticDocumentById(Handle handle, long id) {
-        try (PreparedStatement stmt = handle.getConnection().prepareStatement(HARD_DELETE_SOMATIC_DOCUMENT)) {
+        try (PreparedStatement stmt = handle.getConnection().prepareStatement(SQL_HARD_DELETE_SOMATIC_DOCUMENT)) {
             stmt.setLong(1, id);
             int rowsDeleted = stmt.executeUpdate();
             if (rowsDeleted != 1) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
@@ -95,6 +95,8 @@ public class SomaticResultUploadService {
                                            SomaticResultMetaData somaticResultMetaData) {
         FileValidator fileValidator = new FileValidator();
         if (somaticResultMetaData.getFileSize() > somaticUploadSettings.getMaxFileSize()) {
+            log.info("File " + somaticResultMetaData.getFileName() + " of size " + somaticResultMetaData.getFileSize()
+                    + " exceeds maximum file size " + somaticUploadSettings.getMaxFileSize());
             return new AuthorizeResult(AuthorizeResultType.FILE_SIZE_EXCEEDS_MAXIMUM, null, null, somaticUploadSettings);
         }
         if (!somaticUploadSettings.getMimeTypes().contains(somaticResultMetaData.getMimeType())) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
@@ -129,7 +129,7 @@ public class SomaticResultUploadService {
         try {
             existingDocument = SomaticResultUpload.getSomaticFileUploadByIdAndRealm(documentId, realm);
         } catch (RuntimeException rte) {
-            throw new DSMBadRequestException("No document found for entry");
+            throw new DSMBadRequestException("No document found for document id " + documentId);
         }
 
         if (isDeletedSomaticResult(existingDocument)) {
@@ -143,16 +143,14 @@ public class SomaticResultUploadService {
             if (deleted) {
                 log.info("User {} deleted somatic document {}", userId, documentId);
             } else {
-                log.error("Somatic document failed to delete from GCS. Manual intervention required.  "
+                log.error("Somatic document failed to delete from GCS for {}. Manual intervention required.  "
                                 + "Last recorded bucket: {}, blobPath: {} ",
-                        deletedSomaticResultUpload.getBucket(), deletedSomaticResultUpload.getBlobPath());
+                        documentId, deletedSomaticResultUpload.getBucket(), deletedSomaticResultUpload.getBlobPath());
                 throw new DsmInternalError("Deletion failed, contact DSM developer.");
             }
         } else {
-            log.error("Somatic document blob not found in bucket when attempting to delete from GCS. Manual intervention required.  "
-                            + "Last recorded bucket: {}, blobPath: {} ",
-                    deletedSomaticResultUpload.getBucket(), deletedSomaticResultUpload.getBlobPath());
-            throw new DsmInternalError("Deletion failed, contact DSM developer.");
+            // sometimes storage blobs aren't written to during uploads, so there's no GCS data to delete
+            log.info("No somatic document blob found for {} so there's no file data to delete.", documentId);
         }
         return deletedSomaticResultUpload;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
@@ -103,7 +103,7 @@ public class SomaticResultUploadService {
         if (!somaticUploadSettings.getMimeTypes().contains(somaticResultMetaData.getMimeType())) {
             log.info("File " + somaticResultMetaData.getFileName() + " has unsupported mime type "
                     + somaticResultMetaData.getMimeType() + ".  Supported mime types are "
-                    + StringUtils.join(somaticUploadSettings.getMaxFileSize(), ","));
+                    + StringUtils.join(somaticUploadSettings.getMimeTypes(), ","));
             return new AuthorizeResult(AuthorizeResultType.MIME_TYPE_NOT_ALLOWED, null, null, somaticUploadSettings);
         }
         if (!fileValidator.isValidFileName("Validating file name",

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
@@ -22,6 +22,7 @@ import com.typesafe.config.Config;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.client.GoogleBucketClient;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -100,6 +101,9 @@ public class SomaticResultUploadService {
             return new AuthorizeResult(AuthorizeResultType.FILE_SIZE_EXCEEDS_MAXIMUM, null, null, somaticUploadSettings);
         }
         if (!somaticUploadSettings.getMimeTypes().contains(somaticResultMetaData.getMimeType())) {
+            log.info("File " + somaticResultMetaData.getFileName() + " has unsupported mime type "
+                    + somaticResultMetaData.getMimeType() + ".  Supported mime types are "
+                    + StringUtils.join(somaticUploadSettings.getMaxFileSize(), ","));
             return new AuthorizeResult(AuthorizeResultType.MIME_TYPE_NOT_ALLOWED, null, null, somaticUploadSettings);
         }
         if (!fileValidator.isValidFileName("Validating file name",

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/SomaticResultUploadService.java
@@ -22,7 +22,6 @@ import com.typesafe.config.Config;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.ddp.client.GoogleBucketClient;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.exception.DDPException;
@@ -96,14 +95,9 @@ public class SomaticResultUploadService {
                                            SomaticResultMetaData somaticResultMetaData) {
         FileValidator fileValidator = new FileValidator();
         if (somaticResultMetaData.getFileSize() > somaticUploadSettings.getMaxFileSize()) {
-            log.info("File " + somaticResultMetaData.getFileName() + " of size " + somaticResultMetaData.getFileSize()
-                    + " exceeds maximum file size " + somaticUploadSettings.getMaxFileSize());
             return new AuthorizeResult(AuthorizeResultType.FILE_SIZE_EXCEEDS_MAXIMUM, null, null, somaticUploadSettings);
         }
         if (!somaticUploadSettings.getMimeTypes().contains(somaticResultMetaData.getMimeType())) {
-            log.info("File " + somaticResultMetaData.getFileName() + " has unsupported mime type "
-                    + somaticResultMetaData.getMimeType() + ".  Supported mime types are "
-                    + StringUtils.join(somaticUploadSettings.getMimeTypes(), ","));
             return new AuthorizeResult(AuthorizeResultType.MIME_TYPE_NOT_ALLOWED, null, null, somaticUploadSettings);
         }
         if (!fileValidator.isValidFileName("Validating file name",

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/somatic/result/SomaticResultUploadSettingsTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/somatic/result/SomaticResultUploadSettingsTest.java
@@ -35,7 +35,7 @@ public class SomaticResultUploadSettingsTest {
     public void test_defaultLoadedSettingsObject() {
         validateSettings(loadedConfigSettings,
                 1000 * 1000 * 30L,
-                2,
+                1,
                 "application/pdf",
                 "pdf",
                 1

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/somatic/result/SomaticResultUploadSettingsTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/model/somatic/result/SomaticResultUploadSettingsTest.java
@@ -35,7 +35,7 @@ public class SomaticResultUploadSettingsTest {
     public void test_defaultLoadedSettingsObject() {
         validateSettings(loadedConfigSettings,
                 1000 * 1000 * 30L,
-                1,
+                2,
                 "application/pdf",
                 "pdf",
                 1
@@ -46,16 +46,16 @@ public class SomaticResultUploadSettingsTest {
     public void test_modifiedConfigSettingsObject() {
         ConfigManager loadedConfig = ConfigManager.getInstance();
         loadedConfig.overrideValue("somatic.maxFileSize", "60");
-        loadedConfig.overrideValue("somatic.mediaTypes", "application/foo,application/json");
-        loadedConfig.overrideValue("somatic.allowedFileExtensions", "foo,json");
+        loadedConfig.overrideValue("somatic.mediaTypes", "application/foo,application/json,application/pdf");
+        loadedConfig.overrideValue("somatic.allowedFileExtensions", "foo,json,pdf");
         Config modifiedConfig = loadedConfig.getConfig();
         SomaticResultUploadSettings uploadSettings = new SomaticResultUploadSettings(modifiedConfig);
         validateSettings(uploadSettings,
                 60L,
-                2,
+                3,
                 "application/foo",
                 "foo",
-                2
+                3
         );
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
 
     private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
+    // the instance name must be included in the somatic.realmToBucketMappings section of the conf file
     private static final String instanceName = "somatic-upload-test";
     private static String esIndex;
     private static DDPInstanceDto ddpInstanceDto;
@@ -36,6 +37,8 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
         ddpInstanceDto = DdpInstanceGroupTestUtil.createTestDdpInstance(instanceName, esIndex, instanceName);
         Config loadedConfig = ConfigManager.getInstance().getConfig();
         somaticResultUploadSerivce = SomaticResultUploadService.fromConfig(loadedConfig);
+        String ddpParticipantId = TestParticipantUtil.genDDPParticipantId("somaticupload");
+        testParticipant = TestParticipantUtil.createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
     }
 
     @AfterClass
@@ -61,8 +64,6 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
 
     @Test
     public void testDelete() {
-        String ddpParticipantId = TestParticipantUtil.genDDPParticipantId("somaticupload");
-        testParticipant = TestParticipantUtil.createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
         SomaticResultMetaData uploadData = new SomaticResultMetaData("testFile.pdf", "application/pdf", 1L);
         SomaticResultUploadService.AuthorizeResult uploadAuth = somaticResultUploadSerivce.authorizeUpload(
                 instanceName, Integer.toString(testParticipant.getRequiredParticipantId()),

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -76,6 +76,7 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
         assertNotNull(deleteResult);
         // verify that the soft delete happened by checking that there's a deletion time and a deleted by user id
         long secondsSinceDeletion = Duration.between(Instant.ofEpochSecond(deleteResult.getDeletedAt()), Instant.now()).getSeconds();
+        // verify that the delete happened recently
         Assert.assertTrue(secondsSinceDeletion < 30);
         Assert.assertEquals(testParticipant.getRequiredParticipantId(), deleteResult.getDeletedByUserId().intValue());
         TransactionWrapper.useTxn(handle -> {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -67,6 +67,7 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
         SomaticResultUploadService.AuthorizeResult uploadAuth = somaticResultUploadSerivce.authorizeUpload(
                 instanceName, Integer.toString(testParticipant.getRequiredParticipantId()),
                 testParticipant.getRequiredDdpParticipantId(), uploadData);
+        Assert.assertEquals(SomaticResultUploadService.AuthorizeResultType.OK, uploadAuth.getAuthorizeResultType());
         Assert.assertNotNull(uploadAuth.getSomaticResultUpload());
         SomaticResultUpload deleteResult = somaticResultUploadSerivce.deleteUpload(
                 testParticipant.getRequiredParticipantId(), uploadAuth.getSomaticResultUpload().getSomaticDocumentId(),

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -67,6 +67,7 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
         SomaticResultUploadService.AuthorizeResult uploadAuth = somaticResultUploadSerivce.authorizeUpload(
                 instanceName, Integer.toString(testParticipant.getRequiredParticipantId()),
                 testParticipant.getRequiredDdpParticipantId(), uploadData);
+        Assert.assertNotNull(uploadAuth.getSomaticResultUpload());
         SomaticResultUpload deleteResult = somaticResultUploadSerivce.deleteUpload(
                 testParticipant.getRequiredParticipantId(), uploadAuth.getSomaticResultUpload().getSomaticDocumentId(),
                 instanceName);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -3,22 +3,81 @@ package org.broadinstitute.dsm.service;
 import static org.junit.Assert.assertNotNull;
 
 import com.typesafe.config.Config;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.dsm.DbAndElasticBaseTest;
+import org.broadinstitute.dsm.db.SomaticResultUpload;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
+import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
+import org.broadinstitute.dsm.model.somatic.result.SomaticResultMetaData;
+import org.broadinstitute.dsm.util.DdpInstanceGroupTestUtil;
+import org.broadinstitute.dsm.util.ElasticTestUtil;
+import org.broadinstitute.dsm.util.TestParticipantUtil;
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class SomaticResultUploadServiceTest {
+import java.time.Duration;
+import java.time.Instant;
 
-    static SomaticResultUploadService somaticResultUploadSerivce;
+public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
+
+    private static final DDPInstanceDao ddpInstanceDao = new DDPInstanceDao();
+    private static final String instanceName = "somatic-upload-test";
+    private static String esIndex;
+    private static DDPInstanceDto ddpInstanceDto;
+    private static ParticipantDto testParticipant = null;
 
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws Exception {
+        esIndex = ElasticTestUtil.createIndex(instanceName, "elastic/lmsMappings.json", null);
+        ddpInstanceDto = DdpInstanceGroupTestUtil.createTestDdpInstance(instanceName, esIndex, instanceName);
         Config loadedConfig = ConfigManager.getInstance().getConfig();
         somaticResultUploadSerivce = SomaticResultUploadService.fromConfig(loadedConfig);
     }
 
+    @AfterClass
+    public static void tearDown() {
+        try {
+            Assert.assertNotNull(testParticipant);
+            TestParticipantUtil.deleteParticipant(testParticipant.getRequiredParticipantId());
+            Assert.assertNotNull(ddpInstanceDto);
+            ddpInstanceDao.delete(ddpInstanceDto.getDdpInstanceId());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception: " + e);
+        }
+        ElasticTestUtil.deleteIndex(esIndex);
+    }
+
+    static SomaticResultUploadService somaticResultUploadSerivce;
+
     @Test
     public void test_authorizeValidRequest() {
         assertNotNull(somaticResultUploadSerivce);
+    }
+
+    @Test
+    public void testDelete() {
+        String ddpParticipantId = TestParticipantUtil.genDDPParticipantId("somaticupload");
+        testParticipant = TestParticipantUtil.createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
+        SomaticResultMetaData uploadData = new SomaticResultMetaData("testFile.pdf", "application/pdf", 100L);
+        SomaticResultUploadService.AuthorizeResult uploadAuth = somaticResultUploadSerivce.authorizeUpload(
+                instanceName, Integer.toString(testParticipant.getRequiredParticipantId()),
+                testParticipant.getRequiredDdpParticipantId(), uploadData);
+        SomaticResultUpload deleteResult = somaticResultUploadSerivce.deleteUpload(
+                testParticipant.getRequiredParticipantId(), uploadAuth.getSomaticResultUpload().getSomaticDocumentId(),
+                instanceName);
+        long secondsSinceDeletion = Duration.between(Instant.ofEpochSecond(deleteResult.getDeletedAt()), Instant.now()).getSeconds();
+        assertNotNull(deleteResult);
+        Assert.assertTrue(secondsSinceDeletion < 30);
+        Assert.assertEquals(testParticipant.getRequiredParticipantId(), deleteResult.getDeletedByUserId().intValue());
+        TransactionWrapper.useTxn(handle -> {
+            SomaticResultUpload.hardDeleteSomaticDocumentById(handle,
+                    uploadAuth.getSomaticResultUpload().getSomaticDocumentId());
+        });
+
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/SomaticResultUploadServiceTest.java
@@ -63,7 +63,7 @@ public class SomaticResultUploadServiceTest extends DbAndElasticBaseTest {
     public void testDelete() {
         String ddpParticipantId = TestParticipantUtil.genDDPParticipantId("somaticupload");
         testParticipant = TestParticipantUtil.createParticipant(ddpParticipantId, ddpInstanceDto.getDdpInstanceId());
-        SomaticResultMetaData uploadData = new SomaticResultMetaData("testFile.pdf", "application/pdf", 100L);
+        SomaticResultMetaData uploadData = new SomaticResultMetaData("testFile.pdf", "application/pdf", 1L);
         SomaticResultUploadService.AuthorizeResult uploadAuth = somaticResultUploadSerivce.authorizeUpload(
                 instanceName, Integer.toString(testParticipant.getRequiredParticipantId()),
                 testParticipant.getRequiredDdpParticipantId(), uploadData);


### PR DESCRIPTION
This PR is a dependency of this [frontend PR](https://github.com/broadinstitute/ddp-angular/pull/2376) that cleans up properly when a somatic upload fails.  Previously, an attempt to delete an upload would result in an error if the file blob was empty.  Because we have found that some uploads fail and don't write any bytes, we need the delete to go through even if there are no bytes in the blob.  This PR removes the exception that was thrown if the byte stream was empty.

For good measure, I added a test to verify that the delete works properly.

_Overall, how are you feeling about these changes?_

- [ x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

