### PR TITLE
Cleaning up logging during shutdown and during liquibase error handling.

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/util/LiquibaseUtil.java
@@ -205,7 +205,7 @@ public class LiquibaseUtil implements AutoCloseable {
                 liquibase.update(new Contexts(context));
             } catch (LiquibaseException originalError) {
                 log.error("LiquibaseException: {}", originalError.getMessage());
-                if (tag != null) {
+                if (tag != null && originalError.getCause() != null) {
                     if (originalError.getCause().getClass() == MigrationFailedException.class
                             || originalError.getCause().getMessage().contains("Migration failed for change set " + changelogFile)) {
                         try {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/publish/pubsub/PubSubPublisherInitializer.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/event/publish/pubsub/PubSubPublisherInitializer.java
@@ -11,6 +11,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.pubsub.v1.ProjectTopicName;
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.appengine.spark.SparkBootUtil;
 import org.broadinstitute.ddp.constants.ConfigFile;
 import org.broadinstitute.ddp.exception.DDPException;
 import org.broadinstitute.ddp.housekeeping.PubSubConnectionManager;
@@ -58,7 +59,11 @@ public class PubSubPublisherInitializer {
             try {
                 publisher.getValue().shutdown();
             } catch (Exception e) {
-                log.error("Error shutting down publisher {}", publisher.getKey(), e);
+                if (!SparkBootUtil.isShuttingDown()) {
+                    log.error("Error shutting down publisher {}", publisher.getKey(), e);
+                } else {
+                    log.info("Exception during shutdown", e);
+                }
             }
         }
     }


### PR DESCRIPTION
## PEPPER-1413 cleanups

Post deployment, I noticed a few things that needed some tidying up in order to keep our logs in better shape and avoid false positive errors.  

One issue is that when a liquibase exception occurs during a timeout, the underlying issue is hard to see because of an NPE.  Simple fix to the error logging.

The other issue was that during shutdowns, it appears that the database pool shuts down before quartz jobs, despite the fact that code-wise, the quartz job is shutdown before the connection pool.  It's probably the case that quartz just takes a while to clean itself up async, and by the time it does so, the connection pool has already closed, resulting in a raft of db connectivity issues during shutdown.  The fix here was to track a bit of state about whether the app is shutting down, and decide whether to log an error or an info depending on whether the app is shutting down.