### PR TITLE
PEPPER-1214 pancan blood-consent updates

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeQuestion.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/JdbiCompositeQuestion.java
@@ -27,6 +27,10 @@ public interface JdbiCompositeQuestion extends SqlObject {
         insertChild(compositeQuestionId, childQuestionIds, IntStream.rangeClosed(0, childQuestionIds.size() - 1).boxed().collect(toList()));
     }
 
+    default void insertChildren(long compositeQuestionId, List<Long> childQuestionIds, List<Integer> orderIdxs) {
+        insertChild(compositeQuestionId, childQuestionIds, orderIdxs);
+    }
+
     @SqlBatch("INSERT INTO composite_question__question (parent_question_id, child_question_id, display_order)"
             + " VALUES(:parentQuestionId, :childQuestionId, :orderIndex)")
     void insertChild(@Bind("parentQuestionId") long parentQuestionId, @Bind("childQuestionId") List<Long> childQuestionIds,

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
@@ -15,7 +15,6 @@ import org.broadinstitute.ddp.db.dto.QuestionDto;
 import org.broadinstitute.ddp.db.dto.SectionBlockMembershipDto;
 import org.broadinstitute.ddp.db.dto.StudyDto;
 import org.broadinstitute.ddp.exception.DDPException;
-import org.broadinstitute.ddp.model.activity.definition.FormBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
 import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
 import org.broadinstitute.ddp.studybuilder.task.CustomTask;
@@ -84,19 +83,23 @@ public class PancanTherapyQuestion implements CustomTask {
         TextQuestionDef textQuestionDef = gson.fromJson(ConfigUtil.toJson(dataCfg.getConfig("textQuestion")), TextQuestionDef.class);
         questionDao.insertQuestion(currCompositeQuestionDto.getActivityId(), textQuestionDef, currCompositeQuestionDto.getRevisionId());
         //add as child
-        jdbiCompositeQuestion.insertChildren(currCompositeQuestionDto.getId(), Arrays.asList(textQuestionDef.getQuestionId()), Arrays.asList(0));
+        jdbiCompositeQuestion.insertChildren(currCompositeQuestionDto.getId(),
+                Arrays.asList(textQuestionDef.getQuestionId()), Arrays.asList(0));
         log.info("added new txt treatment question : {} as child to composite question...", textQuestionDef.getQuestionId());
 
         //populate new composite for past medications/therapies
         log.info("creating new composite question...");
-        QuestionBlockDef questionBlockDef = gson.fromJson(ConfigUtil.toJson(dataCfg.getConfig("current-therapy-composite")), QuestionBlockDef.class);
+        QuestionBlockDef questionBlockDef = gson.fromJson(ConfigUtil.toJson(
+                dataCfg.getConfig("current-therapy-composite")), QuestionBlockDef.class);
         sectionBlockDao.insertBlockForSection(currCompositeQuestionDto.getActivityId(), currSectionDto.getSectionId(),
                 65, questionBlockDef, currCompositeQuestionDto.getRevisionId());
         log.info("inserted new composite question for past treatments : {} ", questionBlockDef.getQuestion().getQuestionId());
 
         //update stableIds
-        helper.updateCompositeQuestionStableId(currCompositeQuestionDto.getId(), newCompositeStableId);
-        helper.updateCompositeQuestionStableId(currPLQuestionDto.getId(), "CURRENT_MED_CLINICAL_TRIAL");
+        rowCount = helper.updateCompositeQuestionStableId(currCompositeQuestionDto.getId(), newCompositeStableId);
+        DBUtils.checkUpdate(1, rowCount);
+        rowCount = helper.updateCompositeQuestionStableId(currPLQuestionDto.getId(), "CURRENT_MED_CLINICAL_TRIAL");
+        DBUtils.checkUpdate(1, rowCount);
 
     }
 

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
@@ -46,12 +46,10 @@ public class PancanTherapyQuestion implements CustomTask {
             throw new DDPException("Data file is missing: " + file);
         }
         dataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
-
         studyGuid = dataCfg.getString("studyGuid");
         if (!studyCfg.getString("study.guid").equals(studyGuid)) {
             throw new DDPException("This task is only for the " + studyGuid + " study!");
         }
-
         gson = GsonUtil.standardGson();
     }
 
@@ -76,7 +74,7 @@ public class PancanTherapyQuestion implements CustomTask {
 
         long currCompositeBlockId = helper.findQuestionBlockId(currCompositeQuestionDto.getId());
         SectionBlockMembershipDto currSectionDto = jdbiFormSectionBlock.getActiveMembershipByBlockId(currCompositeBlockId).get();
-        //update existing child questions display order to accomodate new txt question
+        //update existing child questions display order to accommodate new txt question
         int rowCount = helper.incrementCompositeChildrenDisplayOrder(currCompositeQuestionDto.getId());
         DBUtils.checkUpdate(2, rowCount);
         //insert new txt question for current medication/therapies
@@ -86,13 +84,11 @@ public class PancanTherapyQuestion implements CustomTask {
         jdbiCompositeQuestion.insertChildren(currCompositeQuestionDto.getId(), Arrays.asList(textQuestionDef.getQuestionId()), Arrays.asList(0));
         log.info("added new txt treatment question : {} as child to composite question...", textQuestionDef.getQuestionId());
 
-
         //populate new composite for past medications/therapies
-        //todo identify display order of this new question
         log.info("creating new composite question...");
         QuestionBlockDef questionBlockDef = gson.fromJson(ConfigUtil.toJson(dataCfg.getConfig("current-therapy-composite")), QuestionBlockDef.class);
         sectionBlockDao.insertBlockForSection(currCompositeQuestionDto.getActivityId(), currSectionDto.getSectionId(),
-                6, (FormBlockDef) questionBlockDef, currCompositeQuestionDto.getRevisionId());
+                65, questionBlockDef, currCompositeQuestionDto.getRevisionId());
         log.info("inserted new composite question for past treatments : {} ", questionBlockDef.getQuestion().getQuestionId());
 
     }

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
@@ -108,8 +108,8 @@ public class PancanTherapyQuestion implements CustomTask {
         int incrementCompositeChildrenDisplayOrder(@Bind("parentQuestionId") long parentQuestionId);
 
         @SqlUpdate("update question_stable_code qsc "
-                + "set qsc.stable_id = : "
-                + "where qsc.question_id = :questionId")
+                + "set qsc.stable_id = :stableId "
+                + "where qsc.question_stable_code_id = (select question_stable_code_id from question where question_id = :questionId)")
         int updateCompositeQuestionStableId(@Bind("questionId") long questionId, @Bind("stableId") String stableId);
 
         @SqlQuery("select block_id from block__question where question_id = :questionId")

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanTherapyQuestion.java
@@ -1,0 +1,112 @@
+package org.broadinstitute.ddp.studybuilder.task.pancan;
+
+import com.google.gson.Gson;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.JdbiCompositeQuestion;
+import org.broadinstitute.ddp.db.dao.JdbiFormSectionBlock;
+import org.broadinstitute.ddp.db.dao.JdbiQuestion;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.db.dao.QuestionDao;
+import org.broadinstitute.ddp.db.dao.SectionBlockDao;
+import org.broadinstitute.ddp.db.dto.QuestionDto;
+import org.broadinstitute.ddp.db.dto.SectionBlockMembershipDto;
+import org.broadinstitute.ddp.db.dto.StudyDto;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.model.activity.definition.FormBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.QuestionBlockDef;
+import org.broadinstitute.ddp.model.activity.definition.question.TextQuestionDef;
+import org.broadinstitute.ddp.studybuilder.task.CustomTask;
+import org.broadinstitute.ddp.util.ConfigUtil;
+import org.broadinstitute.ddp.util.GsonUtil;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+@Slf4j
+public class PancanTherapyQuestion implements CustomTask {
+    private static final String DATA_FILE = "patches/composite-therapy-question.conf";
+
+    private Config dataCfg;
+    private String studyGuid;
+    private Gson gson;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        File file = cfgPath.getParent().resolve(DATA_FILE).toFile();
+        if (!file.exists()) {
+            throw new DDPException("Data file is missing: " + file);
+        }
+        dataCfg = ConfigFactory.parseFile(file).resolveWith(varsCfg);
+
+        studyGuid = dataCfg.getString("studyGuid");
+        if (!studyCfg.getString("study.guid").equals(studyGuid)) {
+            throw new DDPException("This task is only for the " + studyGuid + " study!");
+        }
+
+        gson = GsonUtil.standardGson();
+    }
+
+    @Override
+    public void run(Handle handle) {
+        StudyDto studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyGuid);
+
+        SqlHelper helper = handle.attach(SqlHelper.class);
+        QuestionDao questionDao = handle.attach(QuestionDao.class);
+        JdbiQuestion jdbiQuestion = handle.attach(JdbiQuestion.class);
+        JdbiCompositeQuestion jdbiCompositeQuestion = handle.attach(JdbiCompositeQuestion.class);
+        JdbiFormSectionBlock jdbiFormSectionBlock = handle.attach(JdbiFormSectionBlock.class);
+        SectionBlockDao sectionBlockDao = handle.attach(SectionBlockDao.class);
+
+        log.info("updating current treatment question...");
+        String currCompositeQuestionStableId = dataCfg.getString("currCompositeQuestionStableId");
+        //String newQuestionStableId = dataCfg.getString("newQuestionStableId");
+
+        QuestionDto currCompositeQuestionDto = jdbiQuestion
+                .findLatestDtoByStudyIdAndQuestionStableId(studyDto.getId(), currCompositeQuestionStableId)
+                .orElseThrow(() -> new DDPException("Could not find question " + currCompositeQuestionStableId));
+
+        long currCompositeBlockId = helper.findQuestionBlockId(currCompositeQuestionDto.getId());
+        SectionBlockMembershipDto currSectionDto = jdbiFormSectionBlock.getActiveMembershipByBlockId(currCompositeBlockId).get();
+        //update existing child questions display order to accomodate new txt question
+        int rowCount = helper.incrementCompositeChildrenDisplayOrder(currCompositeQuestionDto.getId());
+        DBUtils.checkUpdate(2, rowCount);
+        //insert new txt question for current medication/therapies
+        TextQuestionDef textQuestionDef = gson.fromJson(ConfigUtil.toJson(dataCfg.getConfig("textQuestion")), TextQuestionDef.class);
+        questionDao.insertQuestion(currCompositeQuestionDto.getActivityId(), textQuestionDef, currCompositeQuestionDto.getRevisionId());
+        //add as child
+        jdbiCompositeQuestion.insertChildren(currCompositeQuestionDto.getId(), Arrays.asList(textQuestionDef.getQuestionId()), Arrays.asList(0));
+        log.info("added new txt treatment question : {} as child to composite question...", textQuestionDef.getQuestionId());
+
+
+        //populate new composite for past medications/therapies
+        //todo identify display order of this new question
+        log.info("creating new composite question...");
+        QuestionBlockDef questionBlockDef = gson.fromJson(ConfigUtil.toJson(dataCfg.getConfig("current-therapy-composite")), QuestionBlockDef.class);
+        sectionBlockDao.insertBlockForSection(currCompositeQuestionDto.getActivityId(), currSectionDto.getSectionId(),
+                6, (FormBlockDef) questionBlockDef, currCompositeQuestionDto.getRevisionId());
+        log.info("inserted new composite question for past treatments : {} ", questionBlockDef.getQuestion().getQuestionId());
+
+    }
+
+    private interface SqlHelper extends SqlObject {
+
+        @SqlUpdate("update composite_question__question cqq "
+                + "set display_order = display_order + 1 "
+                + "where cqq.parent_question_id = :parentQuestionId")
+        int incrementCompositeChildrenDisplayOrder(@Bind("parentQuestionId") long parentQuestionId);
+
+        @SqlQuery("select block_id from block__question where question_id = :questionId")
+        int findQuestionBlockId(@Bind("questionId") long questionId);
+
+    }
+
+}

--- a/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
@@ -641,9 +641,8 @@
             },
             "children": [
               {
-              include required("../snippets/text-question.conf"),
+                include required("./snippets/question-therapy-name.conf"),
                 "stableId": "CURRENT_MED_NAME",
-                "suggestionType": "DRUG",
                 "promptTemplate": {
                   "templateType": "TEXT",
                   "templateCode": null,
@@ -773,9 +772,8 @@
             },
             "children": [
               {
-                include required("../snippets/text-question.conf"),
+                include required("./snippets/question-therapy-name.conf"),
                 "stableId": "PAST_MED_NAME",
-                "suggestionType": "DRUG",
                 "promptTemplate": {
                   "templateType": "TEXT",
                   "templateCode": null,

--- a/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
@@ -650,7 +650,7 @@
                   "templateText": "$current_med_name",
                   "variables": [
                     {
-                      "name": "$current_med_name",
+                      "name": "current_med_name",
                       "translations": [
                         { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.current_med_name} },
                         { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.current_med_name} }
@@ -784,7 +784,7 @@
                   "templateText": "$past_med_name",
                   "variables": [
                     {
-                      "name": "$past_med_name",
+                      "name": "past_med_name",
                       "translations": [
                         { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.past_med_name} },
                         { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.past_med_name} }

--- a/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
@@ -605,8 +605,8 @@
               {
                 "name": "prompt_therapy_name",
                 "translations": [
-                  { "language": "en", "text": ${i18n.en.blood_consent.all_treatments.prompt_is_clinical_trial} },
-                  { "language": "es", "text": ${i18n.es.blood_consent.all_treatments.prompt_is_clinical_trial} }
+                  { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.prompt_is_clinical_trial} },
+                  { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.prompt_is_clinical_trial} }
                 ]
               }
             ]
@@ -614,10 +614,11 @@
           "blockType": "CONTENT",
           "shownExpr": null
         },
+
         {
           "question": {
             include required("../snippets/composite-question.conf"),
-            "stableId": "ALL_TREATMENTS",
+            "stableId": "CURRENT_MED_LIST",
             "hideNumber": true,
             "promptTemplate": {
               "templateType": "TEXT",
@@ -627,21 +628,40 @@
             "allowMultiple": true,
             "addButtonTemplate": {
               "templateType": "TEXT",
-              "templateText": "$all_treatments_add_button",
+              "templateText": "$current_treatments_add_button",
               "variables": [
                 {
-                  "name": "all_treatments_add_button",
+                  "name": "current_treatments_add_button",
                   "translations": [
-                    { "language": "en", "text": ${i18n.en.blood_consent.all_treatments.button} },
-                    { "language": "es", "text": ${i18n.es.blood_consent.all_treatments.button} }
+                    { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.button} },
+                    { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.button} }
                   ]
                 }
               ]
             },
             "children": [
               {
+              include required("../snippets/text-question.conf"),
+                "stableId": "CURRENT_MED_NAME",
+                "suggestionType": "DRUG",
+                "promptTemplate": {
+                  "templateType": "TEXT",
+                  "templateCode": null,
+                  "templateText": "$current_med_name",
+                  "variables": [
+                    {
+                      "name": "$current_med_name",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.current_med_name} },
+                        { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.current_med_name} }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
                 include required("../snippets/picklist-question-multi-list.conf"),
-                "stableId": "THERAPY_NAME_CHOOSE",
+                "stableId": "CURRENT_MED_CLINICAL_TRIAL",
                 "hideNumber": true,
                 "promptTemplate": {
                   "templateType": "HTML",
@@ -650,17 +670,17 @@
                 },
                 "picklistOptions": [
                   {
-                    "stableId": "IS_CLINICAL_TRIAL",
+                    "stableId": "CURRENT_MED_IS_CLINICAL_TRIAL",
                     "optionLabelTemplate": {
                       "templateType": "TEXT",
                       "templateCode": null,
-                      "templateText": "$is_clinical_trial",
+                      "templateText": "$current_med_is_clinical_trial",
                       "variables": [
                         {
-                          "name": "is_clinical_trial",
+                          "name": "current_med_is_clinical_trial",
                           "translations": [
-                            { "language": "en", "text": ${i18n.en.blood_consent.all_treatments.is_clinical_trial} },
-                            { "language": "es", "text": ${i18n.es.blood_consent.all_treatments.is_clinical_trial} }
+                            { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.is_clinical_trial} },
+                            { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.is_clinical_trial} }
                           ]
                         }
                       ]
@@ -673,7 +693,7 @@
               },
               {
                 include required("../snippets/date-question-month-year-dropdown.conf"),
-                "stableId": "TREATMENT_START",
+                "stableId": "CURRENT_MED_START",
                 "promptTemplate": {
                   "templateType": "HTML",
                   "templateCode": null,
@@ -682,8 +702,8 @@
                     {
                       "name": "prompt_treatment_start",
                       "translations": [
-                        { "language": "en", "text": ${i18n.en.blood_consent.all_treatments.prompt_treatment_start} },
-                        { "language": "es", "text": ${i18n.es.blood_consent.all_treatments.prompt_treatment_start} }
+                        { "language": "en", "text": ${i18n.en.blood_consent.current_treatments.prompt_treatment_start} },
+                        { "language": "es", "text": ${i18n.es.blood_consent.current_treatments.prompt_treatment_start} }
                       ]
                     }
                   ]
@@ -694,6 +714,10 @@
           "blockType": "QUESTION",
           "shownExpr": null
         },
+
+
+
+
         {
           "titleTemplate": {
             "templateType": "HTML",
@@ -724,6 +748,127 @@
           "blockType": "CONTENT",
           "shownExpr": null
         },
+
+        {
+          "question": {
+            include required("../snippets/composite-question.conf"),
+            "stableId": "PAST_MED_LIST",
+            "hideNumber": true,
+            "promptTemplate": {
+              "templateType": "TEXT",
+              "templateText": "",
+              "variables": []
+            },
+            "allowMultiple": true,
+            "addButtonTemplate": {
+              "templateType": "TEXT",
+              "templateText": "$past_treatments_add_button",
+              "variables": [
+                {
+                  "name": "past_treatments_add_button",
+                  "translations": [
+                    { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.button} },
+                    { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.button} }
+                  ]
+                }
+              ]
+            },
+            "children": [
+              {
+                include required("../snippets/text-question.conf"),
+                "stableId": "PAST_MED_NAME",
+                "suggestionType": "DRUG",
+                "promptTemplate": {
+                  "templateType": "TEXT",
+                  "templateCode": null,
+                  "templateText": "$past_med_name",
+                  "variables": [
+                    {
+                      "name": "$past_med_name",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.past_med_name} },
+                        { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.past_med_name} }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                include required("../snippets/picklist-question-multi-list.conf"),
+                "stableId": "PAST_MED_CLINICAL_TRIAL",
+                "hideNumber": true,
+                "promptTemplate": {
+                  "templateType": "HTML",
+                  "templateText": "",
+                  "variables": [],
+                },
+                "picklistOptions": [
+                  {
+                    "stableId": "PAST_MED_IS_CLINICAL_TRIAL",
+                    "optionLabelTemplate": {
+                      "templateType": "TEXT",
+                      "templateCode": null,
+                      "templateText": "$past_med_is_clinical_trial",
+                      "variables": [
+                        {
+                          "name": "past_med_is_clinical_trial",
+                          "translations": [
+                            { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.is_clinical_trial} },
+                            { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.is_clinical_trial} }
+                          ]
+                        }
+                      ]
+                    },
+                    "detailLabelTemplate": null,
+                    "allowDetails": false,
+                    "exclusive": false
+                  }
+                ]
+              },
+              {
+                include required("../snippets/date-question-month-year-dropdown.conf"),
+                "stableId": "PAST_MED_START",
+                "promptTemplate": {
+                  "templateType": "HTML",
+                  "templateCode": null,
+                  "templateText": "$prompt_past_treatment_start",
+                  "variables": [
+                    {
+                      "name": "prompt_past_treatment_start",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.prompt_past_treatment_start} },
+                        { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.prompt_past_treatment_start} }
+                      ]
+                    }
+                  ]
+                }
+              },
+
+              {
+                include required("../snippets/date-question-month-year-dropdown.conf"),
+                "stableId": "PAST_MED_STOP",
+                "promptTemplate": {
+                  "templateType": "HTML",
+                  "templateCode": null,
+                  "templateText": "$prompt_past_treatment_stop",
+                  "variables": [
+                    {
+                      "name": "prompt_past_treatment_stop",
+                      "translations": [
+                        { "language": "en", "text": ${i18n.en.blood_consent.past_treatments.prompt_past_treatment_stop} },
+                        { "language": "es", "text": ${i18n.es.blood_consent.past_treatments.prompt_past_treatment_stop} }
+                      ]
+                    }
+                  ]
+                }
+              }
+              
+            ]
+          },
+          "blockType": "QUESTION",
+          "shownExpr": null
+        },
+        
         {
           "componentType": "MAILING_ADDRESS",
           "titleTemplate": {

--- a/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/blood-consent.conf
@@ -670,7 +670,7 @@
                 },
                 "picklistOptions": [
                   {
-                    "stableId": "CURRENT_MED_IS_CLINICAL_TRIAL",
+                    "stableId": "IS_CLINICAL_TRIAL",
                     "optionLabelTemplate": {
                       "templateType": "TEXT",
                       "templateCode": null,
@@ -714,8 +714,6 @@
           "blockType": "QUESTION",
           "shownExpr": null
         },
-
-
 
 
         {

--- a/pepper-apis/studybuilder-cli/studies/pancan/i18n/en.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/i18n/en.conf
@@ -2286,10 +2286,21 @@
       """,
     },
 
-    "all_treatments": {
+    "current_treatments": {
+      "therapy_name": "Choose medication / chemotherapy.",
+      "current_med_name": "Choose medication / chemotherapy.",
       "prompt_is_clinical_trial": "Choose medication / chemotherapy.",
       "is_clinical_trial": "This is part of a clinical trial ",
       "prompt_treatment_start": "When did you first begin this treatment?",
+      "button": "+ ADD ANOTHER MEDICATION/CHEMOTHERAPY"
+    }
+    "past_treatments": {
+      "therapy_name": "Choose past medication / chemotherapy.",
+      "past_med_name": "Choose past medication / chemotherapy.",
+      "prompt_is_clinical_trial": "Choose past medication / chemotherapy.",
+      "is_clinical_trial": "This was part of a clinical trial ",
+      "prompt_past_treatment_start": "When did you first begin this treatment?",
+      "prompt_past_treatment_stop": "When did you stop this treatment?",
       "button": "+ ADD ANOTHER MEDICATION/CHEMOTHERAPY"
     }
     "other_medications": {

--- a/pepper-apis/studybuilder-cli/studies/pancan/i18n/es.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/i18n/es.conf
@@ -2278,6 +2278,24 @@
       """,
     },
 
+    "current_treatments": {
+      "therapy_name": "[es]Choose medication / chemotherapy.",
+      "current_med_name": "[es]Choose medication / chemotherapy.",
+      "prompt_is_clinical_trial": "[es]Choose medication / chemotherapy.",
+      "is_clinical_trial": "[es]This is part of a clinical trial ",
+      "prompt_treatment_start": "[es]When did you first begin this treatment?",
+      "button": "+ ADD ANOTHER MEDICATION/CHEMOTHERAPY"
+    }
+    "past_treatments": {
+      "therapy_name": "[es]Choose past medication / chemotherapy.",
+      "past_med_name": "[es]Choose past medication / chemotherapy.",
+      "prompt_is_clinical_trial": "[es]Choose past medication / chemotherapy.",
+      "is_clinical_trial": "[es]This was part of a clinical trial ",
+      "prompt_past_treatment_start": "[es]When did you first begin this treatment?",
+      "prompt_past_treatment_stop": "[es]When did you stop this treatment?",
+      "button": "+ ADD ANOTHER MEDICATION/CHEMOTHERAPY"
+    }
+
     "all_treatments": {
       "prompt_is_clinical_trial": "[es]Choose medication / chemotherapy.",
       "is_clinical_trial": "[es]This is part of a clinical trial ",

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
@@ -6,7 +6,7 @@
 
   "textQuestion": {
     include required("../../snippets/text-question.conf"),
-    "stableId": "CURRENT_MEDICATION_NAME",
+    "stableId": "CURRENT_MED_NAME",
     "suggestionType": "DRUG",
     "promptTemplate": {
       "templateType": "TEXT",

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
@@ -1,7 +1,7 @@
 {
   "studyGuid": "cmi-pancan",
   "currCompositeQuestionStableId": "ALL_TREATMENTS",
-  "newQuestionStableId": "CURRENT_TREATMENTS_LIST",
+  "newQuestionStableId": "CURRENT_MED_LIST",
   "newQuestionPromptText": "Choose medication/chemotherapy...",
 
   "textQuestion": {
@@ -23,7 +23,6 @@
       ]
     }
   },
-
 
   "current-therapy-composite": {
     "activityCode": "BLOOD_CONSENT",

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
@@ -1,0 +1,149 @@
+{
+  "studyGuid": "cmi-pancan",
+  "currCompositeQuestionStableId": "ALL_TREATMENTS",
+  "newQuestionStableId": "CURRENT_TREATMENTS_LIST",
+  "newQuestionPromptText": "Choose medication/chemotherapy...",
+
+  "textQuestion": {
+    include required("../../snippets/text-question.conf"),
+    "stableId": "CURRENT_MEDICATION_NAME",
+    "suggestionType": "DRUG",
+    "promptTemplate": {
+      "templateType": "TEXT",
+      "templateCode": null,
+      "templateText": "$current_med_name",
+      "variables": [
+        {
+          "name": "current_med_name",
+          "translations": [
+            {"language": "en", "text": ${i18n.en.blood_consent.current_treatments.current_med_name}},
+            {"language": "es", "text": ${i18n.es.blood_consent.current_treatments.current_med_name}}
+          ]
+        }
+      ]
+    }
+  },
+
+
+  "current-therapy-composite": {
+    "activityCode": "BLOOD_CONSENT",
+    "question": {
+      include required("../../snippets/composite-question.conf"),
+      "stableId": "PAST_MED_LIST",
+      "hideNumber": true,
+      "promptTemplate": {
+        "templateType": "TEXT",
+        "templateText": "",
+        "variables": []
+      },
+      "allowMultiple": true,
+      "addButtonTemplate": {
+        "templateType": "TEXT",
+        "templateText": "$past_treatments_add_button",
+        "variables": [
+          {
+            "name": "past_treatments_add_button",
+            "translations": [
+              {"language": "en", "text": ${i18n.en.blood_consent.past_treatments.button}},
+              {"language": "es", "text": ${i18n.es.blood_consent.past_treatments.button}}
+            ]
+          }
+        ]
+      },
+      "children": [
+        {
+          include required("../../snippets/text-question.conf"),
+          "stableId": "PAST_MED_NAME",
+          "suggestionType": "DRUG",
+          "promptTemplate": {
+            "templateType": "TEXT",
+            "templateCode": null,
+            "templateText": "$past_med_name",
+            "variables": [
+              {
+                "name": "past_med_name",
+                "translations": [
+                  {"language": "en", "text": ${i18n.en.blood_consent.past_treatments.past_med_name}},
+                  {"language": "es", "text": ${i18n.es.blood_consent.past_treatments.past_med_name}}
+                ]
+              }
+            ]
+          }
+        },
+        {
+          include required("../../snippets/picklist-question-multi-list.conf"),
+          "stableId": "PAST_MED_CLINICAL_TRIAL",
+          "hideNumber": true,
+          "promptTemplate": {
+            "templateType": "HTML",
+            "templateText": "",
+            "variables": [],
+          },
+          "picklistOptions": [
+            {
+              "stableId": "PAST_MED_IS_CLINICAL_TRIAL",
+              "optionLabelTemplate": {
+                "templateType": "TEXT",
+                "templateCode": null,
+                "templateText": "$past_med_is_clinical_trial",
+                "variables": [
+                  {
+                    "name": "past_med_is_clinical_trial",
+                    "translations": [
+                      {"language": "en", "text": ${i18n.en.blood_consent.past_treatments.is_clinical_trial}},
+                      {"language": "es", "text": ${i18n.es.blood_consent.past_treatments.is_clinical_trial}}
+                    ]
+                  }
+                ]
+              },
+              "detailLabelTemplate": null,
+              "allowDetails": false,
+              "exclusive": false
+            }
+          ]
+        },
+        {
+          include required("../../snippets/date-question-month-year-dropdown.conf"),
+          "stableId": "PAST_MED_START",
+          "promptTemplate": {
+            "templateType": "HTML",
+            "templateCode": null,
+            "templateText": "$prompt_past_treatment_start",
+            "variables": [
+              {
+                "name": "prompt_past_treatment_start",
+                "translations": [
+                  {"language": "en", "text": ${i18n.en.blood_consent.past_treatments.prompt_past_treatment_start}},
+                  {"language": "es", "text": ${i18n.es.blood_consent.past_treatments.prompt_past_treatment_start}}
+                ]
+              }
+            ]
+          }
+        },
+
+        {
+          include required("../../snippets/date-question-month-year-dropdown.conf"),
+          "stableId": "PAST_MED_STOP",
+          "promptTemplate": {
+            "templateType": "HTML",
+            "templateCode": null,
+            "templateText": "$prompt_past_treatment_stop",
+            "variables": [
+              {
+                "name": "prompt_past_treatment_stop",
+                "translations": [
+                  {"language": "en", "text": ${i18n.en.blood_consent.past_treatments.prompt_past_treatment_stop}},
+                  {"language": "es", "text": ${i18n.es.blood_consent.past_treatments.prompt_past_treatment_stop}}
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+    "blockType": "QUESTION",
+    "shownExpr": null
+  },
+
+
+}

--- a/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/patches/composite-therapy-question.conf
@@ -5,9 +5,8 @@
   "newQuestionPromptText": "Choose medication/chemotherapy...",
 
   "textQuestion": {
-    include required("../../snippets/text-question.conf"),
+    include required("../snippets/question-therapy-name.conf"),
     "stableId": "CURRENT_MED_NAME",
-    "suggestionType": "DRUG",
     "promptTemplate": {
       "templateType": "TEXT",
       "templateCode": null,
@@ -51,9 +50,8 @@
       },
       "children": [
         {
-          include required("../../snippets/text-question.conf"),
+          include required("../snippets/question-therapy-name.conf"),
           "stableId": "PAST_MED_NAME",
-          "suggestionType": "DRUG",
           "promptTemplate": {
             "templateType": "TEXT",
             "templateCode": null,


### PR DESCRIPTION
PEPPER-1214
Fix current therapy/medications composite question in pancan blood consent activity.
Add new composite question to collect past medications/therapies
Rename some templates/question stable ids to reflect what is being captured correctly.
Need to execute below two StudyBuilder tasks to deploy the changes
pancan.PancanTherapyQuestion
UpdateActivityTemplatesInPlace 
NOTE: Whitney confirmed that we can deploy these changes after looking at the screenshots of medication/therapy questions attached here.

limitations
No spanish translations (content , emails and pdf). As per whitney, not needed as of now.
Captured medication dates doesn't have any validations. Existing studies like MBC which have same questions doesn't have it too.



Initial requirements ticket/document which is being reviewed by Whitney. ok with current implementation in the PR though.
https://broadinstitute.atlassian.net/browse/DDP-7272
https://drive.google.com/file/d/17NFBlXtGk9ph0kWf7UTTgbjs0LSKZ_Sw/view