### PR TITLE
PEPPER-1509 . sequencing-order collection date fix

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
@@ -160,7 +160,8 @@ public class Patch {
                 if (result == 1) {
                     logger.info("Updated {} value in table {}, record ID={}", nameValue.getName(), dbElement.getTableName(), id);
                 } else {
-                    logger.warn("Updated {} values in table {}, record ID={} , rows updated: {}", nameValue.getName(), dbElement.getTableName(), id, result);
+                    //logging as warn in case we want to investigate or track the scenarios where we updated more than one row.
+                    logger.warn("Updated more than one {} values in table {}, record ID={} , rows updated: {}", nameValue.getName(), dbElement.getTableName(), id, result);
                 }
             } catch (SQLIntegrityConstraintViolationException ex) {
                 throw new DsmInternalError(toErrorMessage(dbElement.getTableName(), dbElement.getColumnName(),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
@@ -161,7 +161,8 @@ public class Patch {
                     logger.info("Updated {} value in table {}, record ID={}", nameValue.getName(), dbElement.getTableName(), id);
                 } else {
                     //logging as warn in case we want to investigate or track the scenarios where we updated more than one row.
-                    logger.warn("Updated more than one {} values in table {}, record ID={} , rows updated: {}", nameValue.getName(), dbElement.getTableName(), id, result);
+                    logger.warn("Updated more than one {} values in table {}, record ID={} , rows updated: {}",
+                            nameValue.getName(), dbElement.getTableName(), id, result);
                 }
             } catch (SQLIntegrityConstraintViolationException ex) {
                 throw new DsmInternalError(toErrorMessage(dbElement.getTableName(), dbElement.getColumnName(),

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/patch/Patch.java
@@ -160,8 +160,7 @@ public class Patch {
                 if (result == 1) {
                     logger.info("Updated {} value in table {}, record ID={}", nameValue.getName(), dbElement.getTableName(), id);
                 } else {
-                    throw new DsmInternalError(toErrorMessage(dbElement.getTableName(), dbElement.getColumnName(),
-                            nameValue.getValue(), dbElement.getPrimaryKey(), id) + ": " + result + " rows updated");
+                    logger.warn("Updated {} values in table {}, record ID={} , rows updated: {}", nameValue.getName(), dbElement.getTableName(), id, result);
                 }
             } catch (SQLIntegrityConstraintViolationException ex) {
                 throw new DsmInternalError(toErrorMessage(dbElement.getTableName(), dbElement.getColumnName(),


### PR DESCRIPTION
PEPPER-1509

Some scenarios on collection date addition in sequencing order tab, backend is throwing 500 error.
In scenarios where a kit-request was de-activated and re-activated  new row is written into DDP_KIT table for same ddp-kit-request-id. . WHen patch is updating ddp-kit with ddp-kit-request-id, its updating multiple rows and throwing error post successful DB update.
Transaction is committed any way.
Solution: Updated to not throw error but log as a warning incase we want to track these warnings.

QA
Tested locally and looks good