### PR TITLE
PEPPER-1492 adding more details to log when patch id is null.

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
@@ -238,7 +238,13 @@ public class Patch {
     public int getParentIdAsInt() {
         return Integer.parseInt(parentId);
     }
+
     public int getIdAsInt() {
+        if (id == null) {
+            throw new DsmInternalError("No id for this patch:" + this);
+        }
         return Integer.parseInt(this.id);
     }
+
+
 }


### PR DESCRIPTION
## PEPPER-1492

Adding `toString()` to the error message so that we can get more information about what the overall patch payload is when the id is null.


