### PR TITLE
PEPPER-1407 Exception mapper for handling unique constraints

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -44,6 +44,7 @@ import org.broadinstitute.dsm.exception.AuthenticationException;
 import org.broadinstitute.dsm.exception.AuthorizationException;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.exception.DuplicateEntityException;
 import org.broadinstitute.dsm.exception.UnsafeDeleteError;
 import org.broadinstitute.dsm.jobs.DDPEventJob;
 import org.broadinstitute.dsm.jobs.DDPRequestJob;
@@ -1067,6 +1068,13 @@ public class DSMServer {
             logger.warn("Authentication error while processing request: {}: {}", request.url(), exception.toString());
             response.status(401);
             response.body(exception.getMessage());
+        });
+        exception(DuplicateEntityException.class, (e, request, response) -> {
+            // Tell the user to retry with a different name.  Not logged as an error,
+            // since this can happen during normal operations.
+            response.status(400);
+            response.body(String.format("%s %s is already taken.  Please retry with a different value.",
+                    e.getEntityName(), e.getEntityValue()));
         });
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -1072,7 +1072,7 @@ public class DSMServer {
         exception(DuplicateEntityException.class, (e, request, response) -> {
             // Tell the user to retry with a different name.  Not logged as an error,
             // since this can happen during normal operations.
-            response.status(400);
+            response.status(422);
             response.body(String.format("%s %s is already taken.  Please retry with a different value.",
                     e.getEntityName(), e.getEntityValue()));
         });

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -1073,8 +1073,8 @@ public class DSMServer {
             // Tell the user to retry with a different name.  Not logged as an error,
             // since this can happen during normal operations.
             response.status(422);
-            response.body(String.format("%s %s is already taken.  Please retry with a different value.",
-                    e.getEntityName(), e.getEntityValue()));
+            response.body(String.format("%s %s is already taken.  Please retry with a different %s.",
+                    e.getEntityName(), e.getEntityValue(), e.getEntityName()));
         });
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
@@ -108,7 +108,7 @@ public class ViewFilter {
                       Integer[] realmId) {
         this.userId = userId;
         this.fDeleted = fDeleted;
-        this.filterName = filterName;
+        setFilterName(filterName);
         this.columns = columns;
         this.shared = shared;
         this.id = id;
@@ -119,6 +119,13 @@ public class ViewFilter {
         this.queryItems = queryItems;
         this.filterQuery = filterQuery;
         this.realmId = realmId;
+    }
+
+    public void setFilterName(String filterName) {
+        this.filterName = filterName;
+        if (StringUtils.isNotBlank(this.filterName)) {
+            this.filterName = this.filterName.trim();
+        }
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/ViewFilter.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.gson.Gson;
 import lombok.Data;
@@ -120,42 +121,30 @@ public class ViewFilter {
         this.realmId = realmId;
     }
 
-    private static SimpleResult checkUniqueFilterName(String suggestedName) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
+    /**
+     * Returns true if a filter with the given name exists in the database,
+     * false if it does not exist.
+     */
+    public static boolean doesFilterExist(String filterName) {
+        final AtomicBoolean filterExists = new AtomicBoolean(false);
+        inTransaction((conn) -> {
             try (PreparedStatement stmt = conn.prepareStatement(SQL_CHECK_VIEW_NAME)) {
-                stmt.setString(1, suggestedName);
-                try {
-                    ResultSet rs = stmt.executeQuery();
-                    if (rs.next()) {
-                        dbVals.resultValue = "Duplicate Name";
-                    }
-                } catch (Exception e) {
-                    dbVals.resultException = e;
+                stmt.setString(1, filterName);
+                ResultSet rs = stmt.executeQuery();
+                if (rs.next()) {
+                    filterExists.set(true);
                 }
-            } catch (SQLException ex) {
-                dbVals.resultException = ex;
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error checking uniqueness of filter " + filterName, e);
             }
-            return dbVals;
+            return null;
         });
-        return results;
+        return filterExists.get();
     }
 
-    public static Object saveFilter(@NonNull String filterViewToSave, String userId, @NonNull Map<String, DBElement> columnNameMap,
+    public static Object saveFilter(@NonNull ViewFilter viewFilter, String userId, @NonNull Map<String, DBElement> columnNameMap,
                                     @NonNull String ddpGroupId) {
-        ViewFilter viewFilter = new Gson().fromJson(filterViewToSave, ViewFilter.class);
-        if (viewFilter == null) {
-            throw new RuntimeException("The request for saving filter doesn't have a ViewFilter");
-        }
         String query;
-        String suggestedName = viewFilter.getFilterName();
-        SimpleResult results = checkUniqueFilterName(suggestedName);
-        if (results.resultValue != null && results.resultValue instanceof String) {
-            return new Result(500, (String) results.resultValue);
-        }
-        if (results.resultException != null) {
-            throw new RuntimeException(results.resultException);
-        }
         if (StringUtils.isBlank(viewFilter.getQueryItems())) {
             Filter[] filters = viewFilter.getFilters();
             Map<String, String> queryConditions = new HashMap<>();

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/DuplicateEntityException.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/DuplicateEntityException.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsm.exception;
+
+/**
+ * Exception thrown when there is a duplicate value
+ * and the user should try their operation again
+ * after changing the duplicate value to a unique value
+ */
+public class DuplicateEntityException extends RuntimeException {
+
+    private final String entityName;
+
+    private final String entityValue;
+
+    /**
+     * Create a new one in response to an attempt to save
+     * a duplicte value
+     * @param entityName the name of the entity, in a way that
+     *                   makes sense to the user
+     * @param entityValue the value of the entity
+     */
+    public DuplicateEntityException(String entityName, String entityValue) {
+        this.entityName = entityName;
+        this.entityValue = entityValue;
+    }
+
+    /**
+     * The kind of entity that has a duplicate value, such as "filter"
+     */
+    public String getEntityName() {
+        return entityName;
+    }
+
+    /**
+     * The name of the entity that is duplicated, that the user
+     * has control over and can change on a retry
+     */
+    public String getEntityValue() {
+        return entityValue;
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
@@ -75,7 +75,7 @@ public class ViewFilterRoute extends RequestHandler {
                 String filterName = viewFilter.getFilterName();
                 if (ViewFilter.doesFilterExist(filterName)) {
                     // tell the user to retry with a different name for the filter if the name is already taken
-                    throw new DuplicateEntityException("filter", filterName);
+                    throw new DuplicateEntityException("filter name", filterName);
                 }
                 return ViewFilter.saveFilter(viewFilter, userIdRequest, patchUtil.getColumnNameMap(), ddpGroupId);
             } else if (request.url().contains(RoutePath.FILTER_DEFAULT)) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
@@ -2,10 +2,12 @@ package org.broadinstitute.dsm.route;
 
 import java.util.Collection;
 
+import com.google.gson.Gson;
 import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.ViewFilter;
+import org.broadinstitute.dsm.exception.DuplicateEntityException;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.statics.DBConstants;
 import org.broadinstitute.dsm.statics.RequestParameter;
@@ -67,7 +69,14 @@ public class ViewFilterRoute extends RequestHandler {
                 }
             } else if (request.url().contains(RoutePath.SAVE_FILTER)) {
                 String ddpGroupId = DDPInstance.getDDPGroupId(realm);
-                return ViewFilter.saveFilter(json, userIdRequest, patchUtil.getColumnNameMap(), ddpGroupId);
+                ViewFilter viewFilter = new Gson().fromJson(json, ViewFilter.class);
+
+                String filterName = viewFilter.getFilterName();
+                if (ViewFilter.doesFilterExist(filterName)) {
+                    // tell the user to retry with a different name for the filter if the name is already taken
+                    throw new DuplicateEntityException("filter", filterName);
+                }
+                return ViewFilter.saveFilter(viewFilter, userIdRequest, patchUtil.getColumnNameMap(), ddpGroupId);
             } else if (request.url().contains(RoutePath.FILTER_DEFAULT)) {
                 if (StringUtils.isBlank(parent)) {
                     throw new RuntimeException("No parent was sent in the request.");

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ViewFilterRoute.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.ViewFilter;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.exception.DuplicateEntityException;
 import org.broadinstitute.dsm.security.RequestHandler;
 import org.broadinstitute.dsm.statics.DBConstants;


### PR DESCRIPTION
## PEPPER-1407

Added exception mapper to help handle attempts to insertdata that will break unique constraints or is otherwise considered duplicative.  Along the way, changed a few things to simplify how we check for uniqueness of filters.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

* Make a new filter that has the same name as an existing filter.  When saving the filter with the same name, you should see a better error message in the red popup at the bottom of the screen.

## Release

- [ x] These changes require no special release procedures--just code!

