### PR TITLE
PEPPER-1612 Brain tumor end enrollment support. Kit check for only ac…

### DIFF
--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/KitConfigurationDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/KitConfigurationDao.java
@@ -108,8 +108,10 @@ public interface KitConfigurationDao extends SqlObject {
     }
 
     @SqlQuery("select kc.kit_configuration_id, kc.number_of_kits, kc.kit_type_id, kc.study_id, kc.needs_approval,"
-            + "       (select guid from umbrella_study where umbrella_study_id = kc.study_id) as study_guid"
-            + "  from kit_configuration as kc")
+            + " s.guid as study_guid"
+            + " from kit_configuration as kc, umbrella_study s"
+            + " where s.umbrella_study_id = kc.study_id "
+            + " and s.guid in ('CMI-OSTEO', 'cmi-lms', 'cmi-pancan', 'brugada')")
     @RegisterConstructorMapper(KitConfigurationDto.class)
     List<KitConfigurationDto> getKitConfigurationDtos();
 

--- a/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/KitConfigurationDao.java
+++ b/pepper-apis/dss-core/src/main/java/org/broadinstitute/ddp/db/dao/KitConfigurationDao.java
@@ -111,7 +111,7 @@ public interface KitConfigurationDao extends SqlObject {
             + " s.guid as study_guid"
             + " from kit_configuration as kc, umbrella_study s"
             + " where s.umbrella_study_id = kc.study_id "
-            + " and s.guid in ('CMI-OSTEO', 'cmi-lms', 'cmi-pancan', 'brugada')")
+            + " and s.guid not in ('ANGIO', 'cmi-mbc', 'cmi-mpc', 'cmi-esc', 'cmi-brain', 'singular', 'testboston')")
     @RegisterConstructorMapper(KitConfigurationDto.class)
     List<KitConfigurationDto> getKitConfigurationDtos();
 


### PR DESCRIPTION
PEPPER-1612
Remove disabled pepper studies from Housekeeping KitCheckService and check only active pepper studies which has kit configuration in DSS
After executing the SQL in prod and eliminating non active enrollment studies, added active studies.

Will check Housekeeping logs in DEV, post merge