### PR TITLE
PEPPER-1527 in person kits from juniper

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -209,7 +209,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                     + "ON kit.dsm_kit_request_id = groupedKit.dsm_kit_request_id AND kit.dsm_kit_id = groupedKit.kit_id "
                     + "SET deactivated_date = ?,deactivation_reason = ?, deactivated_by = ? WHERE kit.dsm_kit_request_id = ?";
     private static final String INSERT_KIT =
-            "INSERT INTO ddp_kit (dsm_kit_request_id, easypost_address_id_to,  error, message, needs_approval) VALUES (?,?,?,?,?)";
+            "INSERT INTO ddp_kit (dsm_kit_request_id, easypost_address_id_to,  error, message, needs_approval, kit_complete, tracking_return_id, kit_label) VALUES (?,?,?,?,?,?,?,?)";
     private static final String UPDATE_KIT =
             "UPDATE ddp_kit SET label_url_to = ?, label_url_return = ?, easypost_to_id = ?, easypost_return_id = ?, tracking_to_id = ?, "
                     + "tracking_return_id = ?, easypost_tracking_to_url = ?, easypost_tracking_return_url = ?, error = ?, message = ?, "
@@ -945,9 +945,9 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                     errorMessage += "bspCollaboratorSampleId was too long ";
                 }
             }
-            writeRequest(instanceId, kitRequestId, kitTypeId, participantId, collaboratorParticipantId, collaboratorSampleId, "SYSTEM",
-                    null, errorMessage, externalOrderNumber, needsApproval, uploadReason, ddpInstance, bspCollaboratorSampleType,
-                    subkitsDdpLabel);
+            writeRequest(conn, instanceId, kitRequestId, kitTypeId, participantId, collaboratorParticipantId, collaboratorSampleId,
+                    "SYSTEM", null, errorMessage, externalOrderNumber, needsApproval, uploadReason, ddpInstance,
+                    bspCollaboratorSampleType, subkitsDdpLabel, false, null);
             return null;
         });
     }
@@ -962,60 +962,55 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
      *      4. BSP and Mercury dummy kit routes in non-prod
      * @return dsm_kit_request_id of the new kit
      * */
-    public static String writeRequest(@NonNull String instanceId, @NonNull String ddpKitRequestId, int kitTypeId,
+    public static String writeRequest(Connection conn, @NonNull String instanceId, @NonNull String ddpKitRequestId, int kitTypeId,
                                       @NonNull String ddpParticipantId, String bspCollaboratorParticipantId, String collaboratorSampleId,
                                       @NonNull String createdBy, String addressIdTo, String errorMessage, String externalOrderNumber,
                                       boolean needsApproval, String uploadReason, DDPInstance ddpInstance, String kitTypeName,
-                                      String subKitddpLabel) {
-
+                                      String subKitddpLabel, boolean isReturnOnly, String returnTrackingId, String kitLabel) {
         String ddpLabel = StringUtils.isBlank(subKitddpLabel)
                 ? (StringUtils.isNotBlank(externalOrderNumber) ? null : generateDdpLabelID()) : subKitddpLabel;
 
-        SimpleResult results = inTransaction(conn -> {
-            SimpleResult dbVals = new SimpleResult();
-            try (PreparedStatement insertKitRequest = conn.prepareStatement(INSERT_KIT_REQUEST, Statement.RETURN_GENERATED_KEYS)) {
-                insertKitRequest.setString(1, instanceId);
-                insertKitRequest.setString(2, ddpKitRequestId);
-                insertKitRequest.setInt(3, kitTypeId);
-                insertKitRequest.setString(4, ddpParticipantId);
-                insertKitRequest.setObject(5, bspCollaboratorParticipantId);
-                insertKitRequest.setObject(6, collaboratorSampleId);
-                insertKitRequest.setObject(7, ddpLabel); //ddp_label or shipping_id
-                insertKitRequest.setString(8, createdBy);
-                insertKitRequest.setLong(9, System.currentTimeMillis());
-                insertKitRequest.setObject(10,
-                        StringUtils.isNotBlank(externalOrderNumber) ? externalOrderNumber : null); //external_order_number
-                insertKitRequest.setString(11, uploadReason); //upload reason
-                insertKitRequest.executeUpdate();
-                try (ResultSet rs = insertKitRequest.getGeneratedKeys()) {
-                    if (rs.next()) {
-                        KitRequestShipping kitRequestShipping = new KitRequestShipping();
-                        kitRequestShipping.setDsmKitRequestId(rs.getInt(1));
-                        dbVals.resultValue = kitRequestShipping;
-                    }
-                } catch (Exception e) {
-                    throw new DsmInternalError("Error getting id of new kit request ", e);
+        SimpleResult dbVals = new SimpleResult();
+        try (PreparedStatement insertKitRequest = conn.prepareStatement(INSERT_KIT_REQUEST, Statement.RETURN_GENERATED_KEYS)) {
+            insertKitRequest.setString(1, instanceId);
+            insertKitRequest.setString(2, ddpKitRequestId);
+            insertKitRequest.setInt(3, kitTypeId);
+            insertKitRequest.setString(4, ddpParticipantId);
+            insertKitRequest.setObject(5, bspCollaboratorParticipantId);
+            insertKitRequest.setObject(6, collaboratorSampleId);
+            insertKitRequest.setObject(7, ddpLabel); //ddp_label or shipping_id
+            insertKitRequest.setString(8, createdBy);
+            insertKitRequest.setLong(9, System.currentTimeMillis());
+            insertKitRequest.setObject(10,
+                    StringUtils.isNotBlank(externalOrderNumber) ? externalOrderNumber : null); //external_order_number
+            insertKitRequest.setString(11, uploadReason); //upload reason
+            insertKitRequest.executeUpdate();
+            try (ResultSet rs = insertKitRequest.getGeneratedKeys()) {
+                if (rs.next()) {
+                    KitRequestShipping kitRequestShipping = new KitRequestShipping();
+                    kitRequestShipping.setDsmKitRequestId(rs.getInt(1));
+                    dbVals.resultValue = kitRequestShipping;
                 }
-            } catch (SQLException ex) {
-                dbVals.resultException = ex;
+            } catch (Exception e) {
+                throw new DsmInternalError("Error getting id of new kit request ", e);
             }
-            if (dbVals.resultException == null && dbVals.resultValue != null) {
-                KitRequestShipping kitRequestShipping = (KitRequestShipping) dbVals.resultValue;
-                SimpleResult simpleResultKitWriting = writeNewKit(conn, kitRequestShipping.getDsmKitRequestId(),
-                        addressIdTo, errorMessage, needsApproval);
-                kitRequestShipping.setDsmKitId((Long) simpleResultKitWriting.resultValue);
-                dbVals.resultValue = kitRequestShipping;
-            }
-            return dbVals;
-        });
+        } catch (SQLException ex) {
+            dbVals.resultException = ex;
+        }
+        if (dbVals.resultException == null && dbVals.resultValue != null) {
+            KitRequestShipping kitRequestShipping = (KitRequestShipping) dbVals.resultValue;
+            SimpleResult simpleResultKitWriting = writeNewKit(conn, kitRequestShipping.getDsmKitRequestId(),
+                    addressIdTo, errorMessage, needsApproval, isReturnOnly, returnTrackingId, kitLabel);
+            kitRequestShipping.setDsmKitId((Long) simpleResultKitWriting.resultValue);
+            dbVals.resultValue = kitRequestShipping;
+        }
 
-
-        if (results.resultException != null) {
-            throw new DsmInternalError("Error adding kit request  w/ ddpKitRequestId " + ddpKitRequestId, results.resultException);
+        if (dbVals.resultException != null) {
+            throw new DsmInternalError("Error adding kit request  w/ ddpKitRequestId " + ddpKitRequestId, dbVals.resultException);
         }
 
         if (Objects.nonNull(ddpInstance)) {
-            KitRequestShipping kitRequestShipping = (KitRequestShipping) results.resultValue;
+            KitRequestShipping kitRequestShipping = (KitRequestShipping) dbVals.resultValue;
             kitRequestShipping.setParticipantId(ddpParticipantId);
             kitRequestShipping.setBspCollaboratorParticipantId(bspCollaboratorParticipantId);
             kitRequestShipping.setBspCollaboratorSampleId(collaboratorSampleId);
@@ -1038,8 +1033,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                             new PutToNestedScriptBuilder()).export();
                 } catch (Exception e) {
                     logger.error(String.format("Error inserting newly created kit request shipping with dsm kit request id: %s in "
-                            + "ElasticSearch", kitRequestShipping.getDsmKitRequestId()));
-                    e.printStackTrace();
+                            + "ElasticSearch", kitRequestShipping.getDsmKitRequestId()), e);
                 }
             }
 
@@ -1050,7 +1044,8 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
     }
 
     private static SimpleResult writeNewKit(Connection conn, int kitRequestId, String addressIdTo, String errorMessage,
-                                            boolean needsApproval) {
+                                            boolean needsApproval, boolean isComplete, String returnTrackingId, String kitLabel) {
+        // todo arz pass through complete and return tracking
         SimpleResult dbVals = new SimpleResult(0);
         try (PreparedStatement insertKit = conn.prepareStatement(INSERT_KIT, Statement.RETURN_GENERATED_KEYS)) {
             insertKit.setInt(1, kitRequestId);
@@ -1066,13 +1061,16 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             }
             insertKit.setObject(4, errorMessage);
             insertKit.setBoolean(5, needsApproval);
+            insertKit.setBoolean(6, isComplete);
+            insertKit.setString(7, returnTrackingId);
+            insertKit.setString(8, kitLabel);
             insertKit.executeUpdate();
             try (ResultSet rs = insertKit.getGeneratedKeys()) {
                 if (rs.next()) {
                     dbVals.resultValue = rs.getLong(1);
                 }
             } catch (Exception e) {
-                throw new DsmInternalError("Error getting id of new kit request ", e);
+                throw new DsmInternalError("Error getting id of new kit request " + kitRequestId, e);
             }
         } catch (SQLException e) {
             dbVals.resultException = e;
@@ -1082,7 +1080,8 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
 
     // called by reactivation of a deactivated kit
     public static long writeNewKit(Integer kitRequestId, String addressIdTo, String errorMessage, boolean needsApproval) {
-        SimpleResult results = inTransaction(conn -> writeNewKit(conn, kitRequestId, addressIdTo, errorMessage, needsApproval));
+        SimpleResult results = inTransaction(conn -> writeNewKit(conn, kitRequestId, addressIdTo, errorMessage, needsApproval,
+                false, null, null));
 
         if (results.resultException != null) {
             logger.error("Error writing new kit w/ dsm_kit_id " + kitRequestId, results.resultException);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -947,7 +947,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             }
             writeRequest(conn, instanceId, kitRequestId, kitTypeId, participantId, collaboratorParticipantId, collaboratorSampleId,
                     "SYSTEM", null, errorMessage, externalOrderNumber, needsApproval, uploadReason, ddpInstance,
-                    bspCollaboratorSampleType, subkitsDdpLabel, false, null);
+                    bspCollaboratorSampleType, subkitsDdpLabel, false, null, null);
             return null;
         });
     }
@@ -1045,7 +1045,6 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
 
     private static SimpleResult writeNewKit(Connection conn, int kitRequestId, String addressIdTo, String errorMessage,
                                             boolean needsApproval, boolean isComplete, String returnTrackingId, String kitLabel) {
-        // todo arz pass through complete and return tracking
         SimpleResult dbVals = new SimpleResult(0);
         try (PreparedStatement insertKit = conn.prepareStatement(INSERT_KIT, Statement.RETURN_GENERATED_KEYS)) {
             insertKit.setInt(1, kitRequestId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -1071,7 +1071,6 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             } else {
                 insertKit.setNull(9, Types.INTEGER);
             }
-            // todo arz must set scan date
             insertKit.executeUpdate();
             try (ResultSet rs = insertKit.getGeneratedKeys()) {
                 if (rs.next()) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitStatusDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitStatusDao.java
@@ -184,7 +184,6 @@ public class KitStatusDao implements Dao<NonPepperKitStatusDto> {
         }
 
         private static boolean isSentKit(ResultSet foundKitResults) throws SQLException {
-//        and kit.kit_complete = 1 and kit.deactivated_date is null
             return ("1".equals(foundKitResults.getString(DBConstants.KIT_COMPLETE)))
                     && StringUtils.isBlank(foundKitResults.getString(DBConstants.DSM_DEACTIVATED_DATE))
                     && StringUtils.isBlank(foundKitResults.getString(DBConstants.DSM_RECEIVE_DATE))

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/JuniperKitRequest.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/JuniperKitRequest.java
@@ -21,4 +21,25 @@ public class JuniperKitRequest extends KitRequest {
     private String juniperParticipantID;
     private String juniperStudyID;
     private String easypostAddressId;
+
+    /**
+     * Carrier's return tracking id, set when the participant
+     * is preparing an in-person kit in the presence
+     * of study staff.
+     */
+    private String returnTrackingId;
+
+    /**
+     * Set to true when the kit should not be sent by mail
+     * to the participant.  Set to true when preparing in-person
+     * kits.
+     */
+    private boolean returnOnly;
+
+    /**
+     * The label on the physical kit, also known as
+     * kit barcode.  Set in conjunction with {@link #returnOnly}
+     * and {@link #returnTrackingId}
+     */
+    private String kitLabel;
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.route;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.dao.kit.BSPDummyKitDao;
@@ -44,11 +45,15 @@ public class CreateBSPDummyKitRoute implements Route {
                     KitRequestShipping.getCollaboratorSampleId(kitTypeId, participantCollaboratorId, DUMMY_KIT_TYPE_NAME, mockDdpInstance);
             if (ddpParticipantId != null) {
                 //if instance not null
-                String dsmKitRequestId = KitRequestShipping.writeRequest(mockDdpInstance.getDdpInstanceId(), mercuryKitRequestId, kitTypeId,
-                        ddpParticipantId, participantCollaboratorId, collaboratorSampleId,
-                        USER_ID, "", "", "", false, "", null,
-                        DUMMY_KIT_TYPE_NAME, null);
-                new BSPDummyKitDao().updateKitLabel(kitLabel, dsmKitRequestId);
+                TransactionWrapper.inTransaction(conn -> {
+                    String dsmKitRequestId = KitRequestShipping.writeRequest(conn, mockDdpInstance.getDdpInstanceId(), mercuryKitRequestId,
+                            kitTypeId, ddpParticipantId, participantCollaboratorId,
+                            collaboratorSampleId, USER_ID, "", "", "", false, "",
+                            null, DUMMY_KIT_TYPE_NAME, null, false, null);
+                    new BSPDummyKitDao().updateKitLabel(kitLabel, dsmKitRequestId);
+                    return null;
+                });
+
             }
             logger.info("Returning 200 to Mercury");
             response.status(200);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
@@ -49,7 +49,7 @@ public class CreateBSPDummyKitRoute implements Route {
                     String dsmKitRequestId = KitRequestShipping.writeRequest(conn, mockDdpInstance.getDdpInstanceId(), mercuryKitRequestId,
                             kitTypeId, ddpParticipantId, participantCollaboratorId,
                             collaboratorSampleId, USER_ID, "", "", "", false, "",
-                            null, DUMMY_KIT_TYPE_NAME, null, false, null);
+                            null, DUMMY_KIT_TYPE_NAME, null, false, null, null, null);
                     new BSPDummyKitDao().updateKitLabel(kitLabel, dsmKitRequestId);
                     return null;
                 });

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
@@ -140,7 +140,7 @@ public class CreateClinicalDummyKitRoute implements Route {
             String dsmKitRequestId  = TransactionWrapper.inTransaction(conn -> {
                 return KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestId, desiredKitType.getKitId(),
                                 ddpParticipantId.get(), participantCollaboratorId, collaboratorSampleId, USER_ID, "", "",
-                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null);
+                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null, null);
             });
             bspDummyKitDao.updateKitLabel(kitLabel, dsmKitRequestId);
             bspDummyKitDao.updateCollectionDate(dsmKitRequestId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
@@ -140,7 +140,7 @@ public class CreateClinicalDummyKitRoute implements Route {
             String dsmKitRequestId  = TransactionWrapper.inTransaction(conn -> {
                 return KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestId, desiredKitType.getKitId(),
                                 ddpParticipantId.get(), participantCollaboratorId, collaboratorSampleId, USER_ID, "", "",
-                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null, null);
+                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null, null, null);
             });
             bspDummyKitDao.updateKitLabel(kitLabel, dsmKitRequestId);
             bspDummyKitDao.updateCollectionDate(dsmKitRequestId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
@@ -3,8 +3,10 @@ package org.broadinstitute.dsm.route;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang3.StringUtils;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.KitType;
@@ -71,7 +73,7 @@ public class CreateClinicalDummyKitRoute implements Route {
         String kitLabel = request.params(RequestParameter.LABEL);
         String kitTypeString = request.params(RequestParameter.KIT_TYPE);
         String participantId = request.params(RequestParameter.PARTICIPANTID);
-        String ddpParticipantId;
+        final AtomicReference<String> ddpParticipantId = new AtomicReference<>();
         if (StringUtils.isBlank(kitLabel)) {
             logger.warn("Got a create Clinical Kit request without a kit label!!");
             response.status(500);
@@ -94,16 +96,16 @@ public class CreateClinicalDummyKitRoute implements Route {
         ElasticSearchParticipantDto esParticipantDto;
         if (StringUtils.isBlank(participantId)) {
             int tries = 0;
-            ddpParticipantId = new BSPDummyKitDao().getRandomParticipantForStudy(ddpInstance);
+            ddpParticipantId.set(new BSPDummyKitDao().getRandomParticipantForStudy(ddpInstance));
             esParticipantDto =
-                    ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId);
+                    ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId.get());
             // check the test participant is still valid, enrolled and haas a valid onc history,
             // if not choose a new one, for a max 10 tries.
             while (tries < 10 && (esParticipantDto.getProfile().map(Profile::getHruid).isEmpty()
                     || !participantIsEnrolled(esParticipantDto))) {
-                ddpParticipantId = new BSPDummyKitDao().getRandomParticipantForStudy(ddpInstance);
+                ddpParticipantId.set(new BSPDummyKitDao().getRandomParticipantForStudy(ddpInstance));
                 esParticipantDto =
-                        ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId);
+                        ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId.get());
                 tries++;
             }
             if (tries == 10) {
@@ -113,10 +115,10 @@ public class CreateClinicalDummyKitRoute implements Route {
             fixedParticipantId = true;
             Optional<String> maybeParticipantId =
                     participantDao.getParticipantFromCollaboratorParticipantId(participantId, ddpInstance.getDdpInstanceId());
-            ddpParticipantId = maybeParticipantId.orElseThrow();
+            ddpParticipantId.set(maybeParticipantId.orElseThrow());
             esParticipantDto =
                     ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(),
-                            ddpParticipantId);
+                            ddpParticipantId.get());
         }
         List<KitType> kitTypes = KitType.getKitTypes(ddpInstance.getName(), null);
         KitType desiredKitType = kitTypes.stream().filter(k -> kitTypeString.equalsIgnoreCase(k.getName())).findFirst().orElseThrow();
@@ -126,7 +128,7 @@ public class CreateClinicalDummyKitRoute implements Route {
             String participantCollaboratorId;
             if (!fixedParticipantId) {
                 participantCollaboratorId = KitRequestShipping
-                        .getCollaboratorParticipantId(ddpInstance, ddpParticipantId,
+                        .getCollaboratorParticipantId(ddpInstance, ddpParticipantId.get(),
                                 esParticipantDto.getProfile().map(Profile::getHruid).orElseThrow(), null);
             } else {
                 participantCollaboratorId = participantId;
@@ -135,10 +137,11 @@ public class CreateClinicalDummyKitRoute implements Route {
                     .getCollaboratorSampleId(desiredKitType.getKitId(), participantCollaboratorId, desiredKitType.getName(), ddpInstance);
             logger.info("Found collaboratorSampleId  " + collaboratorSampleId);
             //if instance not null
-            String dsmKitRequestId = KitRequestShipping
-                    .writeRequest(ddpInstance.getDdpInstanceId(), kitRequestId, desiredKitType.getKitId(), ddpParticipantId,
-                            participantCollaboratorId, collaboratorSampleId, USER_ID, "", "", "",
-                            false, "", ddpInstance, desiredKitType.getName(), null);
+            String dsmKitRequestId  = TransactionWrapper.inTransaction(conn -> {
+                return KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestId, desiredKitType.getKitId(),
+                                ddpParticipantId.get(), participantCollaboratorId, collaboratorSampleId, USER_ID, "", "",
+                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null);
+            });
             bspDummyKitDao.updateKitLabel(kitLabel, dsmKitRequestId);
             bspDummyKitDao.updateCollectionDate(dsmKitRequestId);
             logger.info("Inserted new " + kitTypeString + " for participant " + participantCollaboratorId);
@@ -158,7 +161,7 @@ public class CreateClinicalDummyKitRoute implements Route {
 
             if (fixedParticipantId) {
                 randomOncHistoryDetailId =
-                        bspDummyKitDao.getRandomOncHistoryForParticipant(ddpInstance.getName(), ddpParticipantId);
+                        bspDummyKitDao.getRandomOncHistoryForParticipant(ddpInstance.getName(), ddpParticipantId.get());
                 if (randomOncHistoryDetailId == null) {
                     return "Participant doesn't have an eligible onc history/tissue";
                 }
@@ -168,9 +171,9 @@ public class CreateClinicalDummyKitRoute implements Route {
                 randomOncHistoryDetailId = bspDummyKitDao.getRandomOncHistoryIdForStudy(ddpInstance.getName());
                 oncHistoryDetail =
                         OncHistoryDetail.getOncHistoryDetail(randomOncHistoryDetailId, ddpInstance.getName());
-                ddpParticipantId = oncHistoryDetail.getDdpParticipantId();
+                ddpParticipantId.set(oncHistoryDetail.getDdpParticipantId());
                 esParticipantDto =
-                        ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId);
+                        ElasticSearchUtil.getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId.get());
                 logger.info("found randomOncHistoryDetailId " + randomOncHistoryDetailId);
                 logger.info("found short id " + esParticipantDto.getProfile().map(Profile::getHruid));
                 // check the test participant is still valid, enrolled and haas a valid onc history,
@@ -181,10 +184,10 @@ public class CreateClinicalDummyKitRoute implements Route {
                         || !participantIsEnrolled(esParticipantDto))) {
                     randomOncHistoryDetailId = bspDummyKitDao.getRandomOncHistoryIdForStudy(ddpInstance.getName());
                     oncHistoryDetail = OncHistoryDetail.getOncHistoryDetail(randomOncHistoryDetailId, ddpInstance.getName());
-                    ddpParticipantId = oncHistoryDetail.getDdpParticipantId();
+                    ddpParticipantId.set(oncHistoryDetail.getDdpParticipantId());
                     esParticipantDto =
                             ElasticSearchUtil
-                                    .getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId);
+                                    .getParticipantESDataByParticipantId(ddpInstance.getParticipantIndexES(), ddpParticipantId.get());
                     logger.info("found randomOncHistoryDetailId " + randomOncHistoryDetailId);
                     logger.info("found short id " + esParticipantDto.getProfile().map(Profile::getHruid));
                     tries++;
@@ -210,7 +213,7 @@ public class CreateClinicalDummyKitRoute implements Route {
                     throw new DsmInternalError("Couldn't create a new tissue for the participant" + ddpParticipantId);
                 }
                 String shortId = esParticipantDto.getProfile().map(Profile::getHruid).get();
-                addCollaboratorSampleId(tissueId, ddpInstance, ddpParticipantId, shortId);
+                addCollaboratorSampleId(tissueId, ddpInstance, ddpParticipantId.get(), shortId);
             }
             new TissueSMIDDao().createNewSMIDForTissueWithValue(tissueId, ffpeUser, smIdType, kitLabel);
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
@@ -380,9 +380,9 @@ public class KitUploadRoute extends RequestHandler {
             collaboratorSampleId =
                     KitRequestShipping.generateBspSampleID(conn, collaboratorParticipantId, bspCollaboratorSampleType, kitTypeId,
                             ddpInstance);
-            KitRequestShipping.writeRequest(ddpInstance.getDdpInstanceId(), shippingId, kitTypeId, kit.getParticipantId().trim(),
-                    collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, externalOrderNumber, false,
-                    uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel);
+            KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
+                    kit.getParticipantId().trim(), collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, externalOrderNumber,
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null);
             kit.setDdpLabel(shippingId);
             kit.setExternalOrderNumber(externalOrderNumber);
         } else {
@@ -408,9 +408,9 @@ public class KitUploadRoute extends RequestHandler {
                 participantID = kit.getParticipantId().trim();
             }
 
-            KitRequestShipping.writeRequest(ddpInstance.getDdpInstanceId(), shippingId, kitTypeId, participantID,
-                    collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, kit.getExternalOrderNumber(), false,
-                    uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel);
+            KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
+                    participantID, collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, kit.getExternalOrderNumber(),
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null,);
             kit.setDdpLabel(shippingId);
         }
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
@@ -382,7 +382,7 @@ public class KitUploadRoute extends RequestHandler {
                             ddpInstance);
             KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
                     kit.getParticipantId().trim(), collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, externalOrderNumber,
-                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null);
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null);
             kit.setDdpLabel(shippingId);
             kit.setExternalOrderNumber(externalOrderNumber);
         } else {
@@ -410,7 +410,7 @@ public class KitUploadRoute extends RequestHandler {
 
             KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
                     participantID, collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, kit.getExternalOrderNumber(),
-                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null,);
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null);
             kit.setDdpLabel(shippingId);
         }
     }

--- a/pepper-apis/dsm-core/src/main/resources/application.conf
+++ b/pepper-apis/dsm-core/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 portal {
     maxConnections: 25,
+    defaultTimezone: "UTC",
 
     kit_query:"""
         select

--- a/pepper-apis/dsm-core/src/main/resources/application.conf
+++ b/pepper-apis/dsm-core/src/main/resources/application.conf
@@ -1,6 +1,5 @@
 portal {
     maxConnections: 25,
-    defaultTimezone: "UTC",
 
     kit_query:"""
         select

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
@@ -139,6 +139,7 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
         createNonPepperTestKit(juniperTestKit);
         KitResponse kitResponse = nonPepperStatusKitService.getKitsBasedOnJuniperKitId(juniperTestKit.getJuniperKitId());
 
+        // kit requests that are marked as return only should come back as "SENT" as soon as they are created
         verifyStatusKitResponse(kitResponse, juniperTestKit, rand, KitCurrentStatus.SENT.getValue());
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
@@ -76,7 +76,6 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
 
     @BeforeClass
     public static void setupJuniperBefore() {
-
         juniperKitUtil =
                 new KitTestUtil(instanceName, instanceGuid, "JuniperTestProject",  "Juniper-Group", "SALIVA", "SALIVA", null, true);
         juniperKitUtil.setupInstanceAndSettings();
@@ -128,6 +127,19 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
         KitResponse kitResponse = nonPepperStatusKitService.getKitsBasedOnJuniperKitId(juniperTestKit.getJuniperKitId());
 
         verifyStatusKitResponse(kitResponse, juniperTestKit, rand, KitCurrentStatus.KIT_WITHOUT_LABEL.getValue());
+    }
+
+    @Test
+    public void testReturnOnlyKit() {
+        int rand = new Random().nextInt() & Integer.MAX_VALUE;
+        JuniperKitRequest juniperTestKit = generateJuniperKitRequest(rand);
+        juniperTestKit.setReturnOnly(true);
+        juniperTestKit.setKitLabel(juniperTestKit.getParticipantId() + ".kit");
+        juniperTestKit.setReturnTrackingId(juniperTestKit.getJuniperParticipantID() + ".tracking");
+        createNonPepperTestKit(juniperTestKit);
+        KitResponse kitResponse = nonPepperStatusKitService.getKitsBasedOnJuniperKitId(juniperTestKit.getJuniperKitId());
+
+        verifyStatusKitResponse(kitResponse, juniperTestKit, rand, KitCurrentStatus.SENT.getValue());
     }
 
     @Test

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
@@ -22,11 +22,10 @@ import com.easypost.model.Parcel;
 import com.easypost.model.PostageLabel;
 import com.easypost.model.Shipment;
 import com.easypost.model.Tracker;
-import com.typesafe.config.Config;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.broadinstitute.ddp.util.ConfigManager;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.KitRequestCreateLabel;
 import org.broadinstitute.dsm.db.KitRequestShipping;
@@ -42,7 +41,6 @@ import org.broadinstitute.dsm.model.kit.ScanResult;
 import org.broadinstitute.dsm.route.kit.KitPayload;
 import org.broadinstitute.dsm.route.kit.SentAndFinalScanPayload;
 import org.broadinstitute.dsm.service.admin.UserAdminTestUtil;
-import org.broadinstitute.dsm.util.DSMConfig;
 import org.broadinstitute.dsm.util.EasyPostUtil;
 import org.broadinstitute.dsm.util.KitUtil;
 import org.broadinstitute.dsm.util.NotificationUtil;
@@ -471,10 +469,11 @@ public class KitTestUtil {
     public String createKitRequestShipping(KitRequestShipping kitRequestShipping, DDPInstance ddpInstance,
                                            String userId) {
 
-        return KitRequestShipping.writeRequest(ddpInstance.getDdpInstanceId(), kitRequestShipping.getDdpKitRequestId(), kitTypeId,
-                kitRequestShipping.getDdpParticipantId(), kitRequestShipping.getBspCollaboratorParticipantId(),
-                kitRequestShipping.getBspCollaboratorSampleId(), userId, null, null, null, false, null,
-                ddpInstance, kitTypeName, null);
+        return TransactionWrapper.inTransaction(conn ->
+                KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestShipping.getDdpKitRequestId(),
+                        kitTypeId, kitRequestShipping.getDdpParticipantId(),
+                        kitRequestShipping.getBspCollaboratorParticipantId(), kitRequestShipping.getBspCollaboratorSampleId(), userId, null, null, null, false,
+                        null, ddpInstance, kitTypeName, null, false, kitRequestShipping.getTrackingReturnId(), kitRequestShipping.getKitLabel()));
     }
 
     public void createEventsForDDPInstance(String eventName, String eventType, String eventDescription, boolean nullKitType) {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
@@ -473,7 +473,7 @@ public class KitTestUtil {
                 KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestShipping.getDdpKitRequestId(),
                         kitTypeId, kitRequestShipping.getDdpParticipantId(),
                         kitRequestShipping.getBspCollaboratorParticipantId(), kitRequestShipping.getBspCollaboratorSampleId(), userId, null, null, null, false,
-                        null, ddpInstance, kitTypeName, null, false, kitRequestShipping.getTrackingReturnId(), kitRequestShipping.getKitLabel()));
+                        null, ddpInstance, kitTypeName, null, false, kitRequestShipping.getTrackingReturnId(), kitRequestShipping.getKitLabel(), null));
     }
 
     public void createEventsForDDPInstance(String eventName, String eventType, String eventDescription, boolean nullKitType) {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
@@ -95,7 +95,7 @@ public class KitShippingTestUtil {
         String kitReqestIdStr = TransactionWrapper.inTransaction(conn ->
                 KitRequestShipping.writeRequest(conn, instanceDto.getDdpInstanceId().toString(), dsmKitRequestId,
                         kitTypeId, participant.getDdpParticipantIdOrThrow(), "test", "test", testUser, "test", "",
-                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null));
+                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null, null, null));
         return Integer.parseInt(kitReqestIdStr);
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.dao.kit.KitDao;
@@ -91,10 +92,10 @@ public class KitShippingTestUtil {
     public int createKitShipping(ParticipantDto participant, DDPInstanceDto instanceDto, String kitTypeName, int kitTypeId) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstance(instanceDto.getInstanceName());
         String dsmKitRequestId = genDsmKitRequestId();
-        String kitReqestIdStr = KitRequestShipping.writeRequest(instanceDto.getDdpInstanceId().toString(),
-                dsmKitRequestId, kitTypeId, participant.getDdpParticipantIdOrThrow(),
-                "test", "test", testUser, "test", "", "test",
-                false, null, ddpInstance, kitTypeName, dsmKitRequestId);
+        String kitReqestIdStr = TransactionWrapper.inTransaction(conn ->
+                KitRequestShipping.writeRequest(conn, instanceDto.getDdpInstanceId().toString(), dsmKitRequestId,
+                        kitTypeId, participant.getDdpParticipantIdOrThrow(), "test", "test", testUser, "test", "",
+                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null));
         return Integer.parseInt(kitReqestIdStr);
     }
 


### PR DESCRIPTION
## Context

PEPPER-1527 adds a few new fields to the endpoint that juniper uses to make a kit request in order to support "in-person" kits, whereby participants complete a kit in-person, obviating the need to ship the kit to the participant. The new fields are `returnTrackingId`, `returnOnly`, and `kitLabel`.  More information about what these fields do is [here](https://github.com/broadinstitute/ddp-study-server/pull/2935/files#r1761772405).

When `returnOnly` is set, a kit is created at the same time the kit request is made, the kit is given a scan date of today, and the kit is marked as complete.  This ensures that the kit requests do not appear in DSM's "kits without label" queue.  The kit can still be queried in DSM, but since the kit does not need to be shipped, it's paramount that the kit does not appear in a worklist of kits to be mailed.

Beyond changing the json coming over from juniper, most of the changes flow from passing through these additional params through methods in `NonPepperKitCreationService`.

Along the way, I noticed that some aspects of kit request creation went across transactions, so I did some clean up to pass around `conn` so that the endpoint is a little bit more atomic.

## FUD Score

_Overall, how are you feeling about these changes?_

- [x ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

Hop over to juniper and use the admin pages to scan in a kit for a participant.  Then come back to DSM and you should be able to query the kit, but it should not be available in the kits without label view.

## Testing

- [x ] I have written automated positive tests

## Release

- [x ] These changes require no special release procedures--just code!

