### PR TITLE
PEPPER-978 and PEPPER-979 adding a few headers as per appsec.

### DIFF
--- a/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/appengine/spark/SparkBootUtil.java
+++ b/pepper-apis/ddp-common/src/main/java/org/broadinstitute/ddp/appengine/spark/SparkBootUtil.java
@@ -98,6 +98,14 @@ public class SparkBootUtil {
                 stopRouteCallback.onTerminate();
             }));
         }
+
+        Spark.afterAfter((req, res) -> {
+            // enable hsts
+            res.header("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+            // assume everything is sensitive and don't allow browser caching
+            res.header("Cache-control", "no-store");
+            res.header("Pragma", "no-cache");
+        });
     }
 
     public static boolean isShuttingDown() {


### PR DESCRIPTION
## PEPPER-978 and PEPPER-979

The above tickets were flagged by appsec as must-dos.  Resolving them just required adding a few headers.  They are added to the backends directly instead of by load balancers or app engine configs so that regardless of deployment technology, the headers are there.  Once these are on dev, we'll have appsec validate that things are working properly before promoting to other environments.  There are no tests included here because appsec gets to determine whether the deployed app is sending the right headers.

## Release

- [ x] These changes require no special release procedures--just code!

