### PR TITLE
PEPPER-1388 remove angio from pancan redirect

### DIFF
--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
@@ -55,14 +55,17 @@ public class PancanAngioRedirectRemoval implements CustomTask {
                 + "  from workflow_transition as trans "
                 + "  join umbrella_study as s on s.umbrella_study_id = trans.umbrella_study_id "
                 + "  join workflow_state as next_state on next_state.workflow_state_id = trans.next_state_id "
-                + "  join workflow_state_type as next_state_type on next_state_type.workflow_state_type_id = next_state.workflow_state_type_id "
-                + "  left join workflow_activity_state as next_act_state on next_act_state.workflow_state_id = next_state.workflow_state_id "
-                + "  left join expression as expr on expr.expression_id = trans.precondition_expression_id "
-                + "  left join workflow_study_redirect_state as next_redirect_state on next_redirect_state.workflow_state_id = next_state.workflow_state_id "
+                + "  join workflow_state_type as next_state_type on next_state_type.workflow_state_type_id "
+                + " = next_state.workflow_state_type_id "
+                + " left join workflow_activity_state as next_act_state on next_act_state.workflow_state_id "
+                + " = next_state.workflow_state_id "
+                + " left join expression as expr on expr.expression_id = trans.precondition_expression_id "
+                + " left join workflow_study_redirect_state as next_redirect_state on "
+                + " next_redirect_state.workflow_state_id = next_state.workflow_state_id "
                 + " where s.guid = 'cmi-pancan' "
-                + "   and trans.is_active "
-                + "   and next_state_type.workflow_state_type_code = 'STUDY_REDIRECT' "
-                + "   and study_guid = 'ANGIO'")
+                + " and trans.is_active "
+                + " and next_state_type.workflow_state_type_code = 'STUDY_REDIRECT' "
+                + " and study_guid = 'ANGIO'")
         long findPancanAngioStudyRedirectWorkflowId();
 
         @SqlUpdate("delete workflow_transition  "

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
@@ -1,0 +1,81 @@
+package org.broadinstitute.ddp.studybuilder.task.pancan;
+
+import com.typesafe.config.Config;
+import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.DBUtils;
+import org.broadinstitute.ddp.db.dao.JdbiUmbrellaStudy;
+import org.broadinstitute.ddp.exception.DDPException;
+import org.broadinstitute.ddp.studybuilder.task.CustomTask;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.nio.file.Path;
+
+@Slf4j
+public class PancanAngioRedirectRemoval implements CustomTask {
+
+    private Path cfgPath;
+    private Config studyCfg;
+    private Config varsCfg;
+    private SqlHelper sqlHelper;
+
+    @Override
+    public void init(Path cfgPath, Config studyCfg, Config varsCfg) {
+        this.cfgPath = cfgPath;
+        this.studyCfg = studyCfg;
+        this.varsCfg = varsCfg;
+    }
+
+    @Override
+    public void run(Handle handle) {
+        var studyDto = handle.attach(JdbiUmbrellaStudy.class).findByStudyGuid(studyCfg.getString("study.guid"));
+        if (!studyDto.getGuid().equals("cmi-pancan")) {
+            throw new DDPException("This task is only for the pancan study!");
+        }
+
+        sqlHelper = handle.attach(SqlHelper.class);
+
+        //find and delete the ANGIO study redirect workflow transition
+        long workflowTransitionId = sqlHelper.findPancanAngioStudyRedirectWorkflowId();
+        DBUtils.checkDelete(1, sqlHelper.updatePancanAngioRedirectPex(workflowTransitionId));
+        log.info("Deleted workflow transition with ID: {}", workflowTransitionId);
+
+        //update pex expressions to remove ANGIO (C_SARCOMAS_ANGIOSARCOMA)
+        int rowCount = sqlHelper.updatePancanAngioRedirectPex();
+        log.info("Updated {} rows in expression table", rowCount);
+    }
+
+
+    private interface SqlHelper extends SqlObject {
+
+        @SqlQuery("select trans.workflow_transition_id\n" +
+                "  from workflow_transition as trans\n" +
+                "  join umbrella_study as s on s.umbrella_study_id = trans.umbrella_study_id\n" +
+                "  join workflow_state as next_state on next_state.workflow_state_id = trans.next_state_id\n" +
+                "  join workflow_state_type as next_state_type on next_state_type.workflow_state_type_id = next_state.workflow_state_type_id\n" +
+                "  left join workflow_activity_state as next_act_state on next_act_state.workflow_state_id = next_state.workflow_state_id\n" +
+                "  left join expression as expr on expr.expression_id = trans.precondition_expression_id\n" +
+                "  left join workflow_study_redirect_state as next_redirect_state on next_redirect_state.workflow_state_id = next_state.workflow_state_id\n" +
+                " where s.guid = 'cmi-pancan'\n" +
+                "   and trans.is_active\n" +
+                "   and next_state_type.workflow_state_type_code = 'STUDY_REDIRECT'\n" +
+                "   and study_guid = 'ANGIO'")
+        long findPancanAngioStudyRedirectWorkflowId();
+
+        @SqlUpdate("delete workflow_transition  "
+                + "from workflow_transition "
+                + "where workflow_transition_id = :workflowTransitionId")
+        int updatePancanAngioRedirectPex(@Bind("workflowTransitionId") long workflowTransitionId);
+
+        @SqlUpdate("update expression  "
+                + "set expression_text = REPLACE(expression_text, '\"C_SARCOMAS_ANGIOSARCOMA\",', '')  "
+                + "where expression_text like '%hasOptionStartsWith(\"C_SARCOMAS_ANGIOSARCOMA\", \"C_GASTRO_ESOPHAGEAL_CANCER\"%' ")
+        int updatePancanAngioRedirectPex();
+
+    }
+
+
+}

--- a/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
+++ b/pepper-apis/studybuilder-cli/src/main/java/org/broadinstitute/ddp/studybuilder/task/pancan/PancanAngioRedirectRemoval.java
@@ -51,18 +51,18 @@ public class PancanAngioRedirectRemoval implements CustomTask {
 
     private interface SqlHelper extends SqlObject {
 
-        @SqlQuery("select trans.workflow_transition_id\n" +
-                "  from workflow_transition as trans\n" +
-                "  join umbrella_study as s on s.umbrella_study_id = trans.umbrella_study_id\n" +
-                "  join workflow_state as next_state on next_state.workflow_state_id = trans.next_state_id\n" +
-                "  join workflow_state_type as next_state_type on next_state_type.workflow_state_type_id = next_state.workflow_state_type_id\n" +
-                "  left join workflow_activity_state as next_act_state on next_act_state.workflow_state_id = next_state.workflow_state_id\n" +
-                "  left join expression as expr on expr.expression_id = trans.precondition_expression_id\n" +
-                "  left join workflow_study_redirect_state as next_redirect_state on next_redirect_state.workflow_state_id = next_state.workflow_state_id\n" +
-                " where s.guid = 'cmi-pancan'\n" +
-                "   and trans.is_active\n" +
-                "   and next_state_type.workflow_state_type_code = 'STUDY_REDIRECT'\n" +
-                "   and study_guid = 'ANGIO'")
+        @SqlQuery("select trans.workflow_transition_id "
+                + "  from workflow_transition as trans "
+                + "  join umbrella_study as s on s.umbrella_study_id = trans.umbrella_study_id "
+                + "  join workflow_state as next_state on next_state.workflow_state_id = trans.next_state_id "
+                + "  join workflow_state_type as next_state_type on next_state_type.workflow_state_type_id = next_state.workflow_state_type_id "
+                + "  left join workflow_activity_state as next_act_state on next_act_state.workflow_state_id = next_state.workflow_state_id "
+                + "  left join expression as expr on expr.expression_id = trans.precondition_expression_id "
+                + "  left join workflow_study_redirect_state as next_redirect_state on next_redirect_state.workflow_state_id = next_state.workflow_state_id "
+                + " where s.guid = 'cmi-pancan' "
+                + "   and trans.is_active "
+                + "   and next_state_type.workflow_state_type_code = 'STUDY_REDIRECT' "
+                + "   and study_guid = 'ANGIO'")
         long findPancanAngioStudyRedirectWorkflowId();
 
         @SqlUpdate("delete workflow_transition  "

--- a/pepper-apis/studybuilder-cli/studies/pancan/subs.conf
+++ b/pepper-apis/studybuilder-cli/studies/pancan/subs.conf
@@ -177,7 +177,7 @@
         )
         ||
         (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].numChildAnswers("PRIMARY_CANCER_CHILD") > 1
-          && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
+          && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
         )
       )
     """,
@@ -193,17 +193,17 @@
           ) &&
           !(
             (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") > 1
-              && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
+              && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"].answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
             )
             ||
             (user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].numChildAnswers("PRIMARY_CANCER_CHILD") > 1
-              && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
+              && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_CHILD"].children["PRIMARY_CANCER_CHILD"].answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
             )
           )
         )
      || ( user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].numChildAnswers("PRIMARY_CANCER_SELF") == 1
             && user.studies["cmi-pancan"].forms["PREQUAL"].questions["PRIMARY_CANCER_LIST_SELF"].children["PRIMARY_CANCER_SELF"]
-            .answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER")
+            .answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER")
             && !user.studies["cmi-pancan"].forms["PREQUAL"].questions["DESCRIBE"].answers.hasOption("CHILD_DIAGNOSED")
             && user.profile.language() == "en"
          )
@@ -542,7 +542,7 @@
     """,
     "addchild_has_cmi_legacy": """
       (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].numChildAnswers("PRIMARY_CANCER_ADD_CHILD") > 1
-          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
+          && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
       )
     """,
     "addchild_is_not_redirect": """
@@ -552,7 +552,7 @@
           ) &&
           !(
             (user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].numChildAnswers("PRIMARY_CANCER_ADD_CHILD") > 1
-              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOptionStartsWith("C_SARCOMAS_ANGIOSARCOMA", "C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
+              && user.studies["cmi-pancan"].forms["ADD_CHILD"].questions["PRIMARY_CANCER_LIST_ADD_CHILD"].children["PRIMARY_CANCER_ADD_CHILD"].answers.hasOptionStartsWith("C_GASTRO_ESOPHAGEAL_CANCER", "C_GASTRO_GASTRIC_STOMACH_CANCER", "C_GENITOURINARY_PROSTATE", "C_BREAST_")
             )
           )
         )


### PR DESCRIPTION
PEPPER-1388
remove angio study redirect from pancan now that angio enrollment is ending.

1. Remove/Delete the study_redirect workflow transition for Angiosarcoma
2. Several prequal pex expressions have "C_SARCOMAS_ANGIOSARCOMA" which check various conditions. Remove this from all pex expressions. No other study has this String C_SARCOMAS_ANGIOSARCOMA, so doing global search and replacing with a pancan related where clause.
below are the overall category of pex expressions which has all different study redirect substitutions. search and replace will cover all of these except has_angio. workflow_transition deletion will make has_angio obsolete (no usages)
"has_angio": """
has_cmi_legacy
is_not_redirect
is_redirect 

Verified locally applying the patch and looked fine.

3. StudyBuilder pancan subs.conf is just to keep config in sync with what patch is doing and patch doest use this file.