### PR TITLE
PEPPER-1389 auth0 action updates

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/route/UserRegistrationRoute.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
-import org.broadinstitute.ddp.client.ApiResult;
 import org.broadinstitute.ddp.client.Auth0ManagementClient;
 import org.broadinstitute.ddp.constants.ErrorCodes;
 import org.broadinstitute.ddp.db.TransactionWrapper;
@@ -592,30 +591,13 @@ public class UserRegistrationRoute extends ValidatedJsonInputRoute<UserRegistrat
             log.info("User {} has auth0 account, proceeding to sync user_metadata", user.getGuid());
             Map<String, Object> metadata = new HashMap<>();
             metadata.put(User.METADATA_LANGUAGE, languageDto.getIsoCode());
-            metadata.put("user_guid", user.getGuid());
-            syncAuth0Metadata(handle, user, auth0UserId, metadata, false);
-
-            //sync user AppMetaData
-            log.info("User {} : proceeding to sync app_metadata", user.getGuid());
-            Map<String, Object> appMetadata = new HashMap<>();
-            metadata.put("study_guid", payload.getStudyGuid());
-            appMetadata.put("user_guid", user.getGuid());
-            syncAuth0Metadata(handle, user, auth0UserId, appMetadata, true);
-        }
-    }
-
-    private static void syncAuth0Metadata(Handle handle, User user, String auth0UserId, Map<String, Object> metadata, boolean appMetadata) {
-        ApiResult result;
-        if (appMetadata) {
-            result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserAppMetadata(auth0UserId, metadata);
-        } else {
-            result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserAppMetadata(auth0UserId, metadata);
-        }
-        if (result.hasThrown() || result.hasError()) {
-            var e = result.hasThrown() ? result.getThrown() : result.getError();
-            log.error("Error while updating user_metadata for user {}, user's language may be out-of-sync", user.getGuid(), e);
-        } else {
-            log.info("Updated user_metadata for user {}", user.getGuid());
+            var result = Auth0ManagementClient.forUser(handle, user.getGuid()).updateUserMetadata(auth0UserId, metadata);
+            if (result.hasThrown() || result.hasError()) {
+                var e = result.hasThrown() ? result.getThrown() : result.getError();
+                log.error("Error while updating user_metadata for user {}, user's language may be out-of-sync", user.getGuid(), e);
+            } else {
+                log.info("Updated user_metadata for user {}", user.getGuid());
+            }
         }
     }
 

--- a/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/actions/force-email-verification.js
@@ -1,83 +1,43 @@
-/**
- * This Action was migrated from Rule.
- * Rule name: Force email verification
- * Created on 9/24/2024
- */
-
-/**
- * Handler that will be called during the execution of a PostLogin flow.
- *
- * @param {Event} event - Details about the user and the context in which they are logging in.
- * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
- */
 exports.onExecutePostLogin = async (event, api) => {
-  /**
-   * The following code block will skip this Action if Rule "Force email verification"
-   * was previously executed in the transaction in order to avoid duplication
-   * of logic.
-   */
-  if (api.rules.wasExecuted("rul_bL3jV04z2KADpdx9")) {
-    return;
-  }
+  const ManagementClient = require('auth0').ManagementClient;
+  const management = new ManagementClient({
+    domain: event.secrets.M2M_DOMAIN,
+    clientId: event.secrets.M2M_CLIENT_ID,
+    clientSecret: event.secrets.M2M_CLIENT_SECRET
+  });
 
-  // YOUR_CODE_HERE
-  console.log('Received user', event.user);
-  console.log('Received context', event);
+  const verified = event.user.email_verified;
 
-  const auth0Sdk = require("auth0");
-  if (!event.user.email_verified) {
-    const ManagementClient = auth0Sdk.ManagementClient;
-    // This will make an Authentication API call
-    const managementClientInstance = new ManagementClient({
-      // These come from a machine-to-machine application
-      domain: event.secrets.M2M_DOMAIN,
-      clientId: event.secrets.M2M_CLIENT_ID,
-      clientSecret: event.secrets.M2M_CLIENT_SECRET,
-      scope: "update:users"
-    });
+  // I am slicing off the 'auth0|' prefix of the user_id here
+  const userIdWithoutAuth0 = event.user.user_id.slice(6);
 
-    const params = {
-      user_id: event.user.user_id,
-      client_id: event.client.client_id,
-    };
+  const params = {
+    client_id: event.client.client_id,
+    user_id: event.user.user_id,
+    identity: {
+      // Passing the corrected user_id here
+      user_id: userIdWithoutAuth0,
+      provider: 'auth0'
+    }
+  };
 
-    console.log('Attempt to resend a confirmation email');
-
-    managementClientInstance.jobs.verifyEmail(params, function (err) {
+  if (!verified) {
+    management.jobs.verifyEmail(params, function (err) {
       if (err) {
-        console.log(
-          'Request to resend a confirmation email failed',
-          'The error is',
-          err
-        );
+        console.log(err)
       } else {
-        console.log(
-          'Successfully created a job to resend a confirmation email'
-        );
+        console.log('Successfully created a job to resend a confirmation email');
       }
-
-      const error = new Error(
-        JSON.stringify({
-          code: 'unauthorized',
-          message: 'You have to confirm your email address before continuing.',
-          statusCode: 401,
-        })
-      );
-
-      return api.access.deny(error.message);
     });
-  } else {
-    return;
+
+    const error = new Error(
+      JSON.stringify({
+        code: 'unauthorized',
+        message: 'You have to confirm your email address before continuing.',
+        statusCode: 401,
+      })
+    );
+
+    return api.access.deny(error.message);
   }
-}
-
-
-/**
- * Handler that will be invoked when this action is resuming after an external redirect. If your
- * onExecutePostLogin function does not perform a redirect, this function can be safely ignored.
- *
- * @param {Event} event - Details about the user and the context in which they are logging in.
- * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
- */
-// exports.onContinuePostLogin = async (event, api) => {
-// };
+};

--- a/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/atcp/tenant.yaml
@@ -44,7 +44,7 @@ actions:
 
   - name: Google Sign In Restriction
     code: ./actions/google-signin-restriction.js
-    deployed: false
+    deployed: true
     status: built
     supported_triggers:
       - id: post-login
@@ -53,18 +53,14 @@ actions:
   - name: Register User in Pepper
     code: ../register-user-in-pepper-action.js
     dependencies:
-      - name: request
-        version: 2.88.2
-    deployed: false
+      - name: axios
+        version: 1.7.7
+    deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
       - name: domain
         value: '##AUTH0_DOMAIN##'
-      - name: M2M_CLIENT_ID
-        value: '##AUTH0_MGMT_CLIENT_ID##'
-      - name: M2M_CLIENT_SECRET
-        value: '##AUTH0_MGMT_CLIENT_SECRET##'
     status: built
     supported_triggers:
       - id: post-login

--- a/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/brugada/tenant.yaml
@@ -24,22 +24,14 @@ actions:
     code: ../register-user-in-pepper-action.js
     runtime: node18
     dependencies:
-      - name: request
-        version: 2.88.2
-      - name: google-cloud/logging
-        version: 11.2.0
-      - name: auth0
-        version: 4.10.0
+      - name: axios
+        version: 1.7.7
     deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
       - name: domain
         value: '##AUTH0_DOMAIN##'
-      - name: M2M_CLIENT_ID
-        value: '##AUTH0_MGMT_CLIENT_ID##'
-      - name: M2M_CLIENT_SECRET
-        value: '##AUTH0_MGMT_CLIENT_SECRET##'
     status: built
     supported_triggers:
       - id: post-login

--- a/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/cmi/tenant.yaml
@@ -32,18 +32,14 @@ actions:
     code: ../register-cmi-user-in-pepper-action.js
     runtime: node18
     dependencies:
-      - name: request
-        version: 2.88.2
+      - name: axios
+        version: 1.7.7
     deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
       - name: domain
         value: '##AUTH0_DOMAIN##'
-      - name: M2M_CLIENT_ID
-        value: '##AUTH0_MGMT_CLIENT_ID##'
-      - name: M2M_CLIENT_SECRET
-        value: '##AUTH0_MGMT_CLIENT_SECRET##'
     status: built
     supported_triggers:
       - id: post-login

--- a/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/prion/tenant.yaml
@@ -6,26 +6,22 @@ rules:
   - name: Register User in Pepper
     script: ../register-user-in-pepper.js
     stage: login_success
-    enabled: true
+    enabled: false
     order: 1
 
 actions:
-  - name: Register User in Pepper v3
+  - name: Register User in Pepper
     code: ../register-user-in-pepper-action.js
     runtime: node18
     dependencies:
-      - name: request
-        version: 2.88.2
-    deployed: false
+      - name: axios
+        version: 1.7.7
+    deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
       - name: domain
         value: '##AUTH0_DOMAIN##'
-      - name: M2M_CLIENT_ID
-        value: '##AUTH0_MGMT_CLIENT_ID##'
-      - name: M2M_CLIENT_SECRET
-        value: '##AUTH0_MGMT_CLIENT_SECRET##'
     status: built
     supported_triggers:
       - id: post-login

--- a/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
@@ -12,8 +12,6 @@
  * @param {PostLoginAPI} api - Interface whose methods can be used to change the behavior of the login.
  */
 exports.onExecutePostLogin = async (event, api) => {
-  console.log('In action register pepper user');
-
   /**
    * The following code block will skip this Action if Rule "Register User in Pepper"
    * was previously executed in the transaction in order to avoid duplication
@@ -24,14 +22,15 @@ exports.onExecutePostLogin = async (event, api) => {
     return;
   }
 
-  // Use of the m2mClients list below should be considered legacy behavior, and
-  // may be removed at any time. Any new clients should set the key 'skipPepperRegistration'
-  // to the value of 'true' in their client metadata if the Pepper registration process
-  // is not required.
+
+// Use of the m2mClients list below should be considered legacy behavior, and
+// may be removed at any time. Any new clients should set the key 'skipPepperRegistration'
+// to the value of 'true' in their client metadata if the Pepper registration process
+// is not required.
   var m2mClients = ['dsm', 'Count Me In (Salt CMS)'];
 
-  // The new flag is opt-in. If no value is defined, the legacy behavior will be used.
-  // If the value is non-null, then assume the client has opted in.
+// The new flag is opt-in. If no value is defined, the legacy behavior will be used.
+// If the value is non-null, then assume the client has opted in.
   var skipPepperRegistration = event.client.metadata.skipPepperRegistration || null;
   if ((skipPepperRegistration === null) && (m2mClients.includes(event.client.name))) {
     console.log('skipping Pepper registration for legacy client \'' + event.client.name + '\'');
@@ -203,7 +202,7 @@ exports.onExecutePostLogin = async (event, api) => {
     //  for one study initially, then attempt to renew it when accessing another. For the moment,
     //  assume that, if a study guid is included with the call, the client wants us to call the
     //  registration endpoint.
-    var isRefreshTokenExchange = event.transaction && event.transaction.protocol  === "oauth2-refresh-token";
+    var isRefreshTokenExchange = event.transaction && event.transaction.protocol === "oauth2-refresh-token";
     console.log('Action Event isRefreshTokenExchange::' + isRefreshTokenExchange);
     var needsStudyRegistration = !!(pepper_params.studyGuid);
     var hasCachedUserGuid = !!(event.user.app_metadata.user_guid);
@@ -221,81 +220,56 @@ exports.onExecutePostLogin = async (event, api) => {
         console.log('User metadata has last name = ' + pepper_params.lastName);
       }
 
-      //added below in action as workaround for not able to update userGUID in user AppMetadata post registration
-      // todo revisit and fix
-      console.log('pepper params: ' + JSON.stringify(pepper_params));
-      console.debug('EVENT: ' + JSON.stringify(event));
-      console.debug('API::: ' + JSON.stringify(api));
-
-      if (pepper_params.mode && pepper_params.mode === 'signup' && pepper_params.tempUserGuid) {
-        console.log('setting userGUID claim from temp user');
-        api.idToken.setCustomClaim(pepperUserGuidClaim, pepper_params.tempUserGuid);
-        api.user.setAppMetadata("user_guid", pepper_params.tempUserGuid);
-        api.user.setAppMetadata("study_guid", pepper_params.studyGuid);
-        console.log('setting userGUID and studyGUID into AppMetadata');
-      }
-      if (pepper_params.mode && pepper_params.mode === 'login' && event.user.app_metadata.user_guid) {
-        console.log('setting userGUID claim from user.app_metadata');
-        api.idToken.setCustomClaim(pepperUserGuidClaim, event.user.app_metadata.user_guid);
-      }
-
       var pepperUrl = event.secrets.pepperBaseUrl;
       if (event.client.metadata.backendUrl) {
         pepperUrl = event.client.metadata.backendUrl;
       }
-      var request = require('request');
+
       console.log('Invoking DDP registration : ' + pepperUrl + ' ... params: ' + JSON.stringify(pepper_params));
-      console.log('ID Token:' + JSON.stringify(api.idToken));
-      request.post({
-        url: pepperUrl + '/pepper/v1/register',
-        json: pepper_params,
-        timeout: 15000
-      }, function (err, response, body) {
-        if (err) {
-          console.log('Error while registering auth0 user ' + event.user.user_id);
-          console.log(err);
-          let error = new Error(JSON.stringify({
-            code: err.code,
-            message: err.message,
-            statusCode: 500
-          }));
-          console.log('Error during registration: ' + err.message);
-          return api.access.deny(JSON.stringify(error));
-        } else if (response && response.statusCode !== 200) {
-          console.log('Response: ' + JSON.stringify(response));
-          console.log('Failed to register auth0 user ' + event.user.user_id + ':' + response.statusCode + ' at ' + pepperUrl);
-          console.log('BODY: ' + JSON.stringify(body));
-          body = body || {};
-          let error = new Error(JSON.stringify({
-            code: body.code,
-            message: body.message,
-            statusCode: response.statusCode
-          }));
 
-          console.log('Access denied...' + JSON.stringify(error));
-          api.idToken.setCustomClaim(pepperUserGuidClaim, null);
-          return api.access.deny(JSON.stringify(error));
-          //todo .. doesnt seem to block UI invoking next steps ?
-        } else {
-          console.log(' register response: ' + JSON.stringify(response));
-          console.log(' register body: ' + JSON.stringify(body));
+      var axios = require('axios');
+      console.log('Invoking DDP registration : ' + pepperUrl);
 
-          // all is well
-          //todo.. below doesnt seem to work..added before register call for now
-          //maybe try API call?
-          var ddpUserGuid = body.ddpUserGuid;
-          api.idToken.setCustomClaim(pepperUserGuidClaim, ddpUserGuid);
-          api.user.setAppMetadata("user_guid", ddpUserGuid);
-          api.user.setUserMetadata("user_guid", ddpUserGuid);
-          console.log('updated user metaData with user GUID ? ');
-
+      try {
+        const response = await axios.post(`${pepperUrl}/pepper/v1/register`, pepper_params, {timeout: 15000});
+        if (response) {
+          console.info(' register response data: ' + JSON.stringify(response.data));
         }
 
-      });
+        if (response && response.status !== 200) {
+          console.log('Response not 200: ' + JSON.stringify(response.data) + ' status code: ' + response.status);
+          console.log('Failed to register auth0 user ' + event.user.user_id + ':' + response.statusCode + ' at ' + pepperUrl);
+          let error = new Error(JSON.stringify({
+            code: response.data.code,
+            message: response.data.message,
+            statusCode: response.statusCode
+          }));
+          return api.access.deny(JSON.stringify(error));
+        }
+
+        //all good
+        var ddpUserGuid = response.data.ddpUserGuid;
+        api.user.setAppMetadata("user_guid", ddpUserGuid);
+        api.user.setAppMetadata("study_guid", pepper_params.studyGuid);
+        api.user.setUserMetadata("user_guid", ddpUserGuid);
+        api.idToken.setCustomClaim(pepperUserGuidClaim, ddpUserGuid);
+        console.log('updated user metaData with user GUID ');
+
+      } catch (err) {
+        console.log('Error while registering auth0 user ' + event.user.user_id, err);
+        console.log(err);
+        let error = new Error(JSON.stringify({
+          code: err.code,
+          message: err.message,
+          statusCode: 500
+        }));
+        console.log('Error during registration: ' + err.message);
+        return api.access.deny(JSON.stringify(error));
+      }
+
     }
   }
 };
-
 
 /**
  * Handler that will be invoked when this action is resuming after an external redirect. If your

--- a/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-cmi-user-in-pepper-action.js
@@ -97,7 +97,8 @@ exports.onExecutePostLogin = async (event, api) => {
       pepper_params.studyGuid = event.client.metadata.study;
       console.log('StudyGuid (defaulting to clientMetadata.study) = ' + pepper_params.studyGuid);
     } else {
-      console.log('No studyGuid passed in request');
+      console.log('No studyGuid passed in request.. request denied');
+      return api.access.deny("No studyGuid passed or found. Request denied.");
     }
 
     console.log('looking for temp_user_guid');

--- a/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
+++ b/pepper-apis/studybuilder-cli/tenants/register-user-in-pepper-action.js
@@ -98,6 +98,7 @@ exports.onExecutePostLogin = async (event, api) => {
       console.log('StudyGuid (defaulting to clientMetadata.study) = ' + pepper_params.studyGuid);
     } else {
       console.log('No studyGuid passed in request');
+      return api.access.deny("No studyGuid passed or found. Request denied.");
     }
 
     console.log('looking for temp_user_guid');

--- a/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/actions/force-email-verification.js
@@ -24,49 +24,20 @@ exports.onExecutePostLogin = async (event, api) => {
   console.log('Received user', event.user);
   console.debug('Received context', event);
 
-  const auth0Sdk = require("auth0");
   if (!event.user.email_verified) {
-    //const ManagementClient = require('auth0@2.9.1').ManagementClient
-    const ManagementClient = auth0Sdk.ManagementClient;
-    // This will make an Authentication API call
-    const managementClientInstance = new ManagementClient({
-      // These come from a machine-to-machine application
-      domain: event.secrets.M2M_DOMAIN,
-      clientId: event.secrets.M2M_CLIENT_ID,
-      clientSecret: event.secrets.M2M_CLIENT_SECRET,
-      scope: "update:users"
-    });
 
-    const params = {
-      user_id: event.user.user_id,
-      client_id: event.client.client_id,
-    };
+    const error = new Error(
+      JSON.stringify({
+        code: 'unauthorized',
+        message: 'You have to confirm your email address before continuing.',
+        statusCode: 401,
+      })
+    );
 
-    console.log('Attempt to resend a confirmation email');
+    console.log('email need to be verified.. denying: ' + JSON.stringify(error));
+    return api.access.deny(error.message);
+    //return api.access.deny(JSON.stringify(error));
 
-    managementClientInstance.jobs.verifyEmail(params, function (err) {
-      if (err) {
-        console.log(
-          'Request to resend a confirmation email failed',
-          'The error is',
-          err
-        );
-      } else {
-        console.log(
-          'Successfully created a job to resend a confirmation email'
-        );
-      }
-
-      const error = new Error(
-        JSON.stringify({
-          code: 'unauthorized',
-          message: 'You have to confirm your email address before continuing.',
-          statusCode: 401,
-        })
-      );
-
-      return api.access.deny(error.message);
-    });
   } else {
     return;
   }

--- a/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
+++ b/pepper-apis/studybuilder-cli/tenants/rgp/tenant.yaml
@@ -9,7 +9,7 @@ rules:
   - name: Register User in Pepper
     script: ../register-user-in-pepper.js
     stage: login_success
-    enabled: true
+    enabled: false
     order: 2
 
 actions:
@@ -36,22 +36,14 @@ actions:
     code: ../register-user-in-pepper-action.js
     runtime: node18
     dependencies:
-      - name: request
-        version: 2.88.2
-      - name: google-cloud/logging
-        version: 11.2.0
-      - name: auth0
-        version: 4.10.0
+      - name: axios
+        version: 1.7.7
     deployed: true
     secrets:
       - name: pepperBaseUrl
         value: '##SERVER_BASE_URL##'
       - name: domain
         value: '##AUTH0_DOMAIN##'
-      - name: M2M_CLIENT_ID
-        value: '##AUTH0_MGMT_CLIENT_ID##'
-      - name: M2M_CLIENT_SECRET
-        value: '##AUTH0_MGMT_CLIENT_SECRET##'
     status: built
     supported_triggers:
       - id: post-login


### PR DESCRIPTION
PEPPER-1389
New changes to handle token claim updates and user AppMetadata updates post pepper/register API call
Main change is user different npm package axios and handke async/await for the registration API response.
Change works for ALL tenants similar to rule. 
Reverted some jave code changes made to UserRegistrationRoute that are NO more needed.

CMI rule has additional check to restrict users trying to login to other cmi studies using study_guid which is not needed for other non-cmi studies, hence separated the cmi rule.

Auth0 changes applied and tested in DEV. looks good.
Prion enrollment/logins work as expected.
CMI tenant restricts users from logging to different cmi studies. (Current prod behavior is retained)

Once merged will update current RC and will redeploy to `test` env. 
 