### PR TITLE
PEPPER-1413 delay the shutdown to give the db more time

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/appengine/spark/SparkBootUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/appengine/spark/SparkBootUtil.java
@@ -78,7 +78,7 @@ public class SparkBootUtil {
                 // as a failure
                 if (numShutdownAttempts == 0) {
                     final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
-                    executor.schedule(() -> stopRouteCallback.onAhStop(), 500, TimeUnit.MILLISECONDS);
+                    executor.schedule(() -> stopRouteCallback.onAhStop(), 5, TimeUnit.SECONDS);
                 } else {
                     log.info("Ignoring shutdown attempt {}", numShutdownAttempts);
                 }


### PR DESCRIPTION
PEPPER-1413 Quick experiment: delay the shutdown to give the db more time to clear connections ahead of starting up replacement instance.  At present, dsm test is starting up, but spark fails to initialize and reports that it's not possible to create a database connection.

One hypothesis is that because ah/stop now returns almost immediately, that a subsequent instance starting up attempts to create a connection pool before the shutting down instance fully releases its connections.  This PR is an experiment to gather more information about the timing.

**Note that this PR merges into the *test* branch, not `develop`, so that we can try things out in the test environment.**