### PR TITLE
PEPPER-1646 using two easypost api keys

### DIFF
--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -85,6 +85,7 @@
     "elasticsearchBatchSize": 100,
     "healthcheckPassword": "{{$testingConf.Data.healthcheckPassword}}",
     "easyPostApiKey": "{{$testingConf.Data.easyPostApiKey}}",
+    "legacyEsyPostApiKey": "{{$testingConf.Data.legacyEasyPostApiKey}}",
     # by default, boot in-processs for testing.  change rendered .conf file manually for local development
     "bootTestAppInSeparateProcess": false,
     "apiBaseUrl": "http://localhost:5555",

--- a/pepper-apis/config/testing-inmemorydb.conf.ctmpl
+++ b/pepper-apis/config/testing-inmemorydb.conf.ctmpl
@@ -85,7 +85,7 @@
     "elasticsearchBatchSize": 100,
     "healthcheckPassword": "{{$testingConf.Data.healthcheckPassword}}",
     "easyPostApiKey": "{{$testingConf.Data.easyPostApiKey}}",
-    "legacyEsyPostApiKey": "{{$testingConf.Data.legacyEasyPostApiKey}}",
+    "legacyEasyPostApiKey": "{{$testingConf.Data.legacyEasyPostApiKey}}",
     # by default, boot in-processs for testing.  change rendered .conf file manually for local development
     "bootTestAppInSeparateProcess": false,
     "apiBaseUrl": "http://localhost:5555",

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/db/dao/kit/KitDao.java
@@ -38,7 +38,7 @@ public class KitDao {
                     + "req.bsp_collaborator_participant_id, req.bsp_collaborator_sample_id, req.ddp_participant_id, req.ddp_label, "
                     + "req.dsm_kit_request_id, req.ddp_kit_request_id,"
                     + "req.kit_type_id, req.external_order_status, req.external_order_number, req.external_order_date, "
-                    + "req.external_response, kt.no_return, req.created_by FROM kit_type kt, ddp_kit_request req, ddp_instance ddp_site "
+                    + "req.external_response, kt.no_return, req.created_by, from_unixtime(req.created_date/1000) as request_created_on FROM kit_type kt, ddp_kit_request req, ddp_instance ddp_site "
                     + "WHERE req.ddp_instance_id = ddp_site.ddp_instance_id AND req.kit_type_id = kt.kit_type_id) AS request "
                     + "LEFT JOIN (SELECT * FROM (SELECT kit.dsm_kit_request_id, kit.dsm_kit_id, kit.kit_complete, kit.label_url_to, "
                     + "kit.label_url_return, kit.tracking_to_id, "

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/EasyPostUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/EasyPostUtil.java
@@ -152,6 +152,18 @@ public class EasyPostUtil {
         return new EasypostLabelRate(express, normal);
     }
 
+    /**
+     * Returns the "old" easypost API key.  This key was used prior to merging
+     * the pepper-specific easypost account into GPKM's easypost account.  Use
+     * this key to look up shipment and tracking information for kits that were ordered
+     * prior to November 15, 2025.  If API calls to easypost return 404s and "NOT_FOUND",
+     * it's likely that the new API key is being used to query data that was written
+     * by the legacy API key.
+     */
+    public static String getLegacyEasyPostApiKey() {
+        return ConfigManager.getInstance().getConfig().getString("legacyEasyPostApiKey");
+    }
+
     public Shipment buyShipment(@NonNull String carrier, String carrierId, String service, @NonNull Address toAddress,
                                 @NonNull Address fromAddress,
                                 @NonNull Parcel parcel, String billingReference, CustomsInfo customsInfo) throws EasyPostException {
@@ -327,7 +339,20 @@ public class EasyPostUtil {
     }
 
     public Shipment getShipment(String shipmentId) throws EasyPostException {
-        return Shipment.retrieve(shipmentId);
+        Shipment shipment = null;
+        try {
+            shipment = Shipment.retrieve(shipmentId);
+        } catch (EasyPostException easyPostException) {
+            // if we're looking up a shipment using an api key for an account that did not create
+            // the shipment, we'll get a 404.  retry with the legacy account's api key
+            if (easyPostException.getMessage().contains("NOT_FOUND")) {
+                logger.info("Querying shipment {} with legacy easypost API key", shipmentId);
+                shipment = Shipment.retrieve(shipmentId, EasyPostUtil.getLegacyEasyPostApiKey());
+            } else {
+                throw easyPostException;
+            }
+        }
+        return shipment;
     }
 
     /**

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/EasyPostUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/EasyPostUtil.java
@@ -346,7 +346,7 @@ public class EasyPostUtil {
             // if we're looking up a shipment using an api key for an account that did not create
             // the shipment, we'll get a 404.  retry with the legacy account's api key
             if (easyPostException.getMessage().contains("NOT_FOUND")) {
-                logger.info("Querying shipment {} with legacy easypost API key", shipmentId);
+                logger.info("Retrying shipment {} with legacy easypost API key", shipmentId);
                 shipment = Shipment.retrieve(shipmentId, EasyPostUtil.getLegacyEasyPostApiKey());
             } else {
                 throw easyPostException;

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
@@ -161,6 +161,9 @@ public class KitUtil {
     private static final String EASYPOST_FAILURE_STATUS = "failure";
     private static final String EASYPOST_RETURN_SENDER_STATUS = "return_to_sender";
     private static final String EASYPOST_ERROR_STATUS = "error";
+    // don't request shipping updates from kits that are > 18 months
+    private static final String AND_KIT_TOO_OLD = " AND request_created_on > DATE_SUB(sysdate(), interval 18 month) ";
+    private static final String AND_KIT_NOT_RECEIVED = " AND receive_date IS NULL ";
 
     /**
      * createLabel buys shipments for the kit and updates their label url in the db
@@ -580,7 +583,7 @@ public class KitUtil {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(
-                    KitDao.SQL_SELECT_KIT_REQUEST + QueryExtension.BY_REALM + AND_EASYPOST_TO_ID + QueryExtension.KIT_TOO_OLD + QueryExtension.KIT_STATUS_RECEIVED)) {
+                    KitDao.SQL_SELECT_KIT_REQUEST + QueryExtension.BY_REALM + AND_EASYPOST_TO_ID + AND_KIT_TOO_OLD + AND_KIT_NOT_RECEIVED)) {
                 stmt.setString(1, realm);
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {

--- a/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
+++ b/pepper-apis/dsm-core/src/main/java/org/broadinstitute/dsm/util/KitUtil.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import com.easypost.EasyPost;
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
 import com.easypost.model.Shipment;
@@ -515,6 +516,7 @@ public class KitUtil {
 
                     for (KitRequestShipping kitRequest : kitRequestShippingList) {
                         if (StringUtils.isNotBlank(kitRequest.getEasypostToId()) && kitRequest.getEasypostToId().startsWith("shp_")) {
+                            logger.info("Looking up status of shipment {}", kitRequest.getEasypostToId());
                             try {
                                 Shipment shipment = easyPostUtil.getShipment(kitRequest.getEasypostToId());
                                 Tracker tracker = shipment.getTracker();
@@ -578,7 +580,7 @@ public class KitUtil {
         SimpleResult results = inTransaction((conn) -> {
             SimpleResult dbVals = new SimpleResult();
             try (PreparedStatement stmt = conn.prepareStatement(
-                    KitDao.SQL_SELECT_KIT_REQUEST + QueryExtension.BY_REALM + AND_EASYPOST_TO_ID)) {
+                    KitDao.SQL_SELECT_KIT_REQUEST + QueryExtension.BY_REALM + AND_EASYPOST_TO_ID + QueryExtension.KIT_TOO_OLD + QueryExtension.KIT_STATUS_RECEIVED)) {
                 stmt.setString(1, realm);
                 try (ResultSet rs = stmt.executeQuery()) {
                     while (rs.next()) {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -1,0 +1,84 @@
+package org.broadinstitute.dsm.kits;
+
+import com.easypost.EasyPost;
+import com.easypost.model.Address;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * One-off script to copy addresses from old easypost account to new easypost account
+ * for kits that are in-process and have not yet been sent out.
+ *
+ * To get a list of kits to copy, run the following:
+ select k.dsm_kit_id, k.easypost_return_id,
+ from_unixtime(k.scan_date/1000) scanned_at, from_unixtime(kr.created_date/1000) created_at,
+ i.instance_name, k.easypost_address_id_to, k.easypost_tracking_return_url, k.kit_complete
+ from ddp_kit_request kr, ddp_kit k, ddp_instance i
+ where
+ i.ddp_instance_id = kr.ddp_instance_id
+ and
+ kr.dsm_kit_request_id = k.dsm_kit_request_id
+ and (
+ ((k.easypost_tracking_to_url is null or k.tracking_to_id is null) and not k.kit_complete and
+ k.easypost_address_id_to is not null)
+ )
+ *
+ * And then copy paste the ids into the main() below.  Copy/paste the sql update statements from stdout
+ * and run them in the db to apply the update.
+ */
+public class CopyAddressToNewEasyPostAccountTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(CopyAddressToNewEasyPostAccountTest.class);
+
+
+    public static void main(String[] args) throws Exception {
+        CopyAddressToNewEasyPostAccountTest copier = new CopyAddressToNewEasyPostAccountTest();
+
+        copier.copyAddressIdFromOldAccountToNewAccount(3164, "adr_5d81b118dab611eca269ac1f6b0a0d1e");
+    }
+
+    // todo move me to a test, run with list of kit request ids
+    public void copyAddressIdFromOldAccountToNewAccount(int dsmKitId, String oldToAddressId) throws Exception {
+        String currentAccountKey = System.getenv("currentEasyPostApiKey");
+        String oldAccountKey = System.getenv("oldEasyPostApiKey");
+        EasyPost.apiKey = oldAccountKey;
+        Address oldAddress = Address.retrieve(oldToAddressId);
+        Address newAddress = null;
+
+        EasyPost.apiKey = currentAccountKey;
+        logger.info("Will query address using old api key {} and copy it with current api key {}", oldAccountKey, currentAccountKey);
+
+        Map<String, Object> toAddressMap = new HashMap<>();
+        toAddressMap.put("name", oldAddress.getName());
+        toAddressMap.put("street1", oldAddress.getStreet1());
+        toAddressMap.put("street2", oldAddress.getStreet2());
+        toAddressMap.put("city", oldAddress.getCity());
+        toAddressMap.put("state", oldAddress.getState());
+        toAddressMap.put("zip", oldAddress.getZip());
+        toAddressMap.put("country", oldAddress.getCountry());
+        toAddressMap.put("company", oldAddress.getCompany());
+        toAddressMap.put("phone", oldAddress.getPhone());
+        toAddressMap.put("residential", true);
+        newAddress = Address.create(toAddressMap);
+
+
+        logger.info("Old address {} is being replaced with new address {} for kit id {}.", oldToAddressId, newAddress.getId(), dsmKitId);
+
+        logger.info(oldAddress.getName() + "->" + newAddress.getName());
+        logger.info(oldAddress.getStreet1() + "->" + newAddress.getStreet1());
+        logger.info(oldAddress.getStreet2() + "->" + newAddress.getStreet2());
+        logger.info(oldAddress.getCity() + "->" + newAddress.getCity());
+        logger.info(oldAddress.getState() + "->" + newAddress.getState());
+        logger.info(oldAddress.getZip() + "->" + newAddress.getZip());
+        logger.info(oldAddress.getCountry() + "->" + newAddress.getCountry());
+        logger.info(oldAddress.getCompany() + "->" + newAddress.getCompany());
+        logger.info(oldAddress.getPhone() + "->" + newAddress.getPhone());
+        logger.info(oldAddress.getResidential() + "->" + newAddress.getResidential());
+
+        logger.info("update ddp_kit set easypost_address_id_to = '" + newAddress.getId() + "' where dsm_kit_id = " + dsmKitId + ";");
+    }
+}

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -37,8 +37,8 @@ public class CopyAddressToNewEasyPostAccountTest {
 
     public static void main(String[] args) throws Exception {
         CopyAddressToNewEasyPostAccountTest copier = new CopyAddressToNewEasyPostAccountTest();
-
-        copier.copyAddressIdFromOldAccountToNewAccount(3164, "adr_5d81b118dab611eca269ac1f6b0a0d1e");
+        copier.copyAddressIdFromOldAccountToNewAccount(1312, "adr_19e9ecc4033611efa8c2ac1f6bc539ae");
+        copier.copyAddressIdFromOldAccountToNewAccount(1278, "adr_19e9ecc4033611efa8c2ac1f6bc539ae");
     }
 
     // todo move me to a test, run with list of kit request ids

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -49,7 +49,6 @@ public class CopyAddressToNewEasyPostAccountTest {
         logger.info("Address: " + address);
     }
 
-    // todo move me to a test, run with list of kit request ids
     public void copyAddressIdFromOldAccountToNewAccount(int dsmKitId, String oldToAddressId) throws Exception {
         EasyPost.apiKey = oldAccountKey;
         Address oldAddress = Address.retrieve(oldToAddressId);
@@ -70,7 +69,6 @@ public class CopyAddressToNewEasyPostAccountTest {
         toAddressMap.put("phone", oldAddress.getPhone());
         toAddressMap.put("residential", true);
         newAddress = Address.create(toAddressMap);
-
 
         logger.info("Old address {} is being replaced with new address {} for kit id {}.", oldToAddressId, newAddress.getId(), dsmKitId);
 

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsm.kits;
 
 import com.easypost.EasyPost;
+import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
 
 import org.slf4j.Logger;
@@ -35,16 +36,23 @@ public class CopyAddressToNewEasyPostAccountTest {
     private static final Logger logger = LoggerFactory.getLogger(CopyAddressToNewEasyPostAccountTest.class);
 
 
+    private final String currentAccountKey = System.getenv("currentEasyPostApiKey");
+    private final String oldAccountKey = System.getenv("oldEasyPostApiKey");
+
     public static void main(String[] args) throws Exception {
         CopyAddressToNewEasyPostAccountTest copier = new CopyAddressToNewEasyPostAccountTest();
-        copier.copyAddressIdFromOldAccountToNewAccount(1312, "adr_19e9ecc4033611efa8c2ac1f6bc539ae");
-        copier.copyAddressIdFromOldAccountToNewAccount(1278, "adr_19e9ecc4033611efa8c2ac1f6bc539ae");
+        copier.lookupAddressWithNewAccount("adr_71a25ffec18311f0975eac1f6bc53342");
+        copier.copyAddressIdFromOldAccountToNewAccount(160716, "adr_71a25ffec18311f0975eac1f6bc53342");
+    }
+
+    private void lookupAddressWithNewAccount(String addressId) throws EasyPostException {
+        EasyPost.apiKey = currentAccountKey;
+        Address address = Address.retrieve(addressId);
+        logger.info("Address: " + address);
     }
 
     // todo move me to a test, run with list of kit request ids
     public void copyAddressIdFromOldAccountToNewAccount(int dsmKitId, String oldToAddressId) throws Exception {
-        String currentAccountKey = System.getenv("currentEasyPostApiKey");
-        String oldAccountKey = System.getenv("oldEasyPostApiKey");
         EasyPost.apiKey = oldAccountKey;
         Address oldAddress = Address.retrieve(oldToAddressId);
         Address newAddress = null;

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -43,12 +43,6 @@ public class CopyAddressToNewEasyPostAccountTest {
         CopyAddressToNewEasyPostAccountTest copier = new CopyAddressToNewEasyPostAccountTest();
     }
 
-    private void lookupAddressWithNewAccount(String addressId) throws EasyPostException {
-        EasyPost.apiKey = currentAccountKey;
-        Address address = Address.retrieve(addressId);
-        logger.info("Address: " + address);
-    }
-
     public void copyAddressIdFromOldAccountToNewAccount(int dsmKitId, String oldToAddressId) throws Exception {
         EasyPost.apiKey = oldAccountKey;
         Address oldAddress = Address.retrieve(oldToAddressId);

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/kits/CopyAddressToNewEasyPostAccountTest.java
@@ -41,8 +41,6 @@ public class CopyAddressToNewEasyPostAccountTest {
 
     public static void main(String[] args) throws Exception {
         CopyAddressToNewEasyPostAccountTest copier = new CopyAddressToNewEasyPostAccountTest();
-        copier.lookupAddressWithNewAccount("adr_71a25ffec18311f0975eac1f6bc53342");
-        copier.copyAddressIdFromOldAccountToNewAccount(160716, "adr_71a25ffec18311f0975eac1f6bc53342");
     }
 
     private void lookupAddressWithNewAccount(String addressId) throws EasyPostException {

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/EasyPostUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/EasyPostUtilTest.java
@@ -2,6 +2,7 @@ package org.broadinstitute.dsm.util;
 
 import com.easypost.exception.EasyPostException;
 import com.easypost.model.Address;
+import com.easypost.model.Shipment;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -22,7 +23,10 @@ public class EasyPostUtilTest {
     }
 
     @Test
-    public void testRetryShipmentWithLegacyAccount() {
-        somehow load this
+    public void testRetryShipmentWithLegacyAccount() throws Exception {
+        // this shipment was created with the legacy easypost account.  it should be accessible
+        // via getShipment's retry with the legacy easypost account.
+        Shipment shipment = easyPostUtil.getShipment("shp_428f62fbafe84b33a4b5d9685981390a");
+        Assert.assertTrue(shipment != null);
     }
 }

--- a/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/EasyPostUtilTest.java
+++ b/pepper-apis/dsm-core/src/test/java/org/broadinstitute/dsm/util/EasyPostUtilTest.java
@@ -20,4 +20,9 @@ public class EasyPostUtilTest {
             Assert.fail(e.getMessage());
         }
     }
+
+    @Test
+    public void testRetryShipmentWithLegacyAccount() {
+        somehow load this
+    }
 }


### PR DESCRIPTION
As described in PEPPER-1646, because we aren't migrated historic shipment information between the old and new easypost account, we need a way for DSM to fallback to using the "old" easypost account api key for shipments that were created using the previous account.  Without this ability, DSM can't keep track of updates on older kits.

Along the way, I realized that DSM is running queries every hour to look up shipment information for some very old kits--going back to 2018.  We tend to give up on kits that are more than 12 months old, both because of historical return rates and because return labels _do_ expire.  I've set the cutoff at 18 months so that DSM now only checks for status of kits that haven't been received _and_ are at most 18 months old.