### PR TITLE
[DSM] PEPPER-294 fixed a small npe bug

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -1255,10 +1255,11 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             if (StringUtils.isNotBlank(type)) {
                 collaboratorSampleId += "_" + type;
             }
-            String participantId = collaboratorParticipantId.split("_")[1];
+
             int counter = getKitCounter(conn, collaboratorSampleId, kitTypeId);
 
-            if  (ddpInstance.isMigratedDDP()) {
+            if  (ddpInstance.isMigratedDDP() && collaboratorParticipantId.contains("_")) {
+                String participantId = collaboratorParticipantId.split("_")[1];
                 //For Migrated studies, if either of the legacy id or pepper short id is given, DSM needs count the number of kits that
                 // were created for this participant with both of these ids and consider that total number when creating the
                 // collaborator sample id for this new kit. For example, if participant PABCDE has legacy short id 1, and has saliva


### PR DESCRIPTION
## Context

PW found that if. a study does not have a collaborator id prefix the code will throw an NPE. Even though that should not be the case, for the sake of avoiding NPE on all costs I have made this fix to do a quick check

