### PR TITLE
PEPPER-1365 . Special handling of lms release v2 pdfs config with consent v1

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/Constants.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/constants/Constants.java
@@ -2,16 +2,22 @@ package org.broadinstitute.ddp.constants;
 
 public class Constants {
     public static final String PANCAN_GUID = "cmi-pancan";
+    public static final String LMS_GUID = "cmi-lms";
     public static final String COUNTMEIN_RELEASE = "countmein-release";
+    public static final String COUNTMEIN_RELEASE_PARENTAL = "countmein-release-parental";
+    public static final String COUNTMEIN_RELEASE_ASSENT = "countmein-release-assent";
+    public static final String LMS_RELEASE = "lmsproject-release";
+    public static final String LMS_RELEASE_PEDIATRIC = "lmsproject-release-pediatric";
+    public static final String LMS_RELEASE_ASSENT = "lmsproject-release-pediatric-assent";
     public static final String RELEASE = "RELEASE";
+    public static final String MEDICAL_RELEASE = "MEDICAL_RELEASE";
     public static final String VERSION_2 = "v2";
     public static final String CONSENT = "CONSENT";
     public static final String VERSION_1 = "v1";
-    public static final String COUNTMEIN_RELEASE_PARENTAL = "countmein-release-parental";
     public static final String RELEASE_MINOR = "RELEASE_MINOR";
     public static final String CONSENT_PARENTAL = "CONSENT_PARENTAL";
-    public static final String COUNTMEIN_RELEASE_ASSENT = "countmein-release-assent";
     public static final String CONSENT_ASSENT = "CONSENT_ASSENT";
+    public static final String PARENTAL_CONSENT = "PARENTAL_CONSENT";
 
     /**
      * Available profile fields that can be used for profile substitution.

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/export/DataExporter.java
@@ -981,7 +981,6 @@ public class DataExporter {
         if (!studyConfigs.isEmpty() && studyConfigs.get(0).getStudyGuid().equals(LMS_GUID)) {
             PdfConfigInfo lmsReleasePdfConfigV2 = getLmsReleaseV2PdfConfigIfNeeded(studyConfigs, userActivityVersions);
             if (lmsReleasePdfConfigV2 != null && !userPdfConfigs.contains(lmsReleasePdfConfigV2)) {
-                log.info("-----------------------------------> Adding LMS Release V2 PDF Config");
                 userPdfConfigs.add(lmsReleasePdfConfigV2);
             }
         }


### PR DESCRIPTION
PEPPER-1365
Handle scenarios where lms user completed release v2 but had old consent v1.

Tried the approach to update release v2 pdf config to remove reference to consent v1 . Approach was clean with one issue for DSM. Since MEDICAL_RELEASE activity was same for all self/parental and consent-assent, DataExporter was updating elastic with ALL 3 release pdfs and DSM is displaying ALL 3 pdf config names . 
Basically DSM displays some additional invalid release configs as download options. 
To avoid that issue and confusion ended with this hardcoded special handling similar to what we did for pancan. 

Other option is add special handling to remove other pdf config names which is equally hardcoded/ugly.
With this way, no pdfconfig changes (studybuilder patch) needed atleast and less invasive
