### PR TITLE
PEPPER-749 . Include sampleType while export to ES on kit deactivate or reactivate

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -182,8 +182,8 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                     + "LEFT JOIN kit_type ty ON (req.kit_type_id = ty.kit_type_id) WHERE req.ddp_participant_id = ? "
                     + "AND realm.instance_name = ?";
     public static final String SQL_SELECT_KIT =
-            "SELECT * FROM (SELECT realm.instance_name, re.dsm_kit_request_id FROM ddp_kit_request re, ddp_instance realm "
-                    + "WHERE realm.ddp_instance_id = re.ddp_instance_id) AS request "
+            "SELECT * FROM (SELECT realm.instance_name, re.dsm_kit_request_id, kt.kit_type_name FROM ddp_kit_request re, ddp_instance realm, kit_type kt "
+                    + "WHERE realm.ddp_instance_id = re.ddp_instance_id and kt.kit_type_id = re.kit_type_id) AS request "
                     + "LEFT JOIN (SELECT * FROM (SELECT k.easypost_to_id, k.easypost_return_id, "
                     + "k.deactivated_date, k.deactivation_reason, k.dsm_kit_request_id, k.easypost_address_id_to, k.dsm_kit_id "
                     + "FROM ddp_kit k INNER JOIN( "
@@ -396,6 +396,13 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
     public KitRequestShipping(Integer dsmKitRequestId, Long dsmKitId, String easypostToId, String easypostAddressId, Boolean error,
                               String message) {
         this(null, null, null, null, null, null, dsmKitRequestId, dsmKitId, null, null, null, null, null, null, null, error, message, null,
+                easypostAddressId, null, null, null, null, easypostToId, null, null, null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null);
+    }
+
+    public KitRequestShipping(Integer dsmKitRequestId, Long dsmKitId, String easypostToId, String easypostAddressId, Boolean error,
+                              String message, String kitTypeName) {
+        this(null, null, null, null, null, kitTypeName, dsmKitRequestId, dsmKitId, null, null, null, null, null, null, null, error, message, null,
                 easypostAddressId, null, null, null, null, easypostToId, null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null);
     }
@@ -1676,7 +1683,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                         dbVals.resultValue =
                                 new KitRequestShipping(rs.getInt(DBConstants.DSM_KIT_REQUEST_ID), rs.getLong(DBConstants.DSM_KIT_ID),
                                         rs.getString(DBConstants.EASYPOST_TO_ID), rs.getString(DBConstants.EASYPOST_ADDRESS_ID_TO), false,
-                                        null);
+                                        null, rs.getString(DBConstants.KIT_TYPE_NAME));
                     }
                 }
             } catch (Exception ex) {
@@ -1693,7 +1700,6 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
 
             long dsmKitId = KitRequestShipping.writeNewKit(dsmKitRequestId, kitRequestShipping.getEasypostAddressId(), message, false);
             kitRequestShipping.setDsmKitId(dsmKitId);
-            kitRequestShipping.setKitTypeName(kitRequestDao.getKitTypeByKitRequestId(dsmKitRequestId));
             try {
                 UpsertPainlessFacade.of(DBConstants.DDP_KIT_REQUEST_ALIAS, kitRequestShipping, ddpInstanceDto, ESObjectConstants.DSM_KIT_ID,
                         ESObjectConstants.DSM_KIT_REQUEST_ID, dsmKitRequestId,

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -854,8 +854,9 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             kitRequestShipping.setDsmKitRequestId(dsmKitRequestId);
             kitRequestShipping.setDeactivationReason(deactivationReason);
             kitRequestShipping.setDeactivatedDate(deactivatedDate);
-
+            kitRequestShipping.setKitTypeName(kitRequestDao.getKitTypeByKitRequestId(dsmKitRequestId));
             try {
+                //todo: if multiple kits exist for same kit-request(dsmKitRequestId), we are updating all elements? edge case though
                 UpsertPainlessFacade.of(DBConstants.DDP_KIT_REQUEST_ALIAS, kitRequestShipping, ddpInstanceDto,
                         ESObjectConstants.DSM_KIT_REQUEST_ID, ESObjectConstants.DSM_KIT_REQUEST_ID, dsmKitRequestId,
                         new PutToNestedScriptBuilder()).export();
@@ -1692,7 +1693,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
 
             long dsmKitId = KitRequestShipping.writeNewKit(dsmKitRequestId, kitRequestShipping.getEasypostAddressId(), message, false);
             kitRequestShipping.setDsmKitId(dsmKitId);
-
+            kitRequestShipping.setKitTypeName(kitRequestDao.getKitTypeByKitRequestId(dsmKitRequestId));
             try {
                 UpsertPainlessFacade.of(DBConstants.DDP_KIT_REQUEST_ALIAS, kitRequestShipping, ddpInstanceDto, ESObjectConstants.DSM_KIT_ID,
                         ESObjectConstants.DSM_KIT_REQUEST_ID, dsmKitRequestId,

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
@@ -159,7 +159,7 @@ public class KitRequestDao implements Dao<KitRequestDto> {
         });
 
         if (results.resultException != null) {
-            throw new RuntimeException("Couldn't get kit type for kit request: " + kitRequestId, results.resultException);
+            throw new DsmInternalError("Couldn't get kit type for kit request: " + kitRequestId, results.resultException);
         }
         return (String) results.resultValue;
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
@@ -140,28 +140,20 @@ public class KitRequestDao implements Dao<KitRequestDto> {
     }
 
     public String getKitTypeByKitRequestId(long kitRequestId) {
-        SimpleResult results = inTransaction((conn) -> {
-            SimpleResult dbVals = new SimpleResult();
+        return inTransaction(conn -> {
+            String result = null;
             try (PreparedStatement stmt = conn.prepareStatement(SQL_GET_KIT_TYPE_BY_KIT_REQUEST_ID)) {
                 stmt.setLong(1, kitRequestId);
                 try (ResultSet rs = stmt.executeQuery()) {
                     if (rs.next()) {
-                        dbVals.resultValue = rs.getString(DBConstants.KIT_TYPE_NAME);
-                    } else {
-                        dbVals.resultValue = null;
-                        dbVals.resultException = new DsmInternalError("No kit request found for kit_request_id " + kitRequestId);
+                        result = rs.getString(DBConstants.KIT_TYPE_NAME);
                     }
                 }
-            } catch (SQLException ex) {
-                dbVals.resultException = ex;
+            } catch (SQLException e) {
+                throw new DsmInternalError("No kit request found for kit_request_id " + kitRequestId, e);
             }
-            return dbVals;
+            return result;
         });
-
-        if (results.resultException != null) {
-            throw new DsmInternalError("Couldn't get kit type for kit request: " + kitRequestId, results.resultException);
-        }
-        return (String) results.resultValue;
     }
 
     /**


### PR DESCRIPTION
PEPPER-749 
Include sampleType while export to ES on kit deactivate or reactivate
Change to handle scenario where kit was reactivated but not yet scanned, make sure sampleType(kitType) is included in ES upsert.
Similarly on deactivate, query and include sampleType(kitType) in ES upsert.