### PR TITLE
PEPPER-1340 . fix os pe-cgs child participants proxy name issue

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/service/phimanifest/PhiManifestService.java
@@ -91,7 +91,7 @@ public class PhiManifestService {
         if (proxies != null && !proxies.isEmpty()) {
             String proxyParticipantId = proxies.get(0);
             ElasticSearchParticipantDto proxyParticipant = ElasticSearchUtil.getParticipantESDataByParticipantId(
-                    ddpInstanceDto.getEsParticipantIndex(), proxyParticipantId);
+                    ddpInstanceDto.getEsUsersIndex(), proxyParticipantId);
             if (proxyParticipant.getProfile().isPresent()) {
                 Profile proxyParticipantProfile = proxyParticipant.getProfile().get();
                 phiManifest.setProxyFirstName(proxyParticipantProfile.getFirstName());


### PR DESCRIPTION
PEPPER-1340
Fix issue with some os-pecgs pediatric participant download not including proxy names.

Root cause:
Osteo1 participants who re-consented and migrated to Osteo2 (Osteo pe-cgs) proxies does not seem to have participants_structured index and hence PHI service couldnt pull proxy names for those participants.
Looks like back in OS1 , PREQUAL was associated with child and DSS skips loading ptp into participants_structured index if NO survey/data. 
Newly registered participants seem to have PREQUAL associated with proxy, hence no issue

Solution:
Proxies are in users index for sure, hence pull proxy profile from elastic users index (users.cmi.cmi-osteo) rather than participants_structured index
