### PR TITLE
Do not include null kit labels when creating Mercury barcodes

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/ddp/kitrequest/KitRequestDao.java
@@ -36,7 +36,7 @@ public class KitRequestDao implements Dao<KitRequestDto> {
                     + "carrier_service cs ON (krs.carrier_service_to_id = cs.carrier_service_id)";
 
     public static final String SQL_GET_KIT_LABEL =
-            "select kit_label from ddp_kit where dsm_kit_request_id = ?";
+            "select kit_label from ddp_kit where dsm_kit_request_id = ? and kit_label is not null";
 
     public static final String BY_INSTANCE_ID = " WHERE kr.ddp_instance_id = ?";
 
@@ -119,12 +119,17 @@ public class KitRequestDao implements Dao<KitRequestDto> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(SQL_GET_KIT_LABEL)) {
                 stmt.setLong(1, dsmKitRequestId);
+                int rowcount = 0;
                 try (ResultSet rs = stmt.executeQuery()) {
-                    if (rs.next()) {
+                    while (rs.next()) {
                         dbVals.resultValue = rs.getString(DBConstants.KIT_LABEL);
-                    } else {
+                        rowcount++;
+                    }
+                    if (rowcount == 0) {
                         dbVals.resultValue = null;
-                        dbVals.resultException = new DsmInternalError("No kit found for dsm_kit_request_id " + dsmKitRequestId);
+                        dbVals.resultException = new DsmInternalError("No kit request found for dsm_kit_request_id " + dsmKitRequestId);
+                    } else if (rowcount > 1) {
+                        dbVals.resultException = new DsmInternalError("Multiple kit requests found for dsm_kit_request_id " + dsmKitRequestId);
                     }
                 }
             } catch (SQLException ex) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
@@ -515,6 +515,19 @@ public class KitDao {
         return (int) simpleResult.resultValue;
     }
 
+    /**
+     * For testing: Deletes a kit but not the kit request
+     */
+    public int deleteKit(int kitId) {
+        return inTransaction(conn -> {
+            try {
+                return deleteKit(conn, kitId);
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error deleting kit with id: " + kitId, e);
+            }
+        });
+    }
+
     private int deleteKit(Connection conn, int kitId) throws SQLException {
         try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_KIT)) {
             stmt.setInt(1, kitId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
@@ -156,6 +156,7 @@ public class KitDao {
     private static final String SQL_DELETE_KIT_REQUEST = "DELETE FROM ddp_kit_request WHERE dsm_kit_request_id = ?";
 
     private static final String SQL_DELETE_KIT = "DELETE FROM ddp_kit WHERE dsm_kit_id = ?";
+    private static final String SQL_DELETE_KIT_BY_REQUEST_ID = "DELETE FROM ddp_kit WHERE dsm_kit_request_id = ?";
 
     private static final String SQL_NUM_KITS_BY_LABEL = "select count(1) from ddp_kit WHERE dsm_kit_request_id = "
             + "(SELECT dsm_kit_request_id FROM ddp_kit_request WHERE ddp_label = ?) and deactivated_date is null";
@@ -520,20 +521,25 @@ public class KitDao {
      */
     public int deleteKit(int kitId) {
         return inTransaction(conn -> {
-            try {
-                return deleteKit(conn, kitId);
+            try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_KIT)) {
+                stmt.setInt(1, kitId);
+                int rowsAffected = stmt.executeUpdate();
+                if (rowsAffected == 0) {
+                    throw new DsmInternalError("No kit found with id: %d".formatted(kitId));
+                }
+                return rowsAffected;
             } catch (SQLException e) {
                 throw new DsmInternalError("Error deleting kit with id: " + kitId, e);
             }
         });
     }
 
-    private int deleteKit(Connection conn, int kitId) throws SQLException {
-        try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_KIT)) {
-            stmt.setInt(1, kitId);
+    private int deleteKitByRequestId(Connection conn, int kitRequestId) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(SQL_DELETE_KIT_BY_REQUEST_ID)) {
+            stmt.setInt(1, kitRequestId);
             int rowsAffected = stmt.executeUpdate();
             if (rowsAffected == 0) {
-                throw new DsmInternalError("No kit found with id: %d".formatted(kitId));
+                throw new DsmInternalError("No kit found with kit request id: %d".formatted(kitRequestId));
             }
             return rowsAffected;
         }
@@ -883,7 +889,7 @@ public class KitDao {
     public int deleteKitRequestShipping(int dsmKitRequestId) {
         return inTransaction(conn -> {
             try {
-                int rowsAffected = deleteKit(conn, dsmKitRequestId);
+                int rowsAffected = deleteKitByRequestId(conn, dsmKitRequestId);
                 deleteKitRequest(conn, dsmKitRequestId);
                 //deletes in the ddp_kit can affect more rows than in ddp_kit_request, because kit reactivation creates more records
                 //of the same kit in the ddp_kit table

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/dao/kit/KitDaoTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/dao/kit/KitDaoTest.java
@@ -260,11 +260,10 @@ public class KitDaoTest extends DbTxnBaseTest {
     }
 
     @Test
-    public void testXxx() {
+    public void testGetKitLabel() {
         // create a second kit that references the same request, but has a null label
         kitReq.setKitLabel(null);
         Integer kitId = kitDao.insertKit(kitReq);
-
         try {
             String barcode = kitRequestDao.getKitLabelFromDsmKitRequestId(kitRequestIds.get(0));
             Assert.assertEquals(KIT_NAME, barcode);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/dao/kit/KitDaoTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/db/dao/kit/KitDaoTest.java
@@ -19,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.broadinstitute.dsm.DbTxnBaseTest;
 import org.broadinstitute.dsm.db.KitRequestShipping;
 import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
+import org.broadinstitute.dsm.db.dao.ddp.kitrequest.KitRequestDao;
 import org.broadinstitute.dsm.db.dao.ddp.participant.ParticipantDao;
 import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.ddp.participant.ParticipantDto;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class KitDaoTest extends DbTxnBaseTest {
 
     private static final KitDao kitDao = new KitDao();
+    private static final KitRequestDao kitRequestDao = new KitRequestDao();
 
     private static final UserAdminTestUtil userAdminTestUtil = new UserAdminTestUtil();
 
@@ -63,7 +65,7 @@ public class KitDaoTest extends DbTxnBaseTest {
 
     private static Integer participantId;
 
-    private static Integer kitRequestId;
+    private static final List<Integer> kitRequestIds = new ArrayList<>();
 
     private static Integer kitTypeId;
 
@@ -104,18 +106,24 @@ public class KitDaoTest extends DbTxnBaseTest {
                         .build();
         participantId = new ParticipantDao().create(participantDto);
 
-        kitReq = new KitRequestShipping(ddpInstanceId);
+        kitReq = createKit(KIT_NAME, ddpInstanceId, participantDto);
+        kitId = kitDao.insertKit(kitReq);
+    }
+
+    private static KitRequestShipping createKit(String kitName, int ddpInstanceId, ParticipantDto participantDto) {
+        KitRequestShipping kitReq = new KitRequestShipping(ddpInstanceId);
         kitReq.setDdpParticipantId(participantDto.getDdpParticipantId().orElse(""));
         kitReq.setParticipantId(PARTICIPANT_ID);
-        kitReq.setKitLabel(KIT_NAME);
-        kitReq.setDdpLabel(KIT_NAME);
+        kitReq.setKitLabel(kitName);
+        kitReq.setDdpLabel(kitName);
         kitReq.setCreatedDate(System.currentTimeMillis());
-        kitReq.setDdpKitRequestId(KIT_NAME);
+        kitReq.setDdpKitRequestId(kitName);
         kitReq.setKitTypeId(Long.toString(kitTypeId));
         kitReq.setBspCollaboratorParticipantId(HRUID);
-        kitRequestId = kitDao.insertKitRequest(kitReq);
+        Integer kitRequestId = kitDao.insertKitRequest(kitReq);
         kitReq.setDsmKitRequestId(kitRequestId);
-        kitId = kitDao.insertKit(kitReq);
+        kitRequestIds.add(kitRequestId);
+        return kitReq;
     }
 
     @AfterClass
@@ -125,7 +133,7 @@ public class KitDaoTest extends DbTxnBaseTest {
             participantDao.delete(participantId);
         }
         kitDao.deleteKitTrackingByKitLabel(KIT_NAME);
-        if (kitId != null) {
+        for (Integer kitRequestId: kitRequestIds) {
             kitDao.deleteKitRequestShipping(kitRequestId);
         }
         if (kitTypeId != null) {
@@ -251,5 +259,18 @@ public class KitDaoTest extends DbTxnBaseTest {
         kitDao.deleteKitTrackingByKitLabel(kitLabel);
     }
 
+    @Test
+    public void testXxx() {
+        // create a second kit that references the same request, but has a null label
+        kitReq.setKitLabel(null);
+        Integer kitId = kitDao.insertKit(kitReq);
 
+        try {
+            String barcode = kitRequestDao.getKitLabelFromDsmKitRequestId(kitRequestIds.get(0));
+            Assert.assertEquals(KIT_NAME, barcode);
+        } finally {
+            // clean up the second kit
+            kitDao.deleteKit(kitId);
+        }
+    }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/DBTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/DBTestUtil.java
@@ -22,10 +22,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.broadinstitute.dsm.TestHelper;
 import org.broadinstitute.dsm.db.DDPInstance;
 import org.broadinstitute.dsm.db.FieldSettings;
-import org.broadinstitute.dsm.db.dao.ddp.instance.DDPInstanceDao;
 import org.broadinstitute.dsm.db.dao.user.UserDao;
-import org.broadinstitute.dsm.db.dto.ddp.instance.DDPInstanceDto;
 import org.broadinstitute.dsm.db.dto.user.UserDto;
+import org.broadinstitute.dsm.exception.DsmInternalError;
 import org.broadinstitute.dsm.model.Value;
 import org.broadinstitute.dsm.util.tools.util.DBUtil;
 import org.broadinstitute.lddp.db.SimpleResult;
@@ -616,6 +615,30 @@ public class DBTestUtil {
         }
         return (String) results.resultValue;
     }
+
+    public static List<String> getStringsFromQuery(String selectQuery, List<String> strings, String returnColumn) {
+        return inTransaction((conn) -> {
+            try (PreparedStatement stmt = conn.prepareStatement(selectQuery)) {
+                int counter = 1;
+                if (strings != null) {
+                    for (String string : strings) {
+                        stmt.setString(counter, string);
+                        counter++;
+                    }
+                }
+                try (ResultSet rs = stmt.executeQuery()) {
+                    List<String> results = new ArrayList<>();
+                    while (rs.next()) {
+                        results.add(rs.getString(returnColumn));
+                    }
+                    return results;
+                }
+            } catch (SQLException e) {
+                throw new DsmInternalError("Error in getStringsFromQuery", e);
+            }
+        });
+    }
+
 
     public static void executeQueryWStrings(String query, List<String> strings) {
         inTransaction((conn) -> {


### PR DESCRIPTION
## Context

See [SUPPORT-14622.](https://gp-broadinstitute.atlassian.net/browse/SUPPORT-14622)

DSM allows multiple kits to refer to the same kit request. The cases I found in the DB are (mostly/all) cases where a kit has been deactivated: a new ddp_kit is created with a dsm_kit_request_id referencing the same ddp_kit_request as the deactivated, but the kit_label is null. 

When DSM publishes a message to Mercury to create a product order, it queries ddp_kit for instances that match appropriate dsm_kit_request_id (one for each kit/sample) and returns the kit_label (which is used as a Mercury barcode). Since this matches more than one ddp_kit_request, and the prior version of the query only returned one row, the outcome was mostly random, so often a null kit_label was returned

The fix here is to exclude null kit_labels from the query. Clearly DSM should have never gotten to this point, with multiple ddp_kits referencing the same ddp_kit_reqest, but fixing DSM kits is a huge job.

## Checklist

- [ ] I have labeled the type of changes involved using the `C-*` labels.
- [ ] I have assessed potential risks and labeled using the `R-*` labels.
- [ ] I have considered error handling and alerts, and added `L-*` labels as needed.
- [ ] I have considered security and privacy, and added `I-*` labels as needed
- [ ] I have analyzed my changes for stability, fault tolerance, graceful degradation, performance bottlenecks and written a brief summary in this PR.
- [ ] If applicable, I have discussed the analytics needs at both a platform and study level with Product and instrumented code accordingly.
- [ ] If applicable, my UI/UX changes have passed muster with Product/Design via an over-the-shoulder review, screenshots, etc.

_If unsure or need help with any of the above items, add the `help wanted` label. For items that starts with `If applicable`, if it is not applicable, check it off and add `n/a` in front._

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ ] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous

## How do we demo these changes?

_How does one observe these changes in a deployed system? Note that **user visible** encompasses many personas--not just patients and study staff, but also ops duty, your fellow devs, compliance, etc._

- [ ] They are user-visible in dev as a regular user journey and require no additional instructions.
- [ ] Getting dev into a state where this is user-visible requires some tech fiddling. I have documented these steps in the related ticket.
- [ ] Requires other features before it's human visible. I have documented the blocking issues in jira.
- [ ] I have no idea how to demo this. Please help me!

## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ ] I have written automated positive tests
- [ ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ ] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

