### PR TITLE
PEPPER-1498 pancan release-v2 pdf fix

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/Constants.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/Constants.java
@@ -1,6 +1,6 @@
 package org.broadinstitute.ddp.constants;
 
-public class PdfConstants {
+public class Constants {
     public static final String PANCAN_GUID = "cmi-pancan";
     public static final String COUNTMEIN_RELEASE = "countmein-release";
     public static final String RELEASE = "RELEASE";

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/PdfConstants.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/PdfConstants.java
@@ -1,6 +1,18 @@
 package org.broadinstitute.ddp.constants;
 
 public class PdfConstants {
+    public static final String PANCAN_GUID = "cmi-pancan";
+    public static final String COUNTMEIN_RELEASE = "countmein-release";
+    public static final String RELEASE = "RELEASE";
+    public static final String VERSION_2 = "v2";
+    public static final String CONSENT = "CONSENT";
+    public static final String VERSION_1 = "v1";
+    public static final String COUNTMEIN_RELEASE_PARENTAL = "countmein-release-parental";
+    public static final String RELEASE_MINOR = "RELEASE_MINOR";
+    public static final String CONSENT_PARENTAL = "CONSENT_PARENTAL";
+    public static final String COUNTMEIN_RELEASE_ASSENT = "countmein-release-assent";
+    public static final String CONSENT_ASSENT = "CONSENT_ASSENT";
+
     /**
      * Available profile fields that can be used for profile substitution.
      * This field is what will be used to query for a specific piece of user profile data.
@@ -9,4 +21,5 @@ public class PdfConstants {
         public static final String FIRST_NAME = "user_profile.first_name";
         public static final String LAST_NAME = "user_profile.last_name";
     }
+
 }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -1,16 +1,16 @@
 package org.broadinstitute.ddp.export;
 
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_ASSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_PARENTAL;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_ASSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_PARENTAL;
-import static org.broadinstitute.ddp.constants.PdfConstants.PANCAN_GUID;
-import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE;
-import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE_MINOR;
-import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_1;
-import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_2;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT_ASSENT;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT_PARENTAL;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE_ASSENT;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE_PARENTAL;
+import static org.broadinstitute.ddp.constants.Constants.PANCAN_GUID;
+import static org.broadinstitute.ddp.constants.Constants.RELEASE;
+import static org.broadinstitute.ddp.constants.Constants.RELEASE_MINOR;
+import static org.broadinstitute.ddp.constants.Constants.VERSION_1;
+import static org.broadinstitute.ddp.constants.Constants.VERSION_2;
 import static org.broadinstitute.ddp.export.ExportUtil.extractParticipantsFromResultSet;
 import static org.broadinstitute.ddp.export.ExportUtil.getSnapshottedMailAddress;
 import static org.broadinstitute.ddp.export.ExportUtil.hideProtectedValue;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -1,5 +1,16 @@
 package org.broadinstitute.ddp.export;
 
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_ASSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_PARENTAL;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_ASSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_PARENTAL;
+import static org.broadinstitute.ddp.constants.PdfConstants.PANCAN_GUID;
+import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE;
+import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE_MINOR;
+import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_1;
+import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_2;
 import static org.broadinstitute.ddp.export.ExportUtil.extractParticipantsFromResultSet;
 import static org.broadinstitute.ddp.export.ExportUtil.getSnapshottedMailAddress;
 import static org.broadinstitute.ddp.export.ExportUtil.hideProtectedValue;
@@ -953,7 +964,7 @@ public class DataExporter {
             }
         }
         //pancan special case to handle scenarios where pancan user consented-v1 but had release-v2
-        if (!studyConfigs.isEmpty() && studyConfigs.get(0).getStudyGuid().equals("cmi-pancan")) {
+        if (!studyConfigs.isEmpty() && studyConfigs.get(0).getStudyGuid().equals(PANCAN_GUID)) {
             PdfConfigInfo pancanReleasePdfConfigV2 = getPancanReleaseV2PdfConfigIfNeeded(studyConfigs, userActivityVersions);
             if (pancanReleasePdfConfigV2 != null && !userPdfConfigs.contains(pancanReleasePdfConfigV2)) {
                 userPdfConfigs.add(pancanReleasePdfConfigV2);
@@ -966,18 +977,18 @@ public class DataExporter {
     private PdfConfigInfo getPancanReleaseV2PdfConfigIfNeeded(
             List<PdfConfigInfo> studyConfigs, Map<String, Set<String>> userActivityVersions) {
         PdfConfigInfo releasePdfConfig = null;
-        if (userActivityVersions.containsKey("RELEASE") && userActivityVersions.get("RELEASE").contains("v2")
-                && userActivityVersions.get("CONSENT").contains("v1")) {
+        if (userActivityVersions.containsKey(RELEASE) && userActivityVersions.get(RELEASE).contains(VERSION_2)
+                && userActivityVersions.get(CONSENT).contains(VERSION_1)) {
             return studyConfigs.stream().filter(pdfConfigInfo ->
-                            pdfConfigInfo.getConfigName().equals("countmein-release")).findFirst().orElse(null);
+                            pdfConfigInfo.getConfigName().equals(COUNTMEIN_RELEASE)).findFirst().orElse(null);
         }
-        if (userActivityVersions.containsKey("RELEASE_MINOR") && userActivityVersions.get("RELEASE_MINOR").contains("v2")) {
-            if (userActivityVersions.get("CONSENT_PARENTAL").contains("v1")) {
+        if (userActivityVersions.containsKey(RELEASE_MINOR) && userActivityVersions.get(RELEASE_MINOR).contains(VERSION_2)) {
+            if (userActivityVersions.get(CONSENT_PARENTAL).contains(VERSION_1)) {
                 releasePdfConfig = studyConfigs.stream().filter(pdfConfigInfo ->
-                        pdfConfigInfo.getConfigName().equals("countmein-release-parental")).findFirst().orElse(null);
-            } else if (userActivityVersions.get("CONSENT_ASSENT").contains("v1")) {
+                        pdfConfigInfo.getConfigName().equals(COUNTMEIN_RELEASE_PARENTAL)).findFirst().orElse(null);
+            } else if (userActivityVersions.get(CONSENT_ASSENT).contains(VERSION_1)) {
                 releasePdfConfig = studyConfigs.stream().filter(
-                        pdfConfigInfo -> pdfConfigInfo.getConfigName().equals("countmein-release-assent")).findFirst().orElse(null);
+                        pdfConfigInfo -> pdfConfigInfo.getConfigName().equals(COUNTMEIN_RELEASE_ASSENT)).findFirst().orElse(null);
             }
         }
         return releasePdfConfig;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -963,17 +963,21 @@ public class DataExporter {
         return userPdfConfigs;
     }
 
-    private PdfConfigInfo getPancanReleaseV2PdfConfigIfNeeded(List<PdfConfigInfo> studyConfigs, Map<String, Set<String>> userActivityVersions) {
+    private PdfConfigInfo getPancanReleaseV2PdfConfigIfNeeded(
+            List<PdfConfigInfo> studyConfigs, Map<String, Set<String>> userActivityVersions) {
         PdfConfigInfo releasePdfConfig = null;
         if (userActivityVersions.containsKey("RELEASE") && userActivityVersions.get("RELEASE").contains("v2")
                 && userActivityVersions.get("CONSENT").contains("v1")) {
-            return studyConfigs.stream().filter(pdfConfigInfo -> pdfConfigInfo.getConfigName().equals("countmein-release")).findFirst().orElse(null);
+            return studyConfigs.stream().filter(pdfConfigInfo ->
+                            pdfConfigInfo.getConfigName().equals("countmein-release")).findFirst().orElse(null);
         }
         if (userActivityVersions.containsKey("RELEASE_MINOR") && userActivityVersions.get("RELEASE_MINOR").contains("v2")) {
             if (userActivityVersions.get("CONSENT_PARENTAL").contains("v1")) {
-                releasePdfConfig = studyConfigs.stream().filter(pdfConfigInfo -> pdfConfigInfo.getConfigName().equals("countmein-release-parental")).findFirst().orElse(null);
+                releasePdfConfig = studyConfigs.stream().filter(pdfConfigInfo ->
+                        pdfConfigInfo.getConfigName().equals("countmein-release-parental")).findFirst().orElse(null);
             } else if (userActivityVersions.get("CONSENT_ASSENT").contains("v1")) {
-                releasePdfConfig = studyConfigs.stream().filter(pdfConfigInfo -> pdfConfigInfo.getConfigName().equals("countmein-release-assent")).findFirst().orElse(null);
+                releasePdfConfig = studyConfigs.stream().filter(
+                        pdfConfigInfo -> pdfConfigInfo.getConfigName().equals("countmein-release-assent")).findFirst().orElse(null);
             }
         }
         return releasePdfConfig;

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -84,17 +84,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_ASSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_PARENTAL;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_ASSENT;
-import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_PARENTAL;
-import static org.broadinstitute.ddp.constants.PdfConstants.PANCAN_GUID;
-import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE;
-import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE_MINOR;
-import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_1;
-import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_2;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT_ASSENT;
+import static org.broadinstitute.ddp.constants.Constants.CONSENT_PARENTAL;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE_ASSENT;
+import static org.broadinstitute.ddp.constants.Constants.COUNTMEIN_RELEASE_PARENTAL;
+import static org.broadinstitute.ddp.constants.Constants.PANCAN_GUID;
+import static org.broadinstitute.ddp.constants.Constants.RELEASE;
+import static org.broadinstitute.ddp.constants.Constants.RELEASE_MINOR;
+import static org.broadinstitute.ddp.constants.Constants.VERSION_1;
+import static org.broadinstitute.ddp.constants.Constants.VERSION_2;
 
 @Slf4j
 public class PdfGenerationService {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -319,20 +319,7 @@ public class PdfGenerationService {
             }
 
             //special case for pancan release v2 completed user who consented v1, add consent-v1 for consent signature substitution
-            if (config.getStudyGuid().equalsIgnoreCase("cmi-pancan")) {
-                if (config.getConfigName().equalsIgnoreCase("countmein-release")
-                        && acceptedActivityVersions.get("RELEASE").contains("v2")) {
-                    acceptedActivityVersions.get("CONSENT").add("v1");
-                } else if (config.getConfigName().equalsIgnoreCase("countmein-release-parental")
-                        && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
-                        && acceptedActivityVersions.containsKey("CONSENT_PARENTAL")) {
-                    acceptedActivityVersions.get("CONSENT_PARENTAL").add("v1");
-                } else if (config.getConfigName().equalsIgnoreCase("countmein-release-assent")
-                        && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
-                        && acceptedActivityVersions.containsKey("CONSENT_ASSENT")) {
-                    acceptedActivityVersions.get("CONSENT_ASSENT").add("v1");
-                }
-            }
+            handlePancanReleaseV2(config, acceptedActivityVersions);
 
             for (Map.Entry<String, Set<String>> entry : acceptedActivityVersions.entrySet()) {
                 String activityCode = entry.getKey();
@@ -349,6 +336,23 @@ public class PdfGenerationService {
         }
 
         return assignments;
+    }
+
+    private void handlePancanReleaseV2(PdfConfiguration config, Map<String, Set<String>> acceptedActivityVersions) {
+        if (config.getStudyGuid().equalsIgnoreCase("cmi-pancan")) {
+            if (config.getConfigName().equalsIgnoreCase("countmein-release")
+                    && acceptedActivityVersions.get("RELEASE").contains("v2")) {
+                acceptedActivityVersions.get("CONSENT").add("v1");
+            } else if (config.getConfigName().equalsIgnoreCase("countmein-release-parental")
+                    && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
+                    && acceptedActivityVersions.containsKey("CONSENT_PARENTAL")) {
+                acceptedActivityVersions.get("CONSENT_PARENTAL").add("v1");
+            } else if (config.getConfigName().equalsIgnoreCase("countmein-release-assent")
+                    && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
+                    && acceptedActivityVersions.containsKey("CONSENT_ASSENT")) {
+                acceptedActivityVersions.get("CONSENT_ASSENT").add("v1");
+            }
+        }
     }
 
     private void checkForErrors(List<String> errors, String userGuid) {

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -1,22 +1,5 @@
 package org.broadinstitute.ddp.service;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.CharsetEncoder;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import com.google.common.collect.Sets;
 import com.itextpdf.forms.PdfAcroForm;
 import com.itextpdf.forms.PdfPageFormCopier;
@@ -83,6 +66,35 @@ import org.broadinstitute.ddp.model.user.UserProfile;
 import org.broadinstitute.ddp.transformers.DateTimeFormatUtils;
 import org.broadinstitute.ddp.util.Auth0Util;
 import org.jdbi.v3.core.Handle;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_ASSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.CONSENT_PARENTAL;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_ASSENT;
+import static org.broadinstitute.ddp.constants.PdfConstants.COUNTMEIN_RELEASE_PARENTAL;
+import static org.broadinstitute.ddp.constants.PdfConstants.PANCAN_GUID;
+import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE;
+import static org.broadinstitute.ddp.constants.PdfConstants.RELEASE_MINOR;
+import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_1;
+import static org.broadinstitute.ddp.constants.PdfConstants.VERSION_2;
 
 @Slf4j
 public class PdfGenerationService {
@@ -339,18 +351,18 @@ public class PdfGenerationService {
     }
 
     private void handlePancanReleaseV2(PdfConfiguration config, Map<String, Set<String>> acceptedActivityVersions) {
-        if (config.getStudyGuid().equalsIgnoreCase("cmi-pancan")) {
-            if (config.getConfigName().equalsIgnoreCase("countmein-release")
-                    && acceptedActivityVersions.get("RELEASE").contains("v2")) {
-                acceptedActivityVersions.get("CONSENT").add("v1");
-            } else if (config.getConfigName().equalsIgnoreCase("countmein-release-parental")
-                    && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
-                    && acceptedActivityVersions.containsKey("CONSENT_PARENTAL")) {
-                acceptedActivityVersions.get("CONSENT_PARENTAL").add("v1");
-            } else if (config.getConfigName().equalsIgnoreCase("countmein-release-assent")
-                    && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
-                    && acceptedActivityVersions.containsKey("CONSENT_ASSENT")) {
-                acceptedActivityVersions.get("CONSENT_ASSENT").add("v1");
+        if (config.getStudyGuid().equalsIgnoreCase(PANCAN_GUID)) {
+            if (config.getConfigName().equalsIgnoreCase(COUNTMEIN_RELEASE)
+                    && acceptedActivityVersions.get(RELEASE).contains(VERSION_2)) {
+                acceptedActivityVersions.get(CONSENT).add(VERSION_1);
+            } else if (config.getConfigName().equalsIgnoreCase(COUNTMEIN_RELEASE_PARENTAL)
+                    && acceptedActivityVersions.get(RELEASE_MINOR).contains(VERSION_2)
+                    && acceptedActivityVersions.containsKey(CONSENT_PARENTAL)) {
+                acceptedActivityVersions.get(CONSENT_PARENTAL).add(VERSION_1);
+            } else if (config.getConfigName().equalsIgnoreCase(COUNTMEIN_RELEASE_ASSENT)
+                    && acceptedActivityVersions.get(RELEASE_MINOR).contains(VERSION_2)
+                    && acceptedActivityVersions.containsKey(CONSENT_ASSENT)) {
+                acceptedActivityVersions.get(CONSENT_ASSENT).add(VERSION_1);
             }
         }
     }

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/service/PdfGenerationService.java
@@ -318,6 +318,22 @@ public class PdfGenerationService {
                         .forEach(participant::addResponse);
             }
 
+            //special case for pancan release v2 completed user who consented v1, add consent-v1 for consent signature substitution
+            if (config.getStudyGuid().equalsIgnoreCase("cmi-pancan")) {
+                if (config.getConfigName().equalsIgnoreCase("countmein-release")
+                        && acceptedActivityVersions.get("RELEASE").contains("v2")) {
+                    acceptedActivityVersions.get("CONSENT").add("v1");
+                } else if (config.getConfigName().equalsIgnoreCase("countmein-release-parental")
+                        && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
+                        && acceptedActivityVersions.containsKey("CONSENT_PARENTAL")) {
+                    acceptedActivityVersions.get("CONSENT_PARENTAL").add("v1");
+                } else if (config.getConfigName().equalsIgnoreCase("countmein-release-assent")
+                        && acceptedActivityVersions.get("RELEASE_MINOR").contains("v2")
+                        && acceptedActivityVersions.containsKey("CONSENT_ASSENT")) {
+                    acceptedActivityVersions.get("CONSENT_ASSENT").add("v1");
+                }
+            }
+
             for (Map.Entry<String, Set<String>> entry : acceptedActivityVersions.entrySet()) {
                 String activityCode = entry.getKey();
                 for (String versionTag : entry.getValue()) {


### PR DESCRIPTION
PEPPER-1498
Special handling for pancan users who submitted release-v2 but consented to v1 .
Hardcoded for pancan and release config so that NO impact to all other study pdfs.
PdfGenerationService.java change is to let it look into consent-v1 if needed
DataExporter.java change is to let the pdfconfig be included in elastic export so that DSM will make it downloadable.

With these two changes, no manual intervention is needed (NO manual pdf creation needed), housekeeping will generate it and can be invoked from DSM

Additional testing will be done in `Dev` post merge. 
