### PR TITLE
Add `sexAtBirth` field to kit requests

### DIFF
--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/KitRequestShipping.java
@@ -195,7 +195,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
 
     public static final String INSERT_KIT_REQUEST = "insert into ddp_kit_request (ddp_instance_id,  ddp_kit_request_id, kit_type_id,"
             + "  ddp_participant_id, bsp_collaborator_participant_id, bsp_collaborator_sample_id, ddp_label, created_by, created_date,"
-            + " external_order_number, upload_reason) values (?,?,?,?,?,?,?,?,?,?,?)";
+            + " external_order_number, upload_reason, sex_at_birth) values (?,?,?,?,?,?,?,?,?,?,?,?)";
     public static final String DEACTIVATION_REASON = "Generated Express";
     public static final String UPLOADED = "uploaded";
     private static final Logger logger = LoggerFactory.getLogger(KitRequestShipping.class);
@@ -917,17 +917,17 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
     //adding kit request to db (called by hourly job to add kits into DSM)
     public static void addKitRequests(@NonNull String instanceId, @NonNull KitDetail kitDetail, @NonNull int kitTypeId,
                                       @NonNull KitRequestSettings kitRequestSettings, String collaboratorParticipantId,
-                                      String externalOrderNumber, String uploadReason, DDPInstance ddpInstance, String subkitsDdpLabel) {
+                                      String externalOrderNumber, String uploadReason, DDPInstance ddpInstance, String subkitsDdpLabel, String sexAtBirth) {
         addKitRequests(instanceId, kitDetail.getKitType(), kitDetail.getParticipantId(), kitDetail.getKitRequestId(), kitTypeId,
                 kitRequestSettings, collaboratorParticipantId, kitDetail.isNeedsApproval(), externalOrderNumber, uploadReason, ddpInstance,
-                subkitsDdpLabel);
+                subkitsDdpLabel, sexAtBirth);
     }
 
     //adding kit request to db (called by hourly job to add kits into DSM)
     public static void addKitRequests(@NonNull String instanceId, @NonNull String kitType, @NonNull String participantId,
                                       @NonNull String kitRequestId, @NonNull int kitTypeId, @NonNull KitRequestSettings kitRequestSettings,
                                       String collaboratorParticipantId, boolean needsApproval, String externalOrderNumber,
-                                      String uploadReason, DDPInstance ddpInstance, String subkitsDdpLabel) {
+                                      String uploadReason, DDPInstance ddpInstance, String subkitsDdpLabel, String sexAtBirth) {
         inTransaction(conn -> {
             String errorMessage = "";
             String collaboratorSampleId = null;
@@ -948,7 +948,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             }
             writeRequest(conn, instanceId, kitRequestId, kitTypeId, participantId, collaboratorParticipantId, collaboratorSampleId,
                     "SYSTEM", null, errorMessage, externalOrderNumber, needsApproval, uploadReason, ddpInstance,
-                    bspCollaboratorSampleType, subkitsDdpLabel, false, null, null, null);
+                    bspCollaboratorSampleType, subkitsDdpLabel, false, null, null, null, sexAtBirth);
             return null;
         });
     }
@@ -968,7 +968,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
                                       @NonNull String createdBy, String addressIdTo, String errorMessage, String externalOrderNumber,
                                       boolean needsApproval, String uploadReason, DDPInstance ddpInstance, String kitTypeName,
                                       String subKitddpLabel, boolean isReturnOnly, String returnTrackingId,
-                                      String kitLabel, Long scanDate) {
+                                      String kitLabel, Long scanDate, String sexAtBirth) {
         String ddpLabel = StringUtils.isBlank(subKitddpLabel)
                 ? (StringUtils.isNotBlank(externalOrderNumber) ? null : generateDdpLabelID()) : subKitddpLabel;
 
@@ -986,6 +986,7 @@ public class KitRequestShipping extends KitRequest implements HasDdpInstanceId {
             insertKitRequest.setObject(10,
                     StringUtils.isNotBlank(externalOrderNumber) ? externalOrderNumber : null); //external_order_number
             insertKitRequest.setString(11, uploadReason); //upload reason
+            insertKitRequest.setObject(12, StringUtils.isNotBlank(sexAtBirth) ? sexAtBirth : null);
             insertKitRequest.executeUpdate();
             try (ResultSet rs = insertKitRequest.getGeneratedKeys()) {
                 if (rs.next()) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitStatusDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitStatusDao.java
@@ -247,6 +247,7 @@ public class KitStatusDao implements Dao<NonPepperKitStatusDto> {
                         .withCurrentStatus(calculateCurrentStatus(foundKitResults).getValue())
                         .withCollaboratorParticipantId(foundKitResults.getString(DBConstants.COLLABORATOR_PARTICIPANT_ID))
                         .withCollaboratorSampleId(foundKitResults.getString(DBConstants.BSP_COLLABORATOR_SAMPLE_ID))
+                        .withSexAtBirth(foundKitResults.getString(DBConstants.SEX_AT_BIRTH))
                         .build();
             } catch (SQLException e) {
                 throw new DsmInternalError("Error building the NonPepperKitStatusDto object from resultSet", e);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/kit/BSPKitDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/kit/BSPKitDto.java
@@ -19,6 +19,7 @@ public class BSPKitDto {
     private String notificationRecipient;
     private String kitTypeName;
     private String collectionDate;
+    private String sexAtBirth;
 
     public BSPKitDto(String instanceName,
                      String baseUrl,

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/kit/nonPepperKit/NonPepperKitStatusDto.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dto/kit/nonPepperKit/NonPepperKitStatusDto.java
@@ -32,6 +32,7 @@ public class NonPepperKitStatusDto {
     private final String currentStatus;
     private String collaboratorParticipantId;
     private String collaboratorSampleId;
+    private String sexAtBirth;
 
     /**
      * Creates a NonPepperKitStatusDto from a builder
@@ -60,6 +61,7 @@ public class NonPepperKitStatusDto {
         this.collaboratorParticipantId = builder.collaboratorParticipantId;
         this.collaboratorSampleId = builder.collaboratorSampleId;
         this.mfBarcode = builder.mfBarcode;
+        this.sexAtBirth = builder.sexAtBirth;
     }
 
     public static class Builder {
@@ -87,6 +89,7 @@ public class NonPepperKitStatusDto {
         private String currentStatus;
         private String collaboratorParticipantId;
         private String collaboratorSampleId;
+        private String sexAtBirth;
 
         public Builder withJuniperKitId(String juniperKitId) {
             this.juniperKitId = juniperKitId;
@@ -200,6 +203,11 @@ public class NonPepperKitStatusDto {
 
         public Builder withCollaboratorSampleId(String collaboratorSampleId) {
             this.collaboratorSampleId = collaboratorSampleId;
+            return this;
+        }
+
+        public Builder withSexAtBirth(String sexAtBirth) {
+            this.sexAtBirth = sexAtBirth;
             return this;
         }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/KitRequest.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/KitRequest.java
@@ -37,6 +37,9 @@ public class KitRequest {
     @DbDateConversion(SqlDateConverter.EPOCH)
     private Long externalOrderDate;
 
+    @ColumnName(DBConstants.SEX_AT_BIRTH)
+    private String sexAtBirth;
+
     public KitRequest() {
     }
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/ddp/KitDetail.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/ddp/KitDetail.java
@@ -9,11 +9,14 @@ public class KitDetail {
     private String kitRequestId;
     private String kitType;
     private boolean needsApproval;
+    private String sexAtBirth;
 
-    public KitDetail(String participantId, String kitRequestId, String kitType, boolean needsApproval) {
+    public KitDetail(String participantId, String kitRequestId, String kitType, boolean needsApproval,
+                     String sexAtBirth) {
         this.participantId = participantId;
         this.kitRequestId = kitRequestId;
         this.kitType = kitType;
         this.needsApproval = needsApproval;
+        this.sexAtBirth = sexAtBirth;
     }
 }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/gp/GPReceivedKit.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/gp/GPReceivedKit.java
@@ -77,7 +77,7 @@ public class GPReceivedKit {
         logger.info("Returning info for kit w/ label " + kitLabel + " for " + bspKitQueryResult.getInstanceName());
         logger.info("Kit returned has sample id " + bspSampleId);
         return Optional.of(
-                new KitInfo(bspKitQueryResult.getBspCollection(), bspOrganism, "U", bspParticipantId, bspSampleId, bspMaterialType,
+                new KitInfo(bspKitQueryResult.getBspCollection(), bspOrganism, bspKitQueryResult.getSexAtBirth(), bspParticipantId, bspSampleId, bspMaterialType,
                         bspReceptacleType, ddpInstance.getName(), bspKitQueryResult.getKitTypeName(), collectionDate));
 
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/NonPepperKitCreationService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/NonPepperKitCreationService.java
@@ -236,7 +236,7 @@ public class NonPepperKitCreationService {
                         KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), juniperKitRequestId, kitTypeId,
                                 participantID, collaboratorParticipantId, collaboratorSampleId, userId, addressId,
                                 errorMessage, kit.getExternalOrderNumber(), false, null, ddpInstance, bspCollaboratorSampleType,
-                                null, kit.isReturnOnly(), kit.getReturnTrackingId(), kit.getKitLabel(), scanDate, "U");
+                                null, kit.isReturnOnly(), kit.getReturnTrackingId(), kit.getKitLabel(), scanDate, sexAtBirth);
                 log.info("Created new kit in DSM with dsm_kit_request_id {} for JuniperKitId {}", dsmKitRequestId, juniperKitRequestId);
             } catch (Exception e) {
                 transactionResults.resultException = e;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/NonPepperKitCreationService.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/model/nonpepperkit/NonPepperKitCreationService.java
@@ -165,7 +165,7 @@ public class NonPepperKitCreationService {
         try {
             addJuniperKitRequest(conn, kitTypeName, kitRequestSettings, ddpInstance, kitType.getKitTypeId(), collaboratorParticipantId,
                     errorMessage, easyPostUtil, kit, externalOrderNumber, juniperKitRequestId, userId, kit.getReturnTrackingId(),
-                    kit.isReturnOnly(), kit.getKitLabel(), transactionResults);
+                    kit.isReturnOnly(), kit.getKitLabel(),  kit.getSexAtBirth(), transactionResults);
         } catch (Exception e) {
             throw new DsmInternalError("unable to add juniper kit request", e);
         }
@@ -177,7 +177,7 @@ public class NonPepperKitCreationService {
                                       String errorMessage, EasyPostUtil easyPostUtil, JuniperKitRequest kit,
                                       String externalOrderNumber, String juniperKitRequestId,
                                       String userId, String returnShipmentTrackingLabel,
-                                      boolean returnOnly, String kitLabel, SimpleResult transactionResults) throws DsmInternalError {
+                                      boolean returnOnly, String kitLabel, String sexAtBirth, SimpleResult transactionResults) throws DsmInternalError {
         String collaboratorSampleId = null;
         String bspCollaboratorSampleType = kitTypeName;
         String addressId = null;
@@ -210,7 +210,7 @@ public class NonPepperKitCreationService {
                 KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), juniperKitRequestId,
                         kitTypeId,
                         kit.getParticipantId().trim(), collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, externalOrderNumber,
-                        false, null, ddpInstance, bspCollaboratorSampleType, null, returnOnly, returnShipmentTrackingLabel, kitLabel, scanDate);
+                        false, null, ddpInstance, bspCollaboratorSampleType, null, returnOnly, returnShipmentTrackingLabel, kitLabel, scanDate, sexAtBirth);
                 kit.setExternalOrderNumber(externalOrderNumber);
             } catch (Exception e) {
                 transactionResults.resultException = e;
@@ -236,7 +236,7 @@ public class NonPepperKitCreationService {
                         KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), juniperKitRequestId, kitTypeId,
                                 participantID, collaboratorParticipantId, collaboratorSampleId, userId, addressId,
                                 errorMessage, kit.getExternalOrderNumber(), false, null, ddpInstance, bspCollaboratorSampleType,
-                                null, kit.isReturnOnly(), kit.getReturnTrackingId(), kit.getKitLabel(), scanDate);
+                                null, kit.isReturnOnly(), kit.getReturnTrackingId(), kit.getKitLabel(), scanDate, "U");
                 log.info("Created new kit in DSM with dsm_kit_request_id {} for JuniperKitId {}", dsmKitRequestId, juniperKitRequestId);
             } catch (Exception e) {
                 transactionResults.resultException = e;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateBSPDummyKitRoute.java
@@ -49,7 +49,7 @@ public class CreateBSPDummyKitRoute implements Route {
                     String dsmKitRequestId = KitRequestShipping.writeRequest(conn, mockDdpInstance.getDdpInstanceId(), mercuryKitRequestId,
                             kitTypeId, ddpParticipantId, participantCollaboratorId,
                             collaboratorSampleId, USER_ID, "", "", "", false, "",
-                            null, DUMMY_KIT_TYPE_NAME, null, false, null, null, null);
+                            null, DUMMY_KIT_TYPE_NAME, null, false, null, null, null, null);
                     new BSPDummyKitDao().updateKitLabel(kitLabel, dsmKitRequestId);
                     return null;
                 });

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/CreateClinicalDummyKitRoute.java
@@ -140,7 +140,7 @@ public class CreateClinicalDummyKitRoute implements Route {
             String dsmKitRequestId  = TransactionWrapper.inTransaction(conn -> {
                 return KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestId, desiredKitType.getKitId(),
                                 ddpParticipantId.get(), participantCollaboratorId, collaboratorSampleId, USER_ID, "", "",
-                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null, null, null);
+                                "", false, "", ddpInstance, desiredKitType.getName(), null, false, null, null, null, null);
             });
             bspDummyKitDao.updateKitLabel(kitLabel, dsmKitRequestId);
             bspDummyKitDao.updateCollectionDate(dsmKitRequestId);

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/route/KitUploadRoute.java
@@ -382,7 +382,7 @@ public class KitUploadRoute extends RequestHandler {
                             ddpInstance);
             KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
                     kit.getParticipantId().trim(), collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, externalOrderNumber,
-                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null);
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null, null);
             kit.setDdpLabel(shippingId);
             kit.setExternalOrderNumber(externalOrderNumber);
         } else {
@@ -410,7 +410,7 @@ public class KitUploadRoute extends RequestHandler {
 
             KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), shippingId, kitTypeId,
                     participantID, collaboratorParticipantId, collaboratorSampleId, userId, addressId, errorMessage, kit.getExternalOrderNumber(),
-                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null);
+                    false, uploadReason, ddpInstance, bspCollaboratorSampleType, ddpLabel, false, null, null, null, null);
             kit.setDdpLabel(shippingId);
         }
     }

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/statics/DBConstants.java
@@ -154,6 +154,7 @@ public class DBConstants {
     public static final String KIT_LABEL_PREFIX = "kit_label_prefix";
     public static final String KIT_LABEL_LENGTH = "kit_label_length";
     public static final String HAS_CARE_OF = "has_care_of";
+    public static final String SEX_AT_BIRTH = "sex_at_birth";
 
     public static final String ONC_HISTORY_ID = "onc_history_id";
 

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/DDPKitRequest.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/DDPKitRequest.java
@@ -92,7 +92,7 @@ public class DDPKitRequest {
                                                             } else {
                                                                 KitRequestShipping.addKitRequests(latestKit.getInstanceID(), kitDetail,
                                                                         kitType.getKitTypeId(), kitRequestSettings,
-                                                                        collaboratorParticipantId, null, null, ddpInstance, null);
+                                                                        collaboratorParticipantId, null, null, ddpInstance, null, kitDetail.getSexAtBirth());
                                                             }
                                                         } else {
                                                             logger.error(
@@ -149,7 +149,7 @@ public class DDPKitRequest {
                         subCounter == 0 ? kitDetail.getKitRequestId() : kitDetail.getKitRequestId() + "_" + subCounter,
                         subKit.getKitTypeId(), kitRequestSettings, collaboratorParticipantId, kitDetail.isNeedsApproval(),
                         externalOrderNumber, uploadReason, ddpInstance, subCounter == 0 ? subKitsDdpLabel : subKitsDdpLabel + "_"
-                                + subCounter);
+                                + subCounter, kitDetail.getSexAtBirth());
                 subCounter = subCounter + 1;
             }
         }

--- a/pepper-apis/dsm-core/src/main/resources/liquibase/PEPPER-1627_AddSexAtBirthToKitRequest.xml
+++ b/pepper-apis/dsm-core/src/main/resources/liquibase/PEPPER-1627_AddSexAtBirthToKitRequest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet author="andrew" id="PEPPER-1627">
+        <addColumn tableName="ddp_kit_request">
+            <column name="sex_at_birth" type="varchar(100)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/pepper-apis/dsm-core/src/main/resources/master-changelog.xml
+++ b/pepper-apis/dsm-core/src/main/resources/master-changelog.xml
@@ -155,4 +155,5 @@
     <include file="liquibase/PEPPER-1438_field_settings.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/PEPPER-1554_scad_rename.xml" relativeToChangelogFile="true"/>
     <include file="liquibase/tRCC/PEPPER-1502_tRCC_study_setup.xml" relativeToChangelogFile="true"/>
+    <include file="liquibase/PEPPER-1627_AddSexAtBirthToKitRequest.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
@@ -130,6 +130,13 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
     }
 
     @Test
+    public void testSexAtBirth() {
+        int rand = new Random().nextInt() & Integer.MAX_VALUE;
+        JuniperKitRequest juniperTestKit = generateJuniperKitRequest(rand);
+        Assert.assertEquals("F", juniperTestKit.getSexAtBirth());
+    }
+
+    @Test
     public void testReturnOnlyKit() {
         int rand = new Random().nextInt() & Integer.MAX_VALUE;
         JuniperKitRequest juniperTestKit = generateJuniperKitRequest(rand);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
@@ -237,7 +237,7 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
                 + "\"skipAddressValidation\":false,"
                 + "\"juniperStudyID\":\"Juniper-test-guid\", "
                 + "\"sexAtBirth\":\"F\""
-                + "\"}";
+                + "}";
 
         return new Gson().fromJson(json, JuniperKitRequest.class);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/juniperkits/JuniperKitCreationStatusTest.java
@@ -150,8 +150,8 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
         createNonPepperTestKit(juniperTestKit);
         KitResponse kitResponse = nonPepperStatusKitService.getKitsBasedOnParticipantId(juniperTestKit.getJuniperParticipantID());
         verifyStatusKitResponse(kitResponse, juniperTestKit, rand, KitCurrentStatus.KIT_WITHOUT_LABEL.getValue());
-
     }
+
     /**
      * this method creates the juniperTestKitRequest in the database  by calling
      * `NonPepperKitCreationService.createNonPepperKit` and verifies the response is as expected
@@ -217,6 +217,7 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
         Assert.assertEquals(expectedStatus, nonPepperKitStatus.getCurrentStatus());
         Assert.assertNotNull(nonPepperKitStatus.getCollaboratorParticipantId());
         Assert.assertNotNull(nonPepperKitStatus.getCollaboratorSampleId());
+        Assert.assertEquals(juniperTestKit.getSexAtBirth(), nonPepperKitStatus.getSexAtBirth());
     }
 
     private JuniperKitRequest generateJuniperKitRequest(int random) {
@@ -234,7 +235,9 @@ public class JuniperKitCreationStatusTest extends DbTxnBaseTest {
                 + "\"juniperKitId\":\"JuniperTestKitId_" + random + "\","
                 + "\"juniperParticipantID\":\"" + participantId + random + "\","
                 + "\"skipAddressValidation\":false,"
-                + "\"juniperStudyID\":\"Juniper-test-guid\"}";
+                + "\"juniperStudyID\":\"Juniper-test-guid\", "
+                + "\"sexAtBirth\":\"F\""
+                + "\"}";
 
         return new Gson().fromJson(json, JuniperKitRequest.class);
     }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitDisplayNameTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitDisplayNameTest.java
@@ -49,7 +49,7 @@ public class KitDisplayNameTest extends DbTxnBaseTest {
     @Test
     public void testKitWithDisplayName() {
         int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto,
-                KitRequestShippingTest.BLOOD_RNA_KIT_TYPE_NAME, kitTestUtil.getKitTypeId(), false);
+                KitRequestShippingTest.BLOOD_RNA_KIT_TYPE_NAME, kitTestUtil.getKitTypeId(), false, null);
         KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
         List<KitRequestShipping> kits = KitRequestShipping.getKitRequestsByRealm(instanceName, KitRequestShipping.OVERVIEW,
                 KitRequestShippingTest.BLOOD_RNA_KIT_TYPE_NAME);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/KitTestUtil.java
@@ -473,7 +473,7 @@ public class KitTestUtil {
                 KitRequestShipping.writeRequest(conn, ddpInstance.getDdpInstanceId(), kitRequestShipping.getDdpKitRequestId(),
                         kitTypeId, kitRequestShipping.getDdpParticipantId(),
                         kitRequestShipping.getBspCollaboratorParticipantId(), kitRequestShipping.getBspCollaboratorSampleId(), userId, null, null, null, false,
-                        null, ddpInstance, kitTypeName, null, false, kitRequestShipping.getTrackingReturnId(), kitRequestShipping.getKitLabel(), null));
+                        null, ddpInstance, kitTypeName, null, false, kitRequestShipping.getTrackingReturnId(), kitRequestShipping.getKitLabel(), null, "U"));
     }
 
     public void createEventsForDDPInstance(String eventName, String eventType, String eventDescription, boolean nullKitType) {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/EventServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/EventServiceTest.java
@@ -100,6 +100,26 @@ public class EventServiceTest extends DbAndElasticBaseTest {
     }
 
     @Test
+    public void testSexAtBirth() {
+        String sexAtBirth = "F";
+        try (MockedStatic<DDPRequestUtil> utilities = Mockito.mockStatic(DDPRequestUtil.class)) {
+            utilities.when(() -> DDPRequestUtil.postRequest(anyString(), any(), anyString(), anyBoolean()))
+                    .thenReturn(200);
+
+            // Assert that mocking is working correctly
+            Assert.assertEquals(200L, (long)DDPRequestUtil.postRequest("", "", "", true));
+
+            int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
+                    kitTestUtil.getKitTypeId(), false, sexAtBirth);
+            KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
+            Assert.assertEquals(sexAtBirth, kitRequestShipping.getSexAtBirth());
+        } catch (IOException e) {
+            e.printStackTrace();
+            Assert.fail("Unexpected exception");
+        }
+    }
+
+    @Test
     public void testKitSentEvent() {
         try (MockedStatic<DDPRequestUtil> utilities = Mockito.mockStatic(DDPRequestUtil.class)) {
             utilities.when(() -> DDPRequestUtil.postRequest(anyString(), any(), anyString(), anyBoolean()))
@@ -109,7 +129,7 @@ public class EventServiceTest extends DbAndElasticBaseTest {
             Assert.assertEquals(200L, (long)DDPRequestUtil.postRequest("", "", "", true));
 
             int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false);
+                    kitTestUtil.getKitTypeId(), false, null);
             KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
             String kitLabel = "EVENT_KIT_LABEL";
             List<ScanResult> scanResultList = kitTestUtil.changeKitRequestShippingToSent(kitRequestShipping, kitLabel);
@@ -176,7 +196,7 @@ public class EventServiceTest extends DbAndElasticBaseTest {
             Assert.assertEquals(500L, (long)DDPRequestUtil.postRequest("", "", "", true));
 
             int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false);
+                    kitTestUtil.getKitTypeId(), false, null);
             KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
             String kitLabel = "EVENT_KIT_LABEL_2";
             kitTestUtil.changeKitRequestShippingToSent(kitRequestShipping, kitLabel);
@@ -204,7 +224,7 @@ public class EventServiceTest extends DbAndElasticBaseTest {
                     any())).thenThrow(exception);
 
             int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false);
+                    kitTestUtil.getKitTypeId(), false, null);
             KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
             String kitLabel = "EVENT_KIT_LABEL_3";
             kitTestUtil.changeKitRequestShippingToSent(kitRequestShipping, kitLabel);
@@ -243,7 +263,7 @@ public class EventServiceTest extends DbAndElasticBaseTest {
                     });
 
             int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false);
+                    kitTestUtil.getKitTypeId(), false, null);
             KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
             String kitLabel = "EVENT_KIT_LABEL_4";
             kitTestUtil.changeKitRequestShippingToSent(kitRequestShipping, kitLabel);
@@ -272,7 +292,7 @@ public class EventServiceTest extends DbAndElasticBaseTest {
             utilities.when(() -> DDPRequestUtil.postRequest(anyString(), any(), anyString(), anyBoolean())).thenReturn(200);
 
             int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false);
+                    kitTestUtil.getKitTypeId(), false, null);
             KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
             String kitLabel = "EVENT_KIT_LABEL_5";
             kitTestUtil.changeKitRequestShippingToSent(kitRequestShipping, kitLabel);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/EventServiceTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/service/EventServiceTest.java
@@ -100,26 +100,6 @@ public class EventServiceTest extends DbAndElasticBaseTest {
     }
 
     @Test
-    public void testSexAtBirth() {
-        String sexAtBirth = "F";
-        try (MockedStatic<DDPRequestUtil> utilities = Mockito.mockStatic(DDPRequestUtil.class)) {
-            utilities.when(() -> DDPRequestUtil.postRequest(anyString(), any(), anyString(), anyBoolean()))
-                    .thenReturn(200);
-
-            // Assert that mocking is working correctly
-            Assert.assertEquals(200L, (long)DDPRequestUtil.postRequest("", "", "", true));
-
-            int kitRequestId = kitShippingTestUtil.createTestKitShippingWithKitType(participantDto, ddpInstanceDto, SALIVA,
-                    kitTestUtil.getKitTypeId(), false, sexAtBirth);
-            KitRequestShipping kitRequestShipping = KitDao.getKitRequest(kitRequestId).orElseThrow();
-            Assert.assertEquals(sexAtBirth, kitRequestShipping.getSexAtBirth());
-        } catch (IOException e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected exception");
-        }
-    }
-
-    @Test
     public void testKitSentEvent() {
         try (MockedStatic<DDPRequestUtil> utilities = Mockito.mockStatic(DDPRequestUtil.class)) {
             utilities.when(() -> DDPRequestUtil.postRequest(anyString(), any(), anyString(), anyBoolean()))

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/DBTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/DBTestUtil.java
@@ -9,6 +9,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
@@ -808,6 +809,7 @@ public class DBTestUtil {
                 stmt.setObject(11, null);
                 stmt.setLong(12, ordered);
                 stmt.setObject(13, "SHIPPED");
+                stmt.setNull(14, Types.VARCHAR);
                 stmt.executeUpdate();
 
                 int kitRequestKey = -1;

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
@@ -95,7 +95,7 @@ public class KitShippingTestUtil {
         String kitReqestIdStr = TransactionWrapper.inTransaction(conn ->
                 KitRequestShipping.writeRequest(conn, instanceDto.getDdpInstanceId().toString(), dsmKitRequestId,
                         kitTypeId, participant.getDdpParticipantIdOrThrow(), "test", "test", testUser, "test", "",
-                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null, null, null));
+                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null, null, null, null));
         return Integer.parseInt(kitReqestIdStr);
     }
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/KitShippingTestUtil.java
@@ -61,17 +61,17 @@ public class KitShippingTestUtil {
 
     public int createTestKitShipping(ParticipantDto participant, DDPInstanceDto instanceDto) {
         KitTypeDto kitTypeDto = createKitType("SALIVA");
-        return createTestKitShippingWithKitType(participant, instanceDto, kitTypeDto.getKitTypeName(), kitTypeDto.getKitTypeId(), true);
+        return createTestKitShippingWithKitType(participant, instanceDto, kitTypeDto.getKitTypeName(), kitTypeDto.getKitTypeId(), true, null);
     }
 
     public int createTestKitShippingWithKitType(ParticipantDto participant, DDPInstanceDto instanceDto, String kitTypeName, int kitTypeId,
-                                                boolean addKitType) {
+                                                boolean addKitType, String sexAtBirth) {
         participantCounter++;
         String ddpParticipantId = participant.getDdpParticipantIdOrThrow();
         if (addKitType) {
             addKitType(ddpParticipantId, kitTypeId);
         }
-        int dsmKitRequestId = createKitShipping(participant, instanceDto, kitTypeName, kitTypeId);
+        int dsmKitRequestId = createKitShipping(participant, instanceDto, kitTypeName, kitTypeId, sexAtBirth);
         addKitRequest(ddpParticipantId, dsmKitRequestId);
         log.info("Created kit request with id {} for ptp {}", dsmKitRequestId, ddpParticipantId);
         return dsmKitRequestId;
@@ -89,13 +89,13 @@ public class KitShippingTestUtil {
      * Creates a kit shipping request for a participant.
      * @return dsmKitRequestId
      */
-    public int createKitShipping(ParticipantDto participant, DDPInstanceDto instanceDto, String kitTypeName, int kitTypeId) {
+    public int createKitShipping(ParticipantDto participant, DDPInstanceDto instanceDto, String kitTypeName, int kitTypeId, String sexAtBirth) {
         DDPInstance ddpInstance = DDPInstance.getDDPInstance(instanceDto.getInstanceName());
         String dsmKitRequestId = genDsmKitRequestId();
         String kitReqestIdStr = TransactionWrapper.inTransaction(conn ->
                 KitRequestShipping.writeRequest(conn, instanceDto.getDdpInstanceId().toString(), dsmKitRequestId,
                         kitTypeId, participant.getDdpParticipantIdOrThrow(), "test", "test", testUser, "test", "",
-                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null, null, null, null));
+                        "test", false, null, ddpInstance, kitTypeName, dsmKitRequestId, false, null, null, null, sexAtBirth));
         return Integer.parseInt(kitReqestIdStr);
     }
 


### PR DESCRIPTION
## PEPPER-1627 

To facilitate the A-T migration to juniper, we're adding a new `sexAtBirth` field to kit requests.  Although juniper kits will be the only kits that set this field, these changes will make it possible for other kits to keep track of `sexAtBirth` as well.  By default, this field is left blank, but if juniper sets the value, it'll be stored in the `ddp_kit_request` table and passed back to BSP, where it will be visible as BSP's `gender` field.

Previously, DSM was hardcoded to return `U` as `gender` for BSP.  This change will allow BSP to store the `sexAtBirth` field using its existing `gender` field.  BSP only stores this value if it is `M` or `F`.  Otherwise, BSP does not store the attribute.

The corresponding change to Juniper is to add the `sexAtBirth` field to the payload it sends to DSM when requesting a kit.

DSM isn't doing any validation of the field, since it's just passing the value through to BSP.

Will need to do some manual integration testing on this one to make sure existing workflows without `sexAtBirth` are handled properly.

Because this is an additive change and the new field is optional, there shouldn't be a need for coordinating changes with Juniper or BSP.

## FUD Score

_Overall, how are you feeling about these changes?_

- [ ] :relaxed: All good, business as usual!
- [ x] :sweat_smile: There might be some issues here
- [ ] :scream: I'm sweaty and nervous


## Testing

- [ ] I have added regression test labels to the jira ticket
- [ ] I have added verification steps to the jira ticket
- [ x] I have written automated positive tests
- [x ] I have written automated negative tests
- [ ] I have written zero automated tests but have poked around locally to verify proper functionality
- [ ] The jira ticket has acceptance criteria and QA has the needed information to test changes

## Release

- [ x] These changes require no special release procedures--just code!
- [ ] Releasing these changes requires special handling and I have documented the special procedures in the release plan document

