### PR TITLE
PEPPER-1389 Migrate auth0 rules to actions

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -180,7 +180,7 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
                 operatorUser = pair.getOperatorUser();
                 if (!payload.skipTriggerEvents()) {
                     triggerUserRegisteredEvents(handle, study, operatorUser, pair.getParticipantUser());
-                    //publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
+                    publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
                 } else {
                     log.warn("Skipped triggering events & publishing participant-registered event for {}", operatorUser.getGuid());
                 }
@@ -260,7 +260,7 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
             log.info("Assigned invitation {} of type {} to participant user {}", invitation.getInvitationGuid(),
                     invitation.getInvitationType(), pair.getParticipantUser().getGuid());
             triggerUserRegisteredEvents(handle, study, pair.getOperatorUser(), pair.getParticipantUser());
-            //publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
+            publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
             return pair.getOperatorUser();
         } else {
             throw new DDPException("Unhandled invitation type " + invitation.getInvitationType());

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
+import org.broadinstitute.ddp.client.ApiResult;
 import org.broadinstitute.ddp.client.Auth0ManagementClient;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -179,7 +180,7 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
                 operatorUser = pair.getOperatorUser();
                 if (!payload.skipTriggerEvents()) {
                     triggerUserRegisteredEvents(handle, study, operatorUser, pair.getParticipantUser());
-                    publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
+                    //publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
                 } else {
                     log.warn("Skipped triggering events & publishing participant-registered event for {}", operatorUser.getGuid());
                 }
@@ -259,7 +260,7 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
             log.info("Assigned invitation {} of type {} to participant user {}", invitation.getInvitationGuid(),
                     invitation.getInvitationType(), pair.getParticipantUser().getGuid());
             triggerUserRegisteredEvents(handle, study, pair.getOperatorUser(), pair.getParticipantUser());
-            publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
+            //publishRegisteredPubSubMessage(studyGuid, pair.getParticipantUser().getGuid());
             return pair.getOperatorUser();
         } else {
             throw new DDPException("Unhandled invitation type " + invitation.getInvitationType());
@@ -591,13 +592,30 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
             log.info("User {} has auth0 account, proceeding to sync user_metadata", user.getGuid());
             Map<String, Object> metadata = new HashMap<>();
             metadata.put(User.METADATA_LANGUAGE, languageDto.getIsoCode());
-            var result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserMetadata(auth0UserId, metadata);
-            if (result.hasThrown() || result.hasError()) {
-                var e = result.hasThrown() ? result.getThrown() : result.getError();
-                log.error("Error while updating user_metadata for user {}, user's language may be out-of-sync", user.getGuid(), e);
-            } else {
-                log.info("Updated user_metadata for user {}", user.getGuid());
-            }
+            metadata.put("user_guid", user.getGuid());
+            syncAuth0Metadata(handle, user, auth0UserId, metadata, false);
+
+            //sync user AppMetaData
+            log.info("User {} : proceeding to sync app_metadata", user.getGuid());
+            Map<String, Object> appMetadata = new HashMap<>();
+            metadata.put("study_guid", payload.getStudyGuid());
+            appMetadata.put("user_guid", user.getGuid());
+            syncAuth0Metadata(handle, user, auth0UserId, appMetadata, true);
+        }
+    }
+
+    private static void syncAuth0Metadata(Handle handle, User user, String auth0UserId, Map<String, Object> metadata, boolean appMetadata) {
+        ApiResult result;
+        if (appMetadata) {
+            result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserAppMetadata(auth0UserId, metadata);
+        } else {
+            result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserAppMetadata(auth0UserId, metadata);
+        }
+        if (result.hasThrown() || result.hasError()) {
+            var e = result.hasThrown() ? result.getThrown() : result.getError();
+            log.error("Error while updating user_metadata for user {}, user's language may be out-of-sync", user.getGuid(), e);
+        } else {
+            log.info("Updated user_metadata for user {}", user.getGuid());
         }
     }
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/security/JWTConverter.java
@@ -28,7 +28,6 @@ import org.broadinstitute.ddp.constants.RouteConstants;
 import org.broadinstitute.ddp.db.TransactionWrapper;
 import org.broadinstitute.ddp.db.dao.AuthDao;
 import org.broadinstitute.ddp.db.dao.ClientDao;
-import org.broadinstitute.ddp.db.dao.JdbiAuth0Tenant;
 import org.broadinstitute.ddp.db.dao.UserDao;
 import org.broadinstitute.ddp.db.dao.UserProfileDao;
 import org.broadinstitute.ddp.exception.DDPTokenException;
@@ -183,15 +182,6 @@ public class JWTConverter {
                     try {
                         DecodedJWT validToken = verifyDDPToken(jwt, jwkProvider);
                         String ddpUserGuid = validToken.getClaim(Auth0Constants.DDP_USER_ID_CLAIM).asString();
-                        //handle if auth0 user_id was set rather than user guid
-                        if (ddpUserGuid != null && ddpUserGuid.startsWith("auth0")) {
-                            long tenantId = handle.attach(JdbiAuth0Tenant.class).findByDomain(auth0Domain).getId();
-                            User user = handle.attach(UserDao.class).findUserByAuth0UserId(ddpUserGuid, tenantId).orElse(null);
-                            if (user != null) {
-                                ddpUserGuid = user.getGuid();
-                            }
-                        }
-
                         UserPermissions userPermissions = handle.attach(AuthDao.class)
                                 .findUserPermissions(ddpUserGuid, auth0ClientId, auth0Domain);
                         userProfile = findUserProfile(handle, ddpUserGuid);

--- a/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
@@ -30,7 +30,7 @@
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
   },
   "AUTH0_ALLOW_DELETE": false,
 

--- a/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
@@ -29,8 +29,8 @@
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
-    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
-    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
+    "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   },
   "AUTH0_ALLOW_DELETE": false,
 

--- a/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
@@ -7,8 +7,6 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
-  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     "LOCALHOST_CALLBACKS": ",http://localhost:4200/auth, http://localhost:4200/login-landing",
@@ -29,7 +27,10 @@
     "LOGIN_DOMAIN": "{{$conf.auth0.loginDomain}}",
     "ASSETS_BUCKET": "{{$conf.assetsBucketName}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
-    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
+    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
+    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
+    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
   },
   "AUTH0_ALLOW_DELETE": false,
 

--- a/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/atcp-config.json.ctmpl
@@ -7,6 +7,8 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
+  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     "LOCALHOST_CALLBACKS": ",http://localhost:4200/auth, http://localhost:4200/login-landing",

--- a/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
@@ -7,8 +7,6 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
-  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
 
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
@@ -27,6 +25,9 @@
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
     "DB_NAME": "{{$conf.auth0.dbName}}"
+    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
+    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
@@ -24,7 +24,7 @@
     "STUDY_EMAIL": "{{$conf.studyEmail}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
-    "DB_NAME": "{{$conf.auth0.dbName}}"
+    "DB_NAME": "{{$conf.auth0.dbName}}",
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
     "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"

--- a/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
@@ -7,6 +7,9 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
+  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
+
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     "LOCALHOST_CALLBACKS": ",http://localhost:4200/auth,http://localhost:4200/login-landing,https://brugada-dot-broad-ddp-dev.uc.r.appspot.com/auth,https://brugada-dot-broad-ddp-dev.uc.r.appspot.com/login-landing",

--- a/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
@@ -26,8 +26,8 @@
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
     "DB_NAME": "{{$conf.auth0.dbName}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
-    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
-    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
+    "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/brugada-config.json.ctmpl
@@ -27,7 +27,7 @@
     "DB_NAME": "{{$conf.auth0.dbName}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
@@ -7,6 +7,8 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.domain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.clientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.clientSecret}}",
+  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     {{/* These end up in a yaml inlined list, so the comma in front is needed. */}}

--- a/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
@@ -52,7 +52,7 @@
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
@@ -51,8 +51,8 @@
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
-    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
-    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
+    "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
@@ -7,8 +7,6 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.domain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.clientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.clientSecret}}",
-  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     {{/* These end up in a yaml inlined list, so the comma in front is needed. */}}
@@ -52,6 +50,9 @@
     "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
+    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
+    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/cmi-config.json.ctmpl
@@ -49,8 +49,8 @@
     "LOGIN_DOMAIN": "{{$conf.auth0.loginDomain}}",
     "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
-    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
-    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
+    "AUTH0_DOMAIN": "{{$conf.auth0.domain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
     "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
   },

--- a/pepper-apis/studybuilder-cli/config/prion-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/prion-config.json.ctmpl
@@ -30,7 +30,11 @@
     "LOGIN_DOMAIN": "{{$conf.auth0.loginDomain}}",
     "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
-    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
+    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
+    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
+
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
@@ -7,8 +7,6 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
-  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     "LOCALHOST_ADMIN_CALLBACKS": ",http://localhost:4200/auth,http://localhost:4200/admin-login-landing",
@@ -35,6 +33,9 @@
     "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
+    "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
+    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
+    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
@@ -34,8 +34,8 @@
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
-    "AUTH0_MGMT_CLIENT_ID": "p1ySwZVs9BG5DY8mXeAvFUd3O1jqSfIx",
-    "AUTH0_MGMT_CLIENT_SECRET": "_7IkqACQ8N4FsVTGkuNOyt8SnikZqFmMmZcMsYEfwdMWbUfOMQsrvHvv0Q6ecB5T"
+    "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
@@ -7,6 +7,8 @@
   "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
   "AUTH0_CLIENT_ID": "{{$conf.auth0.deployClientId}}",
   "AUTH0_CLIENT_SECRET": "{{$conf.auth0.deployClientSecret}}",
+  "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
+  "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
   "AUTH0_KEYWORD_REPLACE_MAPPINGS": {
   {{if eq $environment "dev"}}
     "LOCALHOST_ADMIN_CALLBACKS": ",http://localhost:4200/auth,http://localhost:4200/admin-login-landing",

--- a/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
@@ -35,7 +35,7 @@
     "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
-    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}",
+    "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"
   },
   "AUTH0_ALLOW_DELETE": false,
   "INCLUDED_PROPS": {

--- a/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
+++ b/pepper-apis/studybuilder-cli/config/rgp-config.json.ctmpl
@@ -32,7 +32,7 @@
     "ASSETS_BUCKET": "{{$conf.assetsBucketName}}",
     "SERVER_BASE_URL": "{{$conf.serverBaseUrl}}",
     "SENDGRID_EMAIL": "{{$conf.sendgridFromEmail}}",
-    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}"
+    "SENDGRID_TOKEN": "{{$conf.sendgridApiKey}}",
     "AUTH0_DOMAIN": "{{$conf.auth0.deployDomain}}",
     "AUTH0_MGMT_CLIENT_ID": "{{$conf.auth0.mgmtClientId}}",
     "AUTH0_MGMT_CLIENT_SECRET": "{{$conf.auth0.mgmtSecret}}"

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
@@ -64,7 +64,7 @@ exports.onExecutePostLogin = async (event, api) => {
         })
       );
 
-      return api.access.deny(error.message);
+      return api.access.deny(JSON.stringify(error));
     });
   } else {
     return;

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
@@ -16,7 +16,7 @@ exports.onExecutePostLogin = async (event, api) => {
    * was previously executed in the transaction in order to avoid duplication
    * of logic.
    */
-  if (api.rules.wasExecuted("change_me")) {
+  if (api.rules.wasExecuted("rul_bL3jV04z2KADpdx9")) {
     return;
   }
 

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
@@ -1,0 +1,83 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Force email verification
+ * Created on 9/24/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  /**
+   * The following code block will skip this Action if Rule "Force email verification"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("change_me")) {
+    return;
+  }
+
+  // YOUR_CODE_HERE
+  console.log('Received user', event.user);
+  console.log('Received context', event);
+
+  const auth0Sdk = require("auth0");
+  if (!event.user.email_verified) {
+    const ManagementClient = auth0Sdk.ManagementClient;
+    // This will make an Authentication API call
+    const managementClientInstance = new ManagementClient({
+      // These come from a machine-to-machine application
+      domain: event.secrets.M2M_DOMAIN,
+      clientId: event.secrets.M2M_CLIENT_ID,
+      clientSecret: event.secrets.M2M_CLIENT_SECRET,
+      scope: "update:users"
+    });
+
+    const params = {
+      user_id: event.user.user_id,
+      client_id: event.client.client_id,
+    };
+
+    console.log('Attempt to resend a confirmation email');
+
+    managementClientInstance.jobs.verifyEmail(params, function (err) {
+      if (err) {
+        console.log(
+          'Request to resend a confirmation email failed',
+          'The error is',
+          err
+        );
+      } else {
+        console.log(
+          'Successfully created a job to resend a confirmation email'
+        );
+      }
+
+      const error = new Error(
+        JSON.stringify({
+          code: 'unauthorized',
+          message: 'You have to confirm your email address before continuing.',
+          statusCode: 401,
+        })
+      );
+
+      return api.access.deny(error.message);
+    });
+  } else {
+    return;
+  }
+}
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
@@ -1,0 +1,77 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Google Sign In Restriction
+ * Rule ID: rul_
+ * Created on 9/24/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  /**
+   * The following code block will skip this Action if Rule "Google Sign In Restriction"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("change_me")) {
+    return;
+  }
+
+  // YOUR_CODE_HERE
+  const GOOGLE_CONNECTION_IDENTIFIER = 'google-oauth2';
+
+  const app_metadata = event.user.app_metadata || {};
+  const pepperUserGuid = event.user.app_metadata.user_guid;
+  const connectionType = event.connection.name;
+  console.log('Connection: ' + JSON.stringify(event.connection));
+
+  if (connectionType === GOOGLE_CONNECTION_IDENTIFIER) {
+    if (pepperUserGuid) {
+      console.log('All good, user has pepper_user_guid: ' + pepperUserGuid);
+      return;
+    } else {
+      /**
+       * User was not registered in pepper yet
+       */
+      console.log('Nooo, there is no pepper user guid...', { pepperUserGuid });
+      console.log('User', JSON.stringify(event.user));
+      console.log('Event', JSON.stringify(event));
+
+      const request = event.request || {};
+      const query = request.query || {};
+
+      const tempUserGuid = query.temp_user_guid;
+
+      if (!tempUserGuid) {
+        console.log('There is no temp user guid...', { tempUserGuid });
+
+        const loginErrPayload = {
+          code: 'prequal_skipped',
+          message: 'You have to complete prequal first in order to proceed',
+          statusCode: 422,
+        };
+        return api.access.deny(loginErrPayload.message);
+      } else {
+        console.log('Temp user guid is set to: ' + tempUserGuid);
+        return;
+      }
+    }
+  } else {
+    return;
+  }
+};
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
@@ -1,7 +1,7 @@
 /**
  * This Action was migrated from Rule.
  * Rule name: Google Sign In Restriction
- * Rule ID: rul_
+ * Rule ID: rul_nSlTGpLpwQlfA278
  * Created on 9/24/2024
  */
 
@@ -17,7 +17,7 @@ exports.onExecutePostLogin = async (event, api) => {
    * was previously executed in the transaction in order to avoid duplication
    * of logic.
    */
-  if (api.rules.wasExecuted("change_me")) {
+  if (api.rules.wasExecuted("rul_nSlTGpLpwQlfA278")) {
     return;
   }
 

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/google-signin-restriction.js
@@ -54,7 +54,7 @@ exports.onExecutePostLogin = async (event, api) => {
           message: 'You have to complete prequal first in order to proceed',
           statusCode: 422,
         };
-        return api.access.deny(loginErrPayload.message);
+        return api.access.deny(JSON.stringify(loginErrPayload));
       } else {
         console.log('Temp user guid is set to: ' + tempUserGuid);
         return;

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -1,30 +1,9 @@
 tenant:
   default_directory: Username-Password-Authentication
 
-rules:
-  - name: Google Sign In Restriction
-    script: ./rules/google-signin-restriction.js
-    stage: login_success
-    enabled: false
-    order: 1
-  - name: Force email verification
-    script: ./rules/force-email-verification.js
-    enabled: true
-    order: 2
-  - name: Check user is signed up
-    script: ./rules/check-user-is-signedup.js
-    stage: login_success
-    enabled: false
-    order: 3
-  - name: Register User in Pepper
-    script: ../register-user-in-pepper.js
-    stage: login_success
-    enabled: false
-    order: 4
-
 actions:
   - name: Force email verification
-    code: ../actions/force-email-verification.js
+    code: ./actions/force-email-verification.js
     runtime: node18
     dependencies:
       - name: auth0
@@ -43,22 +22,18 @@ actions:
         version: v3
 
   - name: Google Sign In Restriction
-    code: ../actions/google-signin-restriction.js
+    code: ./actions/google-signin-restriction.js
     deployed: false
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
   - name: Register User in Pepper
-    code: ../register-user-in-pepper-action.js
+    code: ./actions/register-user-in-pepper-action.js
     dependencies:
       - name: request
         version: 2.88.2
-      - name: google-cloud/logging
-        version: 11.2.0
-      - name: auth0
-        version: 4.10.0
     deployed: false
     secrets:
       - name: pepperBaseUrl
@@ -72,7 +47,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
 triggers:
   post-login:
@@ -86,67 +61,3 @@ triggers:
       display_name: Register User in Pepper
       order: 3
 
-pages:
-  - name: guardian_multifactor
-    enabled: false
-    html: ./pages/guardian_multifactor.html
-  - name: login
-    enabled: true
-    html: ./pages/login.html
-  - name: password_reset
-    enabled: true
-    html: ./pages/password_reset.html
-
-emailProvider:
-  name: "sendgrid"
-  enabled: true
-  default_from_address: ##SENDGRID_EMAIL##
-  credentials:
-    api_key: ##SENDGRID_TOKEN##
-
-emailTemplates:
-  - template: reset_email
-    body: ./emailTemplates/reset_email.html
-    from: A-T Project <##STUDY_EMAIL##>
-    resultUrl: '{{ application.callback_domain }}/dashboard'
-    subject: Global A-T Family Data Platform | Reset Password Instructions
-    urlLifetimeInSeconds: 432000
-    syntax: liquid
-    enabled: true
-  - template: verify_email
-    body: ./emailTemplates/verify_email.html
-    from: A-T Project <##STUDY_EMAIL##>
-    resultUrl: '{{ application.callback_domain }}/account-activated'
-    subject: Global AT-Family Data Platform | Activate Account Notification
-    urlLifetimeInSeconds: 432000
-    syntax: liquid
-    enabled: true
-
-# NOTE: client names must match what's in Auth0's dashboard, otherwise deploy
-# will create new clients. Everytime deploy happens, client configurations here
-# will overwrite what's in Auth0. If there are additional urls not in here then
-# those need to be added back manually. Other settings not configured here will
-# also need to be configured manually.
-clients:
-  - name: atcp-angular-client
-    app_type: spa
-    callbacks: [
-      '##BASE_URL##/login-landing'
-      ##LOCALHOST_CALLBACKS##
-    ]
-    allowed_logout_urls: [
-      '##BASE_URL##',
-      '##BASE_URL##/error',
-      '##BASE_URL##/session-expired'
-      ##LOCALHOST_LOGOUTS##
-    ]
-    web_origins: [
-      '##BASE_URL##'
-      ##LOCALHOST_ORIGINS##
-    ]
-    client_metadata:
-      study: ATCP
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-    oidc_conformant: true

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -5,7 +5,7 @@ rules:
   - name: Google Sign In Restriction
     script: ./rules/google-signin-restriction.js
     stage: login_success
-    enabled: true
+    enabled: false
     order: 1
   - name: Force email verification
     script: ./rules/force-email-verification.js
@@ -19,8 +19,59 @@ rules:
   - name: Register User in Pepper
     script: ../register-user-in-pepper.js
     stage: login_success
-    enabled: true
+    enabled: false
     order: 4
+
+actions:
+  - name: Force email verification
+    code: ../actions/force-email-verification.js
+    dependencies:
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: M2M_DOMAIN
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
+  - name: Google Sign In Restriction
+    code: ../actions/google-signin-restriction.js
+    deployed: false
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
+  - name: Register User in Pepper
+    code: ../register-user-in-pepper-action.js
+    dependencies:
+      - name: request
+        version: 2.88.2
+      - name: google-cloud/logging
+        version: 11.2.0
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: pepperBaseUrl
+        value: '##SERVER_BASE_URL##'
+      - name: domain
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
 
 pages:
   - name: guardian_multifactor

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -74,6 +74,18 @@ actions:
       - id: post-login
         version: v1
 
+triggers:
+  post-login:
+    - action_name: Force email verification
+      display_name: Force email verification
+      order: 1
+    - action_name: Google Sign In Restriction
+      display_name: Google Sign In Restriction
+      order: 2
+    - action_name: Register User in Pepper
+      display_name: Register User in Pepper
+      order: 3
+
 pages:
   - name: guardian_multifactor
     enabled: false

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -25,10 +25,11 @@ rules:
 actions:
   - name: Force email verification
     code: ../actions/force-email-verification.js
+    runtime: node18
     dependencies:
       - name: auth0
         version: 4.10.0
-    deployed: false
+    deployed: true
     secrets:
       - name: M2M_DOMAIN
         value: '##AUTH0_DOMAIN##'
@@ -39,7 +40,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
   - name: Google Sign In Restriction
     code: ../actions/google-signin-restriction.js

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -1,6 +1,27 @@
 tenant:
   default_directory: Username-Password-Authentication
 
+rules:
+  - name: Google Sign In Restriction
+    script: ./rules/google-signin-restriction.js
+    stage: login_success
+    enabled: false
+    order: 1
+  - name: Force email verification
+    script: ./rules/force-email-verification.js
+    enabled: true
+    order: 2
+  - name: Check user is signed up
+    script: ./rules/check-user-is-signedup.js
+    stage: login_success
+    enabled: false
+    order: 3
+  - name: Register User in Pepper
+    script: ../register-user-in-pepper.js
+    stage: login_success
+    enabled: false
+    order: 4
+
 actions:
   - name: Force email verification
     code: ./actions/force-email-verification.js
@@ -27,10 +48,10 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v3
+        version: v1
 
   - name: Register User in Pepper
-    code: ./actions/register-user-in-pepper-action.js
+    code: ../register-user-in-pepper-action.js
     dependencies:
       - name: request
         version: 2.88.2
@@ -47,7 +68,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v3
+        version: v1
 
 triggers:
   post-login:
@@ -61,3 +82,67 @@ triggers:
       display_name: Register User in Pepper
       order: 3
 
+pages:
+  - name: guardian_multifactor
+    enabled: false
+    html: ./pages/guardian_multifactor.html
+  - name: login
+    enabled: true
+    html: ./pages/login.html
+  - name: password_reset
+    enabled: true
+    html: ./pages/password_reset.html
+
+emailProvider:
+  name: "sendgrid"
+  enabled: true
+  default_from_address: ##SENDGRID_EMAIL##
+  credentials:
+    api_key: ##SENDGRID_TOKEN##
+
+emailTemplates:
+  - template: reset_email
+    body: ./emailTemplates/reset_email.html
+    from: A-T Project <##STUDY_EMAIL##>
+    resultUrl: '{{ application.callback_domain }}/dashboard'
+    subject: Global A-T Family Data Platform | Reset Password Instructions
+    urlLifetimeInSeconds: 432000
+    syntax: liquid
+    enabled: true
+  - template: verify_email
+    body: ./emailTemplates/verify_email.html
+    from: A-T Project <##STUDY_EMAIL##>
+    resultUrl: '{{ application.callback_domain }}/account-activated'
+    subject: Global AT-Family Data Platform | Activate Account Notification
+    urlLifetimeInSeconds: 432000
+    syntax: liquid
+    enabled: true
+
+# NOTE: client names must match what's in Auth0's dashboard, otherwise deploy
+# will create new clients. Everytime deploy happens, client configurations here
+# will overwrite what's in Auth0. If there are additional urls not in here then
+# those need to be added back manually. Other settings not configured here will
+# also need to be configured manually.
+clients:
+  - name: atcp-angular-client
+    app_type: spa
+    callbacks: [
+      '##BASE_URL##/login-landing'
+      ##LOCALHOST_CALLBACKS##
+    ]
+    allowed_logout_urls: [
+      '##BASE_URL##',
+      '##BASE_URL##/error',
+      '##BASE_URL##/session-expired'
+      ##LOCALHOST_LOGOUTS##
+    ]
+    web_origins: [
+      '##BASE_URL##'
+      ##LOCALHOST_ORIGINS##
+    ]
+    client_metadata:
+      study: ATCP
+    jwt_configuration:
+      alg: RS256
+      lifetime_in_seconds: 36000
+    oidc_conformant: true

--- a/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
@@ -19,6 +19,31 @@ pages:
     enabled: true
     html: ./pages/password_reset.html
 
+actions:
+  - name: Register User in Pepper
+    code: ../register-user-in-pepper-action.js
+    dependencies:
+      - name: request
+        version: 2.88.2
+      - name: google-cloud/logging
+        version: 11.2.0
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: pepperBaseUrl
+        value: '##SERVER_BASE_URL##'
+      - name: domain
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
 emailProvider:
   name: "sendgrid"
   enabled: true

--- a/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
@@ -1,5 +1,5 @@
 tenant:
-  default_directory: ##DB_NAME##
+  default_directory:  Username-Password-Authentication
 
 rules:
   - name: Register User in Pepper
@@ -22,6 +22,7 @@ pages:
 actions:
   - name: Register User in Pepper
     code: ../register-user-in-pepper-action.js
+    runtime: node18
     dependencies:
       - name: request
         version: 2.88.2
@@ -29,7 +30,7 @@ actions:
         version: 11.2.0
       - name: auth0
         version: 4.10.0
-    deployed: false
+    deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
@@ -42,7 +43,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
 emailProvider:
   name: "sendgrid"

--- a/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
@@ -45,6 +45,12 @@ actions:
       - id: post-login
         version: v3
 
+triggers:
+  post-login:
+    - action_name: Register User in Pepper
+      display_name: Register User in Pepper
+      order: 1
+
 emailProvider:
   name: "sendgrid"
   enabled: true

--- a/pepper-apis/studybuilder-cli/tenants/cmi/actions/check-admin-role.js
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/actions/check-admin-role.js
@@ -1,0 +1,56 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Check Admin Role
+ * Rule ID: rul_
+ * Created on 9/24/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  /**
+   * The following code block will skip this Action if Rule "Check Admin Role"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("rul_")) {
+    console.log('check-admin-role rule was executed, skipping check-admin-role action');
+    return;
+  }
+
+  // YOUR_CODE_HERE
+  const adminRole = 'CMI Prism Admin';
+  console.log('Executing check-admin-role action');
+
+  const isAdminClient = event.client.metadata.isAdminClient === 'true';
+  if (!isAdminClient) {
+    console.log('Not an admin client, skipping check-admin-role rule');
+    return;
+  }
+
+  const assignedRoles = (event.authorization || {}).roles || [];
+  if (assignedRoles.includes(adminRole)) {
+    console.log('Current user has admin role, continuing');
+    return;
+  }
+
+  // Throw error so we halt the auth pipeline and skip the Pepper registration rule.
+  console.log(`Did not find admin role for user with email ${event.user.email}`);
+  return api.access.deny('Not an authorized admin');
+
+};
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -28,7 +28,7 @@ actions:
         version: v1
 
   - name: Register User in Pepper
-    code: ../register-user-in-pepper-action.js
+    code: ../register-cmi-user-in-pepper-action.js
     dependencies:
       - name: request
         version: 2.88.2

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -21,14 +21,16 @@ rules:
 actions:
   - name: Check Admin Role
     code: ../actions/check-admin-role.js
-    deployed: false
+    runtime: node18
+    deployed: true
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
   - name: Register User in Pepper
     code: ../register-cmi-user-in-pepper-action.js
+    runtime: node18
     dependencies:
       - name: request
         version: 2.88.2
@@ -36,7 +38,7 @@ actions:
         version: 11.2.0
       - name: auth0
         version: 4.10.0
-    deployed: false
+    deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
@@ -49,7 +51,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
 pages:
   - name: login

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -53,6 +53,15 @@ actions:
       - id: post-login
         version: v3
 
+triggers:
+  post-login:
+    - action_name: Check Admin Role
+      display_name: Check Admin Role
+      order: 1
+    - action_name: Register User in Pepper
+      display_name: Register User in Pepper
+      order: 2
+
 pages:
   - name: login
     html: ./pages/login.html

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -34,10 +34,6 @@ actions:
     dependencies:
       - name: request
         version: 2.88.2
-      - name: google-cloud/logging
-        version: 11.2.0
-      - name: auth0
-        version: 4.10.0
     deployed: true
     secrets:
       - name: pepperBaseUrl

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -20,7 +20,7 @@ rules:
 
 actions:
   - name: Check Admin Role
-    code: ../actions/check-admin-role.js
+    code: ./actions/check-admin-role.js
     runtime: node18
     deployed: true
     status: built

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -18,6 +18,39 @@ rules:
     enabled: true
     order: 2
 
+actions:
+  - name: Check Admin Role
+    code: ../actions/check-admin-role.js
+    deployed: false
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
+  - name: Register User in Pepper
+    code: ../register-user-in-pepper-action.js
+    dependencies:
+      - name: request
+        version: 2.88.2
+      - name: google-cloud/logging
+        version: 11.2.0
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: pepperBaseUrl
+        value: '##SERVER_BASE_URL##'
+      - name: domain
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
 pages:
   - name: login
     html: ./pages/login.html

--- a/pepper-apis/studybuilder-cli/tenants/dsm/actions/add-claims.js
+++ b/pepper-apis/studybuilder-cli/tenants/dsm/actions/add-claims.js
@@ -1,0 +1,47 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Add claims
+ * Rule ID: rul_
+ * Created on 9/16/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  /**
+   * The following code block will skip this Action if Rule "Add claims"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("rul_qE6QN5GnYTDhtbmg")) {
+    return;
+  }
+
+  // YOUR_CODE_HERE
+  console.log('Executing DSM Add Claims action');
+  var pepperClientClaim = 'https://datadonationplatform.org/cid';
+  var pepperTenantClaim = 'https://datadonationplatform.org/t';
+  var auth0UserIdClaim = 'https://datadonationplatform.org/auth0Uid';
+
+  var tenantDomain = 'https://' + event.secrets.domain + '/';
+  api.idToken.setCustomClaim(pepperClientClaim, event.client.client_id);
+  api.idToken.setCustomClaim(pepperTenantClaim, tenantDomain);
+  api.idToken.setCustomClaim(auth0UserIdClaim, event.user.userId);
+
+  return;
+};
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
@@ -1,0 +1,11 @@
+tenant:
+  default_directory: ##DB_NAME##
+
+actions:
+  - name: Add Claims
+    code: ../action/add-claims.js
+    deployed: false
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1

--- a/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
@@ -10,3 +10,9 @@ actions:
     supported_triggers:
       - id: post-login
         version: v3
+
+triggers:
+  post-login:
+    - action_name: Add Claims
+      display_name: Add Claims
+      order: 1

--- a/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/dsm/tenant.yaml
@@ -1,11 +1,12 @@
 tenant:
-  default_directory: ##DB_NAME##
+  default_directory: Username-Password-Authentication
 
 actions:
   - name: Add Claims
     code: ../action/add-claims.js
+    runtime: node18
     deployed: false
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3

--- a/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
@@ -1,14 +1,22 @@
 tenant:
   default_directory: Username-Password-Authentication
+  picture_url: '##BASE_URL##/assets/images/project-logo-dark.svg'
+
+rules:
+  - name: Register User in Pepper
+    script: ../register-user-in-pepper.js
+    stage: login_success
+    enabled: true
+    order: 1
 
 actions:
-  - name: Register User in Pepper
+  - name: Register User in Pepper v3
     code: ../register-user-in-pepper-action.js
     runtime: node18
     dependencies:
       - name: request
         version: 2.88.2
-    deployed: true
+    deployed: false
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
@@ -28,3 +36,61 @@ triggers:
     - action_name: Register User in Pepper
       display_name: Register User in Pepper
       order: 1
+
+pages:
+  - name: login
+    html: ./loginPage.html
+    enabled: true
+  - name: password_reset
+    html: ./passwordResetPage.html
+    enabled: true
+
+emailProvider:
+  name: "sendgrid"
+  enabled: true
+  default_from_address: ##SENDGRID_EMAIL##
+  credentials:
+    api_key: ##SENDGRID_TOKEN##
+
+emailTemplates:
+  - template: reset_email
+    body: ./passwordResetEmail.html
+    from: Prion <##STUDY_EMAIL##>
+    resultUrl: '##SERVER_BASE_URL##/pepper/v1/post-password-reset?clientId={{ application.clientID }}'
+    subject: >-
+      {% if user.user_metadata.language == "es" %} Solicitud de cambio de contraseña
+      {% elsif user.user_metadata.language == "he" %} בקשה להחלפת סיסמה
+      {% elsif user.user_metadata.language == "zh" %} 密码变更请求
+      {% else %} Password Change Request {% endif %}
+    urlLifetimeInSeconds: 432000
+    syntax: liquid
+    enabled: true
+
+# NOTE: client names must match what's in Auth0's dashboard, otherwise deploy
+# will create new clients. Everytime deploy happens, client configurations here
+# will overwrite what's in Auth0. If there are additional urls not in here then
+# those need to be added back manually. Other settings not configured here will
+# also need to be configured manually.
+clients:
+  - name: prion-angular-client
+    app_type: spa
+    callbacks: [
+      '##BASE_URL##/login-landing'
+      ##LOCALHOST_CALLBACKS##
+    ]
+    allowed_logout_urls: [
+      '##BASE_URL##',
+      '##BASE_URL##/error',
+      '##BASE_URL##/session-expired'
+      ##LOCALHOST_LOGOUTS##
+    ]
+    web_origins: [
+      '##BASE_URL##'
+      ##LOCALHOST_ORIGINS##
+    ]
+    client_metadata:
+      study: PRION
+    jwt_configuration:
+      alg: RS256
+      lifetime_in_seconds: 36000
+    oidc_conformant: true

--- a/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
@@ -1,68 +1,30 @@
 tenant:
   default_directory: Username-Password-Authentication
-  picture_url: '##BASE_URL##/assets/images/project-logo-dark.svg'
 
-rules:
+actions:
   - name: Register User in Pepper
-    script: ../register-user-in-pepper.js
-    stage: login_success
-    enabled: true
-    order: 1
+    code: ../register-user-in-pepper-action.js
+    runtime: node18
+    dependencies:
+      - name: request
+        version: 2.88.2
+    deployed: true
+    secrets:
+      - name: pepperBaseUrl
+        value: '##SERVER_BASE_URL##'
+      - name: domain
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v3
 
-pages:
-  - name: login
-    html: ./loginPage.html
-    enabled: true
-  - name: password_reset
-    html: ./passwordResetPage.html
-    enabled: true
-
-emailProvider:
-  name: "sendgrid"
-  enabled: true
-  default_from_address: ##SENDGRID_EMAIL##
-  credentials:
-    api_key: ##SENDGRID_TOKEN##
-
-emailTemplates:
-  - template: reset_email
-    body: ./passwordResetEmail.html
-    from: Prion <##STUDY_EMAIL##>
-    resultUrl: '##SERVER_BASE_URL##/pepper/v1/post-password-reset?clientId={{ application.clientID }}'
-    subject: >-
-      {% if user.user_metadata.language == "es" %} Solicitud de cambio de contraseña
-      {% elsif user.user_metadata.language == "he" %} בקשה להחלפת סיסמה
-      {% elsif user.user_metadata.language == "zh" %} 密码变更请求
-      {% else %} Password Change Request {% endif %}
-    urlLifetimeInSeconds: 432000
-    syntax: liquid
-    enabled: true
-
-# NOTE: client names must match what's in Auth0's dashboard, otherwise deploy
-# will create new clients. Everytime deploy happens, client configurations here
-# will overwrite what's in Auth0. If there are additional urls not in here then
-# those need to be added back manually. Other settings not configured here will
-# also need to be configured manually.
-clients:
-  - name: prion-angular-client
-    app_type: spa
-    callbacks: [
-      '##BASE_URL##/login-landing'
-      ##LOCALHOST_CALLBACKS##
-    ]
-    allowed_logout_urls: [
-      '##BASE_URL##',
-      '##BASE_URL##/error',
-      '##BASE_URL##/session-expired'
-      ##LOCALHOST_LOGOUTS##
-    ]
-    web_origins: [
-      '##BASE_URL##'
-      ##LOCALHOST_ORIGINS##
-    ]
-    client_metadata:
-      study: PRION
-    jwt_configuration:
-      alg: RS256
-      lifetime_in_seconds: 36000
-    oidc_conformant: true
+triggers:
+  post-login:
+    - action_name: Register User in Pepper
+      display_name: Register User in Pepper
+      order: 1

--- a/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
@@ -19,7 +19,7 @@ exports.onExecutePostLogin = async (event, api) => {
    * was previously executed in the transaction in order to avoid duplication
    * of logic.
    */
-  if (api.rules.wasExecuted("rul_*")) {
+  if (api.rules.wasExecuted("rul_pfKZwBRYcntnVEtS")) {
     console.log('In action register pepper user rule executed');
     return;
   }
@@ -288,39 +288,6 @@ exports.onExecutePostLogin = async (event, api) => {
           api.user.setAppMetadata("user_guid", ddpUserGuid);
           api.user.setUserMetadata("user_guid", ddpUserGuid);
           console.log('updated user metaData with user GUID ? ');
-
-          /**
-          // Update user AppMetadata with user_guid using Auth0 Management API
-          const auth0Sdk = require("auth0");
-          const ManagementClient = auth0Sdk.ManagementClient;
-          // This will make an Authentication API call
-          const managementClientInstance = new ManagementClient({
-            // These come from a machine-to-machine application
-            domain: event.secrets.domain,
-            token: api.accessToken,
-            //clientId: event.secrets.M2M_CLIENT_ID,
-            //clientSecret: event.secrets.M2M_CLIENT_SECRET,
-            scope: "update:users"
-          });
-
-          var params = {id: event.user.user_id};
-          var metadata = {
-            user_guid: ddpUserGuid
-          };
-
-          console.log('managementClientInstance userID: ' + JSON.stringify(event.user.user_id));
-           managementClientInstance.users.updateAppMetadata(params, metadata, function (err, user) {
-           if (err) {
-           console.log(
-           'Post registration user AppMetadata update failed:' + err.getMessage());
-           return api.access.deny(err.message);
-
-           } else {
-           console.log('Successfully completed Post registration user AppMetadata update');
-           }
-
-           }); */
-
 
         }
 

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -1,7 +1,7 @@
 /**
  * This Action was migrated from Rule.
  * Rule name: Register User in Pepper
- * Rule ID: rul_
+ * Rule ID: rul_prion
  * Created on 9/24/2024
  */
 

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -24,30 +24,6 @@ exports.onExecutePostLogin = async (event, api) => {
     return;
   }
 
-  const {Logging} = require('@google-cloud/logging');
-  const cloudLoggingEnabled = false; //!!event.secrets.googleApplicationCredentials;
-  var cloudLog = null;
-
-  if (cloudLoggingEnabled) {
-    console.log('cloudLogging Enabled');
-
-    const cloudLogName = "_Default";
-    var applicationCredentials = JSON.parse(event.secrets.googleApplicationCredentials);
-
-    console.log("Successfully loaded googleApplicationCredentials. Google Cloud Logging to project " + applicationCredentials.project_id + " is enabled");
-
-    var cloudLoggingConfig = {
-      projectId: applicationCredentials.project_id,
-      credentials: applicationCredentials
-    };
-
-    var cloudLogging = new Logging(cloudLoggingConfig);
-    cloudLog = cloudLogging.log(cloudLogName);
-  } else {
-    console.log('cloudLogging Disabled');
-  }
-
-
   // Use of the m2mClients list below should be considered legacy behavior, and
   // may be removed at any time. Any new clients should set the key 'skipPepperRegistration'
   // to the value of 'true' in their client metadata if the Pepper registration process
@@ -243,28 +219,6 @@ exports.onExecutePostLogin = async (event, api) => {
       if (event.user.user_metadata.last_name) {
         pepper_params.lastName = event.user.user_metadata.last_name;
         console.log('User metadata has last name = ' + pepper_params.lastName);
-      }
-
-      if (cloudLoggingEnabled) {
-        console.log('trying to log to cloud');
-        var severity = "INFO";
-
-        if (pepper_params.mode) {
-          if ((pepper_params.mode === 'signup') && (!pepper_params.tempUserGuid)) {
-            severity = "ERROR";
-          }
-        }
-
-        var entry = cloudLog.entry({
-          severity: severity,
-          labels: {
-            source: "auth0",
-            mode: pepper_params.mode || "default"
-          }
-        }, event);
-
-        cloudLog.write(entry);
-
       }
 
       //added below in action as workaround for not able to update userGUID in user AppMetadata post registration

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -1,0 +1,389 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Register User in Pepper
+ * Rule ID: rul_
+ * Created on 9/24/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  console.log('In action register pepper user');
+
+  /**
+   * The following code block will skip this Action if Rule "Register User in Pepper"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("rul_*")) {
+    console.log('In action register pepper user rule executed');
+    return;
+  }
+
+  const {Logging} = require('@google-cloud/logging');
+  const cloudLoggingEnabled = false; //!!event.secrets.googleApplicationCredentials;
+  var cloudLog = null;
+
+  if (cloudLoggingEnabled) {
+    console.log('cloudLogging Enabled');
+
+    const cloudLogName = "_Default";
+    var applicationCredentials = JSON.parse(event.secrets.googleApplicationCredentials);
+
+    console.log("Successfully loaded googleApplicationCredentials. Google Cloud Logging to project " + applicationCredentials.project_id + " is enabled");
+
+    var cloudLoggingConfig = {
+      projectId: applicationCredentials.project_id,
+      credentials: applicationCredentials
+    };
+
+    var cloudLogging = new Logging(cloudLoggingConfig);
+    cloudLog = cloudLogging.log(cloudLogName);
+  } else {
+    console.log('cloudLogging Disabled');
+  }
+
+  // Use of the m2mClients list below should be considered legacy behavior, and
+  // may be removed at any time. Any new clients should set the key 'skipPepperRegistration'
+  // to the value of 'true' in their client metadata if the Pepper registration process
+  // is not required.
+  var m2mClients = ['dsm', 'Count Me In (Salt CMS)'];
+
+  // The new flag is opt-in. If no value is defined, the legacy behavior will be used.
+  // If the value is non-null, then assume the client has opted in.
+  var skipPepperRegistration = event.client.metadata.skipPepperRegistration || null;
+  if ((skipPepperRegistration === null) && (m2mClients.includes(event.client.name))) {
+    console.log('skipping Pepper registration for legacy client \'' + event.client.name + '\'');
+    return;
+  } else if (skipPepperRegistration === 'true') {
+    console.log('skipping Pepper registration for \'' + event.client.name + '\'');
+    return;
+  }
+
+  var pepperUserGuidClaim = 'https://datadonationplatform.org/uid';
+  var pepperClientClaim = 'https://datadonationplatform.org/cid';
+  var pepperTenantClaim = 'https://datadonationplatform.org/t';
+  var tenantDomain = 'https://' + event.secrets.domain + '/';
+
+  api.idToken.setCustomClaim(pepperClientClaim, event.client.client_id);
+  api.idToken.setCustomClaim(pepperTenantClaim, tenantDomain);
+
+  var mockRegistration = event.client.metadata.mockRegistration || null;
+  var doLocalRegistration = event.client.metadata.doLocalRegistration || null;
+  if (mockRegistration != null && mockRegistration) {
+    console.log('in mockRegistration');
+    var overrideUserGuid;
+    if (event.user.app_metadata.testingGuid) {
+      overrideUserGuid = event.user.app_metadata.testingGuid;
+      console.log('Using hardcoded guid ' + overrideUserGuid + ' during registration for ' + event.user.user_id + ' for client ' + event.client.client_id);
+    } else if (event.client.metadata.overrideUserGuid) {
+      overrideUserGuid = event.client.metadata.overrideUserGuid;
+      console.log('Using hardcoded guid ' + overrideUserGuid + ' during registration for ' + event.user.user_id + ' for client ' + event.client.client_id);
+    } else {
+      console.log('No hardcoded guid found during mock registration for ' + event.user.user_id + ' from client ' + event.client.client_id);
+    }
+    api.idToken.setCustomClaim(pepperUserGuidClaim, overrideUserGuid);
+    return;
+  } else if (doLocalRegistration != null && doLocalRegistration) {
+    var localRegistrationGuid = null;
+    if (event.user.app_metadata.pepper_user_guids) {
+      console.log('has user.app_metadata..pepper_user_guids');
+      localRegistrationGuid = event.user.app_metadata.pepper_user_guids[event.client.client_id];
+    }
+    if (localRegistrationGuid != null && localRegistrationGuid) {
+      console.log('Using guid ' + localRegistrationGuid + ' during local registration for ' + event.user.user_id + ' for client ' + event.client.client_id);
+      api.idToken.setCustomClaim(pepperUserGuidClaim, localRegistrationGuid);
+    } else {
+      console.log('No pepper guid available during local registration for ' + event.user.user_id + ' for client ' + event.client.client_id);
+    }
+    return;
+  } else {
+    console.log('Action: registration/login flow...');
+    var pepper_params = {
+      auth0UserId: event.user.user_id,
+      auth0ClientId: event.client.client_id,
+      auth0Domain: tenantDomain
+    };
+    console.log('pepper params: ' + JSON.stringify(pepper_params));
+
+    console.log('looking for study_guid');
+    if (event.request.query.study_guid) {
+      pepper_params.studyGuid = event.request.query.study_guid;
+      console.log('StudyGuid passed in (via query) = ' + pepper_params.studyGuid);
+    } else if (event.request.body.study_guid) {
+      pepper_params.studyGuid = event.request.body.study_guid;
+      console.log('StudyGuid passed in (via body) = ' + pepper_params.studyGuid);
+    } else if (event.client.metadata.study) {
+      pepper_params.studyGuid = event.client.metadata.study;
+      console.log('StudyGuid (defaulting to clientMetadata.study) = ' + pepper_params.studyGuid);
+    } else {
+      console.log('No studyGuid passed in request');
+    }
+
+    console.log('looking for temp_user_guid');
+    if (event.request.query.temp_user_guid) {
+      pepper_params.tempUserGuid = event.request.query.temp_user_guid;
+      console.log('Temp user guid passed in (via query) = ' + pepper_params.tempUserGuid);
+    } else if (event.request.body.temp_user_guid) {
+      pepper_params.tempUserGuid = event.request.body.temp_user_guid;
+      console.log('Temp user guid passed in (via body) = ' + pepper_params.tempUserGuid);
+    } else {
+      console.log('No temp user guid passed in request');
+    }
+
+    /**
+     * If `tempUserGuid` was not set with value from request
+     * AND user is not yet registered in pepper (`user.app_metadata.user_guid` is empty)
+     * take `tempUserGuid` from `user_metadata` (if one exists)
+     */
+    if (
+      !pepper_params.tempUserGuid &&
+      !event.user.app_metadata.user_guid &&
+      event.user.user_metadata && !!event.user.user_metadata.temp_user_guid
+    ) {
+      console.log('looking for temp_user_guid in user_metadata.temp_user_guid: ' + event.user.user_metadata.temp_user_guid);
+      pepper_params.tempUserGuid = event.user.user_metadata.temp_user_guid;
+    }
+
+    if (event.request.query.mode) {
+      pepper_params.mode = event.request.query.mode;
+      console.log('Registration Mode passed in (via query) = ' + pepper_params.mode);
+    } else if (event.request.body.mode) {
+      pepper_params.mode = event.request.body.mode;
+      console.log('Registration Mode passed in (via body) = ' + pepper_params.mode);
+    } else {
+      console.log('No Registration Mode passed in request');
+    }
+
+    if (pepper_params.mode && pepper_params.mode === "login" &&
+      !event.user.app_metadata.user_guid && !event.user.app_metadata.pepper_user_guids &&
+      !pepper_params.tempUserGuid
+    ) {
+      console.log('User not registered');
+      const loginErrPayload = {
+        code: 'user_not_registered',
+        message: 'User need to register first in order to login',
+        statusCode: 403,
+      };
+      //const loginErr = new Error(JSON.stringify(loginErrPayload));
+      return api.access.deny(loginErrPayload.message);
+    }
+
+    if (event.request.query.invitation_id) {
+      pepper_params.invitationId = event.request.query.invitation_id;
+      console.log('Invitation id passed in (via query) = ' + pepper_params.invitationId);
+    } else if (event.request.body.invitation_id) {
+      pepper_params.invitationId = event.request.body.invitation_id;
+      console.log('Invitation id passed in (via body) = ' + pepper_params.invitationId);
+    }
+
+    if (event.request.query.language) {
+      pepper_params.languageCode = event.request.query.language;
+      console.log('User language passed in (via query) = ' + pepper_params.languageCode);
+    } else if (event.request.body.language) {
+      pepper_params.languageCode = event.request.body.language;
+      console.log('User language passed in (via body) = ' + pepper_params.languageCode);
+    }
+
+    if (event.request.query.time_zone) {
+      pepper_params.timeZone = event.request.query.time_zone;
+      console.log('User timezone passed in (via query) = ' + pepper_params.timeZone);
+    } else if (event.request.body.time_zone) {
+      pepper_params.timeZone = event.request.body.time_zone;
+      console.log('User timezone passed in (via body) = ' + pepper_params.timeZone);
+    }
+
+    // This is the token renewal case. Let's avoid going through pepper registration
+    if (event.request.query.renew_token_only) {
+      console.log('Action request.query.renew_token_only: ');
+      api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
+      return;
+    }
+
+    // In order to get a refresh token, the client must go through one of the other methods
+    // to get an id/access token first (oauth2-password, oidc-implicit-profile, etc).
+    // This allows us to assume that, if they have a refresh token, they must have gone through the
+    // registration process.
+    //
+    // Errata: This assumption is not valid in a multi-study world. It's possible to fetch a token
+    //  for one study initially, then attempt to renew it when accessing another. For the moment,
+    //  assume that, if a study guid is included with the call, the client wants us to call the
+    //  registration endpoint.
+    //var isRefreshTokenExchange = ""; //todo .. revisit and fix (context.protocol === "oauth2-refresh-token");
+    //var isRefreshTokenExchange = event.transaction.protocol  === "oauth2-refresh-token"; //todo
+    var isRefreshTokenExchange = false;
+    //false; //event.request.body.get("grant_type") == "refresh_token";
+    console.log('Action Event isRefreshTokenExchange::' + isRefreshTokenExchange);
+    var needsStudyRegistration = !!(pepper_params.studyGuid);
+    var hasCachedUserGuid = !!(event.user.app_metadata.user_guid);
+    //if (isRefreshTokenExchange && hasCachedUserGuid && !needsStudyRegistration) { //todo
+    if (hasCachedUserGuid && !needsStudyRegistration) {
+      console.log('using app_metadata cached user GUID: ' + JSON.stringify(event.user.app_metadata));
+      api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
+      return;
+    } else {
+      if (event.user.user_metadata.first_name) {
+        pepper_params.firstName = event.user.user_metadata.first_name;
+        console.log('User metadata has first name = ' + pepper_params.firstName);
+      }
+      if (event.user.user_metadata.last_name) {
+        pepper_params.lastName = event.user.user_metadata.last_name;
+        console.log('User metadata has last name = ' + pepper_params.lastName);
+      }
+
+      if (cloudLoggingEnabled) {
+        console.log('trying to log to cloud');
+        var severity = "INFO";
+
+        if (pepper_params.mode) {
+          if ((pepper_params.mode === 'signup') && (!pepper_params.tempUserGuid)) {
+            severity = "ERROR";
+          }
+        }
+
+        var entry = cloudLog.entry({
+          severity: severity,
+          labels: {
+            source: "auth0",
+            mode: pepper_params.mode || "default"
+          }
+        }, event);
+
+        cloudLog.write(entry);
+
+      }
+
+      //added below in action.. todo revisit and fix
+      console.log('pepper params: ' + JSON.stringify(pepper_params));
+      console.log('EVENT: ' + JSON.stringify(event));
+      console.log('API::: ' + JSON.stringify(api));
+      //console.log('Redirect URI::: ' + event.transaction.redirect_uri);
+
+
+      if (event.user.app_metadata.user_guid) {
+        console.log('setting userGUID claim from user.app_metadata');
+        api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
+      } else if (pepper_params.tempUserGuid) {
+        console.log('setting userGUID claim from temp user');
+        api.idToken.setCustomClaim(pepperUserGuidClaim, pepper_params.tempUserGuid);
+        api.user.setAppMetadata("user_guid", pepper_params.tempUserGuid);
+        //console.log('::: UserGUID claim NOT set.. setting auth0 userID');
+        //api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.user_id);
+      }
+      api.user.setAppMetadata("user_guid_test_1", "test GUID-1");
+
+      /**
+       if (pepper_params.tempUserGuid) {
+       console.log('setting userGUID claim from temp user');
+       api.idToken.setCustomClaim(pepperUserGuidClaim, pepper_params.tempUserGuid);
+       api.user.setAppMetadata("user_guid", pepper_params.tempUserGuid);
+       } else if (event.user.app_metadata.user_guid) {
+       api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
+       } */
+
+      var pepperUrl = event.secrets.pepperBaseUrl;
+      if (event.client.metadata.backendUrl) {
+        pepperUrl = event.client.metadata.backendUrl;
+      }
+      var request = require('request');
+      console.log('Invoking DDP registration : ' + pepperUrl + ' ... params: ' + JSON.stringify(pepper_params));
+      console.log('ID Token:' + JSON.stringify(api.idToken));
+      request.post({
+        url: pepperUrl + '/pepper/v1/register',
+        json: pepper_params,
+        timeout: 15000
+      }, function (err, response, body) {
+        if (err) {
+          console.log('Error while registering auth0 user ' + event.user.user_id);
+          console.log(err);
+          let error = new Error(JSON.stringify({
+            code: err.code,
+            message: err.message,
+            statusCode: 500
+          }));
+          console.log('Error during registration: ' + err.message);
+          return api.access.deny(err.message);
+        } else if (response && response.statusCode !== 200) {
+          console.log('Response: ' + JSON.stringify(response));
+          console.log('Failed to register auth0 user ' + event.user.user_id + ':' + response.statusCode + ' at ' + pepperUrl);
+          console.log('BODY: ' + JSON.stringify(body));
+          body = body || {};
+          let error = new Error(JSON.stringify({
+            code: body.code,
+            message: body.message,
+            statusCode: response.statusCode
+          }));
+
+          console.log('Access denied...' + body.message);
+          return api.access.deny(body.message);
+          //todo .. doesnt seem to block UI invoking next steps ?
+          //try redirect ?
+        } else {
+          console.log(' register response: ' + JSON.stringify(response));
+          console.log(' register body: ' + JSON.stringify(body));
+
+          // all is well
+          //todo.. below doesnt seem to work.. looks AppMetadata update is likely delayed
+          // added before register call for now
+          //maybe try API call?
+          var ddpUserGuid = body.ddpUserGuid;
+          api.idToken.setCustomClaim(pepperUserGuidClaim, ddpUserGuid);
+          api.user.setAppMetadata("user_guid", ddpUserGuid);
+          api.user.setUserMetadata("user_guid", ddpUserGuid);
+          console.log('updated user metaData with user GUID ? ');
+          api.user.setAppMetadata("user_guid_test_2", "test GUID-2");
+          api.user.setUserMetadata("user_guid_test_3", "test GUID-3");
+
+          // Update user AppMetadata with user_guid using Auth0 Management API
+          const auth0Sdk = require("auth0");
+          //const ManagementClient = require('auth0@2.9.1').ManagementClient
+          const ManagementClient = auth0Sdk.ManagementClient;
+          // This will make an Authentication API call
+          const managementClientInstance = new ManagementClient({
+            // These come from a machine-to-machine application
+            domain: event.secrets.domain,
+            token: api.accessToken,
+            //clientId: event.secrets.M2M_CLIENT_ID,
+            //clientSecret: event.secrets.M2M_CLIENT_SECRET,
+            scope: "update:users"
+          });
+
+          var params = {id: event.user.user_id};
+          var metadata = {
+            user_guid: ddpUserGuid
+          };
+
+          console.log('managementClientInstance userID: ' + JSON.stringify(event.user.user_id));
+          managementClientInstance.users.updateAppMetadata(params, metadata, function (err, user) {
+            if (err) {
+              console.log(
+                'Post registration user AppMetadata update failed:' + err.getMessage());
+              return api.access.deny(err.message);
+
+            } else {
+              console.log('Successfully completed Post registration user AppMetadata update');
+            }
+          });
+        }
+
+      });
+    }
+  }
+};
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onContinuePostLogin = async (event, api) => {
+  console.log('In action register pepper user onContinuePostLogin..');
+
+};

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -231,8 +231,7 @@ exports.onExecutePostLogin = async (event, api) => {
     console.log('Action Event isRefreshTokenExchange::' + isRefreshTokenExchange);
     var needsStudyRegistration = !!(pepper_params.studyGuid);
     var hasCachedUserGuid = !!(event.user.app_metadata.user_guid);
-    //if (isRefreshTokenExchange && hasCachedUserGuid && !needsStudyRegistration) { //todo
-    if (hasCachedUserGuid && !needsStudyRegistration) {
+    if (isRefreshTokenExchange && hasCachedUserGuid && !needsStudyRegistration) {
       console.log('using app_metadata cached user GUID: ' + JSON.stringify(event.user.app_metadata));
       api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
       return;

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -1,7 +1,7 @@
 /**
  * This Action was migrated from Rule.
  * Rule name: Register User in Pepper
- * Rule ID: rul_prion
+ * Rule ID: rul_*
  * Created on 9/24/2024
  */
 

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -317,6 +317,7 @@ exports.onExecutePostLogin = async (event, api) => {
           api.user.setUserMetadata("user_guid", ddpUserGuid);
           console.log('updated user metaData with user GUID ? ');
 
+          /**
           // Update user AppMetadata with user_guid using Auth0 Management API
           const auth0Sdk = require("auth0");
           const ManagementClient = auth0Sdk.ManagementClient;
@@ -346,8 +347,9 @@ exports.onExecutePostLogin = async (event, api) => {
               console.log('Successfully completed Post registration user AppMetadata update');
             }
           });
-        }
+           */
 
+        }
       });
     }
   }

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -208,15 +208,10 @@ exports.onExecutePostLogin = async (event, api) => {
 
       //added below in action as workaround for not able to update userGUID in user AppMetadata post registration
       console.log('pepper params: ' + JSON.stringify(pepper_params));
-      if (pepper_params.mode && pepper_params.mode === 'signup' && pepper_params.tempUserGuid) {
-        console.log('setting userGUID claim from temp user');
+      if (pepper_params.tempUserGuid) {
         api.idToken.setCustomClaim(pepperUserGuidClaim, pepper_params.tempUserGuid);
         api.user.setAppMetadata("user_guid", pepper_params.tempUserGuid);
-        api.user.setAppMetadata("study_guid", pepper_params.studyGuid);
-        console.log('setting userGUID and studyGUID into AppMetadata');
-      }
-      if (pepper_params.mode && pepper_params.mode === 'login' && event.user.app_metadata.user_guid) {
-        console.log('setting userGUID claim from user.app_metadata');
+      } else if (event.user.app_metadata.user_guid) {
         api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
       }
 

--- a/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
@@ -1,0 +1,84 @@
+/**
+ * This Action was migrated from Rule.
+ * Rule name: Force email verification
+ * Rule ID: rul_
+ * Created on 9/22/2024
+ */
+
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  /**
+   * The following code block will skip this Action if Rule "Force email verification"
+   * was previously executed in the transaction in order to avoid duplication
+   * of logic.
+   */
+  if (api.rules.wasExecuted("rul_")) {
+    return;
+  }
+
+  console.log('Received user', event.user);
+  console.debug('Received context', event);
+
+  const auth0Sdk = require("auth0");
+  if (!event.user.email_verified) {
+    //const ManagementClient = require('auth0@2.9.1').ManagementClient
+    const ManagementClient = auth0Sdk.ManagementClient;
+    // This will make an Authentication API call
+    const managementClientInstance = new ManagementClient({
+      // These come from a machine-to-machine application
+      domain: event.secrets.M2M_DOMAIN,
+      clientId: event.secrets.M2M_CLIENT_ID,
+      clientSecret: event.secrets.M2M_CLIENT_SECRET,
+      scope: "update:users"
+    });
+
+    const params = {
+      user_id: event.user.user_id,
+      client_id: event.client.client_id,
+    };
+
+    console.log('Attempt to resend a confirmation email');
+
+    managementClientInstance.jobs.verifyEmail(params, function (err) {
+      if (err) {
+        console.log(
+          'Request to resend a confirmation email failed',
+          'The error is',
+          err
+        );
+      } else {
+        console.log(
+          'Successfully created a job to resend a confirmation email'
+        );
+      }
+
+      const error = new Error(
+        JSON.stringify({
+          code: 'unauthorized',
+          message: 'You have to confirm your email address before continuing.',
+          statusCode: 401,
+        })
+      );
+
+      return api.access.deny(error.message);
+    });
+  } else {
+    return;
+  }
+}
+
+
+/**
+ * Handler that will be invoked when this action is resuming after an external redirect. If your
+ * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
+ *
+ * @param {Event} event - Details about the user and the context in which they are logging in.
+ * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
+ */
+// exports.onContinuePostLogin = async (event, api) => {
+// };

--- a/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
@@ -65,7 +65,7 @@ exports.onExecutePostLogin = async (event, api) => {
         })
       );
 
-      return api.access.deny(error.message);
+      return api.access.deny(JSON.stringify(error));
     });
   } else {
     return;

--- a/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
@@ -57,6 +57,15 @@ actions:
       - id: post-login
         version: v3
 
+triggers:
+  post-login:
+    - action_name: Force email verification
+      display_name: Force email verification
+      order: 1
+    - action_name: Register User in Pepper
+      display_name: Register User in Pepper
+      order: 2
+
 pages:
   - name: login
     html: ./pages/login.html

--- a/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
@@ -15,10 +15,11 @@ rules:
 actions:
   - name: Force email verification
     code: ../actions/force-email-verification.js
+    runtime: node18
     dependencies:
       - name: auth0
         version: 4.10.0
-    deployed: false
+    deployed: true
     secrets:
       - name: M2M_DOMAIN
         value: '##AUTH0_DOMAIN##'
@@ -29,10 +30,11 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
   - name: Register User in Pepper
     code: ../register-user-in-pepper-action.js
+    runtime: node18
     dependencies:
       - name: request
         version: 2.88.2
@@ -40,7 +42,7 @@ actions:
         version: 11.2.0
       - name: auth0
         version: 4.10.0
-    deployed: false
+    deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
@@ -53,7 +55,7 @@ actions:
     status: built
     supported_triggers:
       - id: post-login
-        version: v1
+        version: v3
 
 pages:
   - name: login

--- a/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
@@ -1,5 +1,5 @@
 tenant:
-  default_directory: ##DB_NAME##
+  "DB_NAME": "Username-Password-Authentication",
 
 rules:
   - name: Force email verification
@@ -14,7 +14,7 @@ rules:
 
 actions:
   - name: Force email verification
-    code: ../actions/force-email-verification.js
+    code: ./actions/force-email-verification.js
     runtime: node18
     dependencies:
       - name: auth0

--- a/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
@@ -12,6 +12,49 @@ rules:
     enabled: true
     order: 2
 
+actions:
+  - name: Force email verification
+    code: ../actions/force-email-verification.js
+    dependencies:
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: M2M_DOMAIN
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
+  - name: Register User in Pepper
+    code: ../register-user-in-pepper-action.js
+    dependencies:
+      - name: request
+        version: 2.88.2
+      - name: google-cloud/logging
+        version: 11.2.0
+      - name: auth0
+        version: 4.10.0
+    deployed: false
+    secrets:
+      - name: pepperBaseUrl
+        value: '##SERVER_BASE_URL##'
+      - name: domain
+        value: '##AUTH0_DOMAIN##'
+      - name: M2M_CLIENT_ID
+        value: '##AUTH0_MGMT_CLIENT_ID##'
+      - name: M2M_CLIENT_SECRET
+        value: '##AUTH0_MGMT_CLIENT_SECRET##'
+    status: built
+    supported_triggers:
+      - id: post-login
+        version: v1
+
 pages:
   - name: login
     html: ./pages/login.html


### PR DESCRIPTION
Migrate auth0 rules to actions as per 
https://auth0.com/docs/customize/actions/migrate/migrate-from-rules-to-actions

Tenants included: ATCP, RGP, Brugada, CMI
CMI has issue of letting login into other CMI tenant studies if enrolled in one (work-in-progress)
While auth0CLI seem to work to some extent, planning to manually deploy initial tenant actions using Migrate tool in Auth0 UI and copy the action code. 
Will include manual steps instructions as part of RC plan.
steps to execute in Auth0  
1. Migrate Rule to Action.
2. Copy updated action code into created actions. Click Deploy.
3. Add actions to flow
4. Disable rule