### PR TITLE
[PEPPER-1429] Refactor ParticipantExitRoute and add tests

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/DSMServer.java
@@ -44,6 +44,7 @@ import org.broadinstitute.dsm.exception.AuthenticationException;
 import org.broadinstitute.dsm.exception.AuthorizationException;
 import org.broadinstitute.dsm.exception.DSMBadRequestException;
 import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.exception.EntityNotFound;
 import org.broadinstitute.dsm.exception.UnsafeDeleteError;
 import org.broadinstitute.dsm.jobs.DDPEventJob;
 import org.broadinstitute.dsm.jobs.DDPRequestJob;
@@ -1066,6 +1067,11 @@ public class DSMServer {
             // this is a fallback exception, log it warn level to see why it is happening
             logger.warn("Authentication error while processing request: {}: {}", request.url(), exception.toString());
             response.status(401);
+            response.body(exception.getMessage());
+        });
+        exception(EntityNotFound.class, (exception, request, response) -> {
+            logger.info("Entity not found while processing request: {}: {}", request.url(), exception.toString());
+            response.status(404);
             response.body(exception.getMessage());
         });
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/EntityNotFound.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/EntityNotFound.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsm.exception;
+
+public class EntityNotFound extends RuntimeException {
+
+    public EntityNotFound(String message) {
+        super(message);
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/ParticipantNotExist.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/exception/ParticipantNotExist.java
@@ -1,8 +1,0 @@
-package org.broadinstitute.dsm.exception;
-
-public class ParticipantNotExist extends RuntimeException {
-
-    public ParticipantNotExist(String message) {
-        super(message);
-    }
-}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ParticipantExitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/ParticipantExitRoute.java
@@ -1,115 +1,75 @@
 package org.broadinstitute.dsm.route;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import lombok.NonNull;
+import com.google.gson.Gson;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.dsm.DSMServer;
-import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.KitDiscard;
-import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.ParticipantExit;
-import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
-import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
-import org.broadinstitute.dsm.exception.ParticipantNotExist;
+import org.broadinstitute.dsm.exception.AuthorizationException;
+import org.broadinstitute.dsm.exception.DSMBadRequestException;
+import org.broadinstitute.dsm.route.request.ParticipantExitRequest;
 import org.broadinstitute.dsm.security.RequestHandler;
-import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.service.participant.ParticipantExitService;
 import org.broadinstitute.dsm.statics.RequestParameter;
 import org.broadinstitute.dsm.statics.RoutePath;
-import org.broadinstitute.dsm.statics.UserErrorMessages;
-import org.broadinstitute.dsm.util.DDPRequestUtil;
 import org.broadinstitute.dsm.util.UserUtil;
-import org.broadinstitute.lddp.handlers.util.Result;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
+@Slf4j
 public class ParticipantExitRoute extends RequestHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(ParticipantExitRoute.class);
-    private static final String ROLE = "participant_exit";
+    private static final String PARTICIPANT_EXIT_ROLE = "participant_exit";
 
     @Override
-    public Object processRequest(Request request, Response response, String userId) throws Exception {
-        String requestBody = request.body();
-        String realm = request.params(RequestParameter.REALM);
-        if (StringUtils.isNotBlank(realm)) {
-            if (UserUtil.checkUserAccess(realm, userId, ROLE, null)) {
-                return ParticipantExit.getExitedParticipants(realm).values();
-            } else {
-                response.status(500);
-                logger.warn("User with id={} could not access realm={} with role={}", userId, realm, ROLE);
-                return new Result(500, UserErrorMessages.NO_RIGHTS);
-            }
+    public Object processRequest(Request request, Response response, String userId) {
+        String requestMethod = request.requestMethod();
+        if (requestMethod.equals(RoutePath.RequestMethod.GET.toString())) {
+            String realm = request.params(RequestParameter.REALM);
+            return handleGetRequest(realm, userId, new UserUtil(), new ParticipantExitService());
+        } else if (requestMethod.equals(RoutePath.RequestMethod.POST.toString())) {
+            String requestBody = RouteUtil.requireRequestBody(request);
+            return handlePostRequest(requestBody, userId, new UserUtil(), new ParticipantExitService());
         }
-
-        if (requestBody != null) {
-            long currentTime = System.currentTimeMillis();
-            JsonObject jsonObject = new JsonParser().parse(request.body()).getAsJsonObject();
-            realm = jsonObject.getAsJsonObject().get("realm").getAsString();
-            if (UserUtil.checkUserAccess(realm, userId, ROLE, null)) {
-                String ddpParticipantId = jsonObject.getAsJsonObject().get("participantId").getAsString();
-                String userIdRequest = jsonObject.getAsJsonObject().get("user").getAsString();
-                boolean inDDP = jsonObject.getAsJsonObject().get("inDDP").getAsBoolean();
-
-                try {
-                    exitParticipant(realm, ddpParticipantId, userIdRequest, currentTime, inDDP);
-                    List<KitRequestShipping> kitRequests = KitRequestShipping.getKitRequestsByParticipant(realm, ddpParticipantId, true);
-                    List<KitDiscard> kitsNeedAction = new ArrayList<>();
-                    logger.info("Found " + kitRequests.size() + " kit requests");
-                    Optional<DDPInstanceDto> maybeInstance = new DDPInstanceDao().getDDPInstanceByInstanceName(realm);
-                    for (KitRequestShipping kit : kitRequests) {
-                        if (kit.getScanDate() != 0 && kit.getReceiveDate() == 0) {
-                            String discardId = KitDiscard.addKitToDiscard(kit.getDsmKitRequestId(), KitDiscard.HOLD);
-                            kitsNeedAction.add(new KitDiscard(discardId, kit.getKitTypeName(), KitDiscard.HOLD));
-                        } else {
-                            //refund label of kits which are not sent yet
-                            KitRequestShipping.refundKit(kit.getDsmKitRequestId(), DSMServer.getDDPEasypostApiKey(realm),
-                                    maybeInstance.orElse(null));
-                        }
-                    }
-                    return kitsNeedAction;
-                } catch (ParticipantNotExist e) {
-                    logger.error("DDP didn't find participant w/ ddpParticipantId " + ddpParticipantId);
-                    return new Result(404, e.getMessage());
-                }
-            } else {
-                response.status(500);
-                logger.warn("User with id={} could not access realm={} with role={}", userId, realm, ROLE);
-                return new Result(500, UserErrorMessages.NO_RIGHTS);
-            }
-        }
-        logger.error("Request body was missing");
-        return new Result(500);
+        RouteUtil.handleInvalidRouteMethod(request, "ParticipantExitRoute");
+        return null;
     }
 
-    private void exitParticipant(@NonNull String realm, @NonNull String ddpParticipantId, @NonNull String userId,
-                                 @NonNull long currentTime, boolean inDDP) {
-        if (StringUtils.isNotBlank(realm) && StringUtils.isNotBlank(ddpParticipantId) && StringUtils.isNotBlank(userId)) {
-            DDPInstance instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.HAS_EXIT_PARTICIPANT_ENDPOINT);
-            if (instance.isHasRole()) {
-                String sendRequest = instance.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EXIT_PATH + "/" + ddpParticipantId;
-                Integer response = null;
-                try {
-                    response = DDPRequestUtil.postRequest(sendRequest, null, instance.getName(), instance.isHasAuth0Token());
-                } catch (Exception e) {
-                    throw new RuntimeException("Couldn't exit participant " + sendRequest, e);
-                }
-                if (response == HttpStatusCodes.STATUS_CODE_OK) {
-                    logger.info("Triggered DDP to exit participant w/ ddpParticipantId " + ddpParticipantId);
-                    ParticipantExit.exitParticipant(ddpParticipantId, currentTime, userId, instance, inDDP);
-                } else if (response == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-                    throw new ParticipantNotExist("Participant not found");
-                }
-            } else {
-                ParticipantExit.exitParticipant(ddpParticipantId, currentTime, userId, instance, false);
-            }
+    protected static Collection<ParticipantExit> handleGetRequest(String realm, String userId, UserUtil userUtil,
+                                                                  ParticipantExitService participantExitService) {
+        if (!userUtil.userHasRole(realm, userId, PARTICIPANT_EXIT_ROLE, null)) {
+            log.warn("User {} not authorized to access realm {} with role {}", userId, realm, PARTICIPANT_EXIT_ROLE);
+            throw new AuthorizationException();
         }
+        return participantExitService.getExitedParticipants(realm).values();
+    }
+
+    protected static List<KitDiscard> handlePostRequest(String requestBody, String userId, UserUtil userUtil,
+                                                        ParticipantExitService participantExitService) {
+        ParticipantExitRequest req;
+        try {
+            req = new Gson().fromJson(requestBody, ParticipantExitRequest.class);
+        } catch (Exception e) {
+            log.info("Invalid request format for {}", requestBody);
+            throw new DSMBadRequestException("Invalid request format");
+        }
+        String realm = req.getRealm().trim();
+        if (StringUtils.isBlank(realm)) {
+            throw new DSMBadRequestException("Realm is required");
+        }
+
+        if (!userUtil.userHasRole(realm, userId, PARTICIPANT_EXIT_ROLE, req.getUser())) {
+            log.warn("User {} not authorized to access realm {} with role {}", userId, realm, PARTICIPANT_EXIT_ROLE);
+            throw new AuthorizationException();
+        }
+
+        String ddpParticipantId = req.getParticipantId().trim();
+        if (StringUtils.isBlank(ddpParticipantId)) {
+            throw new DSMBadRequestException("Participant ID is required");
+        }
+        return participantExitService.exitParticipant(realm, ddpParticipantId, userId, req.isInDDP());
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/RouteUtil.java
@@ -17,16 +17,16 @@ public class RouteUtil {
     public static String requireParam(Request request, String param) {
         QueryParamsMap queryParams = request.queryMap();
         if (!queryParams.hasKey(param)) {
-            throw new DSMBadRequestException("Request must include realm parameter");
+            throw new DSMBadRequestException("Request must include %s parameter".formatted(param));
         }
         return requireParam(param, queryParams.value(param));
     }
 
     public static String requireParam(String paramName, String paramValue) {
-        if (StringUtils.isEmpty(paramValue)) {
+        if (StringUtils.isBlank(paramValue)) {
             throw new DSMBadRequestException("Missing request parameter: " + paramName);
         }
-        return paramValue;
+        return paramValue.trim();
     }
 
     public static String requireRequestBody(Request request) {
@@ -38,7 +38,7 @@ public class RouteUtil {
     }
 
     public static String requireStringFromJsonObject(JsonObject jsonObject, String field) {
-        String val = jsonObject.get(field).getAsString();
+        String val = jsonObject.get(field).getAsString().trim();
         if (StringUtils.isBlank(val)) {
             throw new DSMBadRequestException(String.format("Request body must include %s field", field));
         }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/request/ParticipantExitRequest.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/request/ParticipantExitRequest.java
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsm.route.request;
+
+import lombok.Data;
+
+@Data
+public class ParticipantExitRequest {
+    private final String realm;
+    private final String participantId;
+    private final String user;
+    private final boolean inDDP;
+    private final String exitDate;
+    private final String shortId;
+    private final String legacyShortId;
+
+    public ParticipantExitRequest(String realm, String participantId, String user, boolean inDDP) {
+        this.realm = realm;
+        this.participantId = participantId;
+        this.user = user;
+        this.inDDP = inDDP;
+        this.exitDate = null;
+        this.shortId = null;
+        this.legacyShortId = null;
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/ParticipantExitService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/ParticipantExitService.java
@@ -25,10 +25,19 @@ import org.broadinstitute.dsm.util.DDPRequestUtil;
 @Slf4j
 public class ParticipantExitService {
 
+    /**
+     * Return a map of DDP participant ID to ParticipantExit object for all exited participants in the given realm
+     */
     public Map<String, ParticipantExit> getExitedParticipants(String realm) {
         return ParticipantExit.getExitedParticipants(realm, true);
     }
 
+    /**
+     * Exit a participant from DSM and DSS
+     * @param inDDP true if the participant is in DSS. (See note in _participantExit Java doc.)
+     * @return a list of KitDiscard for the participant, which allows the user to select what should be done with dangling kits
+     *      if they are returned for GP processing
+     */
     public List<KitDiscard> exitParticipant(String realm, String ddpParticipantId, String userId, boolean inDDP) {
         _exitParticipant(realm, ddpParticipantId, userId, inDDP);
 
@@ -55,8 +64,8 @@ public class ParticipantExitService {
     /**
      * Exit a participant from DSM and DSS
      * @param inDDP true if the participant is in DSS. Note: The role of this parameter is unclear. It is passed from
-     *             the front end and the pre-existing code recorded it in the DB, but used
-     *             different criteria to determine if the participant is in DSS. -DC
+     *             the front end (and is always true) The pre-existing code (modified here) recorded it in the DB, but used
+     *             different criteria to determine if the participant is in DSS, so we kept that intact. -DC
      */
     protected void _exitParticipant(String realm, String ddpParticipantId, String userId, boolean inDDP) {
         // assert input

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/ParticipantExitService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/participant/ParticipantExitService.java
@@ -1,0 +1,93 @@
+package org.broadinstitute.dsm.service.participant;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.api.client.http.HttpStatusCodes;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.dsm.DSMServer;
+import org.broadinstitute.dsm.db.DDPInstance;
+import org.broadinstitute.dsm.db.KitDiscard;
+import org.broadinstitute.dsm.db.KitRequestShipping;
+import org.broadinstitute.dsm.db.ParticipantExit;
+import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
+import org.broadinstitute.dsm.exception.DsmInternalError;
+import org.broadinstitute.dsm.exception.EntityNotFound;
+import org.broadinstitute.dsm.statics.DBConstants;
+import org.broadinstitute.dsm.statics.RoutePath;
+import org.broadinstitute.dsm.util.DDPRequestUtil;
+
+
+@Slf4j
+public class ParticipantExitService {
+
+    public Map<String, ParticipantExit> getExitedParticipants(String realm) {
+        return ParticipantExit.getExitedParticipants(realm, true);
+    }
+
+    public List<KitDiscard> exitParticipant(String realm, String ddpParticipantId, String userId, boolean inDDP) {
+        _exitParticipant(realm, ddpParticipantId, userId, inDDP);
+
+        // NOTE: The following code was lifted as-is from ParticipantExitRoute.java. I did not attempt to
+        // clean it up since we do not have functional tests in place. We will verify with our system tests. -DC
+        List<KitRequestShipping> kitRequests =
+                KitRequestShipping.getKitRequestsByParticipant(realm, ddpParticipantId, true);
+        List<KitDiscard> kitsNeedAction = new ArrayList<>();
+        log.info("Found {} kit requests", kitRequests.size());
+        Optional<DDPInstanceDto> maybeInstance = new DDPInstanceDao().getDDPInstanceByInstanceName(realm);
+        for (KitRequestShipping kit : kitRequests) {
+            if (kit.getScanDate() != 0 && kit.getReceiveDate() == 0) {
+                String discardId = KitDiscard.addKitToDiscard(kit.getDsmKitRequestId(), KitDiscard.HOLD);
+                kitsNeedAction.add(new KitDiscard(discardId, kit.getKitTypeName(), KitDiscard.HOLD));
+            } else {
+                //refund label of kits which are not sent yet
+                KitRequestShipping.refundKit(kit.getDsmKitRequestId(), DSMServer.getDDPEasypostApiKey(realm),
+                        maybeInstance.orElse(null));
+            }
+        }
+        return kitsNeedAction;
+    }
+
+    /**
+     * Exit a participant from DSM and DSS
+     * @param inDDP true if the participant is in DSS. Note: The role of this parameter is unclear. It is passed from
+     *             the front end and the pre-existing code recorded it in the DB, but used
+     *             different criteria to determine if the participant is in DSS. -DC
+     */
+    protected void _exitParticipant(String realm, String ddpParticipantId, String userId, boolean inDDP) {
+        // assert input
+        if (StringUtils.isBlank(realm) || StringUtils.isBlank(ddpParticipantId) || StringUtils.isBlank(userId)) {
+            throw new DsmInternalError("Invalid parameters for exitParticipant");
+        }
+
+        long currentTime = System.currentTimeMillis();
+        DDPInstance instance = DDPInstance.getDDPInstanceWithRole(realm, DBConstants.HAS_EXIT_PARTICIPANT_ENDPOINT);
+        if (!instance.isHasRole()) {
+            // role indicates whether DSM should call DSS to exit participant
+            // NOTE: The role of 'inDDP' is unclear here, see comment above, so I left that parameter as is it was -DC
+            ParticipantExit.exitParticipant(ddpParticipantId, currentTime, userId, instance, false);
+            return;
+        }
+
+        // request DSS to exit participant
+        String requestUrl = instance.getBaseUrl() + RoutePath.DDP_PARTICIPANT_EXIT_PATH + "/" + ddpParticipantId;
+        Integer response;
+        try {
+            response = DDPRequestUtil.postRequest(requestUrl, null, instance.getName(), instance.isHasAuth0Token());
+        } catch (Exception e) {
+            throw new DsmInternalError("Error requesting DSS exit participant for URL " + requestUrl, e);
+        }
+        if (response == HttpStatusCodes.STATUS_CODE_OK) {
+            log.info("Requesting DSS exit participant {}", ddpParticipantId);
+            ParticipantExit.exitParticipant(ddpParticipantId, currentTime, userId, instance, inDDP);
+        } else if (response == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+            throw new EntityNotFound("Participant not found in DSS. ID: %s".formatted(ddpParticipantId));
+        } else {
+            throw new DsmInternalError("Unexpected response code from DSS exit participant request: %d".formatted(response));
+        }
+    }
+}

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/UserUtil.java
@@ -254,6 +254,10 @@ public class UserUtil {
         }
     }
 
+    public boolean userHasRole(String realm, String userId, String role, String userIdRequest) {
+        return checkUserAccess(realm, userId, role, userIdRequest);
+    }
+
     public static boolean checkUserAccess(String realm, String userId, String role, String userIdRequest) {
         if (StringUtils.isNotBlank(userIdRequest) && !userId.equals(userIdRequest)) {
             String msg = "User id was not equal. User Id in token " + userId + " user Id in request " + userIdRequest;

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/ParticipantExitTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/ParticipantExitTest.java
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsm.db;
+
+
+import org.broadinstitute.dsm.DbAndElasticBaseTest;
+
+public class ParticipantExitTest extends DbAndElasticBaseTest {
+
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/ParticipantExitTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/ParticipantExitTest.java
@@ -1,8 +1,0 @@
-package org.broadinstitute.dsm.db;
-
-
-import org.broadinstitute.dsm.DbAndElasticBaseTest;
-
-public class ParticipantExitTest extends DbAndElasticBaseTest {
-
-}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/route/ParticipantExitRouteTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/route/ParticipantExitRouteTest.java
@@ -1,0 +1,93 @@
+package org.broadinstitute.dsm.route;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import liquibase.pro.packaged.E;
+import org.broadinstitute.dsm.db.KitDiscard;
+import org.broadinstitute.dsm.exception.AuthorizationException;
+import org.broadinstitute.dsm.exception.EntityNotFound;
+import org.broadinstitute.dsm.route.request.ParticipantExitRequest;
+import org.broadinstitute.dsm.service.participant.ParticipantExitService;
+import org.broadinstitute.dsm.util.UserUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ParticipantExitRouteTest {
+
+    @Test
+    public void testParticipantExitGet() {
+        ParticipantExitService exitService = mock(ParticipantExitService.class);
+        when(exitService.getExitedParticipants(anyString())).thenReturn(Collections.emptyMap());
+
+        UserUtil userUtil = mock(UserUtil.class);
+        when(userUtil.userHasRole(anyString(), anyString(), anyString(), any())).thenReturn(true);
+
+        try {
+            ParticipantExitRoute.handleGetRequest("realm", "userId", userUtil, exitService);
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception: " + e.getMessage());
+        }
+
+        when(userUtil.userHasRole(anyString(), anyString(), anyString(), any())).thenReturn(false);
+        try {
+            ParticipantExitRoute.handleGetRequest("realm", "userId", userUtil, exitService);
+            Assert.fail("Expected AuthorizationException");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof AuthorizationException);
+        }
+    }
+
+    @Test
+    public void testParticipantExitPost() {
+        KitDiscard kitDiscard = new KitDiscard("discardId", "kitType", "action");
+        ParticipantExitService exitService = mock(ParticipantExitService.class);
+        when(exitService.exitParticipant(eq("realm"), eq("participantId"), eq("userId"), anyBoolean()))
+                .thenReturn(List.of(kitDiscard));
+
+        // note the spaces in the string fields
+        ParticipantExitRequest participantExitRequest =
+                new ParticipantExitRequest("realm ", " participantId", " userId", true);
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        UserUtil userUtil = mock(UserUtil.class);
+        when(userUtil.userHasRole(anyString(), anyString(), anyString(), anyString())).thenReturn(false);
+        try {
+            ParticipantExitRoute.handlePostRequest(objectMapper.writeValueAsString(participantExitRequest),
+                    "userId", userUtil, exitService);
+            Assert.fail("Expected AuthorizationException");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof AuthorizationException);
+        }
+
+        when(userUtil.userHasRole(anyString(), anyString(), anyString(), anyString())).thenReturn(true);
+        try {
+            List<KitDiscard> res = ParticipantExitRoute.handlePostRequest(objectMapper.writeValueAsString(participantExitRequest),
+                    "userId", userUtil, exitService);
+            Assert.assertTrue(res.contains(kitDiscard));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception: " + e.getMessage());
+        }
+
+        when(exitService.exitParticipant(anyString(), anyString(), anyString(), anyBoolean()))
+                .thenThrow(new EntityNotFound("Participant not found"));
+        try {
+            ParticipantExitRoute.handlePostRequest(objectMapper.writeValueAsString(participantExitRequest),
+                    "userId", userUtil, exitService);
+            Assert.fail("Expected EntityNotFound");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof EntityNotFound);
+        }
+    }
+}


### PR DESCRIPTION
PEPPER-1429

The fix here was easy (trim input fields), but building appropriate tests was hard, due to Spark Java, which is a poor, outdated framework, and due to the existing structure of the code which was also poor and not conducive to testing.

The main work was in rewriting and testing ParticipantExitRoute -- it was poorly structured, did not handle a handful of cases properly, and mixed route and service code (which makes building tests difficult.) I broke out the exit logic into ParticipantExitService, which enabled testing the route code, and provides a clean break should service tests be added in the future. (I did not add those tests here since that would have taken an additional day, at least, and required additional restructuring downstream. For now we will continue to rely on our PW system test for coverage.)

Since we do not have JUnit tests for ParticipantExitService, I largely kept the code as it was in ParticipantExitRoute, but did some refactoring of `_exitParticipant` since it had a couple obvious deficiencies. I also added some notes where the code intention was unclear.

Other things:

- Renamed `ParticipantNotExist` exception to `EntityNotFound`, and added handling for it in DSMServer, since we did not have a general not found response exception.
- Added a non-static method to UserUtil to allow for mocking. UserUtil is really a service, but at this point there is limited value in setting it up properly and refactoring adjacent code.


## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

