### PR TITLE
PEPPER-1349 DSM clinical order page update

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/ClinicalOrderDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/mercury/ClinicalOrderDao.java
@@ -30,6 +30,7 @@ public class ClinicalOrderDao implements Dao<ClinicalOrderDto> {
 
     public static final String GET_ORDERS_BY_TISSUE_IDS =
             "SELECT t.collaborator_sample_id, m.order_id, m.order_status, m.order_date, m.status_date, m.status_detail,"
+                    + "m.order_message, m.status_message, "
             + "st.sm_id_type, t.tissue_id, st.sm_id_type as sample_type, m.mercury_sequencing_id "
             + "FROM ddp_mercury_sequencing m, ddp_tissue t , sm_id s, sm_id_type st "
             + "where t.tissue_id = m.tissue_id "
@@ -39,7 +40,7 @@ public class ClinicalOrderDao implements Dao<ClinicalOrderDto> {
 
     public static String SQL_GET_ALL_ORDERS_FOR_CLINICAL_KIT_PAGE = "select ms.mercury_sequencing_id, ms.order_id, ms.ddp_participant_id, "
             + "IFNULL(t.collaborator_sample_id, kit.bsp_collaborator_sample_id) as collaborator_sample_id, order_date, order_status, "
-            + "status_date, status_detail,  IF(ms.tissue_id is null, \"Normal\", \"Tumor\") as sample_type "
+            + "status_date, status_detail, order_message, status_message, IF(ms.tissue_id is null, \"Normal\", \"Tumor\") as sample_type "
             + "FROM ddp_mercury_sequencing ms "
             + "LEFT join ddp_tissue t on (ms.tissue_id = t.tissue_id  and ms.tissue_id ) "
             + "LEFT join ddp_kit_request kit on (ms.dsm_kit_request_id = kit.dsm_kit_request_id)"
@@ -88,7 +89,9 @@ public class ClinicalOrderDao implements Dao<ClinicalOrderDto> {
                                     rs.getString(DBConstants.MERCURY_ORDER_STATUS), rs.getLong(DBConstants.MERCURY_ORDER_DATE),
                                     rs.getLong(DBConstants.MERCURY_STATUS_DATE), rs.getString(DBConstants.MERCURY_STATUS_DETAIL),
                                     rs.getString(DBConstants.MERCURY_SAMPLE_TYPE),
-                                    rs.getInt(DBConstants.MERCURY_SEQUENCING_ID)
+                                    rs.getInt(DBConstants.MERCURY_SEQUENCING_ID),
+                                    rs.getString(DBConstants.MERCURY_ORDER_MESSAGE),
+                                    rs.getString(DBConstants.MERCURY_STATUS_MESSAGE)
                             );
                             map.put(key, clinicalOrderDto);
                             if (!COMPLETED_ORDER_STATUS.equals(clinicalOrderDto.getStatusDetail())) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/ClinicalOrderDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/mercury/ClinicalOrderDto.java
@@ -30,6 +30,8 @@ public class ClinicalOrderDto {
     String sampleType;
 
     int mercurySequencingId;
+    String orderMessage;
+    String statusMessage;
 
     /**
      * Create a new one from the given result set
@@ -41,7 +43,8 @@ public class ClinicalOrderDto {
                         rs.getString(DBConstants.MERCURY_ORDER_ID), rs.getString(DBConstants.MERCURY_ORDER_STATUS),
                 rs.getLong(DBConstants.MERCURY_ORDER_DATE), rs.getLong(DBConstants.MERCURY_STATUS_DATE),
                 rs.getString(DBConstants.MERCURY_STATUS_DETAIL), rs.getString(DBConstants.MERCURY_SAMPLE_TYPE),
-                rs.getInt(DBConstants.MERCURY_SEQUENCING_ID));
+                rs.getInt(DBConstants.MERCURY_SEQUENCING_ID),
+                rs.getString(DBConstants.MERCURY_SAMPLE_TYPE), rs.getString(DBConstants.MERCURY_SAMPLE_TYPE));
     }
 
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
@@ -566,6 +566,8 @@ public class DBConstants {
     public static final String MERCURY_ORDER_ID = "order_id";
     public static final String MERCURY_ORDER_STATUS = "order_status";
     public static final String MERCURY_STATUS_DETAIL = "status_detail";
+    public static final String MERCURY_ORDER_MESSAGE = "order_message";
+    public static final String MERCURY_STATUS_MESSAGE = "status_message";
     public static final String MERCURY_SAMPLE_TYPE = "sample_type";
     public static final String DDP_MERCURY_SEQUENCING = "ddp_mercury_sequencing";
     public static final String MERCURY_SEQUENCING_ID = "mercury_sequencing_id";

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/mercury/ComparisonTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/mercury/ComparisonTest.java
@@ -24,9 +24,9 @@ public class ComparisonTest {
 
         ArrayList<ClinicalOrderDto> clinicalOrderDtoArrayList = new ArrayList<>();
         clinicalOrderDtoArrayList.add(new ClinicalOrderDto("FAKE_SHORT_ID", "FAKE_SAMPLE", "FAKE_ORDER", "FAKE_STATUS",
-                1L, 1L, null, "FAKE_TYPE", 1));
+                1L, 1L, null, "FAKE_TYPE", 1, "FAKE_ORDER_MSG", "FAKE_STATUS_MSG"));
         clinicalOrderDtoArrayList.add(new ClinicalOrderDto("FAKE_SHORT_ID_2", "FAKE_SAMPLE_2", "FAKE_ORDER_2", "FAKE_STATUS",
-                2L, 2L, null, "FAKE_TYPE", 2));
+                2L, 2L, null, "FAKE_TYPE", 2, "FAKE_ORDER_MSG", "FAKE_STATUS_MSG"));
 
         List<ClinicalOrderDto> clinicalOrderDtoList = clinicalOrderDtoArrayList.stream()
                 .sorted(Comparator.comparingLong(ClinicalOrderDto::getOrderDate).reversed()).collect(Collectors.toList());


### PR DESCRIPTION
Query additional columns (order_message and status_message) from DB and pass to DSM UI so that new columns can be displayed as part of DSM clinical order page