### PR TITLE
PEPPER-499 . onc history & MR fax dates elastic patch update fix

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/BaseStrategy.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/elastic/export/generate/BaseStrategy.java
@@ -11,6 +11,9 @@ public class BaseStrategy implements Generator {
     public BaseStrategy(String fieldName, Object value) {
         this.fieldName = fieldName;
         this.value = value;
+        if (value instanceof String && ((String) value).isEmpty()) {
+            this.value = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
PEPPER-499 
onc history and Medical Record fax dates elastic patch update issue.
When fax dates are being cleared/deleted from UI, related additional fax confirmed date fields are passing empty string to elastic and elastic patch updates are failing because of strict date mapping.
Made a fix to pass null rather than empty string to elastic.
Initial scope of the ticket was Onc History fax sent dates , during the investigation found same issue exists for MR fax dates too. 
Solution provided fixes MR fax dates too.

QA
Tested locally by providing valid fax Dates and deleting existing dates. 
Tested for both onc history  & MR fax dates .
Tested multiple studies (lms and osteo2)
