### PR TITLE
[DSM] PEPPER-294 Fix for RGP kits

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -75,6 +75,7 @@ import org.broadinstitute.dsm.util.DSMConfig;
 import org.broadinstitute.dsm.util.EasyPostUtil;
 import org.broadinstitute.dsm.util.ElasticSearchUtil;
 import org.broadinstitute.dsm.util.KitUtil;
+import org.broadinstitute.dsm.util.ParticipantUtil;
 import org.broadinstitute.dsm.util.proxy.jackson.ObjectMapperSingleton;
 import org.broadinstitute.lddp.db.SimpleResult;
 import org.eclipse.jetty.util.StringUtil;
@@ -1699,8 +1700,11 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
         String baseUrl = ddpInstance.getBaseUrl();
         String collaboratorIdPrefix = ddpInstance.getCollaboratorIdPrefix();
         //TODO PT collaboratorParticipantLengthOverwrite should be an int
-        if (ddpInstance.isMigratedDDP()) {
-            // This should only be checked for studies that have an ES index, like cmi and rgp, and not for studies like darwin
+        //
+        if (ddpInstance.isMigratedDDP() && ParticipantUtil.isHruid(shortId)) {
+            // This check should be performed only for studies that have an ES index and are migrated studies, like CMI,
+            // and not for studies like Darwin. It should only be applied if the shortId used to create the kit is a Pepper HRUID
+            // rather than a legacy shortId or RGP's family/subject ID.
             String legacyId = getLegacyCollaboratorParticipantId(ddpInstance, shortId, collaboratorParticipantLengthOverwrite);
             if (legacyParticipantIdExists(legacyId)) {
                 //this participant have kits with legacy participant id from before, use that id instead of generating new one to keep the

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitRequestShippingTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitRequestShippingTest.java
@@ -72,13 +72,6 @@ public class KitRequestShippingTest extends DbAndElasticBaseTest {
         notLegacyParticipant = TestParticipantUtil.createParticipantWithEsProfile(notLegacyParticipantGuid, profile, ddpInstanceDto);
         notLegacyParticipantGuid = notLegacyParticipant.getRequiredDdpParticipantId();
         participants.add(notLegacyParticipant);
-
-        Profile mimicNotHuridParticipant = new Profile();
-        mimicNotHuridParticipant.setHruid(notHruidParticipantShortID);
-        notHruidParticipant = TestParticipantUtil.createParticipantWithEsProfile(notHruidParticipantGuid, mimicNotHuridParticipant,
-                ddpInstanceDto);
-        notHruidParticipantGuid = notHruidParticipant.getRequiredDdpParticipantId();
-        participants.add(notHruidParticipant);
     }
 
     @AfterClass
@@ -212,12 +205,20 @@ public class KitRequestShippingTest extends DbAndElasticBaseTest {
 
     @Test
     public void testNotHruidParticipantKitUpload() {
+        Profile mimicNotHruidParticipant = new Profile();
+        mimicNotHruidParticipant.setHruid(notHruidParticipantShortID);
+        notHruidParticipant = TestParticipantUtil.createParticipantWithEsProfile(notHruidParticipantGuid, mimicNotHruidParticipant,
+                ddpInstanceDto);
+        notHruidParticipantGuid = notHruidParticipant.getRequiredDdpParticipantId();
+        participants.add(notHruidParticipant);
+
+        String collaboratorParticipantId = "PROJ_" + notHruidId;
+        String collaboratorSampleId = collaboratorParticipantId + "_SALIVA";
+        // Checking the generated collaborator participant ID and sample ID for the case where the ID passed as short ID is not an HRUID
+        String nextCollaboratorParticipantId = KitRequestShipping.getCollaboratorParticipantId(ddpInstance,
+                notHruidParticipantGuid, notHruidId, "0");
+
         TransactionWrapper.inTransaction(conn -> {
-            String collaboratorParticipantId = "PROJ_" + notHruidId;
-            String collaboratorSampleId = collaboratorParticipantId + "_SALIVA";
-            //check when upload is made without hruid
-            String nextCollaboratorParticipantId = KitRequestShipping.getCollaboratorParticipantId(ddpInstance,
-                    notHruidParticipantGuid, notHruidId, "0");
             String nextCollaboratorSampleId = KitRequestShipping.generateBspSampleID(conn, nextCollaboratorParticipantId, "SALIVA",
                     kitTestUtil.kitTypeId);
             Assert.assertEquals(collaboratorParticipantId, nextCollaboratorParticipantId);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitRequestShippingTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitRequestShippingTest.java
@@ -41,7 +41,7 @@ public class KitRequestShippingTest extends DbAndElasticBaseTest {
 
     //mimics when a participant is having kit creation by using legacy id or RGP subject id
     private static ParticipantDto notHruidParticipant;
-    private static String notHruidParticipantGuid = "DDP_PT_ID_2";
+    private static String notHruidParticipantGuid = "DDP_PT_ID_3";
     private static final String notHruidId = "RGP_5883_3";
     private static final String notHruidParticipantShortID = "PABRGP";
     private static int participantCounter = 0;
@@ -75,7 +75,8 @@ public class KitRequestShippingTest extends DbAndElasticBaseTest {
 
         Profile mimicNotHuridParticipant = new Profile();
         mimicNotHuridParticipant.setHruid(notHruidParticipantShortID);
-        notHruidParticipant = TestParticipantUtil.createParticipantWithEsProfile(notHruidParticipantGuid, profile, ddpInstanceDto);
+        notHruidParticipant = TestParticipantUtil.createParticipantWithEsProfile(notHruidParticipantGuid, mimicNotHuridParticipant,
+                ddpInstanceDto);
         notHruidParticipantGuid = notHruidParticipant.getRequiredDdpParticipantId();
         participants.add(notHruidParticipant);
     }
@@ -214,7 +215,7 @@ public class KitRequestShippingTest extends DbAndElasticBaseTest {
         TransactionWrapper.inTransaction(conn -> {
             String collaboratorParticipantId = "PROJ_" + notHruidId;
             String collaboratorSampleId = collaboratorParticipantId + "_SALIVA";
-            //check when legacy participant doesn't have a prior legacy kit
+            //check when upload is made without hruid
             String nextCollaboratorParticipantId = KitRequestShipping.getCollaboratorParticipantId(ddpInstance,
                     notHruidParticipantGuid, notHruidId, "0");
             String nextCollaboratorSampleId = KitRequestShipping.generateBspSampleID(conn, nextCollaboratorParticipantId, "SALIVA",

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/model/ParticipantUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/model/ParticipantUtilTest.java
@@ -9,26 +9,23 @@ import org.junit.Test;
 public class ParticipantUtilTest {
 
     @Test
-    public void testIsHruid_validHruid() {
+    public void testIsHruid() {
+        //test valid HRUIDs
         assertTrue(ParticipantUtil.isHruid("P12340")); // Valid HRUID with numbers after 'P'
         assertTrue(ParticipantUtil.isHruid("Pabcde")); // Valid HRUID with lowercase letters
         assertTrue(ParticipantUtil.isHruid("PABCDE")); // Valid HRUID with upper letters
         assertTrue(ParticipantUtil.isHruid("PX45RI")); // Valid HRUID with a mix of letters and numbers
-    }
 
-    @Test
-    public void testIsHruid_invalidHruid() {
+        //test invalid HRUIDs
         assertFalse(ParticipantUtil.isHruid("P1234"));  // Less than 5 characters after 'P'
         assertFalse(ParticipantUtil.isHruid("P123456")); // More than 5 characters after 'P'
         assertFalse(ParticipantUtil.isHruid("P?123A"));   // Special character within HRUID
         assertFalse(ParticipantUtil.isHruid("12345P"));  // 'P' not at the beginning
         assertFalse(ParticipantUtil.isHruid("123456"));   // No 'P' at all
         assertFalse(ParticipantUtil.isHruid("RGP_5883_3"));   // RGP subject id
-        assertFalse(ParticipantUtil.isHruid("5883_3"));   // RGP subject id without the RGP
-    }
+        assertFalse(ParticipantUtil.isHruid("5883_3"));   // RGP subject id without the RGP prefix
 
-    @Test
-    public void testIsHruid_edgeCases() {
+        //testing edge cases
         assertFalse(ParticipantUtil.isHruid(""));          // Empty string
         assertFalse(ParticipantUtil.isHruid("P"));         // Only 'P'
         assertFalse(ParticipantUtil.isHruid("P1234 "));    // Space at the end

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/model/ParticipantUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/model/ParticipantUtilTest.java
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsm.util.model;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.broadinstitute.dsm.util.ParticipantUtil;
+import org.junit.Test;
+
+public class ParticipantUtilTest {
+
+    @Test
+    public void testIsHruid_validHruid() {
+        assertTrue(ParticipantUtil.isHruid("P12340")); // Valid HRUID with numbers after 'P'
+        assertTrue(ParticipantUtil.isHruid("Pabcde")); // Valid HRUID with lowercase letters
+        assertTrue(ParticipantUtil.isHruid("PABCDE")); // Valid HRUID with upper letters
+        assertTrue(ParticipantUtil.isHruid("PX45RI")); // Valid HRUID with a mix of letters and numbers
+    }
+
+    @Test
+    public void testIsHruid_invalidHruid() {
+        assertFalse(ParticipantUtil.isHruid("P1234"));  // Less than 5 characters after 'P'
+        assertFalse(ParticipantUtil.isHruid("P123456")); // More than 5 characters after 'P'
+        assertFalse(ParticipantUtil.isHruid("P?123A"));   // Special character within HRUID
+        assertFalse(ParticipantUtil.isHruid("12345P"));  // 'P' not at the beginning
+        assertFalse(ParticipantUtil.isHruid("123456"));   // No 'P' at all
+        assertFalse(ParticipantUtil.isHruid("RGP_5883_3"));   // RGP subject id
+        assertFalse(ParticipantUtil.isHruid("5883_3"));   // RGP subject id without the RGP
+    }
+
+    @Test
+    public void testIsHruid_edgeCases() {
+        assertFalse(ParticipantUtil.isHruid(""));          // Empty string
+        assertFalse(ParticipantUtil.isHruid("P"));         // Only 'P'
+        assertFalse(ParticipantUtil.isHruid("P1234 "));    // Space at the end
+        assertFalse(ParticipantUtil.isHruid(" P12345"));   // Space at the beginning
+        assertFalse(ParticipantUtil.isHruid(" P1234 "));   // Space around
+        assertFalse(ParticipantUtil.isHruid("P 1234"));    // Space in the middle
+    }
+
+}


### PR DESCRIPTION
## Context

RGP kits are uploaded using the subject ID, but since it is still called shortID in the upload file, DSM checks for participant kits with legacy IDs, which is not necesaary for RGP. This PR addresses the issue where the getCollaboratorParticipantId method needed to correctly handle subject IDs.

Changes
* Introduced a check using the new isHruid method to determine if a given short ID is an HRUID by comparing formats
* If the short ID is an HRUID, the method checks for any existing legacy participant IDs and uses those to maintain consistency with older data.

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [x] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [x] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [x] I have written automated positive tests
- [x] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

