### PR TITLE
PEPPER-1389 . handle scenarios where auth0 user_id was set into token 

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
@@ -28,6 +28,7 @@ import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.AuthDao;
 import org.broadinstitute.ddp.db.dao.ClientDao;
+import org.broadinstitute.ddp.db.dao.JdbiAuth0Tenant;
 import org.broadinstitute.ddp.db.dao.UserDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.exception.DDPTokenException;
@@ -182,6 +183,15 @@ public class JWTConverter {
                     try {
                         DecodedJWT validToken = verifyDDPToken(jwt, jwkProvider);
                         String ddpUserGuid = validToken.getClaim(Auth0Constants.DDP_USER_ID_CLAIM).asString();
+                        //handle if auth0 user_id was set rather than user guid
+                        if (ddpUserGuid != null && ddpUserGuid.startsWith("auth0")) {
+                            long tenantId = handle.attach(JdbiAuth0Tenant.class).findByDomain(auth0Domain).getId();
+                            User user = handle.attach(UserDao.class).findUserByAuth0UserId(ddpUserGuid, tenantId).orElse(null);
+                            if (user != null) {
+                                ddpUserGuid = user.getGuid();
+                            }
+                        }
+
                         UserPermissions userPermissions = handle.attach(AuthDao.class)
                                 .findUserPermissions(ddpUserGuid, auth0ClientId, auth0Domain);
                         userProfile = findUserProfile(handle, ddpUserGuid);


### PR DESCRIPTION
PEPPER-1389
Experimental code to handle scenarios where auth0 user_id was set into token claim rather than user guid specifically for PRION as part of auth0 rule migration. 

Need to do some testing in DEV post merging. 
This is needed because cant seem to get user AppMetadata updated like we did in rules. 
For non prion setting it from temp userguid and prion doesnt have prequal/temp user guids. 

As of now experimental and will revert if needed or if alternative is found.